### PR TITLE
Closes #1236 - Add GitLab API support

### DIFF
--- a/package.json
+++ b/package.json
@@ -1507,6 +1507,11 @@
 								"default": "https",
 								"description": "Specifies an optional url protocol for the custom remote service"
 							},
+							"ignoreCertErrors": {
+								"type": "boolean",
+								"default": false,
+								"description": "When connecting to the remote API, true will ignore any invalid certificate errors"
+							},
 							"urls": {
 								"type": "object",
 								"required": [

--- a/src/config.ts
+++ b/src/config.ts
@@ -448,6 +448,7 @@ export type RemotesConfig =
 			protocol?: string;
 			type: CustomRemoteType;
 			urls?: RemotesUrlsConfig;
+			ignoreCertErrors?: boolean;
 	  }
 	| {
 			domain: null;
@@ -456,6 +457,7 @@ export type RemotesConfig =
 			protocol?: string;
 			type: CustomRemoteType;
 			urls?: RemotesUrlsConfig;
+			ignoreCertErrors?: boolean;
 	  };
 
 export interface RemotesUrlsConfig {

--- a/src/container.ts
+++ b/src/container.ts
@@ -232,6 +232,24 @@ export class Container {
 		}
 	}
 
+	private static _gitlab: Promise<import('./gitlab/gitlab').GitLabApi | undefined> | undefined;
+	static get gitlab() {
+		if (this._gitlab == null) {
+			this._gitlab = this._loadGitLabApi();
+		}
+
+		return this._gitlab;
+	}
+
+	private static async _loadGitLabApi() {
+		try {
+			return new (await import(/* webpackChunkName: "gitlab" */ './gitlab/gitlab')).GitLabApi();
+		} catch (ex) {
+			Logger.error(ex);
+			return undefined;
+		}
+	}
+
 	@memoize()
 	static get insiders() {
 		return this._extensionId.endsWith('-insiders');

--- a/src/git/remotes/factory.ts
+++ b/src/git/remotes/factory.ts
@@ -1,13 +1,13 @@
 'use strict';
+import { CustomRemoteType, RemotesConfig } from '../../configuration';
+import { Logger } from '../../logger';
 import { AzureDevOpsRemote } from './azure-devops';
 import { BitbucketRemote } from './bitbucket';
 import { BitbucketServerRemote } from './bitbucket-server';
-import { CustomRemoteType, RemotesConfig } from '../../configuration';
 import { CustomRemote } from './custom';
 import { GiteaRemote } from './gitea';
 import { GitHubRemote } from './github';
 import { GitLabRemote } from './gitlab';
-import { Logger } from '../../logger';
 import { RemoteProvider, RichRemoteProvider } from './provider';
 
 export { RemoteProvider, RichRemoteProvider };

--- a/src/gitlab/auth-service.ts
+++ b/src/gitlab/auth-service.ts
@@ -1,0 +1,90 @@
+import assert from 'assert';
+import { window } from 'vscode';
+import { CustomRemoteType, RemotesConfig } from '../config';
+import { configuration } from '../configuration';
+import { Container } from '../container';
+import { debug } from '../system/decorators/log';
+
+const GitLabComUrl = 'https://www.gitlab.com';
+
+export class GitLabAuthService {
+	private get glTokenMap() {
+		assert(Container.context);
+		return Container.context.globalState.get<Record<string, string>>('glTokens', {});
+	}
+
+	currentInstanceUrl(): string {
+		const remotes: RemotesConfig[] | null = configuration.get('remotes');
+		const remote = remotes?.find(remote => remote.type === CustomRemoteType.GitLab);
+		return remote?.domain ? `${remote?.protocol}://${remote?.domain}` : GitLabComUrl;
+	}
+
+	@debug()
+	getInstanceUrls() {
+		return Object.keys(this.glTokenMap);
+	}
+
+	@debug()
+	getToken(instanceUrl: string = this.currentInstanceUrl()) {
+		return this.glTokenMap[instanceUrl];
+	}
+
+	@debug()
+	async setToken(instanceUrl: string, token: string | undefined) {
+		assert(Container.context);
+		const tokenMap = this.glTokenMap;
+
+		if (token) {
+			tokenMap[instanceUrl] = token;
+		} else {
+			delete tokenMap[instanceUrl];
+		}
+
+		await Container.context.globalState.update('glTokens', tokenMap);
+	}
+	@debug()
+	async askForToken() {
+		if (!this.getToken() && !Container.context.workspaceState.get<boolean>('askedForToken')) {
+			const message = 'GitLab Workflow: Please set GitLab Personal Access Token to setup this extension.';
+			const setButton = { title: 'Set Token Now', action: 'set' };
+			const readMore = { title: 'Read More', action: 'more' };
+
+			await Container.context.workspaceState.update('askedForToken', true);
+			const item = await window.showInformationMessage(message, readMore, setButton);
+			if (item != null) {
+				const { action } = item;
+
+				if (action === 'set') {
+					return this.showInput();
+				}
+				//TODO: add docs for setting up gitlab connection
+				// } else {
+				// commands.executeCommand(VS_COMMANDS.OPEN, Uri.parse('https://gitlab.com/gitlab-org/gitlab-vscode-extension#setup'));
+				// }
+			}
+		}
+		return Promise.resolve(this.getToken());
+	}
+
+	@debug()
+	async showInput() {
+		const instance = await window.showInputBox({
+			ignoreFocusOut: true,
+			value: GitLabComUrl,
+			placeHolder: `E.g. ${GitLabComUrl}`,
+			prompt: 'URL to Gitlab instance',
+		});
+
+		const token = await window.showInputBox({
+			ignoreFocusOut: true,
+			password: true,
+			placeHolder: 'Paste your GitLab Personal Access Token...',
+		});
+
+		if (instance && token) {
+			await this.setToken(instance, token);
+		}
+	}
+}
+
+export const gitLabAuthService: GitLabAuthService = new GitLabAuthService();

--- a/src/gitlab/author.ts
+++ b/src/gitlab/author.ts
@@ -1,0 +1,8 @@
+export interface GitLabUser {
+	id: number;
+	name: string;
+	username: string;
+	state: string;
+	avatar_url: string;
+	web_url: string;
+}

--- a/src/gitlab/commit.ts
+++ b/src/gitlab/commit.ts
@@ -1,0 +1,34 @@
+export interface GitLabCommit {
+	id: string;
+	short_id: string;
+	created_at: Date;
+	parent_ids: string[];
+	title: string;
+	message: string;
+	author_name: string;
+	author_email: string;
+	authored_date: Date;
+	committer_name: string;
+	committer_email: string;
+	committed_date: Date;
+	stats: GitLabCommitStats;
+	status: string;
+	project_id: number;
+	last_pipeline: GitLabPipeline;
+}
+
+export interface GitLabCommitStats {
+	additions: number;
+	deletions: number;
+	total: number;
+}
+
+export interface GitLabPipeline {
+	id: number;
+	sha: string;
+	ref: string;
+	status: string;
+	created_at: Date;
+	updated_at: Date;
+	web_url: string;
+}

--- a/src/gitlab/gitlab.ts
+++ b/src/gitlab/gitlab.ts
@@ -1,0 +1,418 @@
+'use strict';
+import https, { Agent } from 'https';
+import fetch from 'node-fetch';
+import { CustomRemoteType } from '../config';
+import { configuration } from '../configuration';
+import { AuthenticationError, ClientError, RichRemoteProvider } from '../git/git';
+import { Account } from '../git/models/author';
+import { DefaultBranch, IssueOrPullRequest, PullRequest } from '../git/models/models';
+import { Logger } from '../logger';
+import { debug } from '../system';
+import { GitLabAuthService, gitLabAuthService } from './auth-service';
+import { GitLabUser } from './author';
+import { GitLabCommit } from './commit';
+import { GitLabIssue } from './issue';
+import { GitLabMergeRequest, GitLabMergeRequestState } from './merge-request';
+import { GitLabProject } from './project';
+
+export class GitLabApi {
+	private _agent: Agent = https.globalAgent;
+
+	constructor() {
+		const config = configuration.get('remotes')?.find(remote => remote.type === CustomRemoteType.GitLab);
+		if (config?.ignoreCertErrors) {
+			this._agent = new Agent({ ...https.globalAgent.options, rejectUnauthorized: !config.ignoreCertErrors });
+		}
+	}
+	get authService(): GitLabAuthService {
+		return gitLabAuthService;
+	}
+
+	private _project: GitLabProject | undefined;
+
+	@debug({
+		args: {
+			3: _ => '<token>',
+		},
+	})
+	async getProjectByPath(
+		group: string,
+		repo: string,
+		baseUrl?: string,
+		token?: string,
+	): Promise<GitLabProject | undefined> {
+		const cc = Logger.getCorrelationContext();
+
+		if (this._project === undefined) {
+			try {
+				Logger.log(cc, `Getting Project By Path ${baseUrl}/v4/projects?search=${group}/${repo}, ${token}`);
+				this._project = (await fetch(`${baseUrl}/v4/projects/${encodeURIComponent(`${group}/${repo}`)}`, {
+					headers: { authorization: `Bearer ${token}` },
+					agent: this._agent,
+				}).then(response => response.json())) as GitLabProject;
+
+				Logger.log(cc, `Project retrieved ${this._project?.id}`);
+			} catch (ex) {
+				Logger.error(ex, cc);
+
+				if (ex.code >= 400 && ex.code <= 500) {
+					if (ex.code === 401) throw new AuthenticationError(ex);
+					throw new ClientError(ex);
+				}
+				throw ex;
+			}
+		}
+		return this._project;
+	}
+
+	@debug({
+		args: {
+			1: _ => '<token>',
+		},
+	})
+	async getAccountForCommit(
+		provider: RichRemoteProvider,
+		token: string,
+		owner: string,
+		repo: string,
+		ref: string,
+		options?: {
+			baseUrl?: string;
+			avatarSize?: number;
+		},
+	): Promise<Account | undefined> {
+		const cc = Logger.getCorrelationContext();
+
+		try {
+			const projectId = await this.getProjectByPath(owner, repo, options?.baseUrl, token).then(
+				project => project?.id,
+			);
+			const commit = (await fetch(`${options?.baseUrl}/v4/projects/${projectId}/repository/commits/${ref}`, {
+				headers: { authorization: `Bearer ${token}` },
+				agent: this._agent,
+				...options,
+			}).then(response => response.json())) as GitLabCommit;
+
+			Logger.log(cc, `Commit retrieved, Getting author ${commit.author_name}`);
+
+			const commitAuthor = await this.getUserByAuthorName(commit.author_name, token, options);
+
+			if (commitAuthor == null) return undefined;
+
+			return {
+				provider: provider,
+				name: commitAuthor.name ?? undefined,
+				email: commit.author_email ?? undefined,
+				avatarUrl: commitAuthor.avatar_url ?? undefined,
+			};
+		} catch (ex) {
+			Logger.error(ex, cc);
+
+			if (ex.code >= 400 && ex.code <= 500) {
+				if (ex.code === 401) throw new AuthenticationError(ex);
+				throw new ClientError(ex);
+			}
+			throw ex;
+		}
+	}
+
+	@debug({
+		args: {
+			1: _ => '<token>',
+		},
+	})
+	async getAccountForEmail(
+		_provider: RichRemoteProvider,
+		_token: string,
+		_owner: string,
+		_repo: string,
+		_email: string,
+		_options?: {
+			baseUrl?: string;
+			avatarSize?: number;
+		},
+	): Promise<Account | undefined> {
+		const cc = Logger.getCorrelationContext();
+
+		try {
+			Logger.warn(cc, 'Get Account by email is not supported by the GitLab API at this time.');
+			return Promise.resolve(undefined);
+		} catch (ex) {
+			Logger.error(ex, cc);
+
+			if (ex.code >= 400 && ex.code <= 500) {
+				if (ex.code === 401) throw new AuthenticationError(ex);
+				throw new ClientError(ex);
+			}
+			throw ex;
+		}
+	}
+
+	@debug({
+		args: {
+			0: (p: RichRemoteProvider) => p.name,
+			1: _ => '<token>',
+		},
+	})
+	async getDefaultBranch(
+		provider: RichRemoteProvider,
+		token: string,
+		owner: string,
+		repo: string,
+		options?: {
+			baseUrl?: string;
+		},
+	): Promise<DefaultBranch | undefined> {
+		const cc = Logger.getCorrelationContext();
+		try {
+			const defaultBranch = await this.getProjectByPath(owner, repo, options?.baseUrl, token).then(
+				project => project?.default_branch,
+			);
+
+			if (defaultBranch === undefined) return undefined;
+
+			return {
+				provider: provider,
+				name: defaultBranch,
+			};
+		} catch (ex) {
+			Logger.error(ex, cc);
+
+			if (ex.code >= 400 && ex.code <= 500) {
+				if (ex.code === 401) throw new AuthenticationError(ex);
+				throw new ClientError(ex);
+			}
+			throw ex;
+		}
+	}
+
+	@debug({
+		args: {
+			1: _ => '<token>',
+		},
+	})
+	async getIssueOrPullRequest(
+		provider: RichRemoteProvider,
+		token: string,
+		owner: string,
+		repo: string,
+		number: number,
+		options?: {
+			baseUrl?: string;
+		},
+	): Promise<IssueOrPullRequest | undefined> {
+		const cc = Logger.getCorrelationContext();
+		const projectId = await this.getProjectByPath(owner, repo, options?.baseUrl, token).then(
+			project => project?.id,
+		);
+		if (projectId) {
+			try {
+				let issueOrMR: IssueOrPullRequest | undefined = await this.getIssueByNumber(
+					number,
+					provider,
+					token,
+					options,
+				);
+				if (issueOrMR == null) {
+					const mr = (await fetch(`${options?.baseUrl}/v4/projects/${projectId}/merge_requests/${number}`, {
+						headers: { authorization: `Bearer ${token}` },
+						agent: this._agent,
+						...options,
+					}).then(response => response.json())) as GitLabMergeRequest;
+
+					issueOrMR = {
+						type: 'PullRequest',
+						closed: mr.closed_at != null,
+						date: new Date(mr.created_at),
+						id: mr.id,
+						provider: provider,
+						title: mr.title,
+						closedDate: mr.closed_at == null ? undefined : new Date(mr.closed_at),
+					};
+				}
+
+				return issueOrMR;
+			} catch (ex) {
+				Logger.error(ex, cc);
+
+				if (ex.code >= 400 && ex.code <= 500) {
+					if (ex.code === 401) throw new AuthenticationError(ex);
+					throw new ClientError(ex);
+				}
+				throw ex;
+			}
+		}
+		return undefined;
+	}
+
+	@debug({
+		args: {
+			1: _ => '<token>',
+		},
+	})
+	async getPullRequestForBranch(
+		provider: RichRemoteProvider,
+		token: string,
+		owner: string,
+		repo: string,
+		branch: string,
+		options?: {
+			baseUrl?: string;
+			avatarSize?: number;
+			include?: GitLabMergeRequestState[];
+		},
+	): Promise<PullRequest | undefined> {
+		const cc = Logger.getCorrelationContext();
+
+		const projectId = await this.getProjectByPath(owner, repo, options?.baseUrl, token).then(
+			project => project?.id,
+		);
+		if (projectId) {
+			try {
+				const response = await fetch(
+					`${options?.baseUrl}/v4/projects/${projectId}/merge_requests?source_branch=${branch}`,
+					{
+						headers: { authorization: `Bearer ${token}` },
+						agent: this._agent,
+						...options,
+					},
+				);
+				const mrs = (await response.json()) as GitLabMergeRequest[];
+				if (mrs == null || mrs.length === 0) return undefined;
+
+				if (mrs.length > 1) {
+					mrs.sort(
+						(a, b) =>
+							(a.state === GitLabMergeRequestState.OPEN ? -1 : 1) -
+								(b.state === GitLabMergeRequestState.OPEN ? -1 : 1) ||
+							new Date(b.updated_at).getTime() - new Date(a.updated_at).getTime(),
+					);
+				}
+
+				return GitLabMergeRequest.from(mrs[0], provider);
+			} catch (ex) {
+				Logger.error(ex, cc);
+
+				if (ex.code >= 400 && ex.code <= 500) {
+					if (ex.code === 401) throw new AuthenticationError(ex);
+					throw new ClientError(ex);
+				}
+				throw ex;
+			}
+		}
+		return undefined;
+	}
+
+	@debug({
+		args: {
+			1: _ => '<token>',
+		},
+	})
+	async getPullRequestForCommit(
+		provider: RichRemoteProvider,
+		token: string,
+		owner: string,
+		repo: string,
+		ref: string,
+		options?: {
+			baseUrl?: string;
+			avatarSize?: number;
+		},
+	): Promise<PullRequest | undefined> {
+		const cc = Logger.getCorrelationContext();
+		const projectId = await this.getProjectByPath(owner, repo, options?.baseUrl, token).then(
+			project => project?.id,
+		);
+		if (projectId) {
+			try {
+				const mrs = (await fetch(
+					`${options?.baseUrl}/v4/projects/${projectId}/repository/commits/${ref}/merge_requests`,
+					{
+						headers: { authorization: `Bearer ${token}` },
+						agent: this._agent,
+						...options,
+					},
+				).then(response => response.json())) as GitLabMergeRequest[];
+
+				if (mrs == null || mrs.length === 0) return undefined;
+				if (mrs.length > 1) {
+					mrs.sort(
+						(a, b) =>
+							(a.state === GitLabMergeRequestState.OPEN ? -1 : 1) -
+								(b.state === GitLabMergeRequestState.OPEN ? -1 : 1) ||
+							new Date(b.updated_at).getTime() - new Date(a.updated_at).getTime(),
+					);
+				}
+
+				return GitLabMergeRequest.from(mrs[0], provider);
+			} catch (ex) {
+				Logger.error(ex, cc);
+
+				if (ex.code >= 400 && ex.code <= 500) {
+					if (ex.code === 401) throw new AuthenticationError(ex);
+					throw new ClientError(ex);
+				}
+				throw ex;
+			}
+		}
+		return undefined;
+	}
+
+	@debug()
+	private async getIssueByNumber(
+		number: number,
+		provider: RichRemoteProvider,
+		token: string,
+		options?: {
+			baseUrl?: string;
+			avatarSize?: number;
+		},
+	): Promise<IssueOrPullRequest | undefined> {
+		const cc = Logger.getCorrelationContext();
+
+		try {
+			const issue = (await fetch(`${options?.baseUrl}/v4/issues/${number}`, {
+				method: 'GET',
+				headers: { authorization: `Bearer ${token}` },
+				agent: this._agent,
+				...options,
+			}).then(response => response.json())) as GitLabIssue;
+
+			if (issue == null) {
+				return Promise.resolve(undefined);
+			}
+			return GitLabIssue.from(issue, provider);
+		} catch (ex) {
+			Logger.error(ex, cc);
+
+			if (ex.code >= 400 && ex.code <= 500) {
+				if (ex.code === 401) throw new AuthenticationError(ex);
+				throw new ClientError(ex);
+			}
+			throw ex;
+		}
+	}
+
+	@debug()
+	private async getUserByAuthorName(
+		authorName: string,
+		token: string,
+		options?: {
+			baseUrl?: string;
+			avatarSize?: number;
+		},
+	): Promise<GitLabUser> {
+		const users = (await fetch(`${options?.baseUrl}/v4/users?search=${authorName}`, {
+			headers: { authorization: `Bearer ${token}` },
+			agent: this._agent,
+			...options,
+		}).then(resp => resp.json())) as GitLabUser[];
+
+		if (users.length > 1) {
+			users.sort(
+				(a: GitLabUser, b: GitLabUser) => (a.state === 'active' ? -1 : 1) - (b.state === 'active' ? -1 : 1),
+			);
+		}
+		return users[0];
+	}
+}

--- a/src/gitlab/issue.ts
+++ b/src/gitlab/issue.ts
@@ -1,0 +1,31 @@
+import { IssueOrPullRequest, RichRemoteProvider } from '../git/git';
+import { GitLabUser } from './author';
+
+export interface GitLabIssue {
+	id: number;
+	iid: number;
+	author: GitLabUser;
+	description: string;
+	assignees: GitLabUser[];
+	assignee: GitLabUser;
+	title: string;
+	created_at: string;
+	updated_at: string;
+	closed_at: string;
+	web_url: string;
+	state: 'opened' | 'closed';
+}
+
+export namespace GitLabIssue {
+	export function from(pr: GitLabIssue, provider: RichRemoteProvider): IssueOrPullRequest {
+		return {
+			type: 'Issue',
+			provider: provider,
+			id: pr.id,
+			date: new Date(pr.created_at),
+			title: pr.title,
+			closed: pr.state === 'closed',
+			closedDate: pr.closed_at == null ? undefined : new Date(pr.closed_at),
+		};
+	}
+}

--- a/src/gitlab/merge-request.ts
+++ b/src/gitlab/merge-request.ts
@@ -1,0 +1,70 @@
+import { PullRequest, PullRequestState } from '../git/git';
+import { RichRemoteProvider } from '../git/remotes/provider';
+
+export interface GitLabMergeRequest {
+	id: number;
+	iid: number;
+	project_id: number;
+	title: string;
+	description: string;
+	state: GitLabMergeRequestState;
+	merged_at: string;
+	closed_by: string | null;
+	closed_at: string | null;
+	created_at: string;
+	updated_at: string;
+	target_branch: string;
+	source_branch: string;
+	author: {
+		id: number;
+		name: string;
+		username: string;
+		state: string;
+		avatar_url: string;
+		web_url: string;
+	};
+	web_url: string;
+}
+
+export enum GitLabMergeRequestState {
+	OPEN = 'open',
+	CLOSED = 'closed',
+	MERGED = 'merged',
+	LOCKED = 'locked',
+}
+
+export namespace GitLabMergeRequest {
+	export function from(pr: GitLabMergeRequest, provider: RichRemoteProvider): PullRequest {
+		return new PullRequest(
+			provider,
+			{
+				name: pr?.author.name,
+				avatarUrl: pr?.author.avatar_url,
+				url: pr?.author.web_url,
+			},
+			String(pr.iid),
+			pr.title,
+			pr.web_url,
+			fromState(pr.state),
+			new Date(pr.updated_at),
+			pr.closed_at == null ? undefined : new Date(pr.closed_at),
+			pr.merged_at == null ? undefined : new Date(pr.merged_at),
+		);
+	}
+
+	export function fromState(state: GitLabMergeRequestState): PullRequestState {
+		return state === GitLabMergeRequestState.MERGED
+			? PullRequestState.Merged
+			: state === GitLabMergeRequestState.CLOSED || state === GitLabMergeRequestState.LOCKED
+			? PullRequestState.Closed
+			: PullRequestState.Open;
+	}
+
+	export function toState(state: PullRequestState): GitLabMergeRequestState {
+		return state === PullRequestState.Merged
+			? GitLabMergeRequestState.MERGED
+			: state === PullRequestState.Closed
+			? GitLabMergeRequestState.CLOSED
+			: GitLabMergeRequestState.OPEN;
+	}
+}

--- a/src/gitlab/project.ts
+++ b/src/gitlab/project.ts
@@ -1,0 +1,19 @@
+export interface GitLabProject {
+	id: number;
+	description: string | null;
+	default_branch: string;
+	ssh_url_to_repo: string;
+	http_url_to_repo: string;
+	web_url: string;
+	readme_url: string;
+	tag_list: string[];
+	name: string;
+	name_with_namespace: string;
+	path: string;
+	path_with_namespace: string;
+	created_at: string;
+	last_activity_at: string;
+	forks_count: number;
+	avatar_url: string;
+	star_count: number;
+}

--- a/yarn.lock
+++ b/yarn.lock
@@ -3553,6 +3553,14 @@ node-fetch@^2.6.1:
   resolved "https://registry.yarnpkg.com/node-fetch/-/node-fetch-2.6.1.tgz#045bd323631f76ed2e2b55573394416b639a0052"
   integrity sha512-V4aYg89jEoVRxRb2fJdAg8FHvI7cEyYdVAh94HH0UIK8oJxUfkjlDQN9RbMx+bEjP7+ggMiFRprSti032Oipxw==
 
+node-fetch@^3.0.0-beta.9:
+  version "3.0.0-beta.9"
+  resolved "https://registry.yarnpkg.com/node-fetch/-/node-fetch-3.0.0-beta.9.tgz#0a7554cfb824380dd6812864389923c783c80d9b"
+  integrity sha512-RdbZCEynH2tH46+tj0ua9caUHVWrd/RHnRfvly2EVdqGmI3ndS1Vn/xjm5KuGejDt2RNDQsVRLPNd2QPwcewVg==
+  dependencies:
+    data-uri-to-buffer "^3.0.1"
+    fetch-blob "^2.1.1"
+
 node-gyp@^7.1.0:
   version "7.1.2"
   resolved "https://registry.yarnpkg.com/node-gyp/-/node-gyp-7.1.2.tgz#21a810aebb187120251c3bcec979af1587b188ae"


### PR DESCRIPTION
* Add GitLab api-v4 support
* Add Personal Token authorization for GitLab Remotes
* Add IgnoreCertErrors remote config param for allowing invalid certs
* Add node-fetch for non-graphql APIs
---

# Description

This PR should add initial support for GitLab remote APIs. GraphQL support is not extensive in the version I was working against (12.6) so this uses their standard REST API v4. It should be compatible with 12.6+ as I was working off docs for the current gitlab.com (v13.7).

Adds support for Personal Token authorization for GitLab Remote APIs. Token is stored in `globalState`. (follows pattern set by GitLab extension)

Adds `ignoreCertErrors` to `remotes` settings to allow for invalid certificates to not be rejected. Uses a custom Agent passed to `node-fetch` to accomplish this.

# Checklist

<!-- Please check off the following -->

- [x] I have followed the guidelines in the Contributing document
- [x] My changes follow the coding style of this project
- [x] My changes build without any errors or warnings
- [x] My changes have been formatted and linted
- [x] My changes include any required corresponding changes to the documentation
- [x] My changes have been rebased and squashed to the minimal number (typically 1) of relevant commits
- [x] My changes have a descriptive commit message with a short title, including a `Fixes $XXX -` or `Closes #XXX -` prefix to auto-close the issue that your PR addresses
