### PR TITLE
Closes #1399 - Adds option to filter out merge commits

### DIFF
--- a/package.json
+++ b/package.json
@@ -6692,6 +6692,16 @@
 				"icon": "$(filter-filled)"
 			},
 			{
+				"command": "gitlens.views.commits.setShowMergeCommitsOff",
+				"title": "Hide Merge Commits",
+				"category": "GitLens"
+			},
+			{
+				"command": "gitlens.views.commits.setShowMergeCommitsOn",
+				"title": "Show Merge Commits",
+				"category": "GitLens"
+			},
+			{
 				"command": "gitlens.views.commits.setShowAvatarsOn",
 				"title": "Show Avatars",
 				"category": "GitLens"
@@ -9522,6 +9532,14 @@
 					"when": "false"
 				},
 				{
+					"command": "gitlens.views.commits.setShowMergeCommitsOff",
+					"when": "false"
+				},
+				{
+					"command": "gitlens.views.commits.setShowMergeCommitsOn",
+					"when": "false"
+				},
+				{
 					"command": "gitlens.views.commits.setShowAvatarsOn",
 					"when": "false"
 				},
@@ -11054,6 +11072,16 @@
 					"command": "gitlens.views.commits.setCommitsFilterAuthors",
 					"when": "view =~ /^gitlens\\.views\\.commits/",
 					"group": "3_gitlens@1"
+				},
+				{
+					"command": "gitlens.views.commits.setShowMergeCommitsOff",
+					"when": "view =~ /^gitlens\\.views\\.commits/ && !gitlens:views:commits:hideMergeCommits",
+					"group": "3_gitlens@0"
+				},
+				{
+					"command": "gitlens.views.commits.setShowMergeCommitsOn",
+					"when": "view =~ /^gitlens\\.views\\.commits/ && gitlens:views:commits:hideMergeCommits",
+					"group": "3_gitlens@0"
 				},
 				{
 					"command": "gitlens.views.commits.setFilesLayoutToAuto",

--- a/src/commands/git/cherry-pick.ts
+++ b/src/commands/git/cherry-pick.ts
@@ -168,7 +168,7 @@ export class CherryPickGitCommand extends QuickCommand<State> {
 
 				let log = context.cache.get(ref);
 				if (log == null) {
-					log = this.container.git.getLog(state.repo.path, { ref: ref, merges: false });
+					log = this.container.git.getLog(state.repo.path, { ref: ref, merges: 'first-parent' });
 					context.cache.set(ref, log);
 				}
 

--- a/src/commands/git/merge.ts
+++ b/src/commands/git/merge.ts
@@ -170,7 +170,7 @@ export class MergeGitCommand extends QuickCommand<State> {
 
 				let log = context.cache.get(ref);
 				if (log == null) {
-					log = this.container.git.getLog(state.repo.path, { ref: ref, merges: false });
+					log = this.container.git.getLog(state.repo.path, { ref: ref, merges: 'first-parent' });
 					context.cache.set(ref, log);
 				}
 

--- a/src/commands/git/rebase.ts
+++ b/src/commands/git/rebase.ts
@@ -178,7 +178,7 @@ export class RebaseGitCommand extends QuickCommand<State> {
 
 				let log = context.cache.get(ref);
 				if (log == null) {
-					log = this.container.git.getLog(state.repo.path, { ref: ref, merges: false });
+					log = this.container.git.getLog(state.repo.path, { ref: ref, merges: 'first-parent' });
 					context.cache.set(ref, log);
 				}
 

--- a/src/commands/git/reset.ts
+++ b/src/commands/git/reset.ts
@@ -123,7 +123,7 @@ export class ResetGitCommand extends QuickCommand<State> {
 
 				let log = context.cache.get(ref);
 				if (log == null) {
-					log = this.container.git.getLog(state.repo.path, { ref: ref, merges: false });
+					log = this.container.git.getLog(state.repo.path, { ref: ref, merges: 'first-parent' });
 					context.cache.set(ref, log);
 				}
 

--- a/src/commands/git/revert.ts
+++ b/src/commands/git/revert.ts
@@ -127,7 +127,7 @@ export class RevertGitCommand extends QuickCommand<State> {
 
 				let log = context.cache.get(ref);
 				if (log == null) {
-					log = this.container.git.getLog(state.repo.path, { ref: ref, merges: false });
+					log = this.container.git.getLog(state.repo.path, { ref: ref, merges: 'first-parent' });
 					context.cache.set(ref, log);
 				}
 

--- a/src/constants.ts
+++ b/src/constants.ts
@@ -337,7 +337,8 @@ export type TreeViewCommands = `gitlens.views.${
 			| `setCommitsFilter${'Authors' | 'Off'}`
 			| `setShowAvatars${'On' | 'Off'}`
 			| `setShowBranchComparison${'On' | 'Off'}`
-			| `setShowBranchPullRequest${'On' | 'Off'}`}`
+			| `setShowBranchPullRequest${'On' | 'Off'}`
+			| `setShowMergeCommits${'On' | 'Off'}`}`
 	| `contributors.${
 			| 'copy'
 			| 'refresh'
@@ -588,6 +589,7 @@ export type ContextKeys =
 	| `${typeof extensionPrefix}:views:canCompare`
 	| `${typeof extensionPrefix}:views:canCompare:file`
 	| `${typeof extensionPrefix}:views:commits:filtered`
+	| `${typeof extensionPrefix}:views:commits:hideMergeCommits`
 	| `${typeof extensionPrefix}:views:fileHistory:canPin`
 	| `${typeof extensionPrefix}:views:fileHistory:cursorFollowing`
 	| `${typeof extensionPrefix}:views:fileHistory:editorFollowing`

--- a/src/env/node/git/localGitProvider.ts
+++ b/src/env/node/git/localGitProvider.ts
@@ -2993,7 +2993,7 @@ export class LocalGitProvider implements GitProvider, Disposable {
 			authors?: GitUser[];
 			cursor?: string;
 			limit?: number;
-			merges?: boolean;
+			merges?: boolean | 'first-parent';
 			ordering?: 'date' | 'author-date' | 'topo' | null;
 			ref?: string;
 			status?: null | 'name-status' | 'numstat' | 'stat';
@@ -3024,6 +3024,8 @@ export class LocalGitProvider implements GitProvider, Disposable {
 				args.push('--all');
 			}
 			if (!merges) {
+				args.push('--no-merges');
+			} else if (merges === 'first-parent') {
 				args.push('--first-parent');
 			}
 			if (ordering) {

--- a/src/git/gitProvider.ts
+++ b/src/git/gitProvider.ts
@@ -322,7 +322,7 @@ export interface GitProvider extends Disposable {
 			authors?: GitUser[] | undefined;
 			cursor?: string | undefined;
 			limit?: number | undefined;
-			merges?: boolean | undefined;
+			merges?: boolean | 'first-parent' | undefined;
 			ordering?: 'date' | 'author-date' | 'topo' | null | undefined;
 			ref?: string | undefined;
 			since?: string | undefined;

--- a/src/git/gitProviderService.ts
+++ b/src/git/gitProviderService.ts
@@ -1815,7 +1815,7 @@ export class GitProviderService implements Disposable {
 			all?: boolean;
 			authors?: GitUser[];
 			limit?: number;
-			merges?: boolean;
+			merges?: boolean | 'first-parent';
 			ordering?: 'date' | 'author-date' | 'topo' | null;
 			ref?: string;
 			since?: string;

--- a/src/views/commitsView.ts
+++ b/src/views/commitsView.ts
@@ -54,6 +54,7 @@ export class CommitsRepositoryNode extends RepositoryFolderNode<CommitsView, Bra
 					limitCommits: !this.splatted,
 					showComparison: this.view.config.showBranchComparison,
 					showCurrent: false,
+					showMergeCommits: !this.view.state.hideMergeCommits,
 					showTracking: true,
 					authors: authors,
 				},
@@ -178,6 +179,7 @@ export class CommitsViewNode extends RepositoriesSubscribeableNode<CommitsView, 
 
 interface CommitsViewState {
 	filterCommits: Map<string, GitUser[] | undefined>;
+	hideMergeCommits?: boolean;
 }
 
 export class CommitsView extends ViewBase<'commits', CommitsViewNode, CommitsViewConfig> {
@@ -250,6 +252,17 @@ export class CommitsView extends ViewBase<'commits', CommitsViewNode, CommitsVie
 				n => this.setCommitsFilter(n, false),
 				this,
 			),
+			registerViewCommand(
+				this.getQualifiedCommand('setShowMergeCommitsOn'),
+				() => this.setShowMergeCommits(true),
+				this,
+			),
+			registerViewCommand(
+				this.getQualifiedCommand('setShowMergeCommitsOff'),
+				() => this.setShowMergeCommits(false),
+				this,
+			),
+
 			registerViewCommand(this.getQualifiedCommand('setShowAvatarsOn'), () => this.setShowAvatars(true), this),
 			registerViewCommand(this.getQualifiedCommand('setShowAvatarsOff'), () => this.setShowAvatars(false), this),
 			registerViewCommand(
@@ -446,6 +459,12 @@ export class CommitsView extends ViewBase<'commits', CommitsViewNode, CommitsVie
 		}
 
 		void setContext('gitlens:views:commits:filtered', this.state.filterCommits.size !== 0);
+		void this.refresh(true);
+	}
+
+	private setShowMergeCommits(on: boolean) {
+		void setContext('gitlens:views:commits:hideMergeCommits', !on);
+		this.state.hideMergeCommits = !on;
 		void this.refresh(true);
 	}
 

--- a/src/views/nodes/branchNode.ts
+++ b/src/views/nodes/branchNode.ts
@@ -46,6 +46,7 @@ export class BranchNode
 		showAsCommits: boolean;
 		showComparison: false | ViewShowBranchComparison;
 		showCurrent: boolean;
+		showMergeCommits?: boolean;
 		showStatus: boolean;
 		showTracking: boolean;
 		authors?: GitUser[];
@@ -66,6 +67,7 @@ export class BranchNode
 			showAsCommits?: boolean;
 			showComparison?: false | ViewShowBranchComparison;
 			showCurrent?: boolean;
+			showMergeCommits?: boolean;
 			showStatus?: boolean;
 			showTracking?: boolean;
 			authors?: GitUser[];
@@ -208,6 +210,7 @@ export class BranchNode
 								? this.view.container.git.getLogRefsOnly(this.uri.repoPath!, {
 										limit: 0,
 										ref: range,
+										merges: this.options.showMergeCommits,
 								  })
 								: undefined,
 					  )
@@ -556,6 +559,7 @@ export class BranchNode
 				limit: limit,
 				ref: this.ref.ref,
 				authors: this.options?.authors,
+				merges: this.options?.showMergeCommits,
 			});
 		}
 


### PR DESCRIPTION
# Description

- Closes #1399 - Implements feature mentioned in https://github.com/eamodio/vscode-gitlens/issues/1399.

# Checklist

<!-- Please check off the following -->

- [x] I have followed the guidelines in the Contributing document
- [x] My changes follow the coding style of this project
- [x] My changes build without any errors or warnings
- [x] My changes have been formatted and linted
- [ ] My changes include any required corresponding changes to the documentation
- [x] My changes have been rebased and squashed to the minimal number (typically 1) of relevant commits
- [x] My changes have a descriptive commit message with a short title, including a `Fixes $XXX -` or `Closes #XXX -` prefix to auto-close the issue that your PR addresses
