### PR TITLE
add another key `ctrl+shift+g ctrl+shift+g`  to show scm view

### DIFF
--- a/package.json
+++ b/package.json
@@ -9431,6 +9431,12 @@
 				"when": "config.gitlens.keymap == chorded && !gitlens:disabled"
 			},
 			{
+				"command": "workbench.view.scm",
+				"key": "ctrl+shift+g ctrl+shift+g",
+				"mac": "ctrl+shift+g ctrl+shift+g",
+				"when": "config.gitlens.keymap == chorded && !gitlens:disabled"
+			},
+			{
 				"command": "gitlens.views.branches.copy",
 				"key": "ctrl+c",
 				"mac": "cmd+c",


### PR DESCRIPTION
this will fix the issue #1617

add another key <kbd>ctrl+shift+g </kbd><kbd>ctrl+shift+g</kbd> to deal with the conflict with chinese ime (and other cjk user?) to show scm view