### PR TITLE
Adds interactive option to all rebase commands

### DIFF
--- a/package.json
+++ b/package.json
@@ -3850,6 +3850,11 @@
 				"category": "GitLens"
 			},
 			{
+				"command": "gitlens.gitCommands.interactiveRebase",
+				"title": "Git Interactive Rebase...",
+				"category": "GitLens"
+			},
+			{
 				"command": "gitlens.gitCommands.reset",
 				"title": "Git Reset...",
 				"category": "GitLens"
@@ -4720,13 +4725,28 @@
 				"category": "GitLens"
 			},
 			{
+				"command": "gitlens.views.interactiveRebaseOntoBranch",
+				"title": "Interactively Rebase Current Branch onto Branch...",
+				"category": "GitLens"
+			},
+			{
 				"command": "gitlens.views.rebaseOntoCommit",
 				"title": "Rebase Current Branch onto Commit...",
 				"category": "GitLens"
 			},
 			{
+				"command": "gitlens.views.interactiveRebaseOntoCommit",
+				"title": "Interactively Rebase Current Branch onto Commit...",
+				"category": "GitLens"
+			},
+			{
 				"command": "gitlens.views.rebaseOntoUpstream",
 				"title": "Rebase Current Branch onto Upstream...",
+				"category": "GitLens"
+			},
+			{
+				"command": "gitlens.views.interactiveRebaseOntoUpstream",
+				"title": "Interactively Rebase Current Branch onto Upstream...",
 				"category": "GitLens"
 			},
 			{
@@ -5834,6 +5854,10 @@
 					"when": "!gitlens:disabled && !gitlens:readonly"
 				},
 				{
+					"command": "gitlens.gitCommands.interactiveRebase",
+					"when": "!gitlens:disabled && !gitlens:readonly"
+				},
+				{
 					"command": "gitlens.gitCommands.reset",
 					"when": "!gitlens:disabled && !gitlens:readonly"
 				},
@@ -6382,11 +6406,23 @@
 					"when": "false"
 				},
 				{
+					"command": "gitlens.views.interactiveRebaseOntoBranch",
+					"when": "false"
+				},
+				{
 					"command": "gitlens.views.rebaseOntoCommit",
 					"when": "false"
 				},
 				{
+					"command": "gitlens.views.interactiveRebaseOntoCommit",
+					"when": "false"
+				},
+				{
 					"command": "gitlens.views.rebaseOntoUpstream",
+					"when": "false"
+				},
+				{
+					"command": "gitlens.views.interactiveRebaseOntoUpstream",
 					"when": "false"
 				},
 				{
@@ -8149,7 +8185,17 @@
 					"group": "1_gitlens_actions@4"
 				},
 				{
+					"command": "gitlens.views.interactiveRebaseOntoBranch",
+					"when": "!gitlens:readonly && viewItem =~ /gitlens:branch\\b(?!.*?\\b\\+current\\b)/",
+					"group": "1_gitlens_actions@4"
+				},
+				{
 					"command": "gitlens.views.rebaseOntoUpstream",
+					"when": "!gitlens:readonly && viewItem =~ /gitlens:branch\\b(?=.*?\\b\\+current\\b)(?=.*?\\b\\+tracking\\b)/",
+					"group": "1_gitlens_actions@4"
+				},
+				{
+					"command": "gitlens.views.interactiveRebaseOntoUpstream",
 					"when": "!gitlens:readonly && viewItem =~ /gitlens:branch\\b(?=.*?\\b\\+current\\b)(?=.*?\\b\\+tracking\\b)/",
 					"group": "1_gitlens_actions@4"
 				},
@@ -8323,6 +8369,11 @@
 				},
 				{
 					"command": "gitlens.views.rebaseOntoCommit",
+					"when": "!gitlens:readonly && viewItem =~ /gitlens:commit\\b/",
+					"group": "1_gitlens_actions@6"
+				},
+				{
+					"command": "gitlens.views.interactiveRebaseOntoCommit",
 					"when": "!gitlens:readonly && viewItem =~ /gitlens:commit\\b/",
 					"group": "1_gitlens_actions@6"
 				},
@@ -9280,6 +9331,11 @@
 				},
 				{
 					"command": "gitlens.views.rebaseOntoCommit",
+					"when": "!gitlens:readonly && viewItem =~ /gitlens:file\\b(?=.*?\\b\\+committed\\b)(?=.*?\\b\\+current\\b)/",
+					"group": "1_gitlens_actions@6"
+				},
+				{
+					"command": "gitlens.views.interactiveRebaseOntoCommit",
 					"when": "!gitlens:readonly && viewItem =~ /gitlens:file\\b(?=.*?\\b\\+committed\\b)(?=.*?\\b\\+current\\b)/",
 					"group": "1_gitlens_actions@6"
 				},

--- a/src/commands/common.ts
+++ b/src/commands/common.ts
@@ -119,6 +119,7 @@ export const enum Commands {
 	GitCommandsCherryPick = 'gitlens.gitCommands.cherryPick',
 	GitCommandsMerge = 'gitlens.gitCommands.merge',
 	GitCommandsRebase = 'gitlens.gitCommands.rebase',
+	GitCommandsInteractiveRebase = 'gitlens.gitCommands.interactiveRebase',
 	GitCommandsReset = 'gitlens.gitCommands.reset',
 	GitCommandsRevert = 'gitlens.gitCommands.revert',
 	GitCommandsSwitch = 'gitlens.gitCommands.switch',

--- a/src/commands/gitCommands.ts
+++ b/src/commands/gitCommands.ts
@@ -85,6 +85,7 @@ export class GitCommandsCommand extends Command {
 			Commands.GitCommandsCherryPick,
 			Commands.GitCommandsMerge,
 			Commands.GitCommandsRebase,
+			Commands.GitCommandsInteractiveRebase,
 			Commands.GitCommandsReset,
 			Commands.GitCommandsRevert,
 			Commands.GitCommandsSwitch,
@@ -105,6 +106,9 @@ export class GitCommandsCommand extends Command {
 				break;
 			case Commands.GitCommandsRebase:
 				args = { command: 'rebase' };
+				break;
+			case Commands.GitCommandsInteractiveRebase:
+				args = { command: 'rebase', state: { flags: ['--interactive'] } };
 				break;
 			case Commands.GitCommandsReset:
 				args = { command: 'reset' };


### PR DESCRIPTION
# Description
https://github.com/gitkraken/vscode-gitlens/issues/1734

This PR adds an interactive alternative to all the rebase commands in GitLens, much like rebase, sometimes an interactive rebase is required, as a GUI type of person I dislike going back-and-forth between vscode git features and the command line, adding this will minimize the need for such a thing.

# Checklist

<!-- Please check off the following -->

- [x] I have followed the guidelines in the Contributing document
- [x] My changes follow the coding style of this project
- [x] My changes build without any errors or warnings
- [x] My changes have been formatted and linted
- [ ] My changes include any required corresponding changes to the documentation
- [x] My changes have been rebased and squashed to the minimal number (typically 1) of relevant commits
- [x] My changes have a descriptive commit message with a short title, including a `Fixes $XXX -` or `Closes #XXX -` prefix to auto-close the issue that your PR addresses
