### PR TITLE
Added support for fixup commit

### DIFF
--- a/package.json
+++ b/package.json
@@ -4740,6 +4740,11 @@
 				"category": "GitLens"
 			},
 			{
+				"command": "gitlens.views.fixupCommit",
+				"title": "Create fixup Commit to Commit...",
+				"category": "GitLens"
+			},
+			{
 				"command": "gitlens.views.revert",
 				"title": "Revert Commit...",
 				"category": "GitLens"
@@ -6395,6 +6400,10 @@
 				},
 				{
 					"command": "gitlens.views.resetToCommit",
+					"when": "false"
+				},
+				{
+					"command": "gitlens.views.fixupCommit",
 					"when": "false"
 				},
 				{
@@ -8297,6 +8306,11 @@
 					"group": "1_gitlens_actions@1"
 				},
 				{
+					"command": "gitlens.views.fixupCommit",
+					"when": "!gitlens:readonly && viewItem =~ /gitlens:commit\\b(?=.*?\\b\\+current\\b)/",
+					"group": "1_gitlens_actions@1"
+				},
+				{
 					"command": "gitlens.views.push",
 					"when": "gitlens:hasRemotes && !gitlens:readonly && viewItem =~ /gitlens:commit\\b(?=.*?\\b\\+current\\b)(?=.*?\\b\\+unpublished\\b)(?=.*?\\b\\+HEAD\\b)/",
 					"group": "1_gitlens_actions@2"
@@ -9267,6 +9281,11 @@
 					"command": "gitlens.views.revert",
 					"when": "!gitlens:readonly && viewItem =~ /gitlens:file\\b(?=.*?\\b\\+committed\\b)(?=.*?\\b\\+current\\b)/",
 					"group": "1_gitlens_actions@3"
+				},
+				{
+					"command": "gitlens.views.fixupCommit",
+					"when": "!gitlens:readonly && viewItem =~ /gitlens:file\\b(?=.*?\\b\\+committed\\b)(?=.*?\\b\\+current\\b)/",
+					"group": "1_gitlens_actions@4"
 				},
 				{
 					"command": "gitlens.views.resetToCommit",

--- a/src/commands/git/commit.ts
+++ b/src/commands/git/commit.ts
@@ -1,0 +1,137 @@
+'use strict';
+import { Container } from '../../container';
+import { GitLog, GitReference, GitRevisionReference, Repository } from '../../git/models';
+import { FlagsQuickPickItem } from '../../quickpicks';
+import { ViewsWithRepositoryFolders } from '../../views/viewBase';
+import {
+	appendReposToTitle,
+	PartialStepState,
+	pickRepositoryStep,
+	QuickCommand,
+	QuickPickStep,
+	StepGenerator,
+	StepResult,
+	StepResultGenerator,
+	StepSelection,
+	StepState,
+} from '../quickCommand';
+
+interface Context {
+	repos: Repository[];
+	associatedView: ViewsWithRepositoryFolders;
+	cache: Map<string, Promise<GitLog | undefined>>;
+	selectedBranchOrTag: GitReference | undefined;
+	showTags: boolean;
+	title: string;
+}
+
+type Flags = '--fixup';
+
+interface State {
+	repo: string | Repository;
+	reference: GitRevisionReference;
+	flags: Flags[];
+}
+
+export interface CommitGitCommandArgs {
+	readonly command: 'commit';
+	state?: Partial<State>;
+}
+
+type CommitStepState<T extends State = State> = ExcludeSome<StepState<T>, 'repo', string>;
+
+export class CommitGitCommand extends QuickCommand<State> {
+	constructor(args?: CommitGitCommandArgs) {
+		super('commit', 'commit', 'Commit', {
+			description: 'Use to add or modify commits',
+		});
+
+		let counter = 0;
+		if (args?.state?.repo != null) {
+			counter++;
+		}
+
+		this.initialState = {
+			counter: counter,
+			confirm: true,
+			...args?.state,
+		};
+	}
+
+	override get canSkipConfirm(): boolean {
+		return true;
+	}
+
+	execute(state: CommitStepState) {
+		const args: string[] = state.flags;
+		if (args.includes('--fixup') && state.reference != null) {
+			args.splice(args.indexOf('--fixup') + 1, 0, state.reference.ref);
+		}
+
+		console.log(args);
+		return state.repo.commit(...args);
+	}
+
+	protected async *steps(state: PartialStepState<State>): StepGenerator {
+		const context: Context = {
+			repos: Container.instance.git.openRepositories,
+			associatedView: Container.instance.commitsView,
+			cache: new Map<string, Promise<GitLog | undefined>>(),
+			selectedBranchOrTag: undefined,
+			showTags: true,
+			title: this.title,
+		};
+
+		if (state.flags == null) {
+			state.flags = [];
+		}
+
+		while (this.canStepsContinue(state)) {
+			context.title = this.title;
+
+			if (state.counter < 1 || state.repo == null || typeof state.repo === 'string') {
+				if (context.repos.length === 1) {
+					state.repo = context.repos[0];
+				} else {
+					const result = yield* pickRepositoryStep(state, context);
+					// Always break on the first step (so we will go back)
+					if (result === StepResult.Break) break;
+
+					state.repo = result;
+				}
+			}
+
+			context.title = `${this.title} as a fixup coommit to  ${GitReference.toString(state.reference, {
+				icon: false,
+			})}`;
+
+			if (this.confirm(state.confirm)) {
+				const result = yield* this.confirmStep(state as CommitStepState, context);
+				if (result === StepResult.Break) continue;
+
+				state.flags = result;
+			}
+
+			QuickCommand.endSteps(state);
+			this.execute(state as CommitStepState<State>);
+		}
+
+		return state.counter < 0 ? StepResult.Break : undefined;
+	}
+
+	private *confirmStep(state: CommitStepState, context: Context): StepResultGenerator<Flags[]> {
+		const step: QuickPickStep<FlagsQuickPickItem<Flags>> = QuickCommand.createConfirmStep(
+			appendReposToTitle(`Confirm ${context.title}`, state, context),
+			[
+				FlagsQuickPickItem.create<Flags>(state.flags, ['--fixup'], {
+					label: `${this.title} as a fixup commit`,
+					description: '--edit',
+					detail: `Will commit as a fixup commit to ${GitReference.toString(state.reference)}`,
+				}),
+			],
+			context,
+		);
+		const selection: StepSelection<typeof step> = yield step;
+		return QuickCommand.canPickStepContinue(step, state, selection) ? selection[0].item : StepResult.Break;
+	}
+}

--- a/src/commands/gitCommands.actions.ts
+++ b/src/commands/gitCommands.actions.ts
@@ -93,6 +93,13 @@ export namespace GitActions {
 		});
 	}
 
+	export function commit(repo?: string | Repository, ref?: GitRevisionReference, fixup: boolean = false) {
+		return executeGitCommand({
+			command: 'commit',
+			state: { repo: repo, reference: ref, flags: fixup ? ['--fixup'] : [] },
+		});
+	}
+
 	export function revert(repo?: string | Repository, refs?: GitRevisionReference | GitRevisionReference[]) {
 		return executeGitCommand({
 			command: 'revert',

--- a/src/commands/gitCommands.ts
+++ b/src/commands/gitCommands.ts
@@ -10,6 +10,7 @@ import { command, Command, CommandContext, Commands } from './common';
 import { BranchGitCommand, BranchGitCommandArgs } from './git/branch';
 import { CherryPickGitCommand, CherryPickGitCommandArgs } from './git/cherry-pick';
 import { CoAuthorsGitCommand, CoAuthorsGitCommandArgs } from './git/coauthors';
+import { CommitGitCommand, CommitGitCommandArgs } from './git/commit';
 import { FetchGitCommand, FetchGitCommandArgs } from './git/fetch';
 import { LogGitCommand, LogGitCommandArgs } from './git/log';
 import { MergeGitCommand, MergeGitCommandArgs } from './git/merge';
@@ -57,7 +58,8 @@ export type GitCommandsCommandArgs =
 	| StashGitCommandArgs
 	| StatusGitCommandArgs
 	| SwitchGitCommandArgs
-	| TagGitCommandArgs;
+	| TagGitCommandArgs
+	| CommitGitCommandArgs;
 
 function* nullSteps(): StepGenerator {
 	/* noop */
@@ -759,6 +761,7 @@ class PickCommandStep implements QuickPickStep {
 			new PushGitCommand(args?.command === 'push' ? args : undefined),
 			new RebaseGitCommand(args?.command === 'rebase' ? args : undefined),
 			new ResetGitCommand(args?.command === 'reset' ? args : undefined),
+			new CommitGitCommand(args?.command === 'commit' ? args : undefined),
 			new RevertGitCommand(args?.command === 'revert' ? args : undefined),
 			new SearchGitCommand(args?.command === 'search' || args?.command === 'grep' ? args : undefined),
 			new ShowGitCommand(args?.command === 'show' ? args : undefined),

--- a/src/constants.ts
+++ b/src/constants.ts
@@ -34,6 +34,7 @@ export const enum BuiltInGitCommands {
 	Push = 'git.push',
 	PushForce = 'git.pushForce',
 	UndoCommit = 'git.undoCommit',
+	FixupCommit = 'git.fixupCommit',
 }
 
 export const enum BuiltInGitConfiguration {

--- a/src/git/models/repository.ts
+++ b/src/git/models/repository.ts
@@ -813,6 +813,11 @@ export class Repository implements Disposable {
 		this.runTerminalCommand('reset', ...args);
 	}
 
+	@log()
+	commit(...args: string[]) {
+		this.runTerminalCommand('commit', ...args);
+	}
+
 	resetCaches(...cache: ('branches' | 'remotes')[]) {
 		if (cache.length === 0 || cache.includes('branches')) {
 			this._branch = undefined;

--- a/src/views/viewCommands.ts
+++ b/src/views/viewCommands.ts
@@ -218,6 +218,7 @@ export class ViewCommands {
 		commands.registerCommand('gitlens.views.resetToCommit', this.resetToCommit, this);
 		commands.registerCommand('gitlens.views.revert', this.revert, this);
 		commands.registerCommand('gitlens.views.undoCommit', this.undoCommit, this);
+		commands.registerCommand('gitlens.views.fixupCommit', this.fixupCommit, this);
 
 		commands.registerCommand('gitlens.views.terminalRemoveRemote', this.terminalRemoveRemote, this);
 
@@ -686,6 +687,21 @@ export class ViewCommands {
 		}
 
 		await commands.executeCommand(BuiltInGitCommands.UndoCommit, node.repoPath);
+	}
+
+	@debug()
+	private fixupCommit(node: CommitNode | FileRevisionAsCommitNode) {
+		if (!(node instanceof CommitNode) && !(node instanceof FileRevisionAsCommitNode)) return Promise.resolve();
+
+		return GitActions.commit(
+			node.repoPath,
+			GitReference.create(`${node.ref.ref}^`, node.ref.repoPath, {
+				refType: 'revision',
+				name: `${node.ref.name}^`,
+				message: node.ref.message,
+			}),
+			true,
+		);
 	}
 
 	@debug()


### PR DESCRIPTION

---
#1031 
# Description

As part of a common workflow with git using rebases and fixup commits to make cleaner history during work with pull requests, creating fixup commits is a crucial part of the flow, so adding a button to do so easily through Gitlens makes the flow much more convenient.

The general implementation here is creating a new git command for `commit` and only expose it through providing a fixup flag with a reference on top of which the fixup commit will be created.

# Checklist

<!-- Please check off the following -->

- [x] I have followed the guidelines in the Contributing document
- [x] My changes follow the coding style of this project
- [x] My changes build without any errors or warnings
- [x] My changes have been formatted and linted
- [ ] My changes include any required corresponding changes to the documentation
- [x] My changes have been rebased and squashed to the minimal number (typically 1) of relevant commits
- [x] My changes have a descriptive commit message with a short title, including a `Fixes $XXX -` or `Closes #XXX -` prefix to auto-close the issue that your PR addresses
