### PR TITLE
Closes #1787 - Remove '-review' from reviewDomain()

### DIFF
--- a/src/git/remotes/gerrit.ts
+++ b/src/git/remotes/gerrit.ts
@@ -41,8 +41,7 @@ export class GerritRemote extends RemoteProvider {
 	}
 
 	private get reviewDomain(): string {
-		const [subdomain, secondLevelDomain, topLevelDomain] = this.domain.split('.');
-		return [`${subdomain}-review`, secondLevelDomain, topLevelDomain].join('.');
+		return this.domain;
 	}
 
 	private get baseReviewUrl(): string {


### PR DESCRIPTION
---

# Description

<!--
This undocumented behavior was breaking integration with my installation of Gerrit.
Why should the subdomain be assumed to be anything other than what was
directly defined in the settings.json
-->

# Checklist

<!-- Please check off the following -->

- [x] I have followed the guidelines in the Contributing document
- [x] My changes follow the coding style of this project
- [x] My changes build without any errors or warnings
- [x] My changes have been formatted and linted
- [x] My changes include any required corresponding changes to the documentation
- [x] My changes have been rebased and squashed to the minimal number (typically 1) of relevant commits
- [x] My changes have a descriptive commit message with a short title, including a `Fixes $XXX -` or `Closes #XXX -` prefix to auto-close the issue that your PR addresses
