### PR TITLE
Fixes #1805 to prevent tracking remote branches if the local branch has not the same name

### DIFF
--- a/src/commands/git/branch.ts
+++ b/src/commands/git/branch.ts
@@ -30,7 +30,7 @@ interface Context {
 	title: string;
 }
 
-type CreateFlags = '--switch';
+type CreateFlags = '--switch' | '--no-track';
 
 interface CreateState {
 	subcommand: 'create';
@@ -324,8 +324,16 @@ export class BranchGitCommand extends QuickCommand<State> {
 			}
 
 			QuickCommand.endSteps(state);
+
+			if ((state.reference as GitBranchReference).remote) {
+				//If remote branch name and local branch name doesn't match, then shouldn't track
+				if (state.name !== GitReference.getNameWithoutRemote(state.reference)) {
+					state.flags.push('--no-track');
+				}
+			}
+
 			if (state.flags.includes('--switch')) {
-				void (await state.repo.switch(state.reference.ref, { createBranch: state.name }));
+				void (await state.repo.switch(state.reference.ref, { createBranch: state.name, track: !state.flags.includes('--no-track') }));
 			} else {
 				void state.repo.branch(...state.flags, state.name, state.reference.ref);
 			}

--- a/src/commands/git/switch.ts
+++ b/src/commands/git/switch.ts
@@ -73,7 +73,7 @@ export class SwitchGitCommand extends QuickCommand<State> {
 			() =>
 				Promise.all(
 					state.repos.map(r =>
-						r.switch(state.reference.ref, { createBranch: state.createBranch, progress: false }),
+						r.switch(state.reference.ref, { createBranch: state.createBranch, progress: false, track: false }),
 					),
 				),
 		));

--- a/src/env/node/git/git.ts
+++ b/src/env/node/git/git.ts
@@ -383,11 +383,15 @@ export class Git {
 	checkout(
 		repoPath: string,
 		ref: string,
-		{ createBranch, fileName }: { createBranch?: string; fileName?: string } = {},
+		{ createBranch, track, fileName }: { createBranch?: string; track?: boolean; fileName?: string } = {},
 	) {
 		const params = ['checkout'];
 		if (createBranch) {
-			params.push('-b', createBranch, ref, '--');
+			params.push('-b', createBranch);
+			if (!track) {
+				params.push('--no-track');
+			}
+			params.push(ref, '--');
 		} else {
 			params.push(ref, '--');
 

--- a/src/env/node/git/localGitProvider.ts
+++ b/src/env/node/git/localGitProvider.ts
@@ -728,7 +728,7 @@ export class LocalGitProvider implements GitProvider, Disposable {
 	async checkout(
 		repoPath: string,
 		ref: string,
-		options?: { createBranch?: string } | { fileName?: string },
+		options?: { createBranch?: string; track?: boolean } | { fileName?: string },
 	): Promise<void> {
 		const cc = Logger.getCorrelationContext();
 

--- a/src/git/gitProvider.ts
+++ b/src/git/gitProvider.ts
@@ -123,7 +123,7 @@ export interface GitProvider extends Disposable {
 	checkout(
 		repoPath: string,
 		ref: string,
-		options?: { createBranch?: string | undefined } | { fileName?: string | undefined },
+		options?: { createBranch?: string | undefined; track?: boolean | undefined } | { fileName?: string | undefined },
 	): Promise<void>;
 	resetCaches(
 		...affects: ('branches' | 'contributors' | 'providers' | 'remotes' | 'stashes' | 'status' | 'tags')[]

--- a/src/git/gitProviderService.ts
+++ b/src/git/gitProviderService.ts
@@ -727,7 +727,7 @@ export class GitProviderService implements Disposable {
 	async checkout(
 		repoPath: string,
 		ref: string,
-		options?: { createBranch?: string } | { fileName?: string },
+		options?: { createBranch?: string; track?:boolean } | { fileName?: string },
 	): Promise<void> {
 		const { provider, path } = this.getProvider(repoPath);
 		return provider.checkout(path, ref, options);

--- a/src/git/models/repository.ts
+++ b/src/git/models/repository.ts
@@ -855,7 +855,7 @@ export class Repository implements Disposable {
 
 	@gate()
 	@log()
-	async switch(ref: string, options: { createBranch?: string | undefined; progress?: boolean } = {}) {
+	async switch(ref: string, options: { createBranch?: string | undefined; progress?: boolean; track?: boolean } = {}) {
 		const { progress, ...opts } = { progress: true, ...options };
 		if (!progress) return this.switchCore(ref, opts);
 
@@ -869,7 +869,7 @@ export class Repository implements Disposable {
 		));
 	}
 
-	private async switchCore(ref: string, options: { createBranch?: string } = {}) {
+	private async switchCore(ref: string, options: { createBranch?: string; track?: boolean } = {}) {
 		try {
 			void (await this.container.git.checkout(this.path, ref, options));
 

--- a/src/premium/github/githubGitProvider.ts
+++ b/src/premium/github/githubGitProvider.ts
@@ -291,7 +291,7 @@ export class GitHubGitProvider implements GitProvider, Disposable {
 	async checkout(
 		_repoPath: string,
 		_ref: string,
-		_options?: { createBranch?: string } | { fileName?: string },
+		_options?: { createBranch?: string; track?: boolean } | { fileName?: string },
 	): Promise<void> {}
 
 	@log()


### PR DESCRIPTION
# Description

When creating a branch, if the ref is remote, then passes along the --no-track option to be added to the command line, both for the branch command, or for the checkout -b command.