### PR TITLE
Add step for publishing to OpenVSX

### DIFF
--- a/.github/workflows/cd-stable.yml
+++ b/.github/workflows/cd-stable.yml
@@ -24,8 +24,10 @@ jobs:
               run: yarn
             - name: Package extension
               run: yarn run package
-            - name: Publish Extension
+            - name: Publish Extension (MS)
               run: yarn vsce publish --yarn --packagePath ./${{ env.PACKAGE_NAME }}.vsix -p ${{ secrets.GITLENS_VSCODE_MARKETPLACE_PAT }}
+            - name: Publish Extension (OpenVSX)
+              run: npx ovsx publish --yarn --packagePath ./${{ env.PACKAGE_NAME }}.vsix -p ${{ secrets.GITLENS_OPENVSX_PAT }}
             - name: Generate Changelog
               id: changelog
               uses: mindsers/changelog-reader-action@v2


### PR DESCRIPTION
# Description

Fixes #1102 as per https://github.com/gitkraken/vscode-gitlens/issues/1245#issuecomment-745796063.

# Checklist

<!-- Please check off the following -->

- [x] I have followed the guidelines in the Contributing document
- [x] My changes follow the coding style of this project
- [x] My changes build without any errors or warnings
- [x] My changes have been formatted and linted
- [x] My changes include any required corresponding changes to the documentation (I suppose there are no docs on this?)
- [x] My changes have been rebased and squashed to the minimal number (typically 1) of relevant commits
- [x] My changes have a descriptive commit message with a short title, including a `Fixes $XXX -` or `Closes #XXX -` prefix to auto-close the issue that your PR addresses

~~cc @eamodio also raising this because v12 broke for OpenVSX and it requires `gitkraken.gitkraken-authentication`, so that will be required to be published first. The repo seems like it is private (https://github.com/gitkraken/vscode-authentication-provider) though, but I will gladly help with any problems you encounter during publishing.~~

- as of https://github.com/gitkraken/vscode-gitlens/releases/tag/v12.0.1 this no longer is an issue.

I only added publishing for stable, since this is the one on OpenVSX as well, but if anyone from the maintainers wants the Insiders version as well, I'll gladly add it to its workflow as well.