### PR TITLE
Closes #1898 - Removing '.jpg' for less stale gravatar

### DIFF
--- a/src/avatars.ts
+++ b/src/avatars.ts
@@ -160,7 +160,7 @@ function getAvatarUriFromGravatar(
 	size: number,
 	defaultStyle: GravatarDefaultStyle = GravatarDefaultStyle.Robot,
 ): Uri {
-	return Uri.parse(`https://www.gravatar.com/avatar/${hash}.jpg?s=${size}&d=${defaultStyle}`);
+	return Uri.parse(`https://www.gravatar.com/avatar/${hash}?s=${size}&d=${defaultStyle}`);
 }
 
 function getAvatarUriFromGitHubNoReplyAddress(email: string, size: number = 16): Uri | undefined {


### PR DESCRIPTION
Closes #1898 

# Description
Was able to alleviate the stale Gravatar issue by deleting '.jpg' in the `getAvatarUriFromGravatar()` function in `avatars.ts`.

Gravatar now updates faster, current avatar compared to issue's screenshot stale avatar.
![image](https://user-images.githubusercontent.com/20881869/157778207-72a25e46-4182-4aa5-96c9-f8b15bbd0d54.png)

# Checklist

<!-- Please check off the following -->

- [x] I have followed the guidelines in the Contributing document
- [x] My changes follow the coding style of this project
- [x] My changes build without any errors or warnings
- [x] My changes have been formatted and linted
- [x] My changes include any required corresponding changes to the documentation
- [x] My changes have been rebased and squashed to the minimal number (typically 1) of relevant commits
- [x] My changes have a descriptive commit message with a short title, including a `Fixes $XXX -` or `Closes #XXX -` prefix to auto-close the issue that your PR addresses
