### PR TITLE
Fixes #1932: Ignores case for pull request autolink in Bitbucket Server

### DIFF
--- a/src/git/remotes/bitbucket-server.ts
+++ b/src/git/remotes/bitbucket-server.ts
@@ -24,6 +24,7 @@ export class BitbucketServerRemote extends RemoteProvider {
 				},
 				{
 					prefix: 'pull request #',
+					ignoreCase: true,
 					url: `${this.baseUrl}/pull-requests/<num>`,
 					title: `Open PR #<num> on ${this.name}`,
 				},


### PR DESCRIPTION
# Description
Fixes #1932
Makes pull request autolink case insensitive, so it also works with Bitbucket Server 7
Now matches both "pull request #<num>" and "Pull request #<num>"

# Checklist

<!-- Please check off the following -->

- [x] I have followed the guidelines in the Contributing document
- [x] My changes follow the coding style of this project
- [x] My changes build without any errors or warnings
- [x] My changes have been formatted and linted
- [x] My changes include any required corresponding changes to the documentation
- [x] My changes have been rebased and squashed to the minimal number (typically 1) of relevant commits
- [x] My changes have a descriptive commit message with a short title, including a `Fixes $XXX -` or `Closes #XXX -` prefix to auto-close the issue that your PR addresses
