### PR TITLE
Fixes #969 adds copy relative path to context menu

### DIFF
--- a/README.md
+++ b/README.md
@@ -675,6 +675,9 @@ Additionally, these integrations provide commands to copy the URL of or open fil
 - Adds an _Add Co-authors_ command (`gitlens.addAuthors`) to add a co-author to the commit message input box
 
 - Adds a _Copy SHA_ command (`gitlens.copyShaToClipboard`) to copy the commit SHA of the current line to the clipboard or from the most recent commit to the current branch, if there is no current editor
+
+- Adds a _Copy Relative Path_ command (`gitlens.copyRelativePathToClipboard`) to copy the relative path, of the active file in the editor, to the clipboard
+
 - Adds a _Copy Message_ command (`gitlens.copyMessageToClipboard`) to copy the commit message of the current line to the clipboard or from the most recent commit to the current branch, if there is no current editor
 
 - Adds a _Copy Current Branch_ command (`gitlens.copyCurrentBranch`) to copy the name of the current branch to the clipboard

--- a/package.json
+++ b/package.json
@@ -9362,17 +9362,17 @@
 				{
 					"command": "gitlens.copyRelativePathToClipboard",
 					"when": "editorTextFocus && gitlens:activeFileStatus =~ /blameable/ && config.gitlens.menus.editor.clipboard",
-					"group": "1_gitlens@4"
+					"group": "2_gitlens@1"
 				},
 				{
 					"command": "gitlens.copyShaToClipboard",
 					"when": "editorTextFocus && gitlens:activeFileStatus =~ /blameable/ && config.gitlens.menus.editor.clipboard",
-					"group": "2_gitlens@1"
+					"group": "3_gitlens@1"
 				},
 				{
 					"command": "gitlens.copyMessageToClipboard",
 					"when": "editorTextFocus && gitlens:activeFileStatus =~ /blameable/ && config.gitlens.menus.editor.clipboard",
-					"group": "2_gitlens@2"
+					"group": "3_gitlens@2"
 				}
 			],
 			"editor/title": [
@@ -12080,27 +12080,27 @@
 				{
 					"command": "gitlens.copyRemoteCommitUrl",
 					"when": "gitlens:hasRemotes && viewItem =~ /gitlens:(commit|file\\b(?=.*?\\b\\+committed\\b))/",
-					"group": "2_gitlens@1"
+					"group": "3_gitlens@1"
 				},
 				{
 					"command": "gitlens.copyRemoteBranchUrl",
 					"when": "gitlens:hasRemotes && viewItem =~ /gitlens:branch/",
-					"group": "2_gitlens@1"
+					"group": "3_gitlens@1"
 				},
 				{
 					"command": "gitlens.copyRemoteRepositoryUrl",
 					"when": "gitlens:hasRemotes && viewItem =~ /gitlens:(remote|repo-folder|repository)\\b/",
-					"group": "2_gitlens@1"
+					"group": "3_gitlens@1"
 				},
 				{
 					"command": "gitlens.copyRemoteFileUrlWithoutRange",
 					"when": "gitlens:hasRemotes && viewItem =~ /gitlens:(file\\b(?=.*?\\b\\+committed\\b)|history:(file|line)|status:file)\\b/",
-					"group": "2_gitlens@2"
+					"group": "3_gitlens@2"
 				},
 				{
 					"command": "gitlens.copyRelativePathToClipboard",
 					"when": "viewItem =~ /gitlens:(file)\\b/",
-					"group": "2_gitlens@3"
+					"group": "2_gitlens@1"
 				},
 				{
 					"command": "gitlens.graph.copySha",
@@ -12115,12 +12115,12 @@
 				{
 					"command": "gitlens.graph.copyRemoteCommitUrl",
 					"when": "gitlens:hasRemotes && webviewItem =~ /gitlens:commit/",
-					"group": "2_gitlens@1"
+					"group": "3_gitlens@1"
 				},
 				{
 					"command": "gitlens.graph.copyRemoteBranchUrl",
 					"when": "gitlens:hasRemotes && webviewItem =~ /gitlens:branch/",
-					"group": "2_gitlens@1"
+					"group": "3_gitlens@1"
 				}
 			],
 			"gitlens/share": [

--- a/package.json
+++ b/package.json
@@ -9360,19 +9360,19 @@
 					"group": "1_gitlens@3"
 				},
 				{
+					"command": "gitlens.copyRelativePathToClipboard",
+					"when": "editorTextFocus && gitlens:activeFileStatus =~ /blameable/ && config.gitlens.menus.editor.clipboard",
+					"group": "1_gitlens@4"
+				},
+				{
 					"command": "gitlens.copyShaToClipboard",
 					"when": "editorTextFocus && gitlens:activeFileStatus =~ /blameable/ && config.gitlens.menus.editor.clipboard",
 					"group": "2_gitlens@1"
 				},
 				{
-					"command": "gitlens.copyRelativePathToClipboard",
-					"when": "editorTextFocus && gitlens:activeFileStatus =~ /blameable/ && config.gitlens.menus.editor.clipboard",
-					"group": "2_gitlens@2"
-				},
-				{
 					"command": "gitlens.copyMessageToClipboard",
 					"when": "editorTextFocus && gitlens:activeFileStatus =~ /blameable/ && config.gitlens.menus.editor.clipboard",
-					"group": "2_gitlens@3"
+					"group": "2_gitlens@2"
 				}
 			],
 			"editor/title": [
@@ -12096,6 +12096,11 @@
 					"command": "gitlens.copyRemoteFileUrlWithoutRange",
 					"when": "gitlens:hasRemotes && viewItem =~ /gitlens:(file\\b(?=.*?\\b\\+committed\\b)|history:(file|line)|status:file)\\b/",
 					"group": "2_gitlens@2"
+				},
+				{
+					"command": "gitlens.copyRelativePathToClipboard",
+					"when": "viewItem =~ /gitlens:(file)\\b/",
+					"group": "2_gitlens@3"
 				},
 				{
 					"command": "gitlens.graph.copySha",

--- a/package.json
+++ b/package.json
@@ -169,6 +169,7 @@
 		"onCommand:gitlens.copyCurrentBranch",
 		"onCommand:gitlens.copyMessageToClipboard",
 		"onCommand:gitlens.copyShaToClipboard",
+		"onCommand:gitlens.copyRelativePathToClipboard",
 		"onCommand:gitlens.closeUnchangedFiles",
 		"onCommand:gitlens.openChangedFiles",
 		"onCommand:gitlens.openBranchesOnRemote",
@@ -5133,6 +5134,12 @@
 				"icon": "$(copy)"
 			},
 			{
+				"command": "gitlens.copyRelativePathToClipboard",
+				"title": "Copy Relative Path",
+				"category": "GitLens",
+				"icon": "$(copy)"
+			},
+			{
 				"command": "gitlens.closeUnchangedFiles",
 				"title": "Close Unchanged Files",
 				"category": "GitLens"
@@ -7880,6 +7887,10 @@
 					"when": "gitlens:activeFileStatus =~ /blameable/"
 				},
 				{
+					"command": "gitlens.copyRelativePathToClipboard",
+					"when": "gitlens:enabled"
+				},
+				{
 					"command": "gitlens.closeUnchangedFiles",
 					"when": "gitlens:enabled"
 				},
@@ -9354,9 +9365,14 @@
 					"group": "2_gitlens@1"
 				},
 				{
-					"command": "gitlens.copyMessageToClipboard",
+					"command": "gitlens.copyRelativePathToClipboard",
 					"when": "editorTextFocus && gitlens:activeFileStatus =~ /blameable/ && config.gitlens.menus.editor.clipboard",
 					"group": "2_gitlens@2"
+				},
+				{
+					"command": "gitlens.copyMessageToClipboard",
+					"when": "editorTextFocus && gitlens:activeFileStatus =~ /blameable/ && config.gitlens.menus.editor.clipboard",
+					"group": "2_gitlens@3"
 				}
 			],
 			"editor/title": [

--- a/src/commands.ts
+++ b/src/commands.ts
@@ -6,6 +6,7 @@ export * from './commands/copyCurrentBranch';
 export * from './commands/copyDeepLink';
 export * from './commands/copyMessageToClipboard';
 export * from './commands/copyShaToClipboard';
+export * from './commands/copyRelativePathToClipboard';
 export * from './commands/createPullRequestOnRemote';
 export * from './commands/openDirectoryCompare';
 export * from './commands/diffLineWithPrevious';

--- a/src/commands/copyRelativePathToClipboard.ts
+++ b/src/commands/copyRelativePathToClipboard.ts
@@ -1,0 +1,26 @@
+import { env, TextEditor, Uri } from 'vscode';
+import { Commands } from '../constants';
+import type { Container } from '../container';
+import { command } from '../system/command';
+import { ActiveEditorCommand, getCommandUri } from './base';
+
+@command()
+export class CopyRelativePathToClipboardCommand extends ActiveEditorCommand {
+	constructor(private readonly container: Container) {
+		super(Commands.CopyRelativePathToClipboard);
+	}
+
+	async execute(editor?: TextEditor, uri?: Uri) {
+		uri = getCommandUri(uri, editor);
+		let relativePath = '';
+		if (uri != null) {
+			const repoPath = this.container.git.getBestRepository(editor)?.uri;
+			if (repoPath != null) {
+				relativePath = this.container.git.getRelativePath(uri, repoPath);
+			}
+		}
+
+		void (await env.clipboard.writeText(relativePath));
+		return undefined;
+	}
+}

--- a/src/commands/copyRelativePathToClipboard.ts
+++ b/src/commands/copyRelativePathToClipboard.ts
@@ -1,13 +1,23 @@
-import { env, TextEditor, Uri } from 'vscode';
+import type { TextEditor, Uri } from 'vscode';
+import { env } from 'vscode';
 import { Commands } from '../constants';
 import type { Container } from '../container';
 import { command } from '../system/command';
-import { ActiveEditorCommand, getCommandUri } from './base';
+import type { CommandContext } from './base';
+import { ActiveEditorCommand, getCommandUri, isCommandContextViewNodeHasFileCommit } from './base';
 
 @command()
 export class CopyRelativePathToClipboardCommand extends ActiveEditorCommand {
 	constructor(private readonly container: Container) {
 		super(Commands.CopyRelativePathToClipboard);
+	}
+
+	protected override preExecute(context: CommandContext) {
+		if (isCommandContextViewNodeHasFileCommit(context)) {
+			return this.execute(context.editor, context.node.commit.file!.uri);
+		}
+
+		return this.execute(context.editor, context.uri);
 	}
 
 	async execute(editor?: TextEditor, uri?: Uri) {
@@ -20,7 +30,7 @@ export class CopyRelativePathToClipboardCommand extends ActiveEditorCommand {
 			}
 		}
 
-		void (await env.clipboard.writeText(relativePath));
+		await env.clipboard.writeText(relativePath);
 		return undefined;
 	}
 }

--- a/src/constants.ts
+++ b/src/constants.ts
@@ -105,6 +105,7 @@ export const enum Commands {
 	CopyRemotePullRequestUrl = 'gitlens.copyRemotePullRequestUrl',
 	CopyRemoteRepositoryUrl = 'gitlens.copyRemoteRepositoryUrl',
 	CopyShaToClipboard = 'gitlens.copyShaToClipboard',
+	CopyRelativePathToClipboard = 'gitlens.copyRelativePathToClipboard',
 	CreatePullRequestOnRemote = 'gitlens.createPullRequestOnRemote',
 	DiffDirectory = 'gitlens.diffDirectory',
 	DiffDirectoryWithHead = 'gitlens.diffDirectoryWithHead',


### PR DESCRIPTION
# Description

<!--
Please include a summary of the changes and which issue will be addressed. Please also include relevant motivation and context.
-->

This change adds a `Copy Relative Path` item to the context menu and the command palette. This copies the relative path, of the active file in the editor, to the clipboard.

Fixes #969

![Screen Shot 2022-04-04 at 11 51 16 PM](https://user-images.githubusercontent.com/293282/161675476-836dc3da-9364-4d0a-9f9b-61c9bfe45d92.png)

# Checklist

<!-- Please check off the following -->

- [x] I have followed the guidelines in the Contributing document
- [x] My changes follow the coding style of this project
- [x] My changes build without any errors or warnings
- [x] My changes have been formatted and linted
- [x] My changes include any required corresponding changes to the documentation
- [x] My changes have been rebased and squashed to the minimal number (typically 1) of relevant commits
- [x] My changes have a descriptive commit message with a short title, including a `Fixes $XXX -` or `Closes #XXX -` prefix to auto-close the issue that your PR addresses
