### PR TITLE
Smartly guess the protocol and port for the remote provider

### DIFF
--- a/package.json
+++ b/package.json
@@ -11070,6 +11070,7 @@
 		"ansi-regex": "6.0.1",
 		"billboard.js": "3.3.2",
 		"chroma-js": "2.3.0",
+		"git-url-parse": "11.6.0",
 		"https-proxy-agent": "5.0.1",
 		"iconv-lite": "0.6.3",
 		"lodash-es": "4.17.21",
@@ -11082,6 +11083,7 @@
 	"devDependencies": {
 		"@squoosh/lib": "0.4.0",
 		"@types/chroma-js": "2.1.3",
+		"@types/git-url-parse": "9.0.1",
 		"@types/glob": "7.2.0",
 		"@types/lodash-es": "4.17.6",
 		"@types/mocha": "9.1.0",

--- a/src/git/parsers/remoteParser.ts
+++ b/src/git/parsers/remoteParser.ts
@@ -1,13 +1,10 @@
+import gitUrlParse from 'git-url-parse';
 import { debug } from '../../system/decorators/log';
 import { GitRemote } from '../models';
 import { GitRemoteType } from '../models/remote';
 import { RemoteProvider } from '../remotes/provider';
 
-const emptyStr = '';
-
 const remoteRegex = /^(.*)\t(.*)\s\((.*)\)$/gm;
-const urlRegex =
-	/^(?:(git:\/\/)(.*?)\/|(https?:\/\/)(?:.*?@)?(.*?)\/|git@(.*):|(ssh:\/\/)(?:.*@)?(.*?)(?::.*?)?(?:\/|(?=~))|(?:.*?@)(.*?):)(.*)$/;
 
 // Test git urls
 /*
@@ -47,12 +44,20 @@ user:password@host.xz:/path/to/repo.git
 user:password@host.xz:/path/to/repo.git/
 */
 
+export interface GitRemoteUrl {
+	url: string;
+	protocol: string;
+	domain: string;
+	port?: number;
+	path: string;
+}
+
 export class GitRemoteParser {
 	@debug({ args: false, singleLine: true })
 	static parse(
 		data: string,
 		repoPath: string,
-		providerFactory: (url: string, domain: string, path: string) => RemoteProvider | undefined,
+		providerFactory: (gitRemoteUrl: GitRemoteUrl) => RemoteProvider | undefined,
 	): GitRemote[] | undefined {
 		if (!data) return undefined;
 
@@ -62,10 +67,6 @@ export class GitRemoteParser {
 		let name;
 		let url;
 		let type;
-
-		let scheme;
-		let domain;
-		let path;
 
 		let uniqueness;
 		let remote: GitRemote | undefined;
@@ -80,12 +81,14 @@ export class GitRemoteParser {
 			// Stops excessive memory usage -- https://bugs.chromium.org/p/v8/issues/detail?id=2869
 			url = ` ${url}`.substr(1);
 
-			[scheme, domain, path] = this.parseGitUrl(url);
+			const gitRemoteUrl = this.parseGitUrl(url);
+			const { domain, path, protocol } = gitRemoteUrl;
+			const scheme = `${protocol}://`;
 
 			uniqueness = `${domain ? `${domain}/` : ''}${path}`;
 			remote = groups[uniqueness];
 			if (remote === undefined) {
-				const provider = providerFactory(url, domain, path);
+				const provider = providerFactory(gitRemoteUrl);
 
 				remote = new GitRemote(
 					repoPath,
@@ -110,14 +113,14 @@ export class GitRemoteParser {
 		return remotes;
 	}
 
-	static parseGitUrl(url: string): [string, string, string] {
-		const match = urlRegex.exec(url);
-		if (match == null) return [emptyStr, emptyStr, url];
-
-		return [
-			match[1] || match[3] || match[6],
-			match[2] || match[4] || match[5] || match[7] || match[8],
-			match[9].replace(/\.git\/?$/, emptyStr),
-		];
+	static parseGitUrl(url: string): GitRemoteUrl {
+		const parsedUrl = gitUrlParse(url);
+		return {
+			url: parsedUrl.toString(),
+			protocol: parsedUrl.protocol,
+			domain: parsedUrl.resource,
+			path: parsedUrl.full_name,
+			port: parsedUrl.port !== null ? parsedUrl.port : undefined,
+		};
 	}
 }

--- a/src/git/remotes/bitbucket-server.ts
+++ b/src/git/remotes/bitbucket-server.ts
@@ -1,16 +1,17 @@
 import { Range, Uri } from 'vscode';
 import { DynamicAutolinkReference } from '../../annotations/autolinks';
-import { AutolinkReference } from '../../config';
+import { AutolinkReference, RemotesConfig } from '../../config';
 import { GitRevision } from '../models';
 import { Repository } from '../models/repository';
+import { GitRemoteUrl } from '../parsers';
 import { RemoteProvider } from './provider';
 
 const fileRegex = /^\/([^/]+)\/([^/]+?)\/src(.+)$/i;
 const rangeRegex = /^lines-(\d+)(?::(\d+))?$/;
 
 export class BitbucketServerRemote extends RemoteProvider {
-	constructor(domain: string, path: string, protocol?: string, name?: string, custom: boolean = false) {
-		super(domain, path, protocol, name, custom);
+	constructor(gitRemoteUrl: GitRemoteUrl, remoteConfig?: RemotesConfig, custom: boolean = false) {
+		super(gitRemoteUrl, remoteConfig, custom);
 	}
 
 	private _autolinks: (AutolinkReference | DynamicAutolinkReference)[] | undefined;

--- a/src/git/remotes/bitbucket.ts
+++ b/src/git/remotes/bitbucket.ts
@@ -1,16 +1,17 @@
 import { Range, Uri } from 'vscode';
 import { DynamicAutolinkReference } from '../../annotations/autolinks';
-import { AutolinkReference } from '../../config';
+import { AutolinkReference, RemotesConfig } from '../../config';
 import { GitRevision } from '../models';
 import { Repository } from '../models/repository';
+import { GitRemoteUrl } from '../parsers';
 import { RemoteProvider } from './provider';
 
 const fileRegex = /^\/([^/]+)\/([^/]+?)\/src(.+)$/i;
 const rangeRegex = /^lines-(\d+)(?::(\d+))?$/;
 
 export class BitbucketRemote extends RemoteProvider {
-	constructor(domain: string, path: string, protocol?: string, name?: string, custom: boolean = false) {
-		super(domain, path, protocol, name, custom);
+	constructor(gitRemoteUrl: GitRemoteUrl, remoteConfig?: RemotesConfig, custom: boolean = false) {
+		super(gitRemoteUrl, remoteConfig, custom);
 	}
 
 	private _autolinks: (AutolinkReference | DynamicAutolinkReference)[] | undefined;

--- a/src/git/remotes/custom.ts
+++ b/src/git/remotes/custom.ts
@@ -1,15 +1,16 @@
 import { Range, Uri } from 'vscode';
-import { RemotesUrlsConfig } from '../../configuration';
+import { RemotesConfig, RemotesUrlsConfig } from '../../configuration';
 import { interpolate } from '../../system/string';
 import { Repository } from '../models/repository';
+import { GitRemoteUrl } from '../parsers';
 import { RemoteProvider } from './provider';
 
 export class CustomRemote extends RemoteProvider {
 	private readonly urls: RemotesUrlsConfig;
 
-	constructor(domain: string, path: string, urls: RemotesUrlsConfig, protocol?: string, name?: string) {
-		super(domain, path, protocol, name, true);
-		this.urls = urls;
+	constructor(gitRemoteUrl: GitRemoteUrl, remoteConfig?: RemotesConfig) {
+		super(gitRemoteUrl, remoteConfig, true);
+		this.urls = remoteConfig!.urls!;
 	}
 
 	get id() {

--- a/src/git/remotes/gerrit.ts
+++ b/src/git/remotes/gerrit.ts
@@ -1,22 +1,16 @@
 import { Range, Uri } from 'vscode';
 import { DynamicAutolinkReference } from '../../annotations/autolinks';
-import { AutolinkReference } from '../../config';
+import { AutolinkReference, RemotesConfig } from '../../config';
 import { GitRevision } from '../models';
 import { Repository } from '../models/repository';
+import { GitRemoteUrl } from '../parsers';
 import { RemoteProvider } from './provider';
 
 const fileRegex = /^\/([^/]+)\/\+(.+)$/i;
 const rangeRegex = /^(\d+)$/;
 
 export class GerritRemote extends RemoteProvider {
-	constructor(
-		domain: string,
-		path: string,
-		protocol?: string,
-		name?: string,
-		custom: boolean = false,
-		trimPath: boolean = true,
-	) {
+	constructor(gitRemoteUrl: GitRemoteUrl, remoteConfig?: RemotesConfig, custom: boolean = false, trimPath: boolean = true) {
 		/*
 		 * Git remote URLs differs when cloned by HTTPS with or without authentication.
 		 * An anonymous clone looks like:
@@ -25,11 +19,11 @@ export class GerritRemote extends RemoteProvider {
 		 * 	 $ git clone "https://felipecrs@review.gerrithub.io/a/jenkinsci/gerrit-code-review-plugin"
 		 *   Where username may be omitted, but the "a/" prefix is always present.
 		 */
-		if (trimPath && protocol !== 'ssh') {
-			path = path.replace(/^a\//, '');
+		if (trimPath && ['http', 'https'].includes(gitRemoteUrl.protocol)) {
+			gitRemoteUrl.path = gitRemoteUrl.path.replace(/^a\//, '');
 		}
 
-		super(domain, path, protocol, name, custom);
+		super(gitRemoteUrl, remoteConfig, custom);
 	}
 
 	private _autolinks: (AutolinkReference | DynamicAutolinkReference)[] | undefined;

--- a/src/git/remotes/gitea.ts
+++ b/src/git/remotes/gitea.ts
@@ -1,16 +1,17 @@
 import { Range, Uri } from 'vscode';
 import { DynamicAutolinkReference } from '../../annotations/autolinks';
-import { AutolinkReference } from '../../config';
+import { AutolinkReference, RemotesConfig } from '../../config';
 import { GitRevision } from '../models';
 import { Repository } from '../models/repository';
+import { GitRemoteUrl } from '../parsers';
 import { RemoteProvider } from './provider';
 
 const fileRegex = /^\/([^/]+)\/([^/]+?)\/src(.+)$/i;
 const rangeRegex = /^L(\d+)(?:-L(\d+))?$/;
 
 export class GiteaRemote extends RemoteProvider {
-	constructor(domain: string, path: string, protocol?: string, name?: string, custom: boolean = false) {
-		super(domain, path, protocol, name, custom);
+	constructor(gitRemoteUrl: GitRemoteUrl, remoteConfig?: RemotesConfig, custom: boolean = false) {
+		super(gitRemoteUrl, remoteConfig, custom);
 	}
 
 	private _autolinks: (AutolinkReference | DynamicAutolinkReference)[] | undefined;

--- a/src/git/remotes/github.ts
+++ b/src/git/remotes/github.ts
@@ -1,6 +1,6 @@
 import { AuthenticationSession, Range, Uri } from 'vscode';
 import { DynamicAutolinkReference } from '../../annotations/autolinks';
-import { AutolinkReference } from '../../config';
+import { AutolinkReference, RemotesConfig } from '../../config';
 import { Container } from '../../container';
 import {
 	Account,
@@ -11,6 +11,7 @@ import {
 	PullRequestState,
 	Repository,
 } from '../models';
+import { GitRemoteUrl } from '../parsers';
 import { RichRemoteProvider } from './provider';
 
 const issueEnricher3rdPartyRegex = /\b(?<repo>[^/\s]+\/[^/\s]+)\\#(?<num>[0-9]+)\b(?!]\()/g;
@@ -24,8 +25,8 @@ export class GitHubRemote extends RichRemoteProvider {
 		return authProvider;
 	}
 
-	constructor(domain: string, path: string, protocol?: string, name?: string, custom: boolean = false) {
-		super(domain, path, protocol, name, custom);
+	constructor(gitRemoteUrl: GitRemoteUrl, remoteConfig?: RemotesConfig, custom: boolean = false) {
+		super(gitRemoteUrl, remoteConfig, custom);
 	}
 
 	get apiBaseUrl() {

--- a/src/git/remotes/gitlab.ts
+++ b/src/git/remotes/gitlab.ts
@@ -1,16 +1,17 @@
 import { Range, Uri } from 'vscode';
 import { DynamicAutolinkReference } from '../../annotations/autolinks';
-import { AutolinkReference } from '../../config';
+import { AutolinkReference, RemotesConfig } from '../../config';
 import { GitRevision } from '../models';
 import { Repository } from '../models/repository';
+import { GitRemoteUrl } from '../parsers';
 import { RemoteProvider } from './provider';
 
 const fileRegex = /^\/([^/]+)\/([^/]+?)\/-\/blob(.+)$/i;
 const rangeRegex = /^L(\d+)(?:-(\d+))?$/;
 
 export class GitLabRemote extends RemoteProvider {
-	constructor(domain: string, path: string, protocol?: string, name?: string, custom: boolean = false) {
-		super(domain, path, protocol, name, custom);
+	constructor(gitRemoteUrl: GitRemoteUrl, remoteConfig?: RemotesConfig, custom: boolean = false) {
+		super(gitRemoteUrl, remoteConfig, custom);
 	}
 
 	private _autolinks: (AutolinkReference | DynamicAutolinkReference)[] | undefined;

--- a/src/plus/github/githubGitProvider.ts
+++ b/src/plus/github/githubGitProvider.ts
@@ -2154,7 +2154,8 @@ export class GitHubGitProvider implements GitProvider, Disposable {
 		const uri = Uri.parse(repoPath, true);
 		const [, owner, repo] = uri.path.split('/', 3);
 
-		const url = `https://github.com/${owner}/${repo}.git`;
+		const protocol = 'https';
+		const url = `${protocol}://github.com/${owner}/${repo}.git`;
 		const domain = 'github.com';
 		const path = `${owner}/${repo}`;
 
@@ -2163,10 +2164,15 @@ export class GitHubGitProvider implements GitProvider, Disposable {
 				repoPath,
 				`${domain}/${path}`,
 				'origin',
-				'https',
+				protocol,
 				domain,
 				path,
-				RemoteProviderFactory.factory(providers)(url, domain, path),
+				RemoteProviderFactory.factory(providers)({
+					url: url,
+					protocol: protocol,
+					domain: domain,
+					path: path,
+				}),
 				[
 					{ type: GitRemoteType.Fetch, url: url },
 					{ type: GitRemoteType.Push, url: url },

--- a/yarn.lock
+++ b/yarn.lock
@@ -256,6 +256,11 @@
   resolved "https://registry.yarnpkg.com/@types/estree/-/estree-0.0.51.tgz#cfd70924a25a3fd32b218e5e420e6897e1ac4f40"
   integrity sha512-CuPgU6f3eT/XgKKPqKd/gLZV1Xmvf1a2R5POBOGQa6uv82xpls89HU5zKeVoyR8XzHd1RGNOlQlvUe3CFkjWNQ==
 
+"@types/git-url-parse@9.0.1":
+  version "9.0.1"
+  resolved "https://registry.yarnpkg.com/@types/git-url-parse/-/git-url-parse-9.0.1.tgz#1c7cc89527ca8b5afcf260ead3b0e4e373c43938"
+  integrity sha512-Zf9mY4Mz7N3Nyi341nUkOtgVUQn4j6NS4ndqEha/lOgEbTkHzpD7wZuRagYKzrXNtvawWfsrojoC1nhsQexvNA==
+
 "@types/glob@7.2.0", "@types/glob@^7.1.1":
   version "7.2.0"
   resolved "https://registry.yarnpkg.com/@types/glob/-/glob-7.2.0.tgz#bc1b5bf3aa92f25bd5dd39f35c57361bdce5b2eb"
@@ -2633,6 +2638,11 @@ fill-range@^7.0.1:
   dependencies:
     to-regex-range "^5.0.1"
 
+filter-obj@^1.1.0:
+  version "1.1.0"
+  resolved "https://registry.yarnpkg.com/filter-obj/-/filter-obj-1.1.0.tgz#9b311112bc6c6127a16e016c6c5d7f19e0805c5b"
+  integrity sha1-mzERErxsYSehbgFsbF1/GeCAXFs=
+
 find-up@5.0.0, find-up@^5.0.0:
   version "5.0.0"
   resolved "https://registry.yarnpkg.com/find-up/-/find-up-5.0.0.tgz#4c92819ecb7083561e4f4a240a86be5198f536fc"
@@ -2837,6 +2847,21 @@ get-symbol-description@^1.0.0:
   dependencies:
     call-bind "^1.0.2"
     get-intrinsic "^1.1.1"
+
+git-up@^4.0.0:
+  version "4.0.5"
+  resolved "https://registry.yarnpkg.com/git-up/-/git-up-4.0.5.tgz#e7bb70981a37ea2fb8fe049669800a1f9a01d759"
+  integrity sha512-YUvVDg/vX3d0syBsk/CKUTib0srcQME0JyHkL5BaYdwLsiCslPWmDSi8PUMo9pXYjrryMcmsCoCgsTpSCJEQaA==
+  dependencies:
+    is-ssh "^1.3.0"
+    parse-url "^6.0.0"
+
+git-url-parse@11.6.0:
+  version "11.6.0"
+  resolved "https://registry.yarnpkg.com/git-url-parse/-/git-url-parse-11.6.0.tgz#c634b8de7faa66498a2b88932df31702c67df605"
+  integrity sha512-WWUxvJs5HsyHL6L08wOusa/IXYtMuCAhrMmnTjQPpBU0TTHyDhnOATNH3xNQz7YOQUsqIIPTGr4xiVti1Hsk5g==
+  dependencies:
+    git-up "^4.0.0"
 
 github-from-package@0.0.0:
   version "0.0.0"
@@ -3501,6 +3526,13 @@ is-shared-array-buffer@^1.0.2:
   integrity sha512-sqN2UDu1/0y6uvXyStCOzyhAjCSlHceFoMKJW8W9EU9cvic/QdsZ0kEU93HEy3IUEFZIiH/3w+AH/UQbPHNdhA==
   dependencies:
     call-bind "^1.0.2"
+
+is-ssh@^1.3.0:
+  version "1.3.3"
+  resolved "https://registry.yarnpkg.com/is-ssh/-/is-ssh-1.3.3.tgz#7f133285ccd7f2c2c7fc897b771b53d95a2b2c7e"
+  integrity sha512-NKzJmQzJfEEma3w5cJNcUMxoXfDjz0Zj0eyCalHn2E6VOwlzjZo0yuO2fcBSf8zhFuVCL/82/r5gRcoi6aEPVQ==
+  dependencies:
+    protocols "^1.1.0"
 
 is-stream@^1.0.0, is-stream@^1.1.0:
   version "1.1.0"
@@ -4262,6 +4294,11 @@ normalize-url@2.0.1:
     query-string "^5.0.1"
     sort-keys "^2.0.0"
 
+normalize-url@^6.1.0:
+  version "6.1.0"
+  resolved "https://registry.yarnpkg.com/normalize-url/-/normalize-url-6.1.0.tgz#40d0885b535deffe3f3147bec877d05fe4c5668a"
+  integrity sha512-DlL+XwOy3NxAQ8xuC0okPgK46iuVNAK01YN7RueYBqqFeGsBjV9XmCAzAdgt+667bCl5kPh9EqKKDwnaPG1I7A==
+
 npm-conf@^1.1.0:
   version "1.1.3"
   resolved "https://registry.yarnpkg.com/npm-conf/-/npm-conf-1.1.3.tgz#256cc47bd0e218c259c4e9550bf413bc2192aff9"
@@ -4554,12 +4591,32 @@ parse-json@^5.0.0, parse-json@^5.2.0:
     json-parse-even-better-errors "^2.3.0"
     lines-and-columns "^1.1.6"
 
+parse-path@^4.0.0:
+  version "4.0.3"
+  resolved "https://registry.yarnpkg.com/parse-path/-/parse-path-4.0.3.tgz#82d81ec3e071dcc4ab49aa9f2c9c0b8966bb22bf"
+  integrity sha512-9Cepbp2asKnWTJ9x2kpw6Fe8y9JDbqwahGCTvklzd/cEq5C5JC59x2Xb0Kx+x0QZ8bvNquGO8/BWP0cwBHzSAA==
+  dependencies:
+    is-ssh "^1.3.0"
+    protocols "^1.4.0"
+    qs "^6.9.4"
+    query-string "^6.13.8"
+
 parse-semver@^1.1.1:
   version "1.1.1"
   resolved "https://registry.yarnpkg.com/parse-semver/-/parse-semver-1.1.1.tgz#9a4afd6df063dc4826f93fba4a99cf223f666cb8"
   integrity sha1-mkr9bfBj3Egm+T+6SpnPIj9mbLg=
   dependencies:
     semver "^5.1.0"
+
+parse-url@^6.0.0:
+  version "6.0.0"
+  resolved "https://registry.yarnpkg.com/parse-url/-/parse-url-6.0.0.tgz#f5dd262a7de9ec00914939220410b66cff09107d"
+  integrity sha512-cYyojeX7yIIwuJzledIHeLUBVJ6COVLeT4eF+2P6aKVzwvgKQPndCBv3+yQ7pcWjqToYwaligxzSYNNmGoMAvw==
+  dependencies:
+    is-ssh "^1.3.0"
+    normalize-url "^6.1.0"
+    parse-path "^4.0.0"
+    protocols "^1.4.0"
 
 parse5-htmlparser2-tree-adapter@^6.0.1:
   version "6.0.1"
@@ -4866,6 +4923,11 @@ proto-list@~1.2.1:
   resolved "https://registry.yarnpkg.com/proto-list/-/proto-list-1.2.4.tgz#212d5bfe1318306a420f6402b8e26ff39647a849"
   integrity sha1-IS1b/hMYMGpCD2QCuOJv85ZHqEk=
 
+protocols@^1.1.0, protocols@^1.4.0:
+  version "1.4.8"
+  resolved "https://registry.yarnpkg.com/protocols/-/protocols-1.4.8.tgz#48eea2d8f58d9644a4a32caae5d5db290a075ce8"
+  integrity sha512-IgjKyaUSjsROSO8/D49Ab7hP8mJgTYcqApOqdPhLoPxAplXmkp+zRvsrSQjFn5by0rhm4VH0GAUELIPpx7B1yg==
+
 proxy-from-env@1.1.0:
   version "1.1.0"
   resolved "https://registry.yarnpkg.com/proxy-from-env/-/proxy-from-env-1.1.0.tgz#e102f16ca355424865755d2c9e8ea4f24d58c3e2"
@@ -4889,7 +4951,7 @@ punycode@^2.1.0:
   resolved "https://registry.yarnpkg.com/punycode/-/punycode-2.1.1.tgz#b58b010ac40c22c5657616c8d2c2c02c7bf479ec"
   integrity sha512-XRsRjdf+j5ml+y/6GKHPZbrF/8p2Yga0JPtdqTIY2Xe5ohJPD9saDJJLPvp9+NSBprVvevdXZybnj2cv8OEd0A==
 
-qs@^6.9.1:
+qs@^6.9.1, qs@^6.9.4:
   version "6.10.3"
   resolved "https://registry.yarnpkg.com/qs/-/qs-6.10.3.tgz#d6cde1b2ffca87b5aa57889816c5f81535e22e8e"
   integrity sha512-wr7M2E0OFRfIfJZjKGieI8lBKb7fRCH4Fv5KNPEs7gJ8jadvotdsS08PzOKR7opXhZ/Xkjtt3WF9g38drmyRqQ==
@@ -4904,6 +4966,16 @@ query-string@^5.0.1:
     decode-uri-component "^0.2.0"
     object-assign "^4.1.0"
     strict-uri-encode "^1.0.0"
+
+query-string@^6.13.8:
+  version "6.14.1"
+  resolved "https://registry.yarnpkg.com/query-string/-/query-string-6.14.1.tgz#7ac2dca46da7f309449ba0f86b1fd28255b0c86a"
+  integrity sha512-XDxAeVmpfu1/6IjyT/gXHOl+S0vQ9owggJ30hhWKdHAsNPOcasn5o9BW0eejZqL2e4vMjhAxoW3jVHcD6mbcYw==
+  dependencies:
+    decode-uri-component "^0.2.0"
+    filter-obj "^1.1.0"
+    split-on-first "^1.0.0"
+    strict-uri-encode "^2.0.0"
 
 queue-lit@^1.2.7:
   version "1.2.7"
@@ -5503,6 +5575,11 @@ spdx-satisfies@^5.0.1:
     spdx-expression-parse "^3.0.0"
     spdx-ranges "^2.0.0"
 
+split-on-first@^1.0.0:
+  version "1.1.0"
+  resolved "https://registry.yarnpkg.com/split-on-first/-/split-on-first-1.1.0.tgz#f610afeee3b12bce1d0c30425e76398b78249a5f"
+  integrity sha512-43ZssAJaMusuKWL8sKUBQXHWOpq8d6CfN/u1p4gUzfJkM05C8rxTmYrkIPTXapZpORA6LkkzcUulJ8FqA7Uudw==
+
 stack-utils@2.0.5:
   version "2.0.5"
   resolved "https://registry.yarnpkg.com/stack-utils/-/stack-utils-2.0.5.tgz#d25265fca995154659dbbfba3b49254778d2fdd5"
@@ -5519,6 +5596,11 @@ strict-uri-encode@^1.0.0:
   version "1.1.0"
   resolved "https://registry.yarnpkg.com/strict-uri-encode/-/strict-uri-encode-1.1.0.tgz#279b225df1d582b1f54e65addd4352e18faa0713"
   integrity sha1-J5siXfHVgrH1TmWt3UNS4Y+qBxM=
+
+strict-uri-encode@^2.0.0:
+  version "2.0.0"
+  resolved "https://registry.yarnpkg.com/strict-uri-encode/-/strict-uri-encode-2.0.0.tgz#b9c7330c7042862f6b142dc274bbcc5866ce3546"
+  integrity sha1-ucczDHBChi9rFC3CdLvMWGbONUY=
 
 string-width@^1.0.1:
   version "1.0.2"


### PR DESCRIPTION
# Description

Currently the remote provider uses https by default and allow users to set a different protocol if they want in the configuration.

This is kept, but now, we try to infer the best protocol by looking at the git remote URL.

And, previously, no custom ports were allowed to be set. This is still true, but now, we try to infer the best port by looking at the git remote URL.

Fixes #632
Fixes #1918

Maybe more.

<!--
Please include a summary of the changes and which issue will be addressed. Please also include relevant motivation and context.
-->

# Checklist

<!-- Please check off the following -->

- [ ] I have followed the guidelines in the Contributing document
- [ ] My changes follow the coding style of this project
- [ ] My changes build without any errors or warnings
- [ ] My changes have been formatted and linted
- [ ] My changes include any required corresponding changes to the documentation
- [ ] My changes have been rebased and squashed to the minimal number (typically 1) of relevant commits
- [x] My changes have a descriptive commit message with a short title, including a `Fixes $XXX -` or `Closes #XXX -` prefix to auto-close the issue that your PR addresses
