### PR TITLE
Fixes #1981 by having the view always enabled

### DIFF
--- a/package.json
+++ b/package.json
@@ -10739,7 +10739,7 @@
 					"type": "webview",
 					"id": "gitlens.views.home",
 					"name": "Home",
-					"when": "!gitlens:disabled && config.gitlens.plusFeatures.enabled",
+					"when": "config.gitlens.plusFeatures.enabled",
 					"contextualTitle": "GitLens",
 					"icon": "images/gitlens-activitybar.svg",
 					"visibility": "visible"


### PR DESCRIPTION
---

# Description

Fixes the issue #1981 by simply allowing the view to be always enabled. At this moment, the content shown on GitLens : Home view looks great to me.

![image](https://user-images.githubusercontent.com/90340232/168050191-fd54d93d-06fc-4f25-a2c6-e2a6767d40ff.png)
