### PR TITLE
Fixes #1998

### DIFF
--- a/src/webviews/apps/settings/partials/dates.html
+++ b/src/webviews/apps/settings/partials/dates.html
@@ -147,7 +147,7 @@
 							</a>
 						</div>
 						<span class="setting__hint"
-							>Example date:
+							>Example time:
 							<span
 								data-setting-preview="defaultTimeFormat"
 								data-setting-preview-type="date"

--- a/src/webviews/apps/welcome/welcome.html
+++ b/src/webviews/apps/welcome/welcome.html
@@ -499,7 +499,7 @@
 									</a>
 								</div>
 								<span class="setting__hint"
-									>Example date:
+									>Example time:
 									<span
 										data-setting-preview="defaultTimeFormat"
 										data-setting-preview-type="date"


### PR DESCRIPTION
# Description

In date & time format settings, the feedback for "Time format" reads "Example date" rather than "Example time". This PR fixes that typo.

# Checklist

<!-- Please check off the following -->

- [x] I have followed the guidelines in the Contributing document
- [x] My changes follow the coding style of this project
- [x] My changes build without any errors or warnings
- [x] My changes have been formatted and linted
- [x] My changes include any required corresponding changes to the documentation
- [x] My changes have been rebased and squashed to the minimal number (typically 1) of relevant commits
- [x] My changes have a descriptive commit message with a short title, including a `Fixes $XXX -` or `Closes #XXX -` prefix to auto-close the issue that your PR addresses
