### PR TITLE
Fixes #2021 - Use scoped routes for GitLab URLs

### DIFF
--- a/src/git/remotes/gitlab.ts
+++ b/src/git/remotes/gitlab.ts
@@ -105,15 +105,15 @@ export class GitLabRemote extends RemoteProvider {
 	}
 
 	protected getUrlForBranches(): string {
-		return this.encodeUrl(`${this.baseUrl}/branches`);
+		return this.encodeUrl(`${this.baseUrl}/-/branches`);
 	}
 
 	protected getUrlForBranch(branch: string): string {
-		return this.encodeUrl(`${this.baseUrl}/tree/${branch}`);
+		return this.encodeUrl(`${this.baseUrl}/-/tree/${branch}`);
 	}
 
 	protected getUrlForCommit(sha: string): string {
-		return this.encodeUrl(`${this.baseUrl}/commit/${sha}`);
+		return this.encodeUrl(`${this.baseUrl}/-/commit/${sha}`);
 	}
 
 	protected override getUrlForComparison(base: string, compare: string, notation: '..' | '...'): string {
@@ -132,8 +132,8 @@ export class GitLabRemote extends RemoteProvider {
 			line = '';
 		}
 
-		if (sha) return `${this.encodeUrl(`${this.baseUrl}/blob/${sha}/${fileName}`)}${line}`;
-		if (branch) return `${this.encodeUrl(`${this.baseUrl}/blob/${branch}/${fileName}`)}${line}`;
+		if (sha) return `${this.encodeUrl(`${this.baseUrl}/-/blob/${sha}/${fileName}`)}${line}`;
+		if (branch) return `${this.encodeUrl(`${this.baseUrl}/-/blob/${branch}/${fileName}`)}${line}`;
 		return `${this.encodeUrl(`${this.baseUrl}?path=${fileName}`)}${line}`;
 	}
 }


### PR DESCRIPTION
# Description

<!--
Please include a summary of the changes and which issue will be addressed. Please also include relevant motivation and context.
-->


GitLens uses legacy project routes for GitLab:

- `${projectURL}/branches`
- `${projectURL}/tree/${branch}`
- `${projectURL}/commit/${sha}`
- `${projectURL}/compare/${base}${notation}${compare}`
- `${projectURL}/blob/${ref}/${fileName}`

These routes are all deprecated and scheduled for removal. See these references:

- https://docs.gitlab.com/ee/development/routing.html#project-routes
- https://gitlab.com/gitlab-org/gitlab/-/issues/118849
- https://gitlab.com/gitlab-org/gitlab/-/issues/28848

This change replaces them with the following scoped routes:

- `${projectURL}/-/branches`
- `${projectURL}/-/tree/${branch}`
- `${projectURL}/-/commit/${sha}`
- `${projectURL}/-/compare/${base}${notation}${compare}`
- `${projectURL}/-/blob/${ref}/${fileName}`

Examples:

- https://gitlab.com/gitlab-org/gitlab/-/branches
- https://gitlab.com/gitlab-org/gitlab/-/tree/master
- https://gitlab.com/gitlab-org/gitlab/-/commit/a5ba5fb96bc40bbd0c5bfb6aea6544a3ff5d0828
- https://gitlab.com/gitlab-org/gitlab/-/compare/69393d64...a998e801
- https://gitlab.com/gitlab-org/gitlab/-/blob/master/README.md

# Checklist

<!-- Please check off the following -->

- [x] I have followed the guidelines in the Contributing document
- [x] My changes follow the coding style of this project
- [x] My changes build without any errors or warnings
- [x] My changes have been formatted and linted
- [x] My changes include any required corresponding changes to the documentation
- [x] My changes have been rebased and squashed to the minimal number (typically 1) of relevant commits
- [x] My changes have a descriptive commit message with a short title, including a `Fixes $XXX -` or `Closes #XXX -` prefix to auto-close the issue that your PR addresses
