### PR TITLE
Uses VSCode as core.editor for rebase

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,10 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/) and this p
   - When a stash is applied or popped and the Source Control input is empty, we will now update the Source Control input to the stash message
   - When stashing changes and the Source Control input is not empty, we will now default the stash message input to the Source Control input value
 
+### Changed
+
+- Uses VSCode as `core.editor` in rebase &mdash; closes [#2084](https://github.com/gitkraken/vscode-gitlens/issues/2084)
+
 ### Fixed
 
 - Fixes [#2082](https://github.com/gitkraken/vscode-gitlens/issues/2082) - GitLens Home view unreadable in certain themes

--- a/src/commands/git/rebase.ts
+++ b/src/commands/git/rebase.ts
@@ -96,7 +96,7 @@ export class RebaseGitCommand extends QuickCommand<State> {
 					break;
 			}
 
-			configs = ['-c', `sequence.editor="${editor}"`];
+			configs = ['-c', `sequence.editor="${editor}"`, '-c', `core.editor="${editor}"`];
 		}
 		return state.repo.rebase(configs, ...state.flags, state.reference.ref);
 	}


### PR DESCRIPTION
# Description

<!--
Please include a summary of the changes and which issue will be addressed. Please also include relevant motivation and context.
-->
When using git commands from terminal, one may prefer to use terminal editors to edit commit messages. But when using VSCode, it's better to use VSCode to edit commit messages. Currently gitlens uses VSCode to edit commit messages for amend. However it uses git's global `core.editor` for 'reword' in rebase. This PR ensures the usage of VSCode as `core.editor` for rebase.

Closes #2084 

# Checklist

<!-- Please check off the following -->

- [x] I have followed the guidelines in the Contributing document
- [x] My changes follow the coding style of this project
- [x] My changes build without any errors or warnings
- [x] My changes have been formatted and linted
- [x] My changes include any required corresponding changes to the documentation
- [x] My changes have been rebased and squashed to the minimal number (typically 1) of relevant commits
- [x] My changes have a descriptive commit message with a short title, including a `Fixes $XXX -` or `Closes #XXX -` prefix to auto-close the issue that your PR addresses
