### PR TITLE
fix centering of text in headers

### DIFF
--- a/src/webviews/apps/plus/graph/graph.scss
+++ b/src/webviews/apps/plus/graph/graph.scss
@@ -7,3 +7,8 @@
 @import '../../shared/codicons';
 @import '../../shared/utils';
 @import '../../../../../node_modules/@axosoft/gitkraken-components/lib/css/GKGraphStyles.css';
+
+// override important font size from base.scss
+#graph-container-helmet {
+    font-size: 14px;
+}


### PR DESCRIPTION

# Description

base.scss contains a css style for the body:
'font-size: 100% !important'
that causes the header of the graph to be misaligned and overrides some font sizing in the graph, making it inconsistent with the original graph.

This PR contains code which will override that style specifically in the graph

