### PR TITLE
GITLENS-271 - Modify the name of the lib to point to "@gitkraken" (Gitlens side modifications)

### DIFF
--- a/src/webviews/apps/plus/graph/GraphWrapper.tsx
+++ b/src/webviews/apps/plus/graph/GraphWrapper.tsx
@@ -7,7 +7,7 @@ import GraphContainer, {
 	Head,
 	Remote,
 	Tag
-} from '@axosoft/gitkraken-components/lib/components/graph/GraphContainer';
+} from '@gitkraken/gitkraken-components/lib/components/graph/GraphContainer';
 import React, { useEffect, useState } from 'react';
 import {
 	CommitListCallback,

--- a/src/webviews/apps/plus/graph/graph.scss
+++ b/src/webviews/apps/plus/graph/graph.scss
@@ -6,4 +6,4 @@
 
 @import '../../shared/codicons';
 @import '../../shared/utils';
-@import '../../../../../node_modules/@axosoft/gitkraken-components/lib/css/GKGraphStyles.css';
+@import '../../../../../node_modules/@gitkraken/gitkraken-components/lib/css/GKGraphStyles.css';


### PR DESCRIPTION
# Summary of changes
- Updated the import paths used in `GitLens` to consume our components to use `@gitkraken` instead of `@axosoft`.

# Notes
- We need both changes merged:
  - `GitLens` import changes. 
  - `GitKrakenComponents` library. PR: https://github.com/gitkraken/GitKrakenComponents/pull/12

# JIRA task
[GITLENS-271](https://gitkraken.atlassian.net/browse/GITLENS-271)