### PR TITLE
GITLENS-198 Add support for stash nodes to the graph

### DIFF
--- a/src/env/node/git/localGitProvider.ts
+++ b/src/env/node/git/localGitProvider.ts
@@ -3334,7 +3334,7 @@ export class LocalGitProvider implements GitProvider, Disposable {
 						message = `WIP: ${matchSummary}`;
 						summary = wipSummary;
 					} else {
-						message = matchSummary;
+						message = matchSummary.length ? matchSummary : wipSummary;
 						summary = message ? message.split('\n', 1)[0] : wipSummary;
 					}
 				} else {

--- a/src/plus/webviews/graph/graphWebview.ts
+++ b/src/plus/webviews/graph/graphWebview.ts
@@ -273,7 +273,8 @@ export class GraphWebview extends WebviewWithConfigBase<State> {
 		]);
 
 		const log = commitsAndLog?.log;
-		const commits = [...(commitsAndLog?.commits ?? []), ...(stashCommits ?? [])];
+		const filteredStashCommits = filterStashCommits(stashCommits, log);
+		const commits = [...(commitsAndLog?.commits ?? []), ...(filteredStashCommits ?? [])];
 
 		return {
 			repositories: formatRepositories(repositories),
@@ -318,6 +319,21 @@ function getCommitType(commit: GitCommit | GitStashCommit): CommitType {
 
 	// TODO: add other needed commit types for graph
 	return type;
+}
+
+function filterStashCommits(stashCommits: GitStashCommit[] | undefined, log: GitLog | undefined): GitStashCommit[] {
+	if (stashCommits === undefined || log === undefined) {
+		return [];
+	}
+
+	// Filter out stash commits whose parents are not in the log
+	return stashCommits.filter((stashCommit: GitStashCommit): boolean => {
+		if (!stashCommit.parents?.length) {
+			return true;
+		}
+		const parentCommit: GitCommitModel | undefined = log.commits.get(stashCommit.parents[0]);
+		return parentCommit !== undefined;
+	});
 }
 
 function formatRepositories(repositories: Repository[]): GraphRepository[] {

--- a/src/plus/webviews/graph/graphWebview.ts
+++ b/src/plus/webviews/graph/graphWebview.ts
@@ -23,6 +23,7 @@ import {
 	DidChangeCommitsNotificationType,
 	DidChangeConfigNotificationType,
 	DidChangeNotificationType,
+	GitCommitType,
 	GraphColumnConfig,
 	GraphColumnConfigDictionary,
 	GraphCommit,
@@ -305,16 +306,10 @@ function formatCommits(commits: (GitCommit | GitStashCommit)[]): GraphCommit[] {
 	}));
 }
 
-// TODO: Move constant to a better home
-const enum CommitType {
-	CommitNode = 'commit-node',
-	StashNode = 'stash-node',
-}
-
-function getCommitType(commit: GitCommit | GitStashCommit): CommitType {
-	let type: CommitType = CommitType.CommitNode;
-	if (GitCommit.isStash(commit)) {
-		type = CommitType.StashNode;
+function getCommitType(commit: GitCommit | GitStashCommit): GitCommitType {
+	let type = GitCommitType.COMMIT;
+	if (GitCommitModel.isStash(commit)) {
+		type = GitCommitType.STASH;
 	}
 
 	// TODO: add other needed commit types for graph

--- a/src/plus/webviews/graph/graphWebview.ts
+++ b/src/plus/webviews/graph/graphWebview.ts
@@ -1,3 +1,5 @@
+import { CommitType } from '@gitkraken/gitkraken-components/lib/components/graph/GraphContainer';
+import { commitNodeType, stashNodeType } from '@gitkraken/gitkraken-components/lib/domain/commit/CommitConstants';
 import { Disposable, ViewColumn, window } from 'vscode';
 import { configuration } from '../../../configuration';
 import { Commands } from '../../../constants';
@@ -23,7 +25,6 @@ import {
 	DidChangeCommitsNotificationType,
 	DidChangeConfigNotificationType,
 	DidChangeNotificationType,
-	GitCommitType,
 	GraphColumnConfig,
 	GraphColumnConfigDictionary,
 	GraphCommit,
@@ -299,17 +300,17 @@ function formatCommits(commits: (GitCommit | GitStashCommit)[]): GraphCommit[] {
 	return commits.map((commit: GitCommit) => ({
 		sha: commit.sha,
 		author: commit.author,
-		message: emojify(commit.message ?? commit.summary),
+		message: emojify(commit.message && String(commit.message).length ? commit.message : commit.summary),
 		parents: commit.parents,
 		committer: commit.committer,
 		type: getCommitType(commit)
 	}));
 }
 
-function getCommitType(commit: GitCommit | GitStashCommit): GitCommitType {
-	let type = GitCommitType.COMMIT;
-	if (GitCommitModel.isStash(commit)) {
-		type = GitCommitType.STASH;
+function getCommitType(commit: GitCommit | GitStashCommit): CommitType {
+	let type: CommitType = commitNodeType;
+	if (GitCommit.isStash(commit)) {
+		type = stashNodeType;
 	}
 
 	// TODO: add other needed commit types for graph
@@ -326,7 +327,7 @@ function filterStashCommits(stashCommits: GitStashCommit[] | undefined, log: Git
 		if (!stashCommit.parents?.length) {
 			return true;
 		}
-		const parentCommit: GitCommitModel | undefined = log.commits.get(stashCommit.parents[0]);
+		const parentCommit: GitCommit | undefined = log.commits.get(stashCommit.parents[0]);
 		return parentCommit !== undefined;
 	});
 }

--- a/src/plus/webviews/graph/protocol.ts
+++ b/src/plus/webviews/graph/protocol.ts
@@ -25,6 +25,11 @@ export type GraphRemote = Record<string, any>;
 export type GraphTag = Record<string, any>;
 export type GraphBranch = Record<string, any>;
 
+export const enum GitCommitType {
+	COMMIT = 'commit',
+	STASH = 'stash'
+}
+
 export interface GraphColumnConfig {
 	width: number;
 }

--- a/src/plus/webviews/graph/protocol.ts
+++ b/src/plus/webviews/graph/protocol.ts
@@ -25,11 +25,6 @@ export type GraphRemote = Record<string, any>;
 export type GraphTag = Record<string, any>;
 export type GraphBranch = Record<string, any>;
 
-export const enum GitCommitType {
-	COMMIT = 'commit',
-	STASH = 'stash'
-}
-
 export interface GraphColumnConfig {
 	width: number;
 }

--- a/src/webviews/apps/plus/graph/GraphWrapper.tsx
+++ b/src/webviews/apps/plus/graph/GraphWrapper.tsx
@@ -90,7 +90,7 @@ const getGraphModel = (
 			email: gitCommit.author.email,
 			date: new Date(gitCommit.committer.date).getTime(),
 			message: gitCommit.message,
-			type: 'commit-node', // TODO: review logic for stash, wip, etc
+			type: gitCommit.type, // TODO: review logic for stash, wip, etc
 			heads: graphHeads,
 			remotes: graphRemotes,
 			tags: graphTags,

--- a/src/webviews/apps/plus/graph/GraphWrapper.tsx
+++ b/src/webviews/apps/plus/graph/GraphWrapper.tsx
@@ -1,6 +1,4 @@
 import GraphContainer, {
-	COMMIT_NODE_TYPE,
-	CommitType,
 	CssVariables,
 	GraphColumnSetting as GKGraphColumnSetting,
 	GraphColumnsSettings as GKGraphColumnsSettings,
@@ -8,13 +6,11 @@ import GraphContainer, {
 	GraphZoneType,
 	Head,
 	Remote,
-	STASH_NODE_TYPE,
 	Tag,
 } from '@gitkraken/gitkraken-components/lib/components/graph/GraphContainer';
 import React, { ChangeEvent, useEffect, useRef, useState } from 'react';
 import {
 	CommitListCallback,
-	GitCommitType,
 	GraphBranch,
 	GraphColumnConfig,
 	GraphCommit,
@@ -44,18 +40,6 @@ export const getCssVariables = (): CssVariables => {
 		// note that we should probably do something theme-related here, (dark theme we lighten, light theme we darken)
 		'--panel__bg0': computedStyle.getPropertyValue('--color-background--lighten-05'),
 	};
-};
-
-export const mapRowsCommitTypeToLibrary = (graphRows: GraphRow[]): GraphRow[] => {
-	const typeMapping: { [Key in GitCommitType] : CommitType } = {
-		[GitCommitType.COMMIT]: COMMIT_NODE_TYPE,
-		[GitCommitType.STASH]: STASH_NODE_TYPE
-	};
-
-	return graphRows.map((row) => ({
-		...row,
-		type: typeMapping[row.type as GitCommitType] ?? COMMIT_NODE_TYPE
-	}));
 };
 
 const getGraphModel = (
@@ -168,8 +152,6 @@ export function GraphWrapper({
 	const [mainHeight, setMainHeight] = useState<number>();
 	const mainRef = useRef<HTMLElement>(null);
 
-	const graphListMapped: GraphRow[] = mapRowsCommitTypeToLibrary(graphList);
-
 	useEffect(() => {
 		if (mainRef.current === null) {
 			return;
@@ -255,7 +237,7 @@ export function GraphWrapper({
 							<GraphContainer
 								columnsSettings={graphColSettings}
 								cssVariables={getCssVariables()}
-								graphRows={graphListMapped}
+								graphRows={graphList}
 								height={mainHeight}
 								hasMoreCommits={logState?.hasMore}
 								isLoadingRows={isLoading}

--- a/src/webviews/apps/plus/graph/GraphWrapper.tsx
+++ b/src/webviews/apps/plus/graph/GraphWrapper.tsx
@@ -1,4 +1,6 @@
 import GraphContainer, {
+	COMMIT_NODE_TYPE,
+	CommitType,
 	CssVariables,
 	GraphColumnSetting as GKGraphColumnSetting,
 	GraphColumnsSettings as GKGraphColumnsSettings,
@@ -6,11 +8,13 @@ import GraphContainer, {
 	GraphZoneType,
 	Head,
 	Remote,
+	STASH_NODE_TYPE,
 	Tag,
 } from '@gitkraken/gitkraken-components/lib/components/graph/GraphContainer';
 import React, { ChangeEvent, useEffect, useRef, useState } from 'react';
 import {
 	CommitListCallback,
+	GitCommitType,
 	GraphBranch,
 	GraphColumnConfig,
 	GraphCommit,
@@ -40,6 +44,18 @@ export const getCssVariables = (): CssVariables => {
 		// note that we should probably do something theme-related here, (dark theme we lighten, light theme we darken)
 		'--panel__bg0': computedStyle.getPropertyValue('--color-background--lighten-05'),
 	};
+};
+
+export const mapRowsCommitTypeToLibrary = (graphRows: GraphRow[]): GraphRow[] => {
+	const typeMapping: { [Key in GitCommitType] : CommitType } = {
+		[GitCommitType.COMMIT]: COMMIT_NODE_TYPE,
+		[GitCommitType.STASH]: STASH_NODE_TYPE
+	};
+
+	return graphRows.map((row) => ({
+		...row,
+		type: typeMapping[row.type as GitCommitType] ?? COMMIT_NODE_TYPE
+	}));
 };
 
 const getGraphModel = (
@@ -152,6 +168,8 @@ export function GraphWrapper({
 	const [mainHeight, setMainHeight] = useState<number>();
 	const mainRef = useRef<HTMLElement>(null);
 
+	const graphListMapped: GraphRow[] = mapRowsCommitTypeToLibrary(graphList);
+
 	useEffect(() => {
 		if (mainRef.current === null) {
 			return;
@@ -237,7 +255,7 @@ export function GraphWrapper({
 							<GraphContainer
 								columnsSettings={graphColSettings}
 								cssVariables={getCssVariables()}
-								graphRows={graphList}
+								graphRows={graphListMapped}
 								height={mainHeight}
 								hasMoreCommits={logState?.hasMore}
 								isLoadingRows={isLoading}


### PR DESCRIPTION
Addresses GITLENS-198: https://gitkraken.atlassian.net/browse/GITLENS-198

Important notes:
1. Our local git provider regex for forming summary and message of a stash can sometimes generate blank messages and summaries when the summary of the stash from the git log does not include a WIP section or a summary section. For example, on stashes created within GitKraken we often get a description like `On expand-graph-container:`. Running `stashSummaryRegex` on this yields an `onRef` group, but a blank `wip` group and a blank `summary` group which causes `getStash` to yield a blank summery and message for that stash commit. In this case, I updated the logic to default to `WIP on ${onRef}`.
2. The local git provider was not previously parsing or storing the parent of a stash commit. This logic was added to `getStash`.
3. Based on the way we currently load commit rows into the graph, we can have orphaned stashes. These are stashes were the parent commit is not loaded into the graph but the stash commit is. You may notice these stashes in your local test, where the edge goes all the way down to the bottom of the graph. In follow-up work, we need a solution for this. One idea is to check if each stash's parent sha exists in the graph and not load the stash if it doesn't, but I'm open to other suggestions.