### PR TITLE
gitlens-258 graph colors

### DIFF
--- a/package.json
+++ b/package.json
@@ -3010,7 +3010,8 @@
 					"gitlens.graph.columnColors": {
 						"type": "array",
 						"items": {
-							"type": "string"
+							"type": "string",
+							"pattern": "^#(?:[0-9a-fA-F]{3,4}){1,2}$"
 						},
 						"default": ["#15a0bf", "#0669f7", "#8e00c2", "#c517b6", "#d90171", "#cd0101", "#f25d2e", "#f2ca33", "#7bd938", "#2ece9d"],
 						"markdownDescription": "Specifies the colors used for the different columns in the graph",

--- a/package.json
+++ b/package.json
@@ -3006,6 +3006,18 @@
 						"markdownDescription": "Specifies the number of items to show in a each page when paginating a graph list. Use 0 to specify no limit",
 						"scope": "window",
 						"order": 20
+					},
+					"gitlens.graph.columnColors": {
+						"type": "array",
+						"items": {
+							"type": "string"
+						},
+						"default": ["#15a0bf", "#0669f7", "#8e00c2", "#c517b6", "#d90171", "#cd0101", "#f25d2e", "#f2ca33", "#7bd938", "#2ece9d"],
+						"markdownDescription": "Specifies the colors used for the different columns in the graph",
+						"scope": "window",
+						"order": 30,
+						"maxItems": 10,
+						"minItems": 10
 					}
 				}
 			},

--- a/src/config.ts
+++ b/src/config.ts
@@ -391,6 +391,7 @@ export interface GraphColumnConfig {
 export interface GraphConfig {
 	defaultLimit: number;
 	pageLimit: number;
+	columnColors: string[];
 }
 
 export interface CodeLensConfig {

--- a/src/plus/webviews/graph/protocol.ts
+++ b/src/plus/webviews/graph/protocol.ts
@@ -10,6 +10,7 @@ export interface State {
 	branches?: GraphBranch[];
 	log?: GraphLog;
 	nonce?: string;
+	mixedColumnColors?: {[variable: string]: string};
 }
 
 export interface GraphLog {
@@ -37,6 +38,7 @@ export interface GraphConfig {
 	defaultLimit: number;
 	pageLimit: number;
 	columns?: GraphColumnConfigDictionary;
+	columnColors: string[];
 }
 
 export interface CommitListCallback {

--- a/src/webviews/apps/plus/graph/GraphWrapper.tsx
+++ b/src/webviews/apps/plus/graph/GraphWrapper.tsx
@@ -35,11 +35,10 @@ export interface GraphWrapperProps extends State {
 const getCssVariables = (): CssVariables => {
     const body = document.body;
     const computedStyle = window.getComputedStyle(body);
-	const isLightTheme = body.className.includes('vscode-light') || body.className.includes('vscode-high-contrast-light');
 
 	return {
         '--app__bg0': computedStyle.getPropertyValue('--color-background'),
-        '--panel__bg0': isLightTheme ? computedStyle.getPropertyValue('--color-background--darken-05') : computedStyle.getPropertyValue('--color-background--lighten-05'),
+        '--panel__bg0': computedStyle.getPropertyValue('--graph-panel-bg'),
 		'--text-selected': computedStyle.getPropertyValue('--color-foreground'),
 		'--text-normal': computedStyle.getPropertyValue('--color-foreground-85'),
 		'--text-secondary': computedStyle.getPropertyValue('--color-foreground-65'),
@@ -47,21 +46,18 @@ const getCssVariables = (): CssVariables => {
 		'--text-accent': computedStyle.getPropertyValue('--color-link-foreground'),
 		'--text-inverse': computedStyle.getPropertyValue('--vscode-input-background'),
 		'--text-bright': computedStyle.getPropertyValue('--vscode-input-background'),
-		... getGraphColors(computedStyle.getPropertyValue('--color-background')),
+		... getGraphColors(computedStyle),
     };
 };
 
-const getGraphColors = (bgColor: string): CssVariables => {
+const getGraphColors = (computedStyle: CSSStyleDeclaration): CssVariables => {
 	// mixed colors for ref labels (ref label color + graph bg color)
 	// making the ref label color transparent is not an option since ref labels overlap the ref line
 	// and can potentially overlap each other, e.g., when a truncated ref is expanded.
 	const mixedGraphColors: CssVariables = {};
-	const graphColors = [
-		'#15a0bf', '#0669f7', '#8e00c2', '#c517b6', '#d90171', '#cd0101', '#f25d2e', '#f2ca33', '#7bd938', '#2ece9d'
-	];
-	for (let i = 0; i < graphColors.length; i++) {
+	for (let i = 0; i < 10; i++) {
 		for (const mixInt of [15,25,45,50]) {
-			mixedGraphColors[`--graph-color-${i}-bg${mixInt}`] = mix(bgColor, graphColors[i], mixInt / 100).hex();
+			mixedGraphColors[`--graph-color-${i}-bg${mixInt}`] = computedStyle.getPropertyValue(`--graph-color-${i}-bg${mixInt}`);
 		}
 	}
 	return mixedGraphColors;
@@ -263,7 +259,7 @@ export function GraphWrapper({
 						{mainWidth !== undefined && mainHeight !== undefined && (
 							<GraphContainer
 								columnsSettings={graphColSettings}
-								cssVariables={cssVariables()}
+								cssVariables={cssVariables}
 								graphRows={graphList}
 								height={mainHeight}
 								hasMoreCommits={logState?.hasMore}

--- a/src/webviews/apps/plus/graph/GraphWrapper.tsx
+++ b/src/webviews/apps/plus/graph/GraphWrapper.tsx
@@ -32,14 +32,39 @@ export interface GraphWrapperProps extends State {
 // Copied from original pushed code of Miggy E.
 // TODO: review that code as I'm not sure if it is the correct way to do that in Gitlens side.
 // I suppose we need to use the GitLens themes here instead.
-export const getCssVariables = (): CssVariables => {
-	const body = document.body;
-	const computedStyle = window.getComputedStyle(body);
+const getCssVariables = (): CssVariables => {
+    const body = document.body;
+    const computedStyle = window.getComputedStyle(body);
+	const isLightTheme = body.className.includes('vscode-light') || body.className.includes('vscode-high-contrast-light');
+
 	return {
-		'--app__bg0': computedStyle.getPropertyValue('--color-background'),
-		// note that we should probably do something theme-related here, (dark theme we lighten, light theme we darken)
-		'--panel__bg0': computedStyle.getPropertyValue('--color-background--lighten-05'),
-	};
+        '--app__bg0': computedStyle.getPropertyValue('--color-background'),
+        '--panel__bg0': isLightTheme ? computedStyle.getPropertyValue('--color-background--darken-05') : computedStyle.getPropertyValue('--color-background--lighten-05'),
+		'--text-selected': computedStyle.getPropertyValue('--color-foreground'),
+		'--text-normal': computedStyle.getPropertyValue('--color-foreground-85'),
+		'--text-secondary': computedStyle.getPropertyValue('--color-foreground-65'),
+		'--text-disabled': computedStyle.getPropertyValue('--color-foreground-50'),
+		'--text-accent': computedStyle.getPropertyValue('--color-link-foreground'),
+		'--text-inverse': computedStyle.getPropertyValue('--vscode-input-background'),
+		'--text-bright': computedStyle.getPropertyValue('--vscode-input-background'),
+		... getGraphColors(computedStyle.getPropertyValue('--color-background')),
+    };
+};
+
+const getGraphColors = (bgColor: string): CssVariables => {
+	// mixed colors for ref labels (ref label color + graph bg color)
+	// making the ref label color transparent is not an option since ref labels overlap the ref line
+	// and can potentially overlap each other, e.g., when a truncated ref is expanded.
+	const mixedGraphColors: CssVariables = {};
+	const graphColors = [
+		'#15a0bf', '#0669f7', '#8e00c2', '#c517b6', '#d90171', '#cd0101', '#f25d2e', '#f2ca33', '#7bd938', '#2ece9d'
+	];
+	for (let i = 0; i < graphColors.length; i++) {
+		for (const mixInt of [15,25,45,50]) {
+			mixedGraphColors[`--graph-color-${i}-bg${mixInt}`] = mix(bgColor, graphColors[i], mixInt / 100).hex();
+		}
+	}
+	return mixedGraphColors;
 };
 
 const getGraphModel = (

--- a/src/webviews/apps/plus/graph/GraphWrapper.tsx
+++ b/src/webviews/apps/plus/graph/GraphWrapper.tsx
@@ -68,7 +68,7 @@ const getStyleProps = ():{cssVariables: CssVariables, themeOpacityFactor: number
     const computedStyle = window.getComputedStyle(body);
 	return {
 		cssVariables: getCssVariables(),
-		themeOpacityFactor: computedStyle.getPropertyValue('--graph-theme') === 'dark' ? 1 : 0.5,
+		themeOpacityFactor: parseInt(computedStyle.getPropertyValue('--graph-theme-opacity-factor')) || 1,
 	};
 };
 

--- a/src/webviews/apps/plus/graph/GraphWrapper.tsx
+++ b/src/webviews/apps/plus/graph/GraphWrapper.tsx
@@ -146,6 +146,7 @@ export function GraphWrapper({
 	const [graphColSettings, setGraphColSettings] = useState(getGraphColSettingsModel(config));
 	const [logState, setLogState] = useState(log);
 	const [isLoading, setIsLoading] = useState(false);
+	const [cssVariables, setCSSVariables] = useState(getCssVariables());
 	// TODO: application shouldn't know about the graph component's header
 	const graphHeaderOffset = 24;
 	const [mainWidth, setMainWidth] = useState<number>();
@@ -181,6 +182,7 @@ export function GraphWrapper({
 		setGraphColSettings(getGraphColSettingsModel(state.config));
 		setLogState(state.log);
 		setIsLoading(false);
+		setCSSVariables(getCssVariables());
 	}
 
 	useEffect(() => {
@@ -236,7 +238,7 @@ export function GraphWrapper({
 						{mainWidth !== undefined && mainHeight !== undefined && (
 							<GraphContainer
 								columnsSettings={graphColSettings}
-								cssVariables={getCssVariables()}
+								cssVariables={cssVariables()}
 								graphRows={graphList}
 								height={mainHeight}
 								hasMoreCommits={logState?.hasMore}

--- a/src/webviews/apps/plus/graph/GraphWrapper.tsx
+++ b/src/webviews/apps/plus/graph/GraphWrapper.tsx
@@ -51,18 +51,6 @@ const getCssVariables = (mixedColumnColors: CssVariables | undefined): CssVariab
     };
 };
 
-export function getGraphColors(config: GraphConfig | undefined, computedStyle: CSSStyleDeclaration): CssVariables {
-    const bgColor = computedStyle.getPropertyValue('--color-background');
-    const columnColors = ((config?.columnColors) != null) ? config.columnColors : ['#00bcd4', '#ff9800', '#9c27b0', '#2196f3', '#009688', '#ffeb3b', '#ff5722', '#795548'];
-    const mixedGraphColors: CssVariables = {};
-    for (let i = 0; i < columnColors.length; i++) {
-        for (const mixInt of [15,25,45,50]) {
-            mixedGraphColors[`--graph-color-${i}-bg${mixInt}`] = mix(bgColor, columnColors[i], mixInt);
-        }
-    }
-    return mixedGraphColors;
-}
-
 const getStyleProps = (mixedColumnColors: CssVariables | undefined):{cssVariables: CssVariables, themeOpacityFactor: number } => {
 	const body = document.body;
     const computedStyle = window.getComputedStyle(body);

--- a/src/webviews/apps/plus/graph/GraphWrapper.tsx
+++ b/src/webviews/apps/plus/graph/GraphWrapper.tsx
@@ -20,7 +20,6 @@ import {
 	GraphTag,
 	State,
 } from '../../../../plus/webviews/graph/protocol';
-import { mix } from '../../shared/colors';
 
 export interface GraphWrapperProps extends State {
 	nonce?: string;

--- a/src/webviews/apps/plus/graph/GraphWrapper.tsx
+++ b/src/webviews/apps/plus/graph/GraphWrapper.tsx
@@ -63,6 +63,15 @@ const getGraphColors = (computedStyle: CSSStyleDeclaration): CssVariables => {
 	return mixedGraphColors;
 };
 
+const getStyleProps = ():{cssVariables: CssVariables, themeOpacityFactor: number } => {
+	const body = document.body;
+    const computedStyle = window.getComputedStyle(body);
+	return {
+		cssVariables: getCssVariables(),
+		themeOpacityFactor: computedStyle.getPropertyValue('--graph-theme') === 'dark' ? 1 : 0.5,
+	};
+};
+
 const getGraphModel = (
 	gitCommits: GraphCommit[] = [],
 	_gitRemotes: GraphRemote[] = [],
@@ -167,7 +176,7 @@ export function GraphWrapper({
 	const [graphColSettings, setGraphColSettings] = useState(getGraphColSettingsModel(config));
 	const [logState, setLogState] = useState(log);
 	const [isLoading, setIsLoading] = useState(false);
-	const [cssVariables, setCSSVariables] = useState(getCssVariables());
+	const [styleProps, setStyleProps] = useState(getStyleProps());
 	// TODO: application shouldn't know about the graph component's header
 	const graphHeaderOffset = 24;
 	const [mainWidth, setMainWidth] = useState<number>();
@@ -203,7 +212,7 @@ export function GraphWrapper({
 		setGraphColSettings(getGraphColSettingsModel(state.config));
 		setLogState(state.log);
 		setIsLoading(false);
-		setCSSVariables(getCssVariables());
+		setStyleProps(getStyleProps());
 	}
 
 	useEffect(() => {
@@ -259,7 +268,7 @@ export function GraphWrapper({
 						{mainWidth !== undefined && mainHeight !== undefined && (
 							<GraphContainer
 								columnsSettings={graphColSettings}
-								cssVariables={cssVariables}
+								cssVariables={styleProps.cssVariables}
 								graphRows={graphList}
 								height={mainHeight}
 								hasMoreCommits={logState?.hasMore}
@@ -268,6 +277,7 @@ export function GraphWrapper({
 								onColumnResized={handleOnColumnResized}
 								onShowMoreCommitsClicked={handleMoreCommits}
 								width={mainWidth}
+								themeOpacityFactor={styleProps.themeOpacityFactor}
 							/>
 						)}
 					</>

--- a/src/webviews/apps/plus/graph/graph.tsx
+++ b/src/webviews/apps/plus/graph/graph.tsx
@@ -25,6 +25,7 @@ export class GraphApp extends App<State> {
 
 	constructor() {
 		super('GraphApp');
+		this.watchThemeColors();
 	}
 
 	protected override onBind() {
@@ -127,6 +128,12 @@ export class GraphApp extends App<State> {
 		if (this.callback !== undefined) {
 			this.callback(state);
 		}
+	}
+
+	private watchThemeColors() {
+		const observer = new MutationObserver(() => this.refresh(this.state));
+		observer.observe(document.body, { attributes: true, attributeFilter: ['class'] });
+		return observer;
 	}
 }
 

--- a/src/webviews/apps/plus/graph/graph.tsx
+++ b/src/webviews/apps/plus/graph/graph.tsx
@@ -25,7 +25,6 @@ export class GraphApp extends App<State> {
 
 	constructor() {
 		super('GraphApp');
-		this.watchThemeColors();
 	}
 
 	protected override onBind() {
@@ -97,6 +96,12 @@ export class GraphApp extends App<State> {
 		}
 	}
 
+	protected override onThemeUpdated() {
+		console.log('zz theme updated, updating');
+		console.log('zz this', this);
+		this.refresh(this.state);
+	}
+
 	private onColumnChanged(name: string, settings: GraphColumnConfig) {
 		this.sendCommand(ColumnChangeCommandType, {
 			name: name,
@@ -128,12 +133,6 @@ export class GraphApp extends App<State> {
 		if (this.callback !== undefined) {
 			this.callback(state);
 		}
-	}
-
-	private watchThemeColors() {
-		const observer = new MutationObserver(() => this.refresh(this.state));
-		observer.observe(document.body, { attributes: true, attributeFilter: ['class'] });
-		return observer;
 	}
 }
 

--- a/src/webviews/apps/plus/graph/graph.tsx
+++ b/src/webviews/apps/plus/graph/graph.tsx
@@ -97,8 +97,6 @@ export class GraphApp extends App<State> {
 	}
 
 	protected override onThemeUpdated() {
-		console.log('zz theme updated, updating');
-		console.log('zz this', this);
 		this.refresh(this.state);
 	}
 

--- a/src/webviews/apps/plus/graph/graph.tsx
+++ b/src/webviews/apps/plus/graph/graph.tsx
@@ -18,7 +18,7 @@ import {
 import { debounce } from '../../../../system/function';
 import { DidChangeConfigurationNotificationType , onIpc } from '../../../../webviews/protocol';
 import { App } from '../../shared/appBase';
-import { mix } from '../../shared/colors';
+import { mix, opacity } from '../../shared/colors';
 import { GraphWrapper } from './GraphWrapper';
 import './graph.scss';
 
@@ -116,8 +116,13 @@ export class GraphApp extends App<State> {
 		const columnColors = ((config?.columnColors) != null) ? config.columnColors : ['#00bcd4', '#ff9800', '#9c27b0', '#2196f3', '#009688', '#ffeb3b', '#ff5722', '#795548'];
 		const mixedGraphColors: CssVariables = {};
 		for (let i = 0; i < columnColors.length; i++) {
+			mixedGraphColors[`--graph-color-${i}`] = columnColors[i];
+			mixedGraphColors[`--column-${i}-color`] = columnColors[i];
 			for (const mixInt of [15,25,45,50]) {
 				mixedGraphColors[`--graph-color-${i}-bg${mixInt}`] = mix(bgColor, columnColors[i], mixInt);
+			}
+			for (const mixInt of [10,50]) {
+				mixedGraphColors[`--graph-color-${i}-f${mixInt}`] = opacity(columnColors[i], mixInt);
 			}
 		}
 		return mixedGraphColors;

--- a/src/webviews/apps/shared/appBase.ts
+++ b/src/webviews/apps/shared/appBase.ts
@@ -44,7 +44,7 @@ export abstract class App<State = void> {
 		// this.log(`${this.appName}(${this.state ? JSON.stringify(this.state) : ''})`);
 
 		this._api = acquireVsCodeApi();
-		initializeAndWatchThemeColors();
+		initializeAndWatchThemeColors(this.onThemeUpdated?.bind(this));
 
 		requestAnimationFrame(() => {
 			this.log(`${this.appName}.initializing`);
@@ -72,6 +72,7 @@ export abstract class App<State = void> {
 	protected onBind?(): Disposable[];
 	protected onInitialized?(): void;
 	protected onMessageReceived?(e: MessageEvent): void;
+	protected onThemeUpdated?(): void;
 
 	private bindDisposables: Disposable[] | undefined;
 	protected bind() {

--- a/src/webviews/apps/shared/colors.ts
+++ b/src/webviews/apps/shared/colors.ts
@@ -1,3 +1,5 @@
+import {mix as mixColor} from 'chroma-js';
+
 const cssColorRegex =
 	/^(?:(#?)([0-9a-f]{3}|[0-9a-f]{6})|((?:rgb|hsl)a?)\((-?\d+%?)[,\s]+(-?\d+%?)[,\s]+(-?\d+%?)[,\s]*(-?[\d.]+%?)?\))$/i;
 
@@ -28,6 +30,19 @@ export function opacity(color: string, percentage: number) {
 	const [r, g, b, a] = rgba;
 	return `rgba(${r}, ${g}, ${b}, ${a * (percentage / 100)})`;
 }
+
+export function mix(color1: string, color2: string, percentage: number) {
+	const rgba1 = toRgba(color1);
+	const rgba2 = toRgba(color2);
+	if (rgba1 == null || rgba2 == null) return color1;
+	const [r1, g1, b1, a1] = rgba1;
+	const [r2, g2, b2, a2] = rgba2;
+	return `rgba(${mixChannel(r1, r2, percentage)}, ${mixChannel(g1, g2, percentage)}, ${mixChannel(b1, b2, percentage)}, ${mixChannel(a1, a2, percentage)})`;
+}
+
+const mixChannel = (channel1: number, channel2: number, percentage: number) => {
+	return channel1 + ((channel2 - channel1) * percentage) / 100;
+};
 
 export function toRgba(color: string) {
 	color = color.trim();

--- a/src/webviews/apps/shared/colors.ts
+++ b/src/webviews/apps/shared/colors.ts
@@ -1,5 +1,3 @@
-import {mix as mixColor} from 'chroma-js';
-
 const cssColorRegex =
 	/^(?:(#?)([0-9a-f]{3}|[0-9a-f]{6})|((?:rgb|hsl)a?)\((-?\d+%?)[,\s]+(-?\d+%?)[,\s]+(-?\d+%?)[,\s]*(-?[\d.]+%?)?\))$/i;
 

--- a/src/webviews/apps/shared/theme.ts
+++ b/src/webviews/apps/shared/theme.ts
@@ -93,7 +93,7 @@ export function initializeAndWatchThemeColors(callback?: () => void) {
 		const isLightTheme = body.className.includes('vscode-light') || body.className.includes('vscode-high-contrast-light');
 		color = computedStyle.getPropertyValue('--vscode-editor-background').trim();
 		bodyStyle.setProperty('--graph-panel-bg', isLightTheme ? darken(color, 5) : lighten(color, 5));
-		bodyStyle.setProperty('--graph-theme', isLightTheme ? 'light' : 'dark');
+		bodyStyle.setProperty('--graph-theme-opacity-factor', isLightTheme ? '0.5' : '1');
 
 		const graphColors = [
 			'#15a0bf', '#0669f7', '#8e00c2', '#c517b6', '#d90171', '#cd0101', '#f25d2e', '#f2ca33', '#7bd938', '#2ece9d'

--- a/src/webviews/apps/shared/theme.ts
+++ b/src/webviews/apps/shared/theme.ts
@@ -1,7 +1,7 @@
 /*global window document MutationObserver*/
-import { darken, lighten, opacity } from './colors';
+import { darken, lighten, mix, opacity } from './colors';
 
-export function initializeAndWatchThemeColors() {
+export function initializeAndWatchThemeColors(callback?: () => void) {
 	const onColorThemeChanged = () => {
 		const body = document.body;
 		const computedStyle = window.getComputedStyle(body);
@@ -88,9 +88,27 @@ export function initializeAndWatchThemeColors() {
 		bodyStyle.setProperty('--color-hover-foreground', color);
 		color = computedStyle.getPropertyValue('--vscode-editorHoverWidget-statusBarBackground').trim();
 		bodyStyle.setProperty('--color-hover-statusBarBackground', color);
+
+		// graph-specific colors
+		const isLightTheme = body.className.includes('vscode-light') || body.className.includes('vscode-high-contrast-light');
+		color = computedStyle.getPropertyValue('--vscode-editor-background').trim();
+		bodyStyle.setProperty('--graph-panel-bg', isLightTheme ? darken(color, 5) : lighten(color, 5));
+
+		const graphColors = [
+			'#15a0bf', '#0669f7', '#8e00c2', '#c517b6', '#d90171', '#cd0101', '#f25d2e', '#f2ca33', '#7bd938', '#2ece9d'
+		];
+		color = computedStyle.getPropertyValue('--color-background');
+		for (let i = 0; i < graphColors.length; i++) {
+			for (const mixInt of [15,25,45,50]) {
+				bodyStyle.setProperty(`--graph-color-${i}-bg${mixInt}`, mix(color, graphColors[i], mixInt));
+			}
+		}
+
+		callback?.();
 	};
 
 	const observer = new MutationObserver(onColorThemeChanged);
+
 	observer.observe(document.body, { attributes: true, attributeFilter: ['class'] });
 
 	onColorThemeChanged();

--- a/src/webviews/apps/shared/theme.ts
+++ b/src/webviews/apps/shared/theme.ts
@@ -93,6 +93,7 @@ export function initializeAndWatchThemeColors(callback?: () => void) {
 		const isLightTheme = body.className.includes('vscode-light') || body.className.includes('vscode-high-contrast-light');
 		color = computedStyle.getPropertyValue('--vscode-editor-background').trim();
 		bodyStyle.setProperty('--graph-panel-bg', isLightTheme ? darken(color, 5) : lighten(color, 5));
+		bodyStyle.setProperty('--graph-theme', isLightTheme ? 'light' : 'dark');
 
 		const graphColors = [
 			'#15a0bf', '#0669f7', '#8e00c2', '#c517b6', '#d90171', '#cd0101', '#f25d2e', '#f2ca33', '#7bd938', '#2ece9d'

--- a/src/webviews/apps/shared/theme.ts
+++ b/src/webviews/apps/shared/theme.ts
@@ -1,5 +1,5 @@
 /*global window document MutationObserver*/
-import { darken, lighten, mix, opacity } from './colors';
+import { darken, lighten, opacity } from './colors';
 
 export function initializeAndWatchThemeColors(callback?: () => void) {
 	const onColorThemeChanged = () => {
@@ -94,16 +94,6 @@ export function initializeAndWatchThemeColors(callback?: () => void) {
 		color = computedStyle.getPropertyValue('--vscode-editor-background').trim();
 		bodyStyle.setProperty('--graph-panel-bg', isLightTheme ? darken(color, 5) : lighten(color, 5));
 		bodyStyle.setProperty('--graph-theme-opacity-factor', isLightTheme ? '0.5' : '1');
-
-		const graphColors = [
-			'#15a0bf', '#0669f7', '#8e00c2', '#c517b6', '#d90171', '#cd0101', '#f25d2e', '#f2ca33', '#7bd938', '#2ece9d'
-		];
-		color = computedStyle.getPropertyValue('--color-background');
-		for (let i = 0; i < graphColors.length; i++) {
-			for (const mixInt of [15,25,45,50]) {
-				bodyStyle.setProperty(`--graph-color-${i}-bg${mixInt}`, mix(color, graphColors[i], mixInt));
-			}
-		}
 
 		callback?.();
 	};


### PR DESCRIPTION
https://gitkraken.atlassian.net/browse/GITLENS-258
changes:
- add mechanism to update the graph colors when the theme is updated in vscode by using a mutation observer. This might be redundant with the current theme.js mutation observer for the gitlens app, but I think this application of it is different enough that justifies a separate instance
- gets the correct font colors
- calculates graph and ref mixed colors that originally was done in the theme compiler.