### PR TITLE
Closes #1550 - allow force-push for non-HEAD commits and from commit widget

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -36,6 +36,7 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/) and this p
 
 ### Fixed
 
+- Fixes [#1550](https://github.com/gitkraken/vscode-gitlens/issues/1550) - Push button in commit widget does not trigger "Push force" when ALT is pressed.
 - Fixes [#1991](https://github.com/gitkraken/vscode-gitlens/issues/1991) - Git lens status bar entry has an incomprehensible accessibility label
 - Fixes [#2125](https://github.com/gitkraken/vscode-gitlens/issues/2125) - "git log" command in version 12.x is very slow
 - Fixes [#2121](https://github.com/gitkraken/vscode-gitlens/issues/2121) - Typo in GitLens header &mdash; thanks to [PR #2122](https://github.com/gitkraken/vscode-gitlens/pull/2122) by Chase Knowlden ([@ChaseKnowlden](https://github.com/ChaseKnowlden))

--- a/package.json
+++ b/package.json
@@ -8806,7 +8806,8 @@
 				{
 					"command": "gitlens.views.push",
 					"when": "gitlens:hasRemotes && !gitlens:readonly && !gitlens:untrusted && !gitlens:hasVirtualFolders && viewItem =~ /gitlens:commit\\b(?=.*?\\b\\+current\\b)(?=.*?\\b\\+unpublished\\b)(?=.*?\\b\\+HEAD\\b)/",
-					"group": "inline@96"
+					"group": "inline@96",
+					"alt": "gitlens.views.pushWithForce"
 				},
 				{
 					"command": "gitlens.views.pushToCommit",

--- a/src/@types/vscode.git.enums.ts
+++ b/src/@types/vscode.git.enums.ts
@@ -3,6 +3,11 @@
  *  Licensed under the MIT License. See License.txt in the project root for license information.
  *--------------------------------------------------------------------------------------------*/
 
+export const enum ForcePushMode {
+	Force,
+	ForceWithLease
+}
+
 export const enum RefType {
 	Head,
 	RemoteHead,
@@ -67,4 +72,5 @@ export const enum GitErrorCodes {
 	PatchDoesNotApply = 'PatchDoesNotApply',
 	NoPathFound = 'NoPathFound',
 	UnknownPath = 'UnknownPath',
+	EmptyCommitMessage = 'EmptyCommitMessage'
 }

--- a/src/git/gitProvider.ts
+++ b/src/git/gitProvider.ts
@@ -1,5 +1,6 @@
 import { Disposable, Event, Range, TextDocument, Uri, WorkspaceFolder } from 'vscode';
 import type { Commit, InputBox } from '../@types/vscode.git';
+import { ForcePushMode } from '../@types/vscode.git.enums';
 import { Features } from '../features';
 import type { GitUri } from './gitUri';
 import type {
@@ -56,7 +57,7 @@ export interface ScmRepository {
 	readonly inputBox: InputBox;
 
 	getCommit(ref: string): Promise<Commit>;
-	push(remoteName?: string, branchName?: string, setUpstream?: boolean): Promise<void>;
+	push(remoteName?: string, branchName?: string, setUpstream?: boolean, force?: ForcePushMode): Promise<void>;
 }
 
 export interface PagedResult<T> {

--- a/src/git/models/repository.ts
+++ b/src/git/models/repository.ts
@@ -10,6 +10,7 @@ import {
 	workspace,
 	WorkspaceFolder,
 } from 'vscode';
+import { ForcePushMode } from '../../@types/vscode.git.enums';
 import type { CreatePullRequestActionContext } from '../../api/gitlens';
 import { configuration } from '../../configuration';
 import { CoreGitCommands, CoreGitConfiguration, Schemes } from '../../constants';
@@ -772,7 +773,7 @@ export class Repository implements Disposable {
 							this.path,
 						));
 					} else {
-						await repo?.push(branch.getRemoteName(), branch.name);
+						await repo?.push(branch.getRemoteName(), branch.name, undefined, options?.force ? ForcePushMode.ForceWithLease : undefined);
 					}
 				}
 			} else if (options?.reference != null) {
@@ -782,7 +783,7 @@ export class Repository implements Disposable {
 				const branch = await this.getBranch();
 				if (branch == null) return;
 
-				await repo?.push(branch.getRemoteName(), `${options.reference.ref}:${branch.getNameWithoutRemote()}`);
+				await repo?.push(branch.getRemoteName(), `${options.reference.ref}:${branch.getNameWithoutRemote()}`, undefined, options?.force ? ForcePushMode.ForceWithLease : undefined);
 			} else {
 				void (await executeCoreGitCommand(
 					options?.force ? CoreGitCommands.PushForce : CoreGitCommands.Push,


### PR DESCRIPTION
# Description

<!--
Please include a summary of the changes and which issue will be addressed. Please also include relevant motivation and context.
-->
Closes #1550. Force-push was also not working for non-HEAD commits in branches view. To fix these, I had to update [git API from the VS Code repo](https://github.com/microsoft/vscode/blob/main/extensions/git/src/api/git.d.ts) as I needed `force` parameter for `repo.push`.

I was also experiencing 2 exceptions before any of my changes - one for circular reference, another for null pr. I have handled them as well.

# Checklist

<!-- Please check off the following -->

- [x] I have followed the guidelines in the Contributing document
- [x] My changes follow the coding style of this project
- [x] My changes build without any errors or warnings
- [x] My changes have been formatted and linted
- [x] My changes include any required corresponding changes to the documentation (including CHANGELOG.md and README.md)
- [x] My changes have been rebased and squashed to the minimal number (typically 1) of relevant commits
- [x] My changes have a descriptive commit message with a short title, including a `Fixes $XXX -` or `Closes #XXX -` prefix to auto-close the issue that your PR addresses
