### PR TITLE
Fixes #1549 - git fetch for different upstream branch name

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/) and this p
 
 ### Fixed
 
+- Fixes [#1549](https://github.com/gitkraken/vscode-gitlens/issues/1549) - Fetch does not work when local branch name differs from remote branch name
 - Fixes [#2292](https://github.com/gitkraken/vscode-gitlens/issues/2292) - Push button in BranchTrackingStatusNode of non-current branch does not trigger "Push force"
 - Fixes [#1488](https://github.com/gitkraken/vscode-gitlens/issues/1488) - Open Folder History not working with non-English language pack
 - Fixes [#2303](https://github.com/gitkraken/vscode-gitlens/issues/2303) - "Googlesource" gerrit only supports two levels of domain &mdash; thanks to [PR #2304](https://github.com/gitkraken/vscode-gitlens/pull/2304) by Matt Buckley ([@Mattadore](https://github.com/Mattadore))

--- a/src/env/node/git/git.ts
+++ b/src/env/node/git/git.ts
@@ -757,7 +757,12 @@ export class Git {
 					throw ex;
 				}
 			} else {
-				params.push(options.remote, options.branch);
+				params.push(
+					options.remote,
+					options.upstream
+						? `${options.upstream}:refs/remotes/${options.remote}/${options.branch}`
+						: options.branch,
+				);
 			}
 		} else if (options.remote) {
 			params.push(options.remote);


### PR DESCRIPTION
# Description

<!--
Please include a summary of the changes and which issue will be addressed. Please also include relevant motivation and context.
-->
Fixes #1549. Fetch was not working when local branch name differs from remote branch name. This PR fixes that.

# Checklist

<!-- Please check off the following -->

- [x] I have followed the guidelines in the Contributing document
- [x] My changes follow the coding style of this project
- [x] My changes build without any errors or warnings
- [x] My changes have been formatted and linted
- [x] My changes include any required corresponding changes to the documentation (including CHANGELOG.md and README.md)
- [x] My changes have been rebased and squashed to the minimal number (typically 1) of relevant commits
- [x] My changes have a descriptive commit message with a short title, including a `Fixes $XXX -` or `Closes #XXX -` prefix to auto-close the issue that your PR addresses
