### PR TITLE
Uses VS Code as core.editor

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,6 +24,7 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/) and this p
 - Changes SHA terminal links to use the _Commit Details_ view &mdash; closes [#2320](https://github.com/gitkraken/vscode-gitlens/issues/2320)
   - Adds a `gitlens.terminalLinks.showDetailsView` setting to specify whether to show the _Commit Details_ view when clicking on a commit link
 - Changes to uses VS Code as Git's `core.editor` for terminal run commands &mdash; closes [#2134](https://github.com/gitkraken/vscode-gitlens/pull/2134) thanks to [PR #2135](https://github.com/gitkraken/vscode-gitlens/pull/2135) by Nafiur Rahman Khadem ([@ShafinKhadem](https://github.com/ShafinKhadem))
+  - Adds a `gitlens.terminal.overrideGitEditor` setting to specify whether to use VS Code as Git's `core.editor` for Gitlens terminal commands
 
 ### Fixed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,6 +23,7 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/) and this p
 - Changes the _Home_ view to always be available
 - Changes SHA terminal links to use the _Commit Details_ view &mdash; closes [#2320](https://github.com/gitkraken/vscode-gitlens/issues/2320)
   - Adds a `gitlens.terminalLinks.showDetailsView` setting to specify whether to show the _Commit Details_ view when clicking on a commit link
+- Changes to uses VS Code as Git's `core.editor` for terminal run commands &mdash; closes [#2134](https://github.com/gitkraken/vscode-gitlens/pull/2134) thanks to [PR #2135](https://github.com/gitkraken/vscode-gitlens/pull/2135) by Nafiur Rahman Khadem ([@ShafinKhadem](https://github.com/ShafinKhadem))
 
 ### Fixed
 

--- a/package.json
+++ b/package.json
@@ -2692,6 +2692,13 @@
 						"markdownDescription": "Specifies whether to show the _Commit Details_ view when clicking on a commit link in the integrated terminal",
 						"scope": "window",
 						"order": 20
+					},
+					"gitlens.terminal.overrideGitEditor": {
+						"type": "boolean",
+						"default": true,
+						"markdownDescription": "Specifies whether to use VS Code as Git's `core.editor` for Gitlens terminal commands",
+						"scope": "window",
+						"order": 100
 					}
 				}
 			},

--- a/src/commands/git/rebase.ts
+++ b/src/commands/git/rebase.ts
@@ -1,4 +1,3 @@
-import { env } from 'vscode';
 import type { Container } from '../../container';
 import type { GitBranch } from '../../git/models/branch';
 import type { GitLog } from '../../git/models/log';
@@ -7,6 +6,7 @@ import type { Repository } from '../../git/models/repository';
 import { Directive, DirectiveQuickPickItem } from '../../quickpicks/items/directive';
 import { FlagsQuickPickItem } from '../../quickpicks/items/flags';
 import { pluralize } from '../../system/string';
+import { getEditorCommand } from '../../system/utils';
 import type { ViewsWithRepositoryFolders } from '../../views/viewBase';
 import type {
 	AsyncStepResultGenerator,
@@ -85,23 +85,8 @@ export class RebaseGitCommand extends QuickCommand<State> {
 		if (state.flags.includes('--interactive')) {
 			await this.container.rebaseEditor.enableForNextUse();
 
-			let editor;
-			switch (env.appName) {
-				case 'Visual Studio Code - Insiders':
-					editor = 'code-insiders --wait --reuse-window';
-					break;
-				case 'Visual Studio Code - Exploration':
-					editor = 'code-exploration --wait --reuse-window';
-					break;
-				case 'VSCodium':
-					editor = 'codium --wait --reuse-window';
-					break;
-				default:
-					editor = 'code --wait --reuse-window';
-					break;
-			}
-
-			configs = ['-c', `"sequence.editor=${editor}"`, '-c', `"core.editor=${editor}"`];
+			const editor = getEditorCommand();
+			configs = ['-c', `"sequence.editor=${editor}"`];
 		}
 		return state.repo.rebase(configs, ...state.flags, state.reference.ref);
 	}

--- a/src/config.ts
+++ b/src/config.ts
@@ -154,6 +154,9 @@ export interface Config {
 			};
 		};
 	};
+	terminal: {
+		overrideGitEditor: boolean;
+	};
 	terminalLinks: {
 		enabled: boolean;
 		showDetailsView: boolean;

--- a/src/system/utils.ts
+++ b/src/system/utils.ts
@@ -1,5 +1,5 @@
 import type { ColorTheme, TextDocument, TextDocumentShowOptions, TextEditor, Uri } from 'vscode';
-import { ColorThemeKind, ViewColumn, window, workspace } from 'vscode';
+import { ColorThemeKind, env, ViewColumn, window, workspace } from 'vscode';
 import { configuration } from '../configuration';
 import { CoreCommands, ImageMimetypes, Schemes } from '../constants';
 import { isGitUri } from '../git/gitUri';
@@ -178,4 +178,23 @@ export function openWorkspace(
 	return void executeCoreCommand(CoreCommands.OpenFolder, uri, {
 		forceNewWindow: options?.location === OpenWorkspaceLocation.NewWindow,
 	});
+}
+
+export function getEditorCommand() {
+	let editor;
+	switch (env.appName) {
+		case 'Visual Studio Code - Insiders':
+			editor = 'code-insiders --wait --reuse-window';
+			break;
+		case 'Visual Studio Code - Exploration':
+			editor = 'code-exploration --wait --reuse-window';
+			break;
+		case 'VSCodium':
+			editor = 'codium --wait --reuse-window';
+			break;
+		default:
+			editor = 'code --wait --reuse-window';
+			break;
+	}
+	return editor;
 }

--- a/src/terminal.ts
+++ b/src/terminal.ts
@@ -1,5 +1,6 @@
 import type { Disposable, Terminal } from 'vscode';
 import { window } from 'vscode';
+import { configuration } from './configuration';
 import { Container } from './container';
 import { getEditorCommand } from './system/utils';
 
@@ -28,6 +29,8 @@ function ensureTerminal(): Terminal {
 export function runGitCommandInTerminal(command: string, args: string, cwd: string, execute: boolean = false) {
 	const terminal = ensureTerminal();
 	terminal.show(false);
-	const editor = getEditorCommand();
-	terminal.sendText(`git -C "${cwd}" -c "core.editor=${editor}" ${command} ${args}`, execute);
+	const coreEditorConfig = configuration.get('terminal.overrideGitEditor')
+		? `-c "core.editor=${getEditorCommand()}" `
+		: '';
+	terminal.sendText(`git -C "${cwd}" ${coreEditorConfig}${command} ${args}`, execute);
 }

--- a/src/terminal.ts
+++ b/src/terminal.ts
@@ -1,6 +1,7 @@
 import type { Disposable, Terminal } from 'vscode';
 import { window } from 'vscode';
 import { Container } from './container';
+import { getEditorCommand } from './system/utils';
 
 let _terminal: Terminal | undefined;
 let _disposable: Disposable | undefined;
@@ -27,5 +28,6 @@ function ensureTerminal(): Terminal {
 export function runGitCommandInTerminal(command: string, args: string, cwd: string, execute: boolean = false) {
 	const terminal = ensureTerminal();
 	terminal.show(false);
-	terminal.sendText(`git -C ${cwd.includes(' ') ? `"${cwd}"` : cwd} ${command} ${args}`, execute);
+	const editor = getEditorCommand();
+	terminal.sendText(`git -C "${cwd}" -c "core.editor=${editor}" ${command} ${args}`, execute);
 }


### PR DESCRIPTION
# Description

<!--
Please include a summary of the changes and which issue will be addressed. Please also include relevant motivation and context.
-->

Closes #2134.

When using git commands from terminal, one may prefer to use terminal editors to edit commit messages. But when using VS Code, it's better to use VS Code to edit the commit messages. This PR ensures the usage of VS Code as `core.editor` whenever a terminal command is used.

# Checklist

<!-- Please check off the following -->

- [x] I have followed the guidelines in the Contributing document
- [x] My changes follow the coding style of this project
- [x] My changes build without any errors or warnings
- [x] My changes have been formatted and linted
- [x] My changes include any required corresponding changes to the documentation (including CHANGELOG.md and README.md)
- [x] My changes have been rebased and squashed to the minimal number (typically 1) of relevant commits
- [x] My changes have a descriptive commit message with a short title, including a `Fixes $XXX -` or `Closes #XXX -` prefix to auto-close the issue that your PR addresses
