### PR TITLE
Graph: Use default column widths

### DIFF
--- a/src/webviews/apps/plus/graph/GraphWrapper.tsx
+++ b/src/webviews/apps/plus/graph/GraphWrapper.tsx
@@ -126,19 +126,15 @@ const defaultGraphColumnsSettings: GKGraphColumnsSettings = {
 };
 
 const getGraphColSettingsModel = (config?: GraphConfig): GKGraphColumnsSettings => {
-	const columnsSettings: GKGraphColumnsSettings = {};
+	const columnsSettings: GKGraphColumnsSettings = { ...defaultGraphColumnsSettings };
 	if (config?.columns !== undefined) {
-		for (const key of Object.keys(config.columns)) {
-			const width = config.columns[key].width;
-			if (width !== undefined) {
-				columnsSettings[key] = { width: width };
-			}
+		for (const column of Object.keys(config.columns)) {
+			columnsSettings[column] = {
+				width: config.columns[column].width,
+			};
 		}
 	}
-	return {
-		...defaultGraphColumnsSettings,
-		...columnsSettings
-	};
+	return columnsSettings;
 };
 
 type DebouncableFn = (...args: any) => void;

--- a/src/webviews/apps/plus/graph/GraphWrapper.tsx
+++ b/src/webviews/apps/plus/graph/GraphWrapper.tsx
@@ -117,16 +117,28 @@ const getGraphModel = (
 	return graphRows;
 };
 
+const defaultGraphColumnsSettings: GKGraphColumnsSettings = {
+	commitAuthorZone: { width: 110 },
+	commitDateTimeZone: { width: 130 },
+	commitMessageZone: { width: 130 },
+	commitZone: { width: 170 },
+	refZone: { width: 150 }
+};
+
 const getGraphColSettingsModel = (config?: GraphConfig): GKGraphColumnsSettings => {
 	const columnsSettings: GKGraphColumnsSettings = {};
 	if (config?.columns !== undefined) {
 		for (const key of Object.keys(config.columns)) {
-			columnsSettings[key] = {
-				width: config.columns[key].width || 0,
-			};
+			const width = config.columns[key].width;
+			if (width !== undefined) {
+				columnsSettings[key] = { width: width };
+			}
 		}
 	}
-	return columnsSettings;
+	return {
+		...defaultGraphColumnsSettings,
+		...columnsSettings
+	};
 };
 
 type DebouncableFn = (...args: any) => void;


### PR DESCRIPTION
Right now, when users first open their graph, they end up using the minimum column widths since the component sends over widths of 0. In this PR, I set up a default column width size that'll adequately show more information in the graph than the minimum (by default the graph nodes are squashed into a single column).

Future work includes auto-sizing the columns, but seems like this is a good fix for now.

testing:
In order to clear your current storage, you can add this line
`void this.container.storage.deleteWorkspace(WorkspaceStorageKeys.GraphColumns);` to the getConfig function in graphWebview.ts and opened the graph. 

Jira task: https://gitkraken.atlassian.net/browse/GITLENS-298