### PR TITLE
Addition of Work In Progress row

### DIFF
--- a/src/plus/webviews/graph/graphWebview.ts
+++ b/src/plus/webviews/graph/graphWebview.ts
@@ -783,7 +783,7 @@ export class GraphWebview extends WebviewBase<State> {
 		if (!this.isReady || !this.visible) return false;
 
 		return this.notify(DidChangeWorkDirStatsNotificationType, {
-			workDirStats: await this.getWorkDirStats() || {added: 0, deleted: 0, modified: 0 },
+			workDirStats: await this.getWorkDirStats() ?? {added: 0, deleted: 0, modified: 0 },
 		});
 	}
 
@@ -947,11 +947,11 @@ export class GraphWebview extends WebviewBase<State> {
 		}
 
 		const status: GitStatus | undefined = await this.container.git.getStatusForRepo(this.repository.path);
-		const workingTreeStatus = status?.getDiffStatus() || undefined;
+		const workingTreeStatus = status?.getDiffStatus();
 		return {
-			added: workingTreeStatus?.added || 0,
-			deleted: workingTreeStatus?.deleted || 0,
-			modified: workingTreeStatus?.changed || 0,
+			added: workingTreeStatus?.added ?? 0,
+			deleted: workingTreeStatus?.deleted ?? 0,
+			modified: workingTreeStatus?.changed ?? 0,
 		};
 	}
 
@@ -1046,7 +1046,7 @@ export class GraphWebview extends WebviewBase<State> {
 				header: this.getColumnHeaderContext(columns),
 			},
 			nonce: this.cspNonce,
-			dirStats: await this.getWorkDirStats() || {added: 0, deleted: 0, modified: 0 },
+			dirStats: await this.getWorkDirStats() ?? {added: 0, deleted: 0, modified: 0 },
 		};
 	}
 

--- a/src/plus/webviews/graph/graphWebview.ts
+++ b/src/plus/webviews/graph/graphWebview.ts
@@ -1,13 +1,20 @@
 import type {
 	ColorTheme,
 	ConfigurationChangeEvent,
-	Disposable,
 	Event,
 	StatusBarItem,
 	WebviewOptions,
 	WebviewPanelOptions,
 } from 'vscode';
-import { CancellationTokenSource, EventEmitter, MarkdownString, StatusBarAlignment, ViewColumn, window } from 'vscode';
+import {
+	CancellationTokenSource,
+	Disposable,
+	EventEmitter,
+	MarkdownString,
+	StatusBarAlignment,
+	ViewColumn,
+	window,
+} from 'vscode';
 import type { CreatePullRequestActionContext } from '../../../api/gitlens';
 import { getAvatarUri } from '../../../avatars';
 import type {
@@ -33,8 +40,9 @@ import type {
 	GitTagReference,
 } from '../../../git/models/reference';
 import { GitReference, GitRevision } from '../../../git/models/reference';
-import type { Repository, RepositoryChangeEvent } from '../../../git/models/repository';
+import type { Repository, RepositoryChangeEvent, RepositoryFileSystemChangeEvent } from '../../../git/models/repository';
 import { RepositoryChange, RepositoryChangeComparisonMode } from '../../../git/models/repository';
+import type { GitStatus } from '../../../git/models/status';
 import type { GitSearch } from '../../../git/search';
 import { getSearchQueryComparisonKey } from '../../../git/search';
 import { executeActionCommand, executeCommand, executeCoreGitCommand, registerCommand } from '../../../system/command';
@@ -68,6 +76,7 @@ import type {
 	GraphColumnsSettings,
 	GraphComponentConfig,
 	GraphRepository,
+	GraphWorkDirStats,
 	SearchCommitsParams,
 	SearchOpenInViewParams,
 	State,
@@ -83,6 +92,7 @@ import {
 	DidChangeNotificationType,
 	DidChangeSelectionNotificationType,
 	DidChangeSubscriptionNotificationType,
+	DidChangeWorkDirStatsNotificationType,
 	DidEnsureCommitNotificationType,
 	DidSearchCommitsNotificationType,
 	DismissBannerCommandType,
@@ -133,7 +143,11 @@ export class GraphWebview extends WebviewBase<State> {
 		this.resetRepositoryState();
 
 		if (value != null) {
-			this._repositoryEventsDisposable = value.onDidChange(this.onRepositoryChanged, this);
+			this._repositoryEventsDisposable = Disposable.from(
+				value.onDidChange(this.onRepositoryChanged, this),
+				value.startWatchingFileSystem(),
+				value.onDidChangeFileSystem(this.onRepositoryFileSystemChanged, this),
+			);
 		}
 
 		this.updateState();
@@ -619,6 +633,11 @@ export class GraphWebview extends WebviewBase<State> {
 		});
 	}
 
+	private onRepositoryFileSystemChanged(e: RepositoryFileSystemChangeEvent) {
+		if (!(e.repository?.path === this.repository?.path)) return;
+		this.updateWorkDirStats();
+	}
+
 	private onRepositorySelectionChanged(e: UpdateSelectedRepositoryParams) {
 		this.repository = this.container.git.getRepository(e.path);
 	}
@@ -633,6 +652,8 @@ export class GraphWebview extends WebviewBase<State> {
 			if (item.type === GitGraphRowType.Stash) {
 				const stash = await this.repository?.getStash();
 				commit = stash?.commits.get(item.id);
+			} else if (item.type === GitGraphRowType.Working) {
+				commit = await this.repository?.getCommit('0000000000000000000000000000000000000000');
 			} else {
 				commit = await this.repository?.getCommit(item?.id);
 			}
@@ -681,6 +702,24 @@ export class GraphWebview extends WebviewBase<State> {
 		}
 
 		this._notifyDidChangeAvatarsDebounced();
+	}
+
+	private _notifyDidChangeWorkDirStatsDebounced: Deferrable<() => void> | undefined = undefined;
+
+	@debug()
+	private updateWorkDirStats(immediate: boolean = false) {
+		if (!this.isReady || !this.visible) return;
+
+		if (immediate) {
+			void this.notifyDidChangeWorkDirStats();
+			return;
+		}
+
+		if (this._notifyDidChangeWorkDirStatsDebounced == null) {
+			this._notifyDidChangeWorkDirStatsDebounced = debounce(this.notifyDidChangeWorkDirStats.bind(this), 500);
+		}
+
+		this._notifyDidChangeWorkDirStatsDebounced();
 	}
 
 	@debug()
@@ -737,6 +776,15 @@ export class GraphWebview extends WebviewBase<State> {
 			},
 			completionId,
 		);
+	}
+
+	@debug()
+	private async notifyDidChangeWorkDirStats() {
+		if (!this.isReady || !this.visible) return false;
+
+		return this.notify(DidChangeWorkDirStatsNotificationType, {
+			workDirStats: await this.getWorkDirStats() || {added: 0, deleted: 0, modified: 0 },
+		});
 	}
 
 	@debug()
@@ -890,6 +938,23 @@ export class GraphWebview extends WebviewBase<State> {
 		return config;
 	}
 
+	private async getWorkDirStats(): Promise<GraphWorkDirStats | undefined> {
+		if (this.container.git.repositoryCount === 0) return undefined;
+
+		if (this.repository == null) {
+			this.repository = this.container.git.getBestRepositoryOrFirst();
+			if (this.repository == null) return undefined;
+		}
+
+		const status: GitStatus | undefined = await this.container.git.getStatusForRepo(this.repository.path);
+		const workingTreeStatus = status?.getDiffStatus() || undefined;
+		return {
+			added: workingTreeStatus?.added || 0,
+			deleted: workingTreeStatus?.deleted || 0,
+			modified: workingTreeStatus?.changed || 0,
+		};
+	}
+
 	private async getGraphAccess() {
 		let access = await this.container.git.access(PlusFeatures.Graph, this.repository?.path);
 		this._etagSubscription = this.container.subscription.etag;
@@ -981,6 +1046,7 @@ export class GraphWebview extends WebviewBase<State> {
 				header: this.getColumnHeaderContext(columns),
 			},
 			nonce: this.cspNonce,
+			dirStats: await this.getWorkDirStats() || {added: 0, deleted: 0, modified: 0 },
 		};
 	}
 

--- a/src/plus/webviews/graph/protocol.ts
+++ b/src/plus/webviews/graph/protocol.ts
@@ -4,6 +4,7 @@ import type {
 	GraphRow,
 	GraphZoneType,
 	Remote,
+    WorkDirStats,
 } from '@gitkraken/gitkraken-components';
 import type { DateStyle } from '../../../config';
 import type { RepositoryVisibility } from '../../../git/gitProvider';
@@ -32,11 +33,14 @@ export interface State {
 	nonce?: string;
 	previewBanner?: boolean;
 	trialBanner?: boolean;
+	dirStats?: WorkDirStats;
 
 	// Props below are computed in the webview (not passed)
 	mixedColumnColors?: Record<string, string>;
 	searchResults?: DidSearchCommitsParams['results'];
 }
+
+export type GraphWorkDirStats = WorkDirStats;
 
 export interface GraphPaging {
 	startingCursor?: string;
@@ -214,4 +218,11 @@ export interface DidSearchCommitsParams {
 export const DidSearchCommitsNotificationType = new IpcNotificationType<DidSearchCommitsParams>(
 	'graph/didSearch',
 	true,
+);
+
+export interface DidChangeWorkDirStatsParams {
+	workDirStats: WorkDirStats;
+}
+export const DidChangeWorkDirStatsNotificationType = new IpcNotificationType<DidChangeWorkDirStatsParams>(
+	'graph/workDirStats/didChange',
 );

--- a/src/webviews/apps/plus/graph/GraphWrapper.tsx
+++ b/src/webviews/apps/plus/graph/GraphWrapper.tsx
@@ -173,6 +173,7 @@ export function GraphWrapper({
 	searchResults,
 	trialBanner = true,
 	onDismissBanner,
+	dirStats = { added: 0, modified: 0, deleted: 0 },
 }: GraphWrapperProps) {
 	const [graphRows, setGraphRows] = useState(rows);
 	const [graphAvatars, setAvatars] = useState(avatars);
@@ -210,6 +211,8 @@ export function GraphWrapper({
 	);
 	const [hasMoreSearchResults, setHasMoreSearchResults] = useState(searchResults?.paging?.hasMore ?? false);
 	const [selectedRow, setSelectedRow] = useState<GraphRow | undefined>(undefined);
+	// workdir state
+	const [workDirStats, setWorkDirStats] = useState(dirStats);
 
 	useEffect(() => {
 		if (graphRows.length === 0) {
@@ -403,6 +406,7 @@ export function GraphWrapper({
 		setIsLoading(state.loading);
 		setSearchResultIds(state.searchResults != null ? Object.entries(state.searchResults.ids) : undefined);
 		setHasMoreSearchResults(state.searchResults?.paging?.hasMore ?? false);
+		setWorkDirStats(state.dirStats ?? { added: 0, modified: 0, deleted: 0 });
 	}
 
 	useEffect(() => subscriber?.(transformData), []);
@@ -679,6 +683,7 @@ export function GraphWrapper({
 								themeOpacityFactor={styleProps.themeOpacityFactor}
 								useAuthorInitialsForAvatars={!graphConfig?.avatars}
 								width={mainWidth}
+								workDirStats={workDirStats}
 							/>
 						)}
 					</>

--- a/src/webviews/apps/plus/graph/graph.tsx
+++ b/src/webviews/apps/plus/graph/graph.tsx
@@ -20,6 +20,7 @@ import {
 	DidChangeNotificationType,
 	DidChangeSelectionNotificationType,
 	DidChangeSubscriptionNotificationType,
+	DidChangeWorkDirStatsNotificationType,
 	DidEnsureCommitNotificationType,
 	DidSearchCommitsNotificationType,
 	DismissBannerCommandType,
@@ -247,6 +248,13 @@ export class GraphApp extends App<State> {
 						subscription: params.subscription,
 						allowed: params.allowed,
 					});
+					this.refresh(this.state);
+				});
+				break;
+
+			case DidChangeWorkDirStatsNotificationType.method:
+				onIpc(DidChangeWorkDirStatsNotificationType, msg, params => {
+					this.setState({ ...this.state, dirStats: params.workDirStats });
 					this.refresh(this.state);
 				});
 				break;


### PR DESCRIPTION
This PR attaches a "WIP" row to the top of the graph when there are changes in the working directory.

**Note:** To support this, I have utilized `git-ls-files`: https://git-scm.com/docs/git-ls-files/2.9.5

I also generated a new "work dir stats" model which represents the number of added, deleted and modified files.

**Additional notes:**
- We currently aren't sending the work dir stats into the graph as we cannot handle renames just yet. They are incredibly tricky to detect with unstaged files using git and it needs to be thought out more.
- We are using ls-files instead of diff shortstat because git diff does not pick up unstaged stuff by itself (which is a shame, because git diff DOES have rename detection).

