### PR TITLE
Send detached HEAD to graph

### DIFF
--- a/src/env/node/git/localGitProvider.ts
+++ b/src/env/node/git/localGitProvider.ts
@@ -1756,7 +1756,7 @@ export class LocalGitProvider implements GitProvider, Disposable {
 
 				if (commit.tips) {
 					for (let tip of commit.tips.split(', ')) {
-						if (tip === 'refs/stash' || tip === 'HEAD') continue;
+						if (tip === 'refs/stash') continue;
 
 						if (tip.startsWith('tag: ')) {
 							refTags.push({
@@ -1768,8 +1768,8 @@ export class LocalGitProvider implements GitProvider, Disposable {
 							continue;
 						}
 
-						current = tip.startsWith('HEAD -> ');
-						if (current) {
+						current = tip.startsWith('HEAD');
+						if (current && tip !== 'HEAD') {
 							tip = tip.substring(8);
 						}
 


### PR DESCRIPTION
In the local git provider, we skip over HEAD in tips. This causes it not to populate in a commit row's Heads collection and therefore the graph doesn't display it when you're on a detached head. This change causes the detached HEAD to be added as a ref, so it makes it to the graph rows and ultimately is displayed as a local ref in the graph:

![image](https://user-images.githubusercontent.com/67011668/188817932-68e52816-60be-428f-bcd0-56d8b3773dfe.png)

**Note:** In GK Client, we display the detached HEAD as a tag, rather than a local ref. I'm not sure why, but if we wish to do it that way, I can modify the logic here accordingly.  We would need to update the component-side graph logic in that case because Tag types don't include an "isCurrentHeadRef" property.