### PR TITLE
Fixes #614 - remote URL not working for wiki links

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,6 +22,7 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/) and this p
 - Fixes prioritization of multiple PRs associated with the same commit to choose a merged PR over others
 - Fixes Graph not showing account banners when access is not allowed and trial banners were previously dimissed
 - Fixes [#2195](https://github.com/gitkraken/vscode-gitlens/issues/2195) - cannot open new files from commit details
+- Fixes [#614](https://github.com/gitkraken/vscode-gitlens/issues/614) - remote URL not working for wiki links
 
 ## [12.2.2] - 2022-09-06
 

--- a/README.md
+++ b/README.md
@@ -1141,6 +1141,7 @@ A big thanks to the people that have contributed to this project:
 - Andrii Dieiev ([@IllusionMH](https://github.com/IllusionMH)) &mdash; [contributions](https://github.com/gitkraken/vscode-gitlens/commits?author=IllusionMH)
 - egfx-notifications ([@egfx-notifications](https://github.com/egfx-notifications)) &mdash; [contributions](https://github.com/gitkraken/vscode-gitlens/commits?author=egfx-notifications)
 - Segev Finer ([@segevfiner](https://github.com/segevfiner)) &mdash; [contributions](https://github.com/gitkraken/vscode-gitlens/commits?author=segevfiner)
+- Jeffrey Fisher ([@jeffslofish](https://github.com/jeffslofish)) &mdash; [contributions](https://github.com/gitkraken/vscode-gitlens/commits?author=jeffslofish)
 - Cory Forsyth ([@bantic](https://github.com/bantic)) &mdash; [contributions](https://github.com/gitkraken/vscode-gitlens/commits?author=bantic)
 - John Gee ([@shadowspawn](https://github.com/shadowspawn)) &mdash; [contributions](https://github.com/gitkraken/vscode-gitlens/commits?author=shadowspawn)
 - Geoffrey ([@g3offrey](https://github.com/g3offrey)) &mdash; [contributions](https://github.com/gitkraken/vscode-gitlens/commits?author=g3offrey)

--- a/src/git/remotes/github.ts
+++ b/src/git/remotes/github.ts
@@ -312,6 +312,10 @@ export class GitHubRemote extends RichRemoteProvider {
 		return `${this.encodeUrl(`${this.baseUrl}?path=${fileName}`)}${line}`;
 	}
 
+	protected override getUrlForRepository(): string {
+		return this.baseUrl.replace(/.wiki$/, '/wiki');
+	}
+
 	protected async getProviderAccountForCommit(
 		{ accessToken }: AuthenticationSession,
 		ref: string,


### PR DESCRIPTION
# Description

Fixes #614 - remote URL not working for wiki links

This only fixes the remote URL for GitHub wikis. If there are additional providers that use wikis that we want to support then those will need to be added.

# Checklist

<!-- Please check off the following -->

- [x] I have followed the guidelines in the Contributing document
- [x] My changes follow the coding style of this project
- [x] My changes build without any errors or warnings
- [x] My changes have been formatted and linted
- [x] My changes include any required corresponding changes to the documentation (including CHANGELOG.md and README.md)
- [x] My changes have been rebased and squashed to the minimal number (typically 1) of relevant commits
- [x] My changes have a descriptive commit message with a short title, including a `Fixes $XXX -` or `Closes #XXX -` prefix to auto-close the issue that your PR addresses
