### PR TITLE
73 - Graph allow user to toggle some features in settings (Gitlens side)

### DIFF
--- a/package.json
+++ b/package.json
@@ -2106,7 +2106,7 @@
 						"scope": "window",
 						"order": 11
 					},
-					"gitlens.graph.enableGhostRefs": {
+					"gitlens.graph.showGhostRefsOnRowHover": {
 						"type": "boolean",
 						"default": true,
 						"markdownDescription": "Specifies whether to show a ghost ref of the hovered/selected row in the _Commit Graph_",

--- a/package.json
+++ b/package.json
@@ -2106,6 +2106,13 @@
 						"scope": "window",
 						"order": 11
 					},
+					"gitlens.graph.enableGhostRefs": {
+						"type": "boolean",
+						"default": true,
+						"markdownDescription": "Specifies whether to show a ghost ref of the hovered/selected row in the _Commit Graph_",
+						"scope": "window",
+						"order": 12
+					},
 					"gitlens.graph.defaultItemLimit": {
 						"type": "number",
 						"default": 500,

--- a/src/config.ts
+++ b/src/config.ts
@@ -380,6 +380,7 @@ export interface GraphConfig {
 	dateStyle: DateStyle | null;
 	defaultItemLimit: number;
 	highlightRowsOnRefHover: boolean;
+	enableGhostRefs: boolean;
 	pageItemLimit: number;
 	searchItemLimit: number;
 	statusBar: {

--- a/src/config.ts
+++ b/src/config.ts
@@ -380,7 +380,7 @@ export interface GraphConfig {
 	dateStyle: DateStyle | null;
 	defaultItemLimit: number;
 	highlightRowsOnRefHover: boolean;
-	enableGhostRefs: boolean;
+	showGhostRefsOnRowHover: boolean;
 	pageItemLimit: number;
 	searchItemLimit: number;
 	statusBar: {

--- a/src/plus/webviews/graph/graphWebview.ts
+++ b/src/plus/webviews/graph/graphWebview.ts
@@ -359,7 +359,7 @@ export class GraphWebview extends WebviewBase<State> {
 			configuration.changed(e, 'graph.dateFormat') ||
 			configuration.changed(e, 'graph.dateStyle') ||
 			configuration.changed(e, 'graph.highlightRowsOnRefHover') ||
-			configuration.changed(e, 'graph.enableGhostRefs')
+			configuration.changed(e, 'graph.showGhostRefsOnRowHover')
 		) {
 			void this.notifyDidChangeConfiguration();
 		}
@@ -748,7 +748,7 @@ export class GraphWebview extends WebviewBase<State> {
 			dateStyle: configuration.get('graph.dateStyle') ?? configuration.get('defaultDateStyle'),
 			enableMultiSelection: false,
 			highlightRowsOnRefHover: configuration.get('graph.highlightRowsOnRefHover'),
-			enableGhostRefs: configuration.get('graph.enableGhostRefs'),
+			showGhostRefsOnRowHover: configuration.get('graph.showGhostRefsOnRowHover'),
 			shaLength: configuration.get('advanced.abbreviatedShaLength'),
 		};
 		return config;

--- a/src/plus/webviews/graph/graphWebview.ts
+++ b/src/plus/webviews/graph/graphWebview.ts
@@ -358,7 +358,8 @@ export class GraphWebview extends WebviewBase<State> {
 			configuration.changed(e, 'graph.avatars') ||
 			configuration.changed(e, 'graph.dateFormat') ||
 			configuration.changed(e, 'graph.dateStyle') ||
-			configuration.changed(e, 'graph.highlightRowsOnRefHover')
+			configuration.changed(e, 'graph.highlightRowsOnRefHover') ||
+			configuration.changed(e, 'graph.enableGhostRefs')
 		) {
 			void this.notifyDidChangeConfiguration();
 		}
@@ -747,6 +748,7 @@ export class GraphWebview extends WebviewBase<State> {
 			dateStyle: configuration.get('graph.dateStyle') ?? configuration.get('defaultDateStyle'),
 			enableMultiSelection: false,
 			highlightRowsOnRefHover: configuration.get('graph.highlightRowsOnRefHover'),
+			enableGhostRefs: configuration.get('graph.enableGhostRefs'),
 			shaLength: configuration.get('advanced.abbreviatedShaLength'),
 		};
 		return config;

--- a/src/plus/webviews/graph/protocol.ts
+++ b/src/plus/webviews/graph/protocol.ts
@@ -75,6 +75,7 @@ export interface GraphComponentConfig {
 	dateStyle: DateStyle;
 	enableMultiSelection?: boolean;
 	highlightRowsOnRefHover?: boolean;
+	enableGhostRefs?: boolean;
 	shaLength?: number;
 }
 

--- a/src/plus/webviews/graph/protocol.ts
+++ b/src/plus/webviews/graph/protocol.ts
@@ -75,7 +75,7 @@ export interface GraphComponentConfig {
 	dateStyle: DateStyle;
 	enableMultiSelection?: boolean;
 	highlightRowsOnRefHover?: boolean;
-	enableGhostRefs?: boolean;
+	showGhostRefsOnRowHover?: boolean;
 	shaLength?: number;
 }
 

--- a/src/webviews/apps/plus/graph/GraphWrapper.tsx
+++ b/src/webviews/apps/plus/graph/GraphWrapper.tsx
@@ -687,7 +687,7 @@ export function GraphWrapper({
 								height={mainHeight}
 								highlightedShas={searchHighlights}
 								highlightRowsOnRefHover={graphConfig?.highlightRowsOnRefHover}
-								enableGhostRefs={graphConfig?.enableGhostRefs}
+								showGhostRefsOnRowHover={graphConfig?.showGhostRefsOnRowHover}
 								isLoadingRows={isLoading}
 								isSelectedBySha={graphSelectedRows}
 								nonce={nonce}

--- a/src/webviews/apps/plus/graph/GraphWrapper.tsx
+++ b/src/webviews/apps/plus/graph/GraphWrapper.tsx
@@ -686,7 +686,8 @@ export function GraphWrapper({
 								hasMoreCommits={pagingState?.hasMore}
 								height={mainHeight}
 								highlightedShas={searchHighlights}
-								// highlightRowssOnRefHover={graphConfig?.highlightRowsOnRefHover}
+								highlightRowsOnRefHover={graphConfig?.highlightRowsOnRefHover}
+								enableGhostRefs={graphConfig?.enableGhostRefs}
 								isLoadingRows={isLoading}
 								isSelectedBySha={graphSelectedRows}
 								nonce={nonce}

--- a/src/webviews/apps/settings/partials/commit-graph.html
+++ b/src/webviews/apps/settings/partials/commit-graph.html
@@ -78,6 +78,20 @@
 					<div class="setting">
 						<div class="setting__input">
 							<input
+								id="graph.enableGhostRefs"
+								name="graph.enableGhostRefs"
+								type="checkbox"
+								data-setting
+							/>
+							<label for="graph.enableGhostRefs"
+								>Show a ghost ref when hovering/selecting on a commit</label
+							>
+						</div>
+					</div>
+
+					<div class="setting">
+						<div class="setting__input">
+							<input
 								id="graph.dateStyle"
 								name="graph.dateStyle"
 								type="checkbox"

--- a/src/webviews/apps/settings/partials/commit-graph.html
+++ b/src/webviews/apps/settings/partials/commit-graph.html
@@ -78,12 +78,12 @@
 					<div class="setting">
 						<div class="setting__input">
 							<input
-								id="graph.enableGhostRefs"
-								name="graph.enableGhostRefs"
+								id="graph.showGhostRefsOnRowHover"
+								name="graph.showGhostRefsOnRowHover"
 								type="checkbox"
 								data-setting
 							/>
-							<label for="graph.enableGhostRefs"
+							<label for="graph.showGhostRefsOnRowHover"
 								>Show a ghost ref when hovering/selecting on a commit</label
 							>
 						</div>


### PR DESCRIPTION
# Summary of changes:
- Added two new input properties to the `GraphContainer` component:
  - `highlightRowsOnRefHover`: boolean to enable/disable feature to highlight the rows on ref hover.
  - `enableGhostRefs`: boolean to enable/disable feature to show ghost refs when hovering a row.
- Added property `enableGhostRefs` in the gitlens section settings: 

<img width="1212" alt="Captura de pantalla 2022-09-21 a las 15 43 00" src="https://user-images.githubusercontent.com/90025366/191520793-8aaed428-16f9-42c0-bace-5a8ed4370f83.png">

# Notes
- Those changes works with PR: https://github.com/gitkraken/GitKrakenComponents/pull/80 
- I have noticed that once we change a setting in the Gitlens settings page, we have to close and reopen the graph to apply changes. I'm not sure if it's done that way on purpose. 

# Task:
https://github.com/gitkraken/GitKrakenComponents/issues/73