### PR TITLE
2232 - Javascript error when searching for a non-existent commit in the graph webview

### DIFF
--- a/src/webviews/apps/plus/graph/GraphWrapper.tsx
+++ b/src/webviews/apps/plus/graph/GraphWrapper.tsx
@@ -264,7 +264,7 @@ export function GraphWrapper({
 	}, [graphRows]);
 
 	useEffect(() => {
-		if (searchResultIds == null) {
+		if (searchResultIds == null || searchResultIds?.length === 0) {
 			setSearchResultKey(undefined);
 			return;
 		}


### PR DESCRIPTION
# Summary of changes:
- Added condition to take into account missing case when `searchResultIds` array length is 0.

# Task:
https://github.com/gitkraken/vscode-gitlens/issues/2232