### PR TITLE
2235 - REGRESSION: Once we hide columns of the graph using the new context menu, we cannot show them again

### DIFF
--- a/src/webviews/apps/plus/graph/GraphWrapper.tsx
+++ b/src/webviews/apps/plus/graph/GraphWrapper.tsx
@@ -689,7 +689,7 @@ export function GraphWrapper({
 					className="column-button"
 					type="button"
 					role="button"
-					data-vscode-context={JSON.stringify({ webviewItem: 'gitlens:graph:columns' })}
+					data-vscode-context={graphContext?.header || JSON.stringify({ webviewItem: 'gitlens:graph:columns' })}
 					onClick={handleToggleColumnSettings}
 				>
 					<span


### PR DESCRIPTION
# Summary of changes:
- Added the column header context on the column button.

# Task:
https://github.com/gitkraken/vscode-gitlens/issues/2235