### PR TITLE
Send remote ids and handle ref metadata requests when remote connected

### DIFF
--- a/package.json
+++ b/package.json
@@ -12336,7 +12336,7 @@
 		"vscode:prepublish": "yarn run bundle"
 	},
 	"dependencies": {
-		"@gitkraken/gitkraken-components": "1.0.0-rc.20",
+		"@gitkraken/gitkraken-components": "1.0.0-rc.21",
 		"@microsoft/fast-element": "1.10.5",
 		"@microsoft/fast-react-wrapper": "0.3.14",
 		"@octokit/core": "4.0.5",

--- a/package.json
+++ b/package.json
@@ -6431,6 +6431,18 @@
 				"icon": "$(git-pull-request-create)"
 			},
 			{
+				"command": "gitlens.graph.openPullRequestOnRemote",
+				"title": "Open Pull Request on Remote",
+				"category": "GitLens",
+				"icon": "$(globe)"
+			},
+			{
+				"command": "gitlens.graph.copyRemotePullRequestUrl",
+				"title": "Copy Pull Request Url",
+				"category": "GitLens",
+				"icon": "$(copy)"
+			},
+			{
 				"command": "gitlens.graph.columnAuthorOn",
 				"title": "Show Author",
 				"category": "GitLens"
@@ -8372,6 +8384,14 @@
 				},
 				{
 					"command": "gitlens.graph.createPullRequest",
+					"when": "false"
+				},
+				{
+					"command": "gitlens.graph.openPullRequestOnRemote",
+					"when": "false"
+				},
+				{
+					"command": "gitlens.graph.copyRemotePullRequestUrl",
 					"when": "false"
 				},
 				{
@@ -10986,6 +11006,16 @@
 					"command": "gitlens.graph.createBranch",
 					"when": "!gitlens:readonly && !gitlens:untrusted && !gitlens:hasVirtualFolders && webviewItem =~ /gitlens:tag\\b/",
 					"group": "1_gitlens_actions@3"
+				},
+				{
+					"command": "gitlens.graph.openPullRequestOnRemote",
+					"when": "webviewItem =~ /gitlens:graph:pullrequest\\b/",
+					"group": "1_gitlens_actions@1"
+				},
+				{
+					"command": "gitlens.graph.copyRemotePullRequestUrl",
+					"when": "webviewItem =~ /gitlens:graph:pullrequest\\b/",
+					"group": "7_gitlens_cutcopypaste@1"
 				},
 				{
 					"command": "gitlens.graph.columnAuthorOn",

--- a/src/git/models/branch.ts
+++ b/src/git/models/branch.ts
@@ -38,6 +38,10 @@ export interface BranchSortOptions {
 	orderBy?: BranchSorting;
 }
 
+export function getBranchId(repoPath: string, remote: boolean, name: string): string {
+	return `${repoPath}|${remote ? 'remotes/' : 'heads/'}${name}`;
+}
+
 export class GitBranch implements GitBranchReference {
 	readonly refType = 'branch';
 	readonly detached: boolean;
@@ -58,7 +62,7 @@ export class GitBranch implements GitBranchReference {
 		detached: boolean = false,
 		public readonly rebasing: boolean = false,
 	) {
-		this.id = `${repoPath}|${remote ? 'remotes/' : 'heads/'}${name}`;
+		this.id = getBranchId(repoPath, remote, name);
 
 		this.detached = detached || (this.current ? isDetachedHead(name) : false);
 		if (this.detached) {

--- a/src/git/models/graph.ts
+++ b/src/git/models/graph.ts
@@ -1,11 +1,9 @@
-import type { GraphRow, Head, HostingServiceType, RefMetadata, Remote, RowContexts, Tag } from '@gitkraken/gitkraken-components';
+import type { GraphRow, Head, Remote, RowContexts, Tag } from '@gitkraken/gitkraken-components';
 
 export type GitGraphRowHead = Head;
 export type GitGraphRowRemoteHead = Remote;
 export type GitGraphRowTag = Tag;
 export type GitGraphRowContexts = RowContexts;
-export type GitGraphRefMetadata = RefMetadata;
-export type GitGraphHostingServiceType = HostingServiceType;
 export const enum GitGraphRowType {
 	Commit = 'commit-node',
 	MergeCommit = 'merge-node',
@@ -27,8 +25,6 @@ export interface GitGraph {
 	readonly repoPath: string;
 	/** A map of all avatar urls */
 	readonly avatars: Map<string, string>;
-	/** A map of all ref metadata */
-	readonly refMetadata: Map<string, RefMetadata> | undefined;
 	/** A set of all "seen" commit ids */
 	readonly ids: Set<string>;
 	/** A set of all skipped commit ids -- typically for stash index/untracked commits */

--- a/src/git/models/graph.ts
+++ b/src/git/models/graph.ts
@@ -1,9 +1,11 @@
-import type { GraphRow, Head, Remote, RowContexts, Tag } from '@gitkraken/gitkraken-components';
+import type { GraphRow, Head, HostingServiceType, RefMetadata, Remote, RowContexts, Tag } from '@gitkraken/gitkraken-components';
 
 export type GitGraphRowHead = Head;
 export type GitGraphRowRemoteHead = Remote;
 export type GitGraphRowTag = Tag;
 export type GitGraphRowContexts = RowContexts;
+export type GitGraphRefMetadata = RefMetadata;
+export type GitGraphHostingServiceType = HostingServiceType;
 export const enum GitGraphRowType {
 	Commit = 'commit-node',
 	MergeCommit = 'merge-node',
@@ -25,6 +27,8 @@ export interface GitGraph {
 	readonly repoPath: string;
 	/** A map of all avatar urls */
 	readonly avatars: Map<string, string>;
+	/** A map of all ref metadata */
+	readonly refMetadata: Map<string, RefMetadata> | undefined;
 	/** A set of all "seen" commit ids */
 	readonly ids: Set<string>;
 	/** A set of all skipped commit ids -- typically for stash index/untracked commits */

--- a/src/plus/webviews/graph/protocol.ts
+++ b/src/plus/webviews/graph/protocol.ts
@@ -4,7 +4,10 @@ import type {
 	GraphContexts,
 	GraphRow,
 	GraphZoneType,
+	HostingServiceType,
+	PullRequestMetadata,
 	RefMetadata,
+	RefMetadataType,
 	Remote,
 	WorkDirStats,
 } from '@gitkraken/gitkraken-components';
@@ -19,8 +22,13 @@ import { IpcCommandType, IpcNotificationType } from '../../../webviews/protocol'
 export type GraphColumnsSettings = Record<GraphColumnName, GraphColumnSetting>;
 export type GraphSelectedRows = Record</*id*/ string, true>;
 export type GraphAvatars = Record</*email*/ string, /*url*/ string>;
-export type GraphRefMetadata = Record</* id */ string, RefMetadata>;
-export type GraphMissingRefMetadata = Record</*id*/ string, /*missingType*/ string[]>;
+
+export type GraphRefMetadata = RefMetadata | null;
+export type GraphRefsMetadata = Record</* id */ string, GraphRefMetadata>;
+export type GraphHostingServiceType = HostingServiceType;
+export type GraphMissingRefsMetadataType = RefMetadataType;
+export type GraphMissingRefsMetadata = Record</*id*/ string, /*missingType*/ GraphMissingRefsMetadataType[]>;
+export type GraphPullRequestMetadata = PullRequestMetadata;
 
 export interface State {
 	repositories?: GraphRepository[];
@@ -31,7 +39,7 @@ export interface State {
 	allowed: boolean;
 	avatars?: GraphAvatars;
 	loading?: boolean;
-	refMetadata?: GraphRefMetadata;
+	refsMetadata?: GraphRefsMetadata | null;
 	rows?: GraphRow[];
 	paging?: GraphPaging;
 	columns?: GraphColumnsSettings;
@@ -121,10 +129,12 @@ export interface GetMissingAvatarsParams {
 }
 export const GetMissingAvatarsCommandType = new IpcCommandType<GetMissingAvatarsParams>('graph/avatars/get');
 
-export interface GetMissingRefMetadataParams {
-	missing: GraphMissingRefMetadata;
+export interface GetMissingRefsMetadataParams {
+	metadata: GraphMissingRefsMetadata;
 }
-export const GetMissingRefMetadataCommandType = new IpcCommandType<GetMissingRefMetadataParams>('graph/refMetadata/get');
+export const GetMissingRefsMetadataCommandType = new IpcCommandType<GetMissingRefsMetadataParams>(
+	'graph/refs/metadata/get',
+);
 
 export interface GetMoreRowsParams {
 	id?: string;
@@ -185,17 +195,19 @@ export const DidChangeSubscriptionNotificationType = new IpcNotificationType<Did
 );
 
 export interface DidChangeAvatarsParams {
-	avatars: { [email: string]: string };
+	avatars: GraphAvatars;
 }
 export const DidChangeAvatarsNotificationType = new IpcNotificationType<DidChangeAvatarsParams>(
 	'graph/avatars/didChange',
+	true,
 );
 
-export interface DidChangeRefMetadataParams {
-	refMetadata: GraphRefMetadata | undefined;
+export interface DidChangeRefsMetadataParams {
+	metadata: GraphRefsMetadata | null | undefined;
 }
-export const DidChangeRefMetadataNotificationType = new IpcNotificationType<DidChangeRefMetadataParams>(
-	'graph/refMetadata/didChange',
+export const DidChangeRefsMetadataNotificationType = new IpcNotificationType<DidChangeRefsMetadataParams>(
+	'graph/refs/didChangeMetadata',
+	true,
 );
 
 export interface DidChangeColumnsParams {
@@ -211,7 +223,7 @@ export interface DidChangeRowsParams {
 	rows: GraphRow[];
 	avatars: { [email: string]: string };
 	paging?: GraphPaging;
-	refMetadata: GraphRefMetadata | undefined;
+	refsMetadata?: GraphRefsMetadata | null;
 	selectedRows?: GraphSelectedRows;
 }
 export const DidChangeRowsNotificationType = new IpcNotificationType<DidChangeRowsParams>('graph/rows/didChange');

--- a/src/plus/webviews/graph/protocol.ts
+++ b/src/plus/webviews/graph/protocol.ts
@@ -4,6 +4,7 @@ import type {
 	GraphContexts,
 	GraphRow,
 	GraphZoneType,
+	RefMetadata,
 	Remote,
 	WorkDirStats,
 } from '@gitkraken/gitkraken-components';
@@ -18,6 +19,8 @@ import { IpcCommandType, IpcNotificationType } from '../../../webviews/protocol'
 export type GraphColumnsSettings = Record<GraphColumnName, GraphColumnSetting>;
 export type GraphSelectedRows = Record</*id*/ string, true>;
 export type GraphAvatars = Record</*email*/ string, /*url*/ string>;
+export type GraphRefMetadata = Record</* id */ string, RefMetadata>;
+export type GraphMissingRefMetadata = Record</*id*/ string, /*missingType*/ string[]>;
 
 export interface State {
 	repositories?: GraphRepository[];
@@ -28,6 +31,7 @@ export interface State {
 	allowed: boolean;
 	avatars?: GraphAvatars;
 	loading?: boolean;
+	refMetadata?: GraphRefMetadata;
 	rows?: GraphRow[];
 	paging?: GraphPaging;
 	columns?: GraphColumnsSettings;
@@ -117,6 +121,11 @@ export interface GetMissingAvatarsParams {
 }
 export const GetMissingAvatarsCommandType = new IpcCommandType<GetMissingAvatarsParams>('graph/avatars/get');
 
+export interface GetMissingRefMetadataParams {
+	missing: GraphMissingRefMetadata;
+}
+export const GetMissingRefMetadataCommandType = new IpcCommandType<GetMissingRefMetadataParams>('graph/refMetadata/get');
+
 export interface GetMoreRowsParams {
 	id?: string;
 }
@@ -182,6 +191,13 @@ export const DidChangeAvatarsNotificationType = new IpcNotificationType<DidChang
 	'graph/avatars/didChange',
 );
 
+export interface DidChangeRefMetadataParams {
+	refMetadata: GraphRefMetadata | undefined;
+}
+export const DidChangeRefMetadataNotificationType = new IpcNotificationType<DidChangeRefMetadataParams>(
+	'graph/refMetadata/didChange',
+);
+
 export interface DidChangeColumnsParams {
 	columns: GraphColumnsSettings | undefined;
 	context?: string;
@@ -195,6 +211,7 @@ export interface DidChangeRowsParams {
 	rows: GraphRow[];
 	avatars: { [email: string]: string };
 	paging?: GraphPaging;
+	refMetadata: GraphRefMetadata | undefined;
 	selectedRows?: GraphSelectedRows;
 }
 export const DidChangeRowsNotificationType = new IpcNotificationType<DidChangeRowsParams>('graph/rows/didChange');

--- a/src/webviews/apps/plus/graph/GraphWrapper.tsx
+++ b/src/webviews/apps/plus/graph/GraphWrapper.tsx
@@ -30,6 +30,7 @@ import {
 	DidChangeAvatarsNotificationType,
 	DidChangeColumnsNotificationType,
 	DidChangeGraphConfigurationNotificationType,
+	DidChangeRefMetadataNotificationType,
 	DidChangeRowsNotificationType,
 	DidChangeSelectionNotificationType,
 	DidChangeSubscriptionNotificationType,
@@ -52,6 +53,7 @@ export interface GraphWrapperProps {
 	onSelectRepository?: (repository: GraphRepository) => void;
 	onColumnChange?: (name: GraphColumnName, settings: GraphColumnConfig) => void;
 	onMissingAvatars?: (emails: { [email: string]: string }) => void;
+	onMissingRefMetadata?: (missing: { [id: string]: string[] }) => void;
 	onMoreRows?: (id?: string) => void;
 	onSearch?: (search: SearchQuery | undefined, options?: { limit?: number }) => void;
 	onSearchPromise?: (
@@ -132,6 +134,7 @@ export function GraphWrapper({
 	onColumnChange,
 	onEnsureRowPromise,
 	onMissingAvatars,
+	onMissingRefMetadata,
 	onMoreRows,
 	onSearch,
 	onSearchPromise,
@@ -148,6 +151,7 @@ export function GraphWrapper({
 
 	const [rows, setRows] = useState(state.rows ?? []);
 	const [avatars, setAvatars] = useState(state.avatars);
+	const [refMetadata, setRefMetadata] = useState(state.refMetadata);
 	const [repos, setRepos] = useState(state.repositories ?? []);
 	const [repo, setRepo] = useState<GraphRepository | undefined>(
 		repos.find(item => item.path === state.selectedRepository),
@@ -205,6 +209,9 @@ export function GraphWrapper({
 			case DidChangeAvatarsNotificationType:
 				setAvatars(state.avatars);
 				break;
+			case DidChangeRefMetadataNotificationType:
+				setRefMetadata(state.refMetadata);
+				break;
 			case DidChangeColumnsNotificationType:
 				setColumns(state.columns);
 				setContext(state.context);
@@ -213,6 +220,7 @@ export function GraphWrapper({
 				setRows(state.rows ?? []);
 				setSelectedRows(state.selectedRows);
 				setAvatars(state.avatars);
+				setRefMetadata(state.refMetadata);
 				setPagingHasMore(state.paging?.hasMore ?? false);
 				setIsLoading(state.loading);
 				break;
@@ -248,6 +256,7 @@ export function GraphWrapper({
 				setSelectedRows(state.selectedRows);
 				setContext(state.context);
 				setAvatars(state.avatars ?? {});
+				setRefMetadata(state.refMetadata ?? {});
 				setPagingHasMore(state.paging?.hasMore ?? false);
 				setRepos(state.repositories ?? []);
 				setRepo(repos.find(item => item.path === state.selectedRepository));
@@ -435,6 +444,10 @@ export function GraphWrapper({
 
 	const handleMissingAvatars = (emails: { [email: string]: string }) => {
 		onMissingAvatars?.(emails);
+	};
+
+	const handleMissingRefMetadata = (missing: { [id: string]: string[] }) => {
+		onMissingRefMetadata?.(missing);
 	};
 
 	const handleToggleColumnSettings = (event: React.MouseEvent<HTMLButtonElement, globalThis.MouseEvent>) => {
@@ -688,8 +701,10 @@ export function GraphWrapper({
 								onColumnResized={handleOnColumnResized}
 								onSelectGraphRows={handleSelectGraphRows}
 								onEmailsMissingAvatarUrls={handleMissingAvatars}
+								onRefsMissingMetadata={handleMissingRefMetadata}
 								onShowMoreCommits={handleMoreCommits}
 								platform={clientPlatform}
+								refMetadataById={refMetadata}
 								shaLength={graphConfig?.idLength}
 								themeOpacityFactor={styleProps?.themeOpacityFactor}
 								useAuthorInitialsForAvatars={!graphConfig?.avatars}

--- a/src/webviews/apps/plus/graph/GraphWrapper.tsx
+++ b/src/webviews/apps/plus/graph/GraphWrapper.tsx
@@ -16,9 +16,11 @@ import type {
 	DidEnsureRowParams,
 	DidSearchParams,
 	DismissBannerParams,
+	GraphAvatars,
 	GraphColumnConfig,
 	GraphColumnName,
 	GraphComponentConfig,
+	GraphMissingRefsMetadata,
 	GraphRepository,
 	GraphSearchResults,
 	GraphSearchResultsError,
@@ -30,7 +32,7 @@ import {
 	DidChangeAvatarsNotificationType,
 	DidChangeColumnsNotificationType,
 	DidChangeGraphConfigurationNotificationType,
-	DidChangeRefMetadataNotificationType,
+	DidChangeRefsMetadataNotificationType,
 	DidChangeRowsNotificationType,
 	DidChangeSelectionNotificationType,
 	DidChangeSubscriptionNotificationType,
@@ -53,7 +55,7 @@ export interface GraphWrapperProps {
 	onSelectRepository?: (repository: GraphRepository) => void;
 	onColumnChange?: (name: GraphColumnName, settings: GraphColumnConfig) => void;
 	onMissingAvatars?: (emails: { [email: string]: string }) => void;
-	onMissingRefMetadata?: (missing: { [id: string]: string[] }) => void;
+	onMissingRefsMetadata?: (metadata: GraphMissingRefsMetadata) => void;
 	onMoreRows?: (id?: string) => void;
 	onSearch?: (search: SearchQuery | undefined, options?: { limit?: number }) => void;
 	onSearchPromise?: (
@@ -134,7 +136,7 @@ export function GraphWrapper({
 	onColumnChange,
 	onEnsureRowPromise,
 	onMissingAvatars,
-	onMissingRefMetadata,
+	onMissingRefsMetadata,
 	onMoreRows,
 	onSearch,
 	onSearchPromise,
@@ -151,7 +153,7 @@ export function GraphWrapper({
 
 	const [rows, setRows] = useState(state.rows ?? []);
 	const [avatars, setAvatars] = useState(state.avatars);
-	const [refMetadata, setRefMetadata] = useState(state.refMetadata);
+	const [refsMetadata, setRefsMetadata] = useState(state.refsMetadata);
 	const [repos, setRepos] = useState(state.repositories ?? []);
 	const [repo, setRepo] = useState<GraphRepository | undefined>(
 		repos.find(item => item.path === state.selectedRepository),
@@ -209,8 +211,8 @@ export function GraphWrapper({
 			case DidChangeAvatarsNotificationType:
 				setAvatars(state.avatars);
 				break;
-			case DidChangeRefMetadataNotificationType:
-				setRefMetadata(state.refMetadata);
+			case DidChangeRefsMetadataNotificationType:
+				setRefsMetadata(state.refsMetadata);
 				break;
 			case DidChangeColumnsNotificationType:
 				setColumns(state.columns);
@@ -220,7 +222,7 @@ export function GraphWrapper({
 				setRows(state.rows ?? []);
 				setSelectedRows(state.selectedRows);
 				setAvatars(state.avatars);
-				setRefMetadata(state.refMetadata);
+				setRefsMetadata(state.refsMetadata);
 				setPagingHasMore(state.paging?.hasMore ?? false);
 				setIsLoading(state.loading);
 				break;
@@ -256,7 +258,7 @@ export function GraphWrapper({
 				setSelectedRows(state.selectedRows);
 				setContext(state.context);
 				setAvatars(state.avatars ?? {});
-				setRefMetadata(state.refMetadata ?? {});
+				setRefsMetadata(state.refsMetadata);
 				setPagingHasMore(state.paging?.hasMore ?? false);
 				setRepos(state.repositories ?? []);
 				setRepo(repos.find(item => item.path === state.selectedRepository));
@@ -442,12 +444,12 @@ export function GraphWrapper({
 		setRepoExpanded(!repoExpanded);
 	};
 
-	const handleMissingAvatars = (emails: { [email: string]: string }) => {
+	const handleMissingAvatars = (emails: GraphAvatars) => {
 		onMissingAvatars?.(emails);
 	};
 
-	const handleMissingRefMetadata = (missing: { [id: string]: string[] }) => {
-		onMissingRefMetadata?.(missing);
+	const handleMissingRefsMetadata = (metadata: GraphMissingRefsMetadata) => {
+		onMissingRefsMetadata?.(metadata);
 	};
 
 	const handleToggleColumnSettings = (event: React.MouseEvent<HTMLButtonElement, globalThis.MouseEvent>) => {
@@ -701,10 +703,10 @@ export function GraphWrapper({
 								onColumnResized={handleOnColumnResized}
 								onSelectGraphRows={handleSelectGraphRows}
 								onEmailsMissingAvatarUrls={handleMissingAvatars}
-								onRefsMissingMetadata={handleMissingRefMetadata}
+								onRefsMissingMetadata={handleMissingRefsMetadata}
 								onShowMoreCommits={handleMoreCommits}
 								platform={clientPlatform}
-								refMetadataById={refMetadata}
+								refMetadataById={refsMetadata}
 								shaLength={graphConfig?.idLength}
 								themeOpacityFactor={styleProps?.themeOpacityFactor}
 								useAuthorInitialsForAvatars={!graphConfig?.avatars}

--- a/src/webviews/apps/plus/graph/graph.tsx
+++ b/src/webviews/apps/plus/graph/graph.tsx
@@ -18,6 +18,7 @@ import {
 	DidChangeColumnsNotificationType,
 	DidChangeGraphConfigurationNotificationType,
 	DidChangeNotificationType,
+	DidChangeRefMetadataNotificationType,
 	DidChangeRowsNotificationType,
 	DidChangeSelectionNotificationType,
 	DidChangeSubscriptionNotificationType,
@@ -27,6 +28,7 @@ import {
 	DismissBannerCommandType,
 	EnsureRowCommandType,
 	GetMissingAvatarsCommandType,
+	GetMissingRefMetadataCommandType,
 	GetMoreRowsCommandType,
 	SearchCommandType,
 	SearchOpenInViewCommandType,
@@ -85,6 +87,7 @@ export class GraphApp extends App<State> {
 						250,
 					)}
 					onMissingAvatars={(...params) => this.onGetMissingAvatars(...params)}
+					onMissingRefMetadata={(...params) => this.onGetMissingRefMetadata(...params)}
 					onMoreRows={(...params) => this.onGetMoreRows(...params)}
 					onSearch={debounce<GraphApp['onSearch']>((search, options) => this.onSearch(search, options), 250)}
 					onSearchPromise={(...params) => this.onSearchPromise(...params)}
@@ -137,6 +140,13 @@ export class GraphApp extends App<State> {
 						this.state.context.header = undefined;
 					}
 
+					this.setState(this.state, type);
+				});
+				break;
+
+			case DidChangeRefMetadataNotificationType.method:
+				onIpc(DidChangeRefMetadataNotificationType, msg, (params, type) => {
+					this.state.refMetadata = params.refMetadata;
 					this.setState(this.state, type);
 				});
 				break;
@@ -205,6 +215,7 @@ export class GraphApp extends App<State> {
 					}
 
 					this.state.avatars = params.avatars;
+					this.state.refMetadata = params.refMetadata;
 					this.state.rows = rows;
 					this.state.paging = params.paging;
 					if (params.selectedRows != null) {
@@ -363,6 +374,10 @@ export class GraphApp extends App<State> {
 
 	private onGetMissingAvatars(emails: { [email: string]: string }) {
 		this.sendCommand(GetMissingAvatarsCommandType, { emails: emails });
+	}
+
+	private onGetMissingRefMetadata(missing: { [id: string]: string[] }) {
+		this.sendCommand(GetMissingRefMetadataCommandType, { missing: missing });
 	}
 
 	private onGetMoreRows(sha?: string) {

--- a/src/webviews/apps/plus/graph/graph.tsx
+++ b/src/webviews/apps/plus/graph/graph.tsx
@@ -6,8 +6,10 @@ import type { GitGraphRowType } from '../../../../git/models/graph';
 import type { SearchQuery } from '../../../../git/search';
 import type {
 	DismissBannerParams,
+	GraphAvatars,
 	GraphColumnConfig,
 	GraphColumnName,
+	GraphMissingRefsMetadata,
 	GraphRepository,
 	InternalNotificationType,
 	State,
@@ -18,7 +20,7 @@ import {
 	DidChangeColumnsNotificationType,
 	DidChangeGraphConfigurationNotificationType,
 	DidChangeNotificationType,
-	DidChangeRefMetadataNotificationType,
+	DidChangeRefsMetadataNotificationType,
 	DidChangeRowsNotificationType,
 	DidChangeSelectionNotificationType,
 	DidChangeSubscriptionNotificationType,
@@ -28,7 +30,7 @@ import {
 	DismissBannerCommandType,
 	EnsureRowCommandType,
 	GetMissingAvatarsCommandType,
-	GetMissingRefMetadataCommandType,
+	GetMissingRefsMetadataCommandType,
 	GetMoreRowsCommandType,
 	SearchCommandType,
 	SearchOpenInViewCommandType,
@@ -87,7 +89,7 @@ export class GraphApp extends App<State> {
 						250,
 					)}
 					onMissingAvatars={(...params) => this.onGetMissingAvatars(...params)}
-					onMissingRefMetadata={(...params) => this.onGetMissingRefMetadata(...params)}
+					onMissingRefsMetadata={(...params) => this.onGetMissingRefsMetadata(...params)}
 					onMoreRows={(...params) => this.onGetMoreRows(...params)}
 					onSearch={debounce<GraphApp['onSearch']>((search, options) => this.onSearch(search, options), 250)}
 					onSearchPromise={(...params) => this.onSearchPromise(...params)}
@@ -144,9 +146,9 @@ export class GraphApp extends App<State> {
 				});
 				break;
 
-			case DidChangeRefMetadataNotificationType.method:
-				onIpc(DidChangeRefMetadataNotificationType, msg, (params, type) => {
-					this.state.refMetadata = params.refMetadata;
+			case DidChangeRefsMetadataNotificationType.method:
+				onIpc(DidChangeRefsMetadataNotificationType, msg, (params, type) => {
+					this.state.refsMetadata = params.metadata;
 					this.setState(this.state, type);
 				});
 				break;
@@ -215,7 +217,9 @@ export class GraphApp extends App<State> {
 					}
 
 					this.state.avatars = params.avatars;
-					this.state.refMetadata = params.refMetadata;
+					if (params.refsMetadata !== undefined) {
+						this.state.refsMetadata = params.refsMetadata;
+					}
 					this.state.rows = rows;
 					this.state.paging = params.paging;
 					if (params.selectedRows != null) {
@@ -372,12 +376,12 @@ export class GraphApp extends App<State> {
 		});
 	}
 
-	private onGetMissingAvatars(emails: { [email: string]: string }) {
+	private onGetMissingAvatars(emails: GraphAvatars) {
 		this.sendCommand(GetMissingAvatarsCommandType, { emails: emails });
 	}
 
-	private onGetMissingRefMetadata(missing: { [id: string]: string[] }) {
-		this.sendCommand(GetMissingRefMetadataCommandType, { missing: missing });
+	private onGetMissingRefsMetadata(metadata: GraphMissingRefsMetadata) {
+		this.sendCommand(GetMissingRefsMetadataCommandType, { metadata: metadata });
 	}
 
 	private onGetMoreRows(sha?: string) {

--- a/yarn.lock
+++ b/yarn.lock
@@ -85,10 +85,10 @@
   resolved "https://registry.yarnpkg.com/@gar/promisify/-/promisify-1.1.3.tgz#555193ab2e3bb3b6adc3d551c9c030d9e860daf6"
   integrity sha512-k2Ty1JcVojjJFwrg/ThKi2ujJ7XNLYaFGNB/bWT9wGR+oSMJHMa5w+CUq6p/pVrKeNNgA7pCqEcjSnHVoqJQFw==
 
-"@gitkraken/gitkraken-components@1.0.0-rc.20":
-  version "1.0.0-rc.20"
-  resolved "https://registry.yarnpkg.com/@gitkraken/gitkraken-components/-/gitkraken-components-1.0.0-rc.20.tgz#4c8e9da9906966661ce7273588f687f796193bf2"
-  integrity sha512-jYip9x0K4lIfmtGQfRmIEqTV+L3LRIX8HDsdTZf5NuJCKM+KL0KrjlRfa/yIxO1rc5+DpvPsDuQm/zn+ql96PQ==
+"@gitkraken/gitkraken-components@1.0.0-rc.21":
+  version "1.0.0-rc.21"
+  resolved "https://registry.yarnpkg.com/@gitkraken/gitkraken-components/-/gitkraken-components-1.0.0-rc.21.tgz#a6849cd03c2272d534adcc42ff15db4065af8f1d"
+  integrity sha512-2ARXZIXGpOZigUylWFKoF1eemBh8NexZ59x5tTt6Uczfu1OXMwB4XXiqSdiuWMD9TDHS0vqU+DxikZvZW0V1KQ==
   dependencies:
     "@axosoft/react-virtualized" "9.22.3-gitkraken.3"
     classnames "2.2.3"


### PR DESCRIPTION
Sends PR metadata through to the graph in order to show PR icons next to refs when they are applicable.

![image](https://user-images.githubusercontent.com/67011668/194058699-d49f6d8e-7653-4438-addf-913dbecaa184.png)

Uses a dynamic system where an empty object is sent and remotes, when they render, ask for ref metadata. If we find something for them, we send it over. Otherwise, we send `null` indicating that this remote should stop asking for PR metadata.

To see PRs for a remote appear, you must connect to that remote first:

<img width="392" alt="image" src="https://user-images.githubusercontent.com/67011668/194062415-d73809b0-8810-4b28-b781-682bcbe46419.png">
