### PR TITLE
Add and send setting to graph for showing remote names on ref branches

### DIFF
--- a/package.json
+++ b/package.json
@@ -2135,6 +2135,13 @@
 						"scope": "window",
 						"order": 13
 					},
+					"gitlens.graph.showRemoteNamesOnRefs": {
+						"type": "boolean",
+						"default": false,
+						"markdownDescription": "Specifies whether to show remote names on remote branches in the _Commit Graph_",
+						"scope": "window",
+						"order": 14
+					},
 					"gitlens.graph.defaultItemLimit": {
 						"type": "number",
 						"default": 500,

--- a/src/config.ts
+++ b/src/config.ts
@@ -382,6 +382,7 @@ export interface GraphConfig {
 	highlightRowsOnRefHover: boolean;
 	showDetailsView: 'open' | 'selection' | false;
 	showGhostRefsOnRowHover: boolean;
+	showRemoteNamesOnRefs: boolean;
 	pageItemLimit: number;
 	searchItemLimit: number;
 	statusBar: {

--- a/src/plus/webviews/graph/graphWebview.ts
+++ b/src/plus/webviews/graph/graphWebview.ts
@@ -468,7 +468,8 @@ export class GraphWebview extends WebviewBase<State> {
 			configuration.changed(e, 'graph.dateFormat') ||
 			configuration.changed(e, 'graph.dateStyle') ||
 			configuration.changed(e, 'graph.highlightRowsOnRefHover') ||
-			configuration.changed(e, 'graph.showGhostRefsOnRowHover')
+			configuration.changed(e, 'graph.showGhostRefsOnRowHover') ||
+			configuration.changed(e, 'graph.showRemoteNamesOnRefs')
 		) {
 			void this.notifyDidChangeConfiguration();
 		}
@@ -1127,6 +1128,7 @@ export class GraphWebview extends WebviewBase<State> {
 			enableMultiSelection: false,
 			highlightRowsOnRefHover: configuration.get('graph.highlightRowsOnRefHover'),
 			showGhostRefsOnRowHover: configuration.get('graph.showGhostRefsOnRowHover'),
+			showRemoteNamesOnRefs: configuration.get('graph.showRemoteNamesOnRefs'),
 			idLength: configuration.get('advanced.abbreviatedShaLength'),
 		};
 		return config;

--- a/src/plus/webviews/graph/protocol.ts
+++ b/src/plus/webviews/graph/protocol.ts
@@ -96,6 +96,7 @@ export interface GraphComponentConfig {
 	enableMultiSelection?: boolean;
 	highlightRowsOnRefHover?: boolean;
 	showGhostRefsOnRowHover?: boolean;
+	showRemoteNamesOnRefs?: boolean;
 	idLength?: number;
 }
 

--- a/src/webviews/apps/plus/graph/GraphWrapper.tsx
+++ b/src/webviews/apps/plus/graph/GraphWrapper.tsx
@@ -711,6 +711,7 @@ export function GraphWrapper({
 								highlightedShas={searchResults?.ids as GraphContainerProps['highlightedShas']}
 								highlightRowsOnRefHover={graphConfig?.highlightRowsOnRefHover}
 								showGhostRefsOnRowHover={graphConfig?.showGhostRefsOnRowHover}
+								showRemoteNamesOnRefs={graphConfig?.showRemoteNamesOnRefs}
 								isLoadingRows={isLoading}
 								isSelectedBySha={selectedRows}
 								nonce={nonce}

--- a/src/webviews/apps/settings/partials/commit-graph.html
+++ b/src/webviews/apps/settings/partials/commit-graph.html
@@ -116,6 +116,20 @@
 					<div class="setting">
 						<div class="setting__input">
 							<input
+								id="graph.showRemoteNamesOnRefs"
+								name="graph.showRemoteNamesOnRefs"
+								type="checkbox"
+								data-setting
+							/>
+							<label for="graph.showRemoteNamesOnRefs"
+								>Show remote names on remote branches</label
+							>
+						</div>
+					</div>
+
+					<div class="setting">
+						<div class="setting__input">
+							<input
 								id="graph.dateStyle"
 								name="graph.dateStyle"
 								type="checkbox"


### PR DESCRIPTION
Requires component-side PR to merge first: https://github.com/gitkraken/GitKrakenComponents/pull/105

Note: Need to bump library version once that PR and this one are merged.

Adds a setting to show remote names on branches.

With the setting off (default):

![image](https://user-images.githubusercontent.com/67011668/194818885-e23a8f99-4bb6-46fc-a253-5d7ad12d252d.png)

With the setting on:

![image](https://user-images.githubusercontent.com/67011668/194818894-80780014-219b-4230-8cfa-dc5e6552be4f.png)

![image](https://user-images.githubusercontent.com/67011668/194818901-0318bbba-5795-4496-b61f-9a6b5b1ba4d3.png)
