### PR TITLE
Graph: double-click on a ref to check it out (similar to GKC)

### DIFF
--- a/src/plus/webviews/graph/graphWebview.ts
+++ b/src/plus/webviews/graph/graphWebview.ts
@@ -1,3 +1,5 @@
+import type { Head } from '@gitkraken/gitkraken-components';
+import { stringify } from 'json5';
 import type {
 	ColorTheme,
 	ConfigurationChangeEvent,
@@ -567,13 +569,13 @@ export class GraphWebview extends WebviewBase<State> {
 	}
 
 	private onDoubleClickRef(e: DoubleClickedRefParams) {
-		const refContext: string | undefined = (e.ref as any).context;
+		if (e.ref.context) {
+			const item: GraphItemContext = typeof e.ref.context === 'string'
+				? JSON.parse(e.ref.context)
+				: e.ref.context as GraphItemContext;
 
-		if (refContext) {
-			const item: GraphItemContext = JSON.parse(refContext);
-			const { ref } = (item.webviewItemValue as any);
-
-			if ((e.ref as any).isCurrentHead) {
+			const { ref } = item.webviewItemValue as GraphItemRefContextValue;
+			if (e.ref.refType === 'head' && (e.ref as Head).isCurrentHead) {
 				return GitActions.switchTo(ref.repoPath);
 			}
 			return GitActions.switchTo(ref.repoPath, ref);

--- a/src/plus/webviews/graph/graphWebview.ts
+++ b/src/plus/webviews/graph/graphWebview.ts
@@ -101,10 +101,11 @@ import type {
 	SearchOpenInViewParams,
 	SearchParams,
 	State,
+	SwitchToRefParams,
 	UpdateColumnParams,
 	UpdateRefsVisibilityParams,
 	UpdateSelectedRepositoryParams,
-	UpdateSelectionParams,
+	UpdateSelectionParams
 } from './protocol';
 import {
 	DidChangeAvatarsNotificationType,
@@ -126,6 +127,7 @@ import {
 	GetMoreRowsCommandType,
 	SearchCommandType,
 	SearchOpenInViewCommandType,
+	SwitchToRefCommandType,
 	UpdateColumnCommandType,
 	UpdateRefsVisibilityCommandType,
 	UpdateSelectedRepositoryCommandType,
@@ -420,6 +422,9 @@ export class GraphWebview extends WebviewBase<State> {
 			case UpdateRefsVisibilityCommandType.method:
 				onIpc(UpdateRefsVisibilityCommandType, e, params => this.onRefsVisibilityChanged(params));
 				break;
+			case SwitchToRefCommandType.method:
+				onIpc(SwitchToRefCommandType, e, params => this.onSwitchToRef(params));
+				break;
 			case UpdateSelectedRepositoryCommandType.method:
 				onIpc(UpdateSelectedRepositoryCommandType, e, params => this.onSelectedRepositoryChanged(params));
 				break;
@@ -559,6 +564,22 @@ export class GraphWebview extends WebviewBase<State> {
 
 	private onRefsVisibilityChanged(e: UpdateRefsVisibilityParams) {
 		this.updateHiddenRefs(e.refs, e.visible);
+	}
+
+	private onSwitchToRef(e: SwitchToRefParams) {
+		const refContext: string | undefined = (e.ref as any).context;
+
+		if (refContext) {
+			const item: GraphItemContext = JSON.parse(refContext);
+			const { ref } = (item.webviewItemValue as any);
+
+			if ((e.ref as any).isCurrentHead) {
+				return GitActions.switchTo(ref.repoPath);
+			}
+			return GitActions.switchTo(ref.repoPath, ref);
+		}
+
+		return Promise.resolve();
 	}
 
 	@debug()

--- a/src/plus/webviews/graph/graphWebview.ts
+++ b/src/plus/webviews/graph/graphWebview.ts
@@ -81,6 +81,7 @@ import type { SubscriptionChangeEvent } from '../../subscription/subscriptionSer
 import { arePlusFeaturesEnabled, ensurePlusFeaturesEnabled } from '../../subscription/utils';
 import type {
 	DismissBannerParams,
+	DoubleClickedRefParams,
 	EnsureRowParams,
 	GetMissingAvatarsParams,
 	GetMissingRefsMetadataParams,
@@ -101,7 +102,6 @@ import type {
 	SearchOpenInViewParams,
 	SearchParams,
 	State,
-	SwitchToRefParams,
 	UpdateColumnParams,
 	UpdateRefsVisibilityParams,
 	UpdateSelectedRepositoryParams,
@@ -121,13 +121,13 @@ import {
 	DidEnsureRowNotificationType,
 	DidSearchNotificationType,
 	DismissBannerCommandType,
+	DoubleClickedRefCommandType,
 	EnsureRowCommandType,
 	GetMissingAvatarsCommandType,
 	GetMissingRefsMetadataCommandType,
 	GetMoreRowsCommandType,
 	SearchCommandType,
 	SearchOpenInViewCommandType,
-	SwitchToRefCommandType,
 	UpdateColumnCommandType,
 	UpdateRefsVisibilityCommandType,
 	UpdateSelectedRepositoryCommandType,
@@ -422,8 +422,8 @@ export class GraphWebview extends WebviewBase<State> {
 			case UpdateRefsVisibilityCommandType.method:
 				onIpc(UpdateRefsVisibilityCommandType, e, params => this.onRefsVisibilityChanged(params));
 				break;
-			case SwitchToRefCommandType.method:
-				onIpc(SwitchToRefCommandType, e, params => this.onSwitchToRef(params));
+			case DoubleClickedRefCommandType.method:
+				onIpc(DoubleClickedRefCommandType, e, params => this.onDoubleClickRef(params));
 				break;
 			case UpdateSelectedRepositoryCommandType.method:
 				onIpc(UpdateSelectedRepositoryCommandType, e, params => this.onSelectedRepositoryChanged(params));
@@ -566,7 +566,7 @@ export class GraphWebview extends WebviewBase<State> {
 		this.updateHiddenRefs(e.refs, e.visible);
 	}
 
-	private onSwitchToRef(e: SwitchToRefParams) {
+	private onDoubleClickRef(e: DoubleClickedRefParams) {
 		const refContext: string | undefined = (e.ref as any).context;
 
 		if (refContext) {

--- a/src/plus/webviews/graph/protocol.ts
+++ b/src/plus/webviews/graph/protocol.ts
@@ -2,6 +2,7 @@ import type {
 	CssVariables,
 	GraphColumnSetting,
 	GraphContexts,
+	GraphRef,
 	GraphRefOptData,
 	GraphRow,
 	GraphZoneType,
@@ -177,6 +178,11 @@ export interface UpdateRefsVisibilityParams {
 export const UpdateRefsVisibilityCommandType = new IpcCommandType<UpdateRefsVisibilityParams>(
 	'graph/refs/update/visibility',
 );
+
+export interface SwitchToRefParams {
+	ref: GraphRef
+}
+export const SwitchToRefCommandType = new IpcCommandType<SwitchToRefParams>('graph/ref/checkout');
 
 export interface UpdateSelectedRepositoryParams {
 	path: string;

--- a/src/plus/webviews/graph/protocol.ts
+++ b/src/plus/webviews/graph/protocol.ts
@@ -179,10 +179,10 @@ export const UpdateRefsVisibilityCommandType = new IpcCommandType<UpdateRefsVisi
 	'graph/refs/update/visibility',
 );
 
-export interface SwitchToRefParams {
+export interface DoubleClickedRefParams {
 	ref: GraphRef
 }
-export const SwitchToRefCommandType = new IpcCommandType<SwitchToRefParams>('graph/ref/checkout');
+export const DoubleClickedRefCommandType = new IpcCommandType<DoubleClickedRefParams>('graph/ref/doubleclick');
 
 export interface UpdateSelectedRepositoryParams {
 	path: string;

--- a/src/webviews/apps/plus/graph/GraphWrapper.tsx
+++ b/src/webviews/apps/plus/graph/GraphWrapper.tsx
@@ -3,7 +3,9 @@ import type {
 	GraphColumnSetting,
 	GraphContainerProps,
 	GraphPlatform,
-	GraphRefOptData,
+	GraphRef,
+	GraphRefGroup,
+    GraphRefOptData,
 	GraphRow,
 	OnFormatCommitDateTime,
 } from '@gitkraken/gitkraken-components';
@@ -57,6 +59,7 @@ export interface GraphWrapperProps {
 	subscriber: (callback: UpdateStateCallback) => () => void;
 	onSelectRepository?: (repository: GraphRepository) => void;
 	onColumnChange?: (name: GraphColumnName, settings: GraphColumnConfig) => void;
+	onSwitchToRef?: (ref: GraphRef) => void;
 	onMissingAvatars?: (emails: { [email: string]: string }) => void;
 	onMissingRefsMetadata?: (metadata: GraphMissingRefsMetadata) => void;
 	onMoreRows?: (id?: string) => void;
@@ -140,6 +143,7 @@ export function GraphWrapper({
 	state,
 	onSelectRepository,
 	onColumnChange,
+	onSwitchToRef,
 	onEnsureRowPromise,
 	onMissingAvatars,
 	onMissingRefsMetadata,
@@ -506,6 +510,12 @@ export function GraphWrapper({
 		onRefsVisibilityChange?.(refs, visible);
 	};
 
+	const handleOnDoubleClickRef = (event: React.MouseEvent<HTMLButtonElement, globalThis.MouseEvent>, refGroup: GraphRefGroup) => {
+		if (refGroup.length > 0) {
+			onSwitchToRef?.(refGroup[0]);
+		}
+	};
+
 	const handleSelectGraphRows = (rows: GraphRow[]) => {
 		const active = rows[0];
 		const activeKey = active != null ? `${active.sha}|${active.date}` : undefined;
@@ -733,6 +743,7 @@ export function GraphWrapper({
 								isSelectedBySha={selectedRows}
 								nonce={nonce}
 								onColumnResized={handleOnColumnResized}
+								onDoubleClickGraphRef={handleOnDoubleClickRef}
 								onSelectGraphRows={handleSelectGraphRows}
 								onToggleRefsVisibilityClick={handleOnToggleRefsVisibilityClick}
 								onEmailsMissingAvatarUrls={handleMissingAvatars}

--- a/src/webviews/apps/plus/graph/GraphWrapper.tsx
+++ b/src/webviews/apps/plus/graph/GraphWrapper.tsx
@@ -59,7 +59,7 @@ export interface GraphWrapperProps {
 	subscriber: (callback: UpdateStateCallback) => () => void;
 	onSelectRepository?: (repository: GraphRepository) => void;
 	onColumnChange?: (name: GraphColumnName, settings: GraphColumnConfig) => void;
-	onSwitchToRef?: (ref: GraphRef) => void;
+	onDoubleClickRef?: (ref: GraphRef) => void;
 	onMissingAvatars?: (emails: { [email: string]: string }) => void;
 	onMissingRefsMetadata?: (metadata: GraphMissingRefsMetadata) => void;
 	onMoreRows?: (id?: string) => void;
@@ -143,7 +143,7 @@ export function GraphWrapper({
 	state,
 	onSelectRepository,
 	onColumnChange,
-	onSwitchToRef,
+	onDoubleClickRef,
 	onEnsureRowPromise,
 	onMissingAvatars,
 	onMissingRefsMetadata,
@@ -512,7 +512,7 @@ export function GraphWrapper({
 
 	const handleOnDoubleClickRef = (event: React.MouseEvent<HTMLButtonElement, globalThis.MouseEvent>, refGroup: GraphRefGroup) => {
 		if (refGroup.length > 0) {
-			onSwitchToRef?.(refGroup[0]);
+			onDoubleClickRef?.(refGroup[0]);
 		}
 	};
 

--- a/src/webviews/apps/plus/graph/graph.tsx
+++ b/src/webviews/apps/plus/graph/graph.tsx
@@ -1,5 +1,5 @@
 /*global document window*/
-import type { CssVariables, GraphRow } from '@gitkraken/gitkraken-components';
+import type { CssVariables, GraphRef, GraphRow } from '@gitkraken/gitkraken-components';
 import React from 'react';
 import { render, unmountComponentAtNode } from 'react-dom';
 import type { GitGraphRowType } from '../../../../git/models/graph';
@@ -14,7 +14,7 @@ import type {
 	GraphRepository,
 	InternalNotificationType,
 	State,
-	UpdateStateCallback,
+	UpdateStateCallback
 } from '../../../../plus/webviews/graph/protocol';
 import {
 	DidChangeAvatarsNotificationType,
@@ -36,6 +36,7 @@ import {
 	GetMoreRowsCommandType,
 	SearchCommandType,
 	SearchOpenInViewCommandType,
+	SwitchToRefCommandType,
 	UpdateColumnCommandType,
 	UpdateRefsVisibilityCommandType,
 	UpdateSelectedRepositoryCommandType as UpdateRepositorySelectionCommandType,
@@ -94,6 +95,7 @@ export class GraphApp extends App<State> {
 						path => this.onRepositorySelectionChanged(path),
 						250,
 					)}
+					onSwitchToRef={(ref) => this.onSwitchToRef(ref)}
 					onMissingAvatars={(...params) => this.onGetMissingAvatars(...params)}
 					onMissingRefsMetadata={(...params) => this.onGetMissingRefsMetadata(...params)}
 					onMoreRows={(...params) => this.onGetMoreRows(...params)}
@@ -387,6 +389,12 @@ export class GraphApp extends App<State> {
 		this.sendCommand(UpdateRefsVisibilityCommandType, {
 			refs: refs,
 			visible: visible,
+		});
+	}
+
+	private onSwitchToRef(ref: GraphRef) {
+		this.sendCommand(SwitchToRefCommandType, {
+			ref: ref,
 		});
 	}
 

--- a/src/webviews/apps/plus/graph/graph.tsx
+++ b/src/webviews/apps/plus/graph/graph.tsx
@@ -30,13 +30,13 @@ import {
 	DidEnsureRowNotificationType,
 	DidSearchNotificationType,
 	DismissBannerCommandType,
+	DoubleClickedRefCommandType,
 	EnsureRowCommandType,
 	GetMissingAvatarsCommandType,
 	GetMissingRefsMetadataCommandType,
 	GetMoreRowsCommandType,
 	SearchCommandType,
 	SearchOpenInViewCommandType,
-	SwitchToRefCommandType,
 	UpdateColumnCommandType,
 	UpdateRefsVisibilityCommandType,
 	UpdateSelectedRepositoryCommandType as UpdateRepositorySelectionCommandType,
@@ -95,7 +95,7 @@ export class GraphApp extends App<State> {
 						path => this.onRepositorySelectionChanged(path),
 						250,
 					)}
-					onSwitchToRef={(ref) => this.onSwitchToRef(ref)}
+					onDoubleClickRef={(ref) => this.onDoubleClickRef(ref)}
 					onMissingAvatars={(...params) => this.onGetMissingAvatars(...params)}
 					onMissingRefsMetadata={(...params) => this.onGetMissingRefsMetadata(...params)}
 					onMoreRows={(...params) => this.onGetMoreRows(...params)}
@@ -392,8 +392,8 @@ export class GraphApp extends App<State> {
 		});
 	}
 
-	private onSwitchToRef(ref: GraphRef) {
-		this.sendCommand(SwitchToRefCommandType, {
+	private onDoubleClickRef(ref: GraphRef) {
+		this.sendCommand(DoubleClickedRefCommandType, {
 			ref: ref,
 		});
 	}


### PR DESCRIPTION
# Summary of changes
- Used the `onDoubleClickGraphRef` input event property of the Graph component to do the check out of the branch.

https://user-images.githubusercontent.com/90025366/194901856-ec889122-34e9-42bf-9675-096ca55a45e4.mov

