### PR TITLE
88 - Graph Styling Issue: Ref icons jump on hover

### DIFF
--- a/src/webviews/apps/plus/graph/graph.scss
+++ b/src/webviews/apps/plus/graph/graph.scss
@@ -351,7 +351,8 @@ a {
 
 // TODO: move this to host-side
 .graph-icon {
-	font: normal normal normal 14px/1 codicon;
+	font: normal normal normal 1.3rem codicon;
+	padding: 0.3em 0 0.3em 0;
 	display: inline-block;
 	text-decoration: none;
 	text-rendering: auto;
@@ -363,7 +364,7 @@ a {
 	-ms-user-select: none;
 
 	vertical-align: middle;
-	line-height: 2rem;
+	line-height: 1.4rem;
 	letter-spacing: normal;
 }
 


### PR DESCRIPTION
# Summary of changes
- It seems that it was happening when the Gitlens trial panel was displayed. 
- Adjusted graph icon class of Gitlens.

# Task
https://github.com/gitkraken/GitKrakenComponents/issues/88