### PR TITLE
116 - Remove "height" and "width" input properties of the "GraphContainer" (Gitlens side)

### DIFF
--- a/src/webviews/apps/plus/graph/GraphWrapper.tsx
+++ b/src/webviews/apps/plus/graph/GraphWrapper.tsx
@@ -10,7 +10,7 @@ import type {
 	OnFormatCommitDateTime,
 } from '@gitkraken/gitkraken-components';
 import type { ReactElement } from 'react';
-import React, { createElement, useEffect, useLayoutEffect, useMemo, useRef, useState } from 'react';
+import React, { createElement, useEffect, useMemo, useRef, useState } from 'react';
 import { getPlatform } from '@env/platform';
 import { DateStyle } from '../../../../config';
 import { RepositoryVisibility } from '../../../../git/gitProvider';
@@ -79,18 +79,6 @@ const getGraphDateFormatter = (config?: GraphComponentConfig): OnFormatCommitDat
 	return (commitDateTime: number) => formatCommitDateTime(commitDateTime, config?.dateStyle, config?.dateFormat);
 };
 
-type DebouncableFn = (...args: any) => void;
-type DebouncedFn = (...args: any) => void;
-const debounceFrame = (func: DebouncableFn): DebouncedFn => {
-	let timer: number;
-	return function (...args: any) {
-		if (timer) cancelAnimationFrame(timer);
-		timer = requestAnimationFrame(() => {
-			func(...args);
-		});
-	};
-};
-
 const createIconElements = (): { [key: string]: ReactElement<any> } => {
 	const iconList = [
 		'head',
@@ -155,10 +143,6 @@ export function GraphWrapper({
 	onSelectionChange,
 	onDismissBanner,
 }: GraphWrapperProps) {
-	// TODO: application shouldn't know about the graph component's header
-	const graphHeaderOffset = 24;
-	const [mainWidth, setMainWidth] = useState<number>();
-	const [mainHeight, setMainHeight] = useState<number>();
 	const mainRef = useRef<HTMLElement>(null);
 	const graphRef = useRef<GraphContainer>(null);
 
@@ -294,22 +278,6 @@ export function GraphWrapper({
 	}
 
 	useEffect(() => subscriber?.(updateState), []);
-
-	useLayoutEffect(() => {
-		if (mainRef.current === null) return;
-
-		const setDimensionsDebounced = debounceFrame((width, height) => {
-			setMainWidth(Math.floor(width));
-			setMainHeight(Math.floor(height) - graphHeaderOffset);
-		});
-
-		const resizeObserver = new ResizeObserver(entries =>
-			entries.forEach(e => setDimensionsDebounced(e.contentRect.width, e.contentRect.height)),
-		);
-		resizeObserver.observe(mainRef.current);
-
-		return () => resizeObserver.disconnect();
-	}, [mainRef]);
 
 	const searchPosition: number = useMemo(() => {
 		if (searchResults?.ids == null || !searchQuery?.query) return 0;
@@ -734,44 +702,40 @@ export function GraphWrapper({
 				{!isAccessAllowed && <div className="graph-app__cover"></div>}
 				{repo !== undefined ? (
 					<>
-						{mainWidth !== undefined && mainHeight !== undefined && (
-							<GraphContainer
-								ref={graphRef}
-								avatarUrlByEmail={avatars}
-								columnsSettings={columns}
-								contexts={context}
-								cssVariables={styleProps?.cssVariables}
-								enableMultiSelection={graphConfig?.enableMultiSelection}
-								formatCommitDateTime={getGraphDateFormatter(graphConfig)}
-								getExternalIcon={getIconElementLibrary}
-								graphRows={rows}
-								hasMoreCommits={pagingHasMore}
-								height={mainHeight}
-								// Just cast the { [id: string]: number } object to { [id: string]: boolean } for performance
-								highlightedShas={searchResults?.ids as GraphContainerProps['highlightedShas']}
-								highlightRowsOnRefHover={graphConfig?.highlightRowsOnRefHover}
-								hiddenRefsById={hiddenRefsById}
-								showGhostRefsOnRowHover={graphConfig?.showGhostRefsOnRowHover}
-								showRemoteNamesOnRefs={graphConfig?.showRemoteNamesOnRefs}
-								isLoadingRows={isLoading}
-								isSelectedBySha={selectedRows}
-								nonce={nonce}
-								onColumnResized={handleOnColumnResized}
-								onDoubleClickGraphRef={handleOnDoubleClickRef}
-								onSelectGraphRows={handleSelectGraphRows}
-								onToggleRefsVisibilityClick={handleOnToggleRefsVisibilityClick}
-								onEmailsMissingAvatarUrls={handleMissingAvatars}
-								onRefsMissingMetadata={handleMissingRefsMetadata}
-								onShowMoreCommits={handleMoreCommits}
-								platform={clientPlatform}
-								refMetadataById={refsMetadata}
-								shaLength={graphConfig?.idLength}
-								themeOpacityFactor={styleProps?.themeOpacityFactor}
-								useAuthorInitialsForAvatars={!graphConfig?.avatars}
-								width={mainWidth}
-								workDirStats={workingTreeStats}
-							/>
-						)}
+						<GraphContainer
+							ref={graphRef}
+							avatarUrlByEmail={avatars}
+							columnsSettings={columns}
+							contexts={context}
+							cssVariables={styleProps?.cssVariables}
+							enableMultiSelection={graphConfig?.enableMultiSelection}
+							formatCommitDateTime={getGraphDateFormatter(graphConfig)}
+							getExternalIcon={getIconElementLibrary}
+							graphRows={rows}
+							hasMoreCommits={pagingHasMore}
+							// Just cast the { [id: string]: number } object to { [id: string]: boolean } for performance
+							highlightedShas={searchResults?.ids as GraphContainerProps['highlightedShas']}
+							highlightRowsOnRefHover={graphConfig?.highlightRowsOnRefHover}
+							hiddenRefsById={hiddenRefsById}
+							showGhostRefsOnRowHover={graphConfig?.showGhostRefsOnRowHover}
+							showRemoteNamesOnRefs={graphConfig?.showRemoteNamesOnRefs}
+							isLoadingRows={isLoading}
+							isSelectedBySha={selectedRows}
+							nonce={nonce}
+							onColumnResized={handleOnColumnResized}
+							onDoubleClickGraphRef={handleOnDoubleClickRef}
+							onSelectGraphRows={handleSelectGraphRows}
+							onToggleRefsVisibilityClick={handleOnToggleRefsVisibilityClick}
+							onEmailsMissingAvatarUrls={handleMissingAvatars}
+							onRefsMissingMetadata={handleMissingRefsMetadata}
+							onShowMoreCommits={handleMoreCommits}
+							platform={clientPlatform}
+							refMetadataById={refsMetadata}
+							shaLength={graphConfig?.idLength}
+							themeOpacityFactor={styleProps?.themeOpacityFactor}
+							useAuthorInitialsForAvatars={!graphConfig?.avatars}
+							workDirStats={workingTreeStats}
+						/>
 					</>
 				) : (
 					<p>No repository is selected</p>

--- a/src/webviews/apps/plus/graph/GraphWrapper.tsx
+++ b/src/webviews/apps/plus/graph/GraphWrapper.tsx
@@ -143,7 +143,6 @@ export function GraphWrapper({
 	onSelectionChange,
 	onDismissBanner,
 }: GraphWrapperProps) {
-	const mainRef = useRef<HTMLElement>(null);
 	const graphRef = useRef<GraphContainer>(null);
 
 	const [rows, setRows] = useState(state.rows ?? []);
@@ -694,7 +693,6 @@ export function GraphWrapper({
 				</header>
 			)}
 			<main
-				ref={mainRef}
 				id="main"
 				className={`graph-app__main${!isAccessAllowed ? ' is-gated' : ''}`}
 				aria-hidden={!isAccessAllowed}


### PR DESCRIPTION
# Description
Right now, Gitlens is calculating the `height` and `width` of the graph and passing its values via input properties to the component.

This calculation should be done internally in the Graph component instead (Graph component should be expanded to the container automatically).

That is, "height" and "width" input properties should be removed as they will no longer be needed.

# Summary of changes
- Removed logic to resize graph component (in `GraphWrapper.jsx` file) when webview is resized. Now, the graph component is able to do these calculations internally
- Removed `height` and `width` input properties of the `GraphContainer` component (in `GraphWrapper.jsx` file).

# Notes
- This PR needs the changes of `Graph component` side as well: https://github.com/gitkraken/GitKrakenComponents/pull/117
- Once we proceed to merge this PR, we will need to do a bump version.

# Task
https://github.com/gitkraken/GitKrakenComponents/issues/116