### PR TITLE
2284 - Enable GK Graph debug

### DIFF
--- a/webpack.config.js
+++ b/webpack.config.js
@@ -344,7 +344,7 @@ function getWebviewsConfig(mode, env) {
 		},
 		mode: mode,
 		target: 'web',
-		devtool: mode === 'production' ? false : 'inline-source-map',
+		devtool: mode === 'production' ? false : 'source-map',
 		output: {
 			filename: '[name].js',
 			path: path.join(__dirname, 'dist', 'webviews'),

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -344,14 +344,14 @@ function getWebviewsConfig(mode, env) {
 		},
 		mode: mode,
 		target: 'web',
-		devtool: mode === 'production' ? false : 'source-map',
+		devtool: mode === 'production' ? false : 'inline-source-map',
 		output: {
 			filename: '[name].js',
 			path: path.join(__dirname, 'dist', 'webviews'),
 			publicPath: '#{root}/dist/webviews/',
 		},
 		optimization: {
-			minimizer: [
+			minimizer: mode === 'production' ? [
 				new TerserPlugin(
 					env.esbuild
 						? {
@@ -396,7 +396,7 @@ function getWebviewsConfig(mode, env) {
 						],
 					},
 				}),
-			],
+			] : [],
 		},
 		module: {
 			rules: [


### PR DESCRIPTION
# Description
- Ability to debug our Graph code by adding a breakpoint.

# Summary of changes
- Modified `webpack.config` to enable inline-source-map and avoid using terser when we are in development mode.
- This works with commit `Enable GK Graph debug` of Graph component side.

# Task
https://github.com/gitkraken/vscode-gitlens/issues/2284