### PR TITLE
Fixes #2292 - force-push to non-current branch

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/) and this p
 
 ### Fixed
 
+- Fixes [#2292](https://github.com/gitkraken/vscode-gitlens/issues/2292) - Push button in BranchTrackingStatusNode of non-current branch does not trigger "Push force"
 - Fixes [#1488](https://github.com/gitkraken/vscode-gitlens/issues/1488) - Open Folder History not working with non-English language pack
 - Fixes [#2303](https://github.com/gitkraken/vscode-gitlens/issues/2303) - "Googlesource" gerrit only supports two levels of domain &mdash; thanks to [PR #2304](https://github.com/gitkraken/vscode-gitlens/pull/2304) by Matt Buckley ([@Mattadore](https://github.com/Mattadore))
 - Fixes [#2300](https://github.com/gitkraken/vscode-gitlens/issues/2300) - extra non-functional toolbar buttons when viewing PR diffs in VSCode web

--- a/src/commands/git/push.ts
+++ b/src/commands/git/push.ts
@@ -226,29 +226,23 @@ export class PushGitCommand extends QuickCommand<State> {
 							);
 						}
 					} else if (branch != null && branch?.state.behind > 0) {
-						const currentBranch = await repo.getBranch();
-
 						step = this.createConfirmStep(
 							appendReposToTitle(`Confirm ${context.title}`, state, context),
-							branch.id === currentBranch?.id
-								? [
-										FlagsQuickPickItem.create<Flags>(state.flags, ['--force'], {
-											label: `Force ${this.title}${useForceWithLease ? ' (with lease)' : ''}`,
-											description: `--force${useForceWithLease ? '-with-lease' : ''}`,
-											detail: `Will force push${useForceWithLease ? ' (with lease)' : ''} ${
-												branch?.state.ahead ? ` ${pluralize('commit', branch.state.ahead)}` : ''
-											}${branch.getRemoteName() ? ` to ${branch.getRemoteName()}` : ''}${
-												branch != null && branch.state.behind > 0
-													? `, overwriting ${pluralize('commit', branch.state.behind)}${
-															branch?.getRemoteName()
-																? ` on ${branch.getRemoteName()}`
-																: ''
-													  }`
-													: ''
-											}`,
-										}),
-								  ]
-								: [],
+							[
+								FlagsQuickPickItem.create<Flags>(state.flags, ['--force'], {
+									label: `Force ${this.title}${useForceWithLease ? ' (with lease)' : ''}`,
+									description: `--force${useForceWithLease ? '-with-lease' : ''}`,
+									detail: `Will force push${useForceWithLease ? ' (with lease)' : ''} ${
+										branch?.state.ahead ? ` ${pluralize('commit', branch.state.ahead)}` : ''
+									}${branch.getRemoteName() ? ` to ${branch.getRemoteName()}` : ''}${
+										branch != null && branch.state.behind > 0
+											? `, overwriting ${pluralize('commit', branch.state.behind)}${
+													branch?.getRemoteName() ? ` on ${branch.getRemoteName()}` : ''
+											  }`
+											: ''
+									}`,
+								}),
+							],
 							DirectiveQuickPickItem.create(Directive.Cancel, true, {
 								label: `Cancel ${this.title}`,
 								detail: `Cannot push; ${GitReference.toString(

--- a/src/git/models/repository.ts
+++ b/src/git/models/repository.ts
@@ -764,20 +764,12 @@ export class Repository implements Disposable {
 					const branch = await this.getBranch(options?.reference.name);
 					if (branch == null) return;
 
-					const currentBranch = await this.getBranch();
-					if (branch.id === currentBranch?.id) {
-						void (await executeCoreGitCommand(
-							options?.force ? CoreGitCommands.PushForce : CoreGitCommands.Push,
-							this.path,
-						));
-					} else {
-						await repo?.push(
-							branch.getRemoteName(),
-							branch.name,
-							undefined,
-							options?.force ? ForcePushMode.ForceWithLease : undefined,
-						);
-					}
+					await repo?.push(
+						branch.getRemoteName(),
+						branch.name,
+						undefined,
+						options?.force ? ForcePushMode.ForceWithLease : undefined,
+					);
 				}
 			} else if (options?.reference != null) {
 				const repo = await this.container.git.getOrOpenScmRepository(this.path);

--- a/src/views/viewCommands.ts
+++ b/src/views/viewCommands.ts
@@ -616,7 +616,7 @@ export class ViewCommands {
 		}
 
 		if (node instanceof BranchNode || node instanceof BranchTrackingStatusNode) {
-			return GitActions.push(node.repoPath, undefined, node.root ? undefined : node.branch);
+			return GitActions.push(node.repoPath, force, node.root ? undefined : node.branch);
 		}
 
 		if (node instanceof CommitNode || node instanceof FileRevisionAsCommitNode) {


### PR DESCRIPTION
# Description

<!--
Please include a summary of the changes and which issue will be addressed. Please also include relevant motivation and context.
-->
From a non-current branch's BranchTrackingStatusNode, push button was not triggering "Push force" when it's supposed to. This PR fixes #2292.

# Checklist

<!-- Please check off the following -->

- [x] I have followed the guidelines in the Contributing document
- [x] My changes follow the coding style of this project
- [x] My changes build without any errors or warnings
- [x] My changes have been formatted and linted
- [x] My changes include any required corresponding changes to the documentation (including CHANGELOG.md and README.md)
- [x] My changes have been rebased and squashed to the minimal number (typically 1) of relevant commits
- [x] My changes have a descriptive commit message with a short title, including a `Fixes $XXX -` or `Closes #XXX -` prefix to auto-close the issue that your PR addresses
