### PR TITLE
Add option to modify the scroll padding for the graph

### DIFF
--- a/package.json
+++ b/package.json
@@ -2181,6 +2181,13 @@
 						"scope": "window",
 						"order": 12
 					},
+					"gitlens.graph.scrollRowPadding": {
+						"type": "number",
+						"default": 0,
+						"markdownDescription": "Specifies how many rows from the edge a selected row should be before scrolling starts",
+						"scope": "window",
+						"order": 14
+					},
 					"gitlens.graph.showDetailsView": {
 						"type": [
 							"boolean",

--- a/src/config.ts
+++ b/src/config.ts
@@ -388,6 +388,7 @@ export interface GraphConfig {
 	dateStyle: DateStyle | null;
 	defaultItemLimit: number;
 	highlightRowsOnRefHover: boolean;
+	scrollRowPadding: number;
 	showDetailsView: 'open' | 'selection' | false;
 	showGhostRefsOnRowHover: boolean;
 	showRemoteNames: boolean;

--- a/src/plus/webviews/graph/graphWebview.ts
+++ b/src/plus/webviews/graph/graphWebview.ts
@@ -511,6 +511,7 @@ export class GraphWebview extends WebviewBase<State> {
 			configuration.changed(e, 'graph.dateFormat') ||
 			configuration.changed(e, 'graph.dateStyle') ||
 			configuration.changed(e, 'graph.highlightRowsOnRefHover') ||
+			configuration.changed(e, 'graph.scrollRowPadding') ||
 			configuration.changed(e, 'graph.showGhostRefsOnRowHover') ||
 			configuration.changed(e, 'graph.showRemoteNames')
 		) {
@@ -1310,6 +1311,7 @@ export class GraphWebview extends WebviewBase<State> {
 			dateStyle: configuration.get('graph.dateStyle') ?? configuration.get('defaultDateStyle'),
 			enableMultiSelection: false,
 			highlightRowsOnRefHover: configuration.get('graph.highlightRowsOnRefHover'),
+			scrollRowPadding: configuration.get('graph.scrollRowPadding'),
 			showGhostRefsOnRowHover: configuration.get('graph.showGhostRefsOnRowHover'),
 			showRemoteNamesOnRefs: configuration.get('graph.showRemoteNames'),
 			idLength: configuration.get('advanced.abbreviatedShaLength'),

--- a/src/plus/webviews/graph/protocol.ts
+++ b/src/plus/webviews/graph/protocol.ts
@@ -102,6 +102,7 @@ export interface GraphComponentConfig {
 	dateStyle: DateStyle;
 	enableMultiSelection?: boolean;
 	highlightRowsOnRefHover?: boolean;
+	scrollRowPadding?: number;
 	showGhostRefsOnRowHover?: boolean;
 	showRemoteNamesOnRefs?: boolean;
 	idLength?: number;

--- a/src/webviews/apps/plus/graph/GraphWrapper.tsx
+++ b/src/webviews/apps/plus/graph/GraphWrapper.tsx
@@ -402,7 +402,7 @@ export function GraphWrapper({
 		}
 
 		if (id != null) {
-			queueMicrotask(() => graphRef.current?.selectCommits([id!], false));
+			queueMicrotask(() => graphRef.current?.selectCommits([id!], false, true));
 		}
 	};
 
@@ -728,6 +728,7 @@ export function GraphWrapper({
 							highlightedShas={searchResults?.ids as GraphContainerProps['highlightedShas']}
 							highlightRowsOnRefHover={graphConfig?.highlightRowsOnRefHover}
 							hiddenRefsById={hiddenRefsById}
+							scrollRowPadding={graphConfig?.scrollRowPadding}
 							showGhostRefsOnRowHover={graphConfig?.showGhostRefsOnRowHover}
 							showRemoteNamesOnRefs={graphConfig?.showRemoteNamesOnRefs}
 							isLoadingRows={isLoading}

--- a/src/webviews/apps/settings/partials/commit-graph.html
+++ b/src/webviews/apps/settings/partials/commit-graph.html
@@ -65,6 +65,21 @@
 					</div>
 
 					<div class="setting">
+						<div class="setting__input">
+							<label for="graph.scrollRowPadding">Start scrolling at </label>
+							<input
+								id="graph.scrollRowPadding"
+								name="graph.scrollRowPadding"
+								type="number"
+								placeholder="0"
+								data-setting
+								data-default-value="0"
+							/>
+							<label for="graph.searchItemLimit"> rows from the edge</label>
+						</div>
+					</div>
+
+					<div class="setting">
 						<div class="setting__input setting__input--inner-select">
 							<input
 								id="graph.showDetailsView"

--- a/src/webviews/apps/settings/partials/commit-graph.html
+++ b/src/webviews/apps/settings/partials/commit-graph.html
@@ -75,7 +75,7 @@
 								data-setting
 								data-default-value="0"
 							/>
-							<label for="graph.searchItemLimit"> rows from the edge</label>
+							<label for="graph.scrollRowPadding"> rows from the edge</label>
 						</div>
 					</div>
 


### PR DESCRIPTION
This is the GitLens-side changes needed for configurable graph scroll padding to work.

[Component-side PR here](https://github.com/gitkraken/GitKrakenComponents/pull/149).

**Note** Must immediately bump library version once this and the component-side changes are merged, or there will be issues with the changes to the graph ref when jumping to commits during commit search.

Adds configurable scroll padding to the graph. This option is shown in the graph options and allows you to configure the number of rows away from the edge before the graph starts to scroll.

![image](https://user-images.githubusercontent.com/67011668/204381477-7f545a4a-3dbd-4a69-bf1a-d4a284977431.png)

![scroll padding with three rows](https://user-images.githubusercontent.com/67011668/204382096-2a97b818-8773-4317-9099-f88f624b0dcd.gif)

**Caveat 1:** This padding is only applied when auto-scrolling to a row (when the graph needs to select and jump to a commit you chose from outside the graph itself, i.e. in the search) or using keyboard scrolling. This padding should NOT be applied when selecting a row with your mouse.

**Caveat 2:** Internal (component-side) restrictions have been placed on the value of the setting. Any padding value below 0 rows will be defaulted to 0 rows. Any value more than half the graph height, in rows, will be defaulted down to that maximum. Note that this isn't easily enforcable in the graph settings on GitLens because you can put in a value that satisfies the constraint and then shrink your graph height.