### PR TITLE
Add "current branch only" filter logic for Graph

### DIFF
--- a/src/env/node/git/localGitProvider.ts
+++ b/src/env/node/git/localGitProvider.ts
@@ -1629,6 +1629,7 @@ export class LocalGitProvider implements GitProvider, Disposable {
 		asWebviewUri: (uri: Uri) => Uri,
 		options?: {
 			branch?: string;
+			currentBranchOnly?: boolean;
 			limit?: number;
 			mode?: 'single' | 'local' | 'all';
 			ref?: string;
@@ -1690,7 +1691,11 @@ export class LocalGitProvider implements GitProvider, Disposable {
 			let size;
 
 			do {
-				const args = [...parser.arguments, `--${ordering}-order`, '--all'];
+				const args = [...parser.arguments, `--${ordering}-order`];
+				if (!options?.currentBranchOnly) {
+					args.push('--all');
+				}
+
 				if (cursor?.skip) {
 					args.push(`--skip=${cursor.skip}`);
 				}

--- a/src/env/node/git/localGitProvider.ts
+++ b/src/env/node/git/localGitProvider.ts
@@ -1664,7 +1664,7 @@ export class LocalGitProvider implements GitProvider, Disposable {
 				: branchMap.get(options.branch)
 			: undefined;
 		const targetBranchName: string | undefined = targetBranch?.name;
-		const targetBranchHasUpstream: boolean = targetBranch?.upstream != null && targetBranch?.upstream !== undefined;
+		const targetBranchHasUpstream: boolean = targetBranch?.upstream != null && !targetBranch?.upstream.missing;
 
 		const currentUser = getSettledValue(currentUserResult);
 
@@ -4429,7 +4429,7 @@ export class LocalGitProvider implements GitProvider, Disposable {
 				const branch = await this.getBranch(repoPath, options.branch);
 				if (branch) {
 					args.push(branch.name);
-					if (branch.upstream && options.includes?.remotes) {
+					if (branch.upstream != null && !branch.upstream.missing && options.includes?.remotes) {
 						args.push(`${branch.name}@{u}`);
 					}
 				}

--- a/src/env/node/git/localGitProvider.ts
+++ b/src/env/node/git/localGitProvider.ts
@@ -1656,7 +1656,7 @@ export class LocalGitProvider implements GitProvider, Disposable {
 		]);
 
 		const branches = getSettledValue(branchesResult)?.values;
-		const branchMap = branches != null ? new Map(branches.map(r => [r.name, r])) : new Map<string, GitBranch>();
+		let branchMap = branches != null ? new Map(branches.map(r => [r.name, r])) : new Map<string, GitBranch>();
 
 		const targetBranch: GitBranch | undefined = options?.branch
 			? options.branch === 'HEAD'
@@ -1665,6 +1665,10 @@ export class LocalGitProvider implements GitProvider, Disposable {
 			: undefined;
 		const targetBranchName: string | undefined = targetBranch?.name;
 		const targetBranchHasUpstream: boolean = targetBranch?.upstream != null && !targetBranch?.upstream.missing;
+		if (options?.branch && targetBranchName != null && targetBranch != null) {
+			branchMap = new Map<string, GitBranch>();
+			branchMap.set(targetBranchName, targetBranch);
+		}
 
 		const currentUser = getSettledValue(currentUserResult);
 
@@ -1942,13 +1946,15 @@ export class LocalGitProvider implements GitProvider, Disposable {
 							},
 						};
 
-						refHead = {
-							id: branchId,
-							name: tip,
-							isCurrentHead: head,
-							context: serializeWebviewItemContext<GraphItemRefContext>(context),
-						};
-						refHeads.push(refHead);
+						if (!options?.branch || options.branch === tip || (options.branch === 'HEAD' && head)) {
+							refHead = {
+								id: branchId,
+								name: tip,
+								isCurrentHead: head,
+								context: serializeWebviewItemContext<GraphItemRefContext>(context),
+							};
+							refHeads.push(refHead);
+						}
 
 						group = groupedRefs.get(tip);
 						if (group == null) {

--- a/src/env/node/git/localGitProvider.ts
+++ b/src/env/node/git/localGitProvider.ts
@@ -1680,7 +1680,12 @@ export class LocalGitProvider implements GitProvider, Disposable {
 		// TODO@eamodio this is insanity -- there *HAS* to be a better way to get git log to return stashes
 		// TODO@ramint Figure out a way to get stashes to work when supplying a local branch
 		const stash = getSettledValue(stashResult);
-		if (!options?.branch && stash != null && stash.commits.size !== 0) {
+		if (
+			!options?.branch &&
+			(!options?.includes || options.includes.stashes) &&
+			stash != null &&
+			stash.commits.size !== 0
+		) {
 			stdin = join(
 				map(stash.commits.values(), c => c.sha.substring(0, 9)),
 				'\n',
@@ -1843,6 +1848,7 @@ export class LocalGitProvider implements GitProvider, Disposable {
 						if (tip === 'refs/stash') continue;
 
 						if (tip.startsWith('tag: ')) {
+							if (options?.includes && !options.includes.tags) continue;
 							tagName = tip.substring(5);
 							tagId = getTagId(repoPath, tagName);
 							context = {
@@ -2015,6 +2021,7 @@ export class LocalGitProvider implements GitProvider, Disposable {
 				isCurrentUser = isUserMatch(currentUser, commit.author, commit.authorEmail);
 
 				if (stashCommit != null) {
+					if (options?.includes && !options.includes.stashes) continue;
 					contexts.row = serializeWebviewItemContext<GraphItemRefContext>({
 						webviewItem: 'gitlens:stash',
 						webviewItemValue: {
@@ -4418,7 +4425,12 @@ export class LocalGitProvider implements GitProvider, Disposable {
 			let stdin: string | undefined;
 			// TODO@eamodio this is insanity -- there *HAS* to be a better way to get git log to return stashes
 			// TODO@ramint Figure out a way to get stashes to work when supplying a local branch
-			if (!options?.branch && stash != null && stash.commits.size !== 0) {
+			if (
+				!options?.branch &&
+				(!options?.includes || options.includes.stashes) &&
+				stash != null &&
+				stash.commits.size !== 0
+			) {
 				stdin = join(
 					map(stash.commits.values(), c => c.sha.substring(0, 9)),
 					'\n',

--- a/src/env/node/git/localGitProvider.ts
+++ b/src/env/node/git/localGitProvider.ts
@@ -1659,7 +1659,9 @@ export class LocalGitProvider implements GitProvider, Disposable {
 		const branchMap = branches != null ? new Map(branches.map(r => [r.name, r])) : new Map<string, GitBranch>();
 
 		const targetBranch: GitBranch | undefined = options?.branch
-			? (options.branch === 'HEAD' ? branches?.find(b => b.current) : branchMap.get(options.branch))
+			? options.branch === 'HEAD'
+				? branches?.find(b => b.current)
+				: branchMap.get(options.branch)
 			: undefined;
 		const targetBranchName: string | undefined = targetBranch?.name;
 		const targetBranchHasUpstream: boolean = targetBranch?.upstream != null && targetBranch?.upstream !== undefined;
@@ -1674,7 +1676,7 @@ export class LocalGitProvider implements GitProvider, Disposable {
 		// TODO@eamodio this is insanity -- there *HAS* to be a better way to get git log to return stashes
 		// TODO@ramint Figure out a way to get stashes to work when supplying a local branch
 		const stash = getSettledValue(stashResult);
-		if (!(options?.branch) && stash != null && stash.commits.size !== 0) {
+		if (!options?.branch && stash != null && stash.commits.size !== 0) {
 			stdin = join(
 				map(stash.commits.values(), c => c.sha.substring(0, 9)),
 				'\n',
@@ -1704,7 +1706,7 @@ export class LocalGitProvider implements GitProvider, Disposable {
 
 			do {
 				const args = [...parser.arguments, `--${ordering}-order`];
-				if (!(options?.branch)) {
+				if (!options?.branch) {
 					args.push('--all');
 				}
 
@@ -4410,7 +4412,7 @@ export class LocalGitProvider implements GitProvider, Disposable {
 			let stdin: string | undefined;
 			// TODO@eamodio this is insanity -- there *HAS* to be a better way to get git log to return stashes
 			// TODO@ramint Figure out a way to get stashes to work when supplying a local branch
-			if (!(options?.branch) && stash != null && stash.commits.size !== 0) {
+			if (!options?.branch && stash != null && stash.commits.size !== 0) {
 				stdin = join(
 					map(stash.commits.values(), c => c.sha.substring(0, 9)),
 					'\n',

--- a/src/git/gitProvider.ts
+++ b/src/git/gitProvider.ts
@@ -34,6 +34,12 @@ export const enum GitProviderId {
 	Vsls = 'vsls',
 }
 
+export interface GitIncludeOptions {
+	remotes?: boolean;
+	stashes?: boolean;
+	tags?: boolean;
+}
+
 export interface GitProviderDescriptor {
 	readonly id: GitProviderId;
 	readonly name: string;
@@ -224,9 +230,8 @@ export interface GitProvider extends Disposable {
 		asWebviewUri: (uri: Uri) => Uri,
 		options?: {
 			branch?: string;
-			currentBranchOnly?: boolean;
+			includes?: GitIncludeOptions;
 			limit?: number;
-			mode?: 'single' | 'local' | 'all';
 			ref?: string;
 		},
 	): Promise<GitGraph>;
@@ -418,6 +423,7 @@ export interface GitProvider extends Disposable {
 		search: SearchQuery,
 		options?: {
 			cancellation?: CancellationToken;
+			includes?: GitIncludeOptions;
 			limit?: number;
 			ordering?: 'date' | 'author-date' | 'topo';
 		},

--- a/src/git/gitProvider.ts
+++ b/src/git/gitProvider.ts
@@ -422,6 +422,7 @@ export interface GitProvider extends Disposable {
 		repoPath: string | Uri,
 		search: SearchQuery,
 		options?: {
+			branch?: string;
 			cancellation?: CancellationToken;
 			includes?: GitIncludeOptions;
 			limit?: number;

--- a/src/git/gitProvider.ts
+++ b/src/git/gitProvider.ts
@@ -224,6 +224,7 @@ export interface GitProvider extends Disposable {
 		asWebviewUri: (uri: Uri) => Uri,
 		options?: {
 			branch?: string;
+			currentBranchOnly?: boolean;
 			limit?: number;
 			mode?: 'single' | 'local' | 'all';
 			ref?: string;

--- a/src/git/gitProvider.ts
+++ b/src/git/gitProvider.ts
@@ -34,7 +34,7 @@ export const enum GitProviderId {
 	Vsls = 'vsls',
 }
 
-export interface GitIncludeOptions {
+export interface GitGraphIncludes {
 	remotes?: boolean;
 	stashes?: boolean;
 	tags?: boolean;
@@ -230,7 +230,7 @@ export interface GitProvider extends Disposable {
 		asWebviewUri: (uri: Uri) => Uri,
 		options?: {
 			branch?: string;
-			includes?: GitIncludeOptions;
+			includes?: GitGraphIncludes;
 			limit?: number;
 			ref?: string;
 		},
@@ -424,7 +424,7 @@ export interface GitProvider extends Disposable {
 		options?: {
 			branch?: string;
 			cancellation?: CancellationToken;
-			includes?: GitIncludeOptions;
+			includes?: GitGraphIncludes;
 			limit?: number;
 			ordering?: 'date' | 'author-date' | 'topo';
 		},

--- a/src/git/gitProviderService.ts
+++ b/src/git/gitProviderService.ts
@@ -1410,6 +1410,7 @@ export class GitProviderService implements Disposable {
 		asWebviewUri: (uri: Uri) => Uri,
 		options?: {
 			branch?: string;
+			currentBranchOnly?: boolean;
 			limit?: number;
 			mode?: 'single' | 'local' | 'all';
 			ref?: string;

--- a/src/git/gitProviderService.ts
+++ b/src/git/gitProviderService.ts
@@ -2339,6 +2339,7 @@ export class GitProviderService implements Disposable {
 		repoPath: string | Uri,
 		search: SearchQuery,
 		options?: {
+			branch?: string;
 			cancellation?: CancellationToken;
 			includes?: GitIncludeOptions;
 			limit?: number;

--- a/src/git/gitProviderService.ts
+++ b/src/git/gitProviderService.ts
@@ -33,7 +33,7 @@ import { getBestPath, getScheme, isAbsolute, maybeUri, normalizePath } from '../
 import { cancellable, fastestSettled, getSettledValue, isPromise, PromiseCancelledError } from '../system/promise';
 import { VisitedPathsTrie } from '../system/trie';
 import type {
-	GitIncludeOptions,
+	GitGraphIncludes,
 	GitProvider,
 	GitProviderDescriptor,
 	GitProviderId,
@@ -1411,7 +1411,7 @@ export class GitProviderService implements Disposable {
 		asWebviewUri: (uri: Uri) => Uri,
 		options?: {
 			branch?: string;
-			includes?: GitIncludeOptions;
+			includes?: GitGraphIncludes;
 			limit?: number;
 			ref?: string;
 		},
@@ -2341,7 +2341,7 @@ export class GitProviderService implements Disposable {
 		options?: {
 			branch?: string;
 			cancellation?: CancellationToken;
-			includes?: GitIncludeOptions;
+			includes?: GitGraphIncludes;
 			limit?: number;
 			ordering?: 'date' | 'author-date' | 'topo';
 		},

--- a/src/git/gitProviderService.ts
+++ b/src/git/gitProviderService.ts
@@ -33,6 +33,7 @@ import { getBestPath, getScheme, isAbsolute, maybeUri, normalizePath } from '../
 import { cancellable, fastestSettled, getSettledValue, isPromise, PromiseCancelledError } from '../system/promise';
 import { VisitedPathsTrie } from '../system/trie';
 import type {
+	GitIncludeOptions,
 	GitProvider,
 	GitProviderDescriptor,
 	GitProviderId,
@@ -1410,9 +1411,8 @@ export class GitProviderService implements Disposable {
 		asWebviewUri: (uri: Uri) => Uri,
 		options?: {
 			branch?: string;
-			currentBranchOnly?: boolean;
+			includes?: GitIncludeOptions;
 			limit?: number;
-			mode?: 'single' | 'local' | 'all';
 			ref?: string;
 		},
 	): Promise<GitGraph> {
@@ -2340,6 +2340,7 @@ export class GitProviderService implements Disposable {
 		search: SearchQuery,
 		options?: {
 			cancellation?: CancellationToken;
+			includes?: GitIncludeOptions;
 			limit?: number;
 			ordering?: 'date' | 'author-date' | 'topo';
 		},

--- a/src/git/models/repository.ts
+++ b/src/git/models/repository.ts
@@ -869,7 +869,12 @@ export class Repository implements Disposable {
 	@debug()
 	searchCommits(
 		search: SearchQuery,
-		options?: { cancellation?: CancellationToken; limit?: number; ordering?: 'date' | 'author-date' | 'topo' },
+		options?: {
+			branch?: string;
+			cancellation?: CancellationToken;
+			limit?: number;
+			ordering?: 'date' | 'author-date' | 'topo';
+		},
 	): Promise<GitSearch> {
 		return this.container.git.searchCommits(this.path, search, options);
 	}

--- a/src/git/models/repository.ts
+++ b/src/git/models/repository.ts
@@ -20,7 +20,7 @@ import { updateRecordValue } from '../../system/object';
 import { basename, normalizePath } from '../../system/path';
 import { md5 } from '../../system/string';
 import { runGitCommandInTerminal } from '../../terminal';
-import type { GitProviderDescriptor } from '../gitProvider';
+import type { GitGraphIncludes, GitProviderDescriptor } from '../gitProvider';
 import { loadRemoteProviders } from '../remotes/remoteProviders';
 import type { RemoteProviders } from '../remotes/remoteProviders';
 import type { RichRemoteProvider } from '../remotes/richRemoteProvider';
@@ -872,6 +872,7 @@ export class Repository implements Disposable {
 		options?: {
 			branch?: string;
 			cancellation?: CancellationToken;
+			includes?: GitGraphIncludes;
 			limit?: number;
 			ordering?: 'date' | 'author-date' | 'topo';
 		},

--- a/src/plus/github/github.ts
+++ b/src/plus/github/github.ts
@@ -1820,6 +1820,7 @@ export class GitHubApi implements Disposable {
 		token: string,
 		query: string,
 		options?: {
+			branch?: string;
 			cursor?: string;
 			limit?: number;
 			order?: 'asc' | 'desc' | undefined;

--- a/src/plus/github/githubGitProvider.ts
+++ b/src/plus/github/githubGitProvider.ts
@@ -26,6 +26,7 @@ import {
 import { Features } from '../../features';
 import { GitSearchError } from '../../git/errors';
 import type {
+	GitIncludeOptions,
 	GitProvider,
 	NextComparisonUrisResult,
 	PagedResult,
@@ -1072,9 +1073,8 @@ export class GitHubGitProvider implements GitProvider, Disposable {
 		asWebviewUri: (uri: Uri) => Uri,
 		options?: {
 			branch?: string;
-			currentBranchOnly?: boolean;
+			includes?: GitIncludeOptions;
 			limit?: number;
-			mode?: 'single' | 'local' | 'all';
 			ref?: string;
 		},
 	): Promise<GitGraph> {
@@ -1120,9 +1120,8 @@ export class GitHubGitProvider implements GitProvider, Disposable {
 		ids: Set<string>,
 		options?: {
 			branch?: string;
-			currentBranchOnly?: boolean;
+			includes?: GitIncludeOptions;
 			limit?: number;
-			mode?: 'single' | 'local' | 'all';
 			ref?: string;
 			useAvatars?: boolean;
 		},
@@ -2723,6 +2722,7 @@ export class GitHubGitProvider implements GitProvider, Disposable {
 		search: SearchQuery,
 		options?: {
 			cancellation?: CancellationToken;
+			includes?: GitIncludeOptions;
 			limit?: number;
 			ordering?: 'date' | 'author-date' | 'topo';
 		},

--- a/src/plus/github/githubGitProvider.ts
+++ b/src/plus/github/githubGitProvider.ts
@@ -765,10 +765,13 @@ export class GitHubGitProvider implements GitProvider, Disposable {
 	}
 
 	@log()
-	async getBranch(repoPath: string | undefined): Promise<GitBranch | undefined> {
+	async getBranch(repoPath: string | undefined, branchName?: string): Promise<GitBranch | undefined> {
+		const isCurrentBranch = !branchName || branchName === 'HEAD';
 		const {
 			values: [branch],
-		} = await this.getBranches(repoPath, { filter: b => b.current });
+		} = await this.getBranches(repoPath, {
+			filter: isCurrentBranch ? b => b.current : b => b.name === branchName
+		});
 		return branch;
 	}
 
@@ -2721,6 +2724,7 @@ export class GitHubGitProvider implements GitProvider, Disposable {
 		repoPath: string,
 		search: SearchQuery,
 		options?: {
+			branch?: string;
 			cancellation?: CancellationToken;
 			includes?: GitIncludeOptions;
 			limit?: number;

--- a/src/plus/github/githubGitProvider.ts
+++ b/src/plus/github/githubGitProvider.ts
@@ -26,7 +26,7 @@ import {
 import { Features } from '../../features';
 import { GitSearchError } from '../../git/errors';
 import type {
-	GitIncludeOptions,
+	GitGraphIncludes,
 	GitProvider,
 	NextComparisonUrisResult,
 	PagedResult,
@@ -1076,7 +1076,7 @@ export class GitHubGitProvider implements GitProvider, Disposable {
 		asWebviewUri: (uri: Uri) => Uri,
 		options?: {
 			branch?: string;
-			includes?: GitIncludeOptions;
+			includes?: GitGraphIncludes;
 			limit?: number;
 			ref?: string;
 		},
@@ -1123,7 +1123,7 @@ export class GitHubGitProvider implements GitProvider, Disposable {
 		ids: Set<string>,
 		options?: {
 			branch?: string;
-			includes?: GitIncludeOptions;
+			includes?: GitGraphIncludes;
 			limit?: number;
 			ref?: string;
 			useAvatars?: boolean;
@@ -2726,7 +2726,7 @@ export class GitHubGitProvider implements GitProvider, Disposable {
 		options?: {
 			branch?: string;
 			cancellation?: CancellationToken;
-			includes?: GitIncludeOptions;
+			includes?: GitGraphIncludes;
 			limit?: number;
 			ordering?: 'date' | 'author-date' | 'topo';
 		},

--- a/src/plus/github/githubGitProvider.ts
+++ b/src/plus/github/githubGitProvider.ts
@@ -770,7 +770,7 @@ export class GitHubGitProvider implements GitProvider, Disposable {
 		const {
 			values: [branch],
 		} = await this.getBranches(repoPath, {
-			filter: isCurrentBranch ? b => b.current : b => b.name === branchName
+			filter: isCurrentBranch ? b => b.current : b => b.name === branchName,
 		});
 		return branch;
 	}

--- a/src/plus/github/githubGitProvider.ts
+++ b/src/plus/github/githubGitProvider.ts
@@ -1072,6 +1072,7 @@ export class GitHubGitProvider implements GitProvider, Disposable {
 		asWebviewUri: (uri: Uri) => Uri,
 		options?: {
 			branch?: string;
+			currentBranchOnly?: boolean;
 			limit?: number;
 			mode?: 'single' | 'local' | 'all';
 			ref?: string;
@@ -1119,6 +1120,7 @@ export class GitHubGitProvider implements GitProvider, Disposable {
 		ids: Set<string>,
 		options?: {
 			branch?: string;
+			currentBranchOnly?: boolean;
 			limit?: number;
 			mode?: 'single' | 'local' | 'all';
 			ref?: string;

--- a/src/plus/github/githubGitProvider.ts
+++ b/src/plus/github/githubGitProvider.ts
@@ -1217,7 +1217,7 @@ export class GitHubGitProvider implements GitProvider, Disposable {
 				refRemoteHeads = [];
 			}
 
-			if (tags != null) {
+			if (tags != null && (!options?.includes || options.includes.tags)) {
 				refTags = [
 					...filterMap(tags, t => {
 						if (t.sha !== commit.sha) return undefined;

--- a/src/plus/webviews/graph/graphWebview.ts
+++ b/src/plus/webviews/graph/graphWebview.ts
@@ -1391,7 +1391,7 @@ export class GraphWebview extends WebviewBase<State> {
 		const dataPromise = this.container.git.getCommitsForGraph(
 			this.repository.path,
 			this._panel!.webview.asWebviewUri.bind(this._panel!.webview),
-			{ currentBranchOnly: commitFilter?.currentBranchOnly || false, limit: limit, ref: ref },
+			{ ...commitFilter?.currentBranchOnly && { branch: 'HEAD'}, limit: limit, ref: ref },
 		);
 
 		// Check for GitLens+ access and working tree stats

--- a/src/plus/webviews/graph/graphWebview.ts
+++ b/src/plus/webviews/graph/graphWebview.ts
@@ -805,7 +805,7 @@ export class GraphWebview extends WebviewBase<State> {
 
 			try {
 				search = await this.repository.searchCommits(e.search, {
-					...commitFilter?.currentBranchOnly && { branch: 'HEAD' },
+					...(commitFilter?.currentBranchOnly && { branch: 'HEAD' }),
 					limit: configuration.get('graph.searchItemLimit') ?? 100,
 					ordering: configuration.get('graph.commitOrdering'),
 					cancellation: cancellation.token,
@@ -882,11 +882,7 @@ export class GraphWebview extends WebviewBase<State> {
 	private onCommitFilterSelectionChanged(e: UpdateCommitFilterSelectionParams) {
 		if (this.repository == null) return;
 		let storedCommitFilter = this.container.storage.getWorkspace('graph:commitFilter');
-		storedCommitFilter = updateRecordValue(
-			storedCommitFilter,
-			this.repository.id,
-			e.commitFilter,
-		);
+		storedCommitFilter = updateRecordValue(storedCommitFilter, this.repository.id, e.commitFilter);
 		void this.container.storage.storeWorkspace('graph:commitFilter', storedCommitFilter);
 		// Reset search and selections in graph when commit filter changes
 		this.setSelectedRows(undefined);
@@ -1405,7 +1401,7 @@ export class GraphWebview extends WebviewBase<State> {
 		const dataPromise = this.container.git.getCommitsForGraph(
 			this.repository.path,
 			this._panel!.webview.asWebviewUri.bind(this._panel!.webview),
-			{ ...commitFilter?.currentBranchOnly && { branch: 'HEAD'}, limit: limit, ref: ref },
+			{ ...(commitFilter?.currentBranchOnly && { branch: 'HEAD' }), limit: limit, ref: ref },
 		);
 
 		// Check for GitLens+ access and working tree stats

--- a/src/plus/webviews/graph/graphWebview.ts
+++ b/src/plus/webviews/graph/graphWebview.ts
@@ -801,9 +801,11 @@ export class GraphWebview extends WebviewBase<State> {
 
 			const cancellation = new CancellationTokenSource();
 			this._searchCancellation = cancellation;
+			const commitFilter = this.container.storage.getWorkspace('graph:commitFilter');
 
 			try {
 				search = await this.repository.searchCommits(e.search, {
+					...commitFilter?.currentBranchOnly && { branch: 'HEAD' },
 					limit: configuration.get('graph.searchItemLimit') ?? 100,
 					ordering: configuration.get('graph.commitOrdering'),
 					cancellation: cancellation.token,
@@ -879,6 +881,11 @@ export class GraphWebview extends WebviewBase<State> {
 
 	private onCommitFilterSelectionChanged(e: UpdateCommitFilterSelectionParams) {
 		void this.container.storage.storeWorkspace('graph:commitFilter', e.commitFilter);
+		// Reset search and selections in graph when commit filter changes
+		this.setSelectedRows(undefined);
+		this.resetSearchState();
+
+		// Update the graph with the new filter applied
 		this.updateState();
 	}
 

--- a/src/plus/webviews/graph/graphWebview.ts
+++ b/src/plus/webviews/graph/graphWebview.ts
@@ -1461,6 +1461,7 @@ export class GraphWebview extends WebviewBase<State> {
 			nonce: this.cspNonce,
 			workingTreeStats: getSettledValue(workingStatsResult) ?? { added: 0, deleted: 0, modified: 0 },
 			commitFilter: commitFilter,
+			isVirtual: this.repository?.provider?.virtual ?? false,
 		};
 	}
 

--- a/src/plus/webviews/graph/graphWebview.ts
+++ b/src/plus/webviews/graph/graphWebview.ts
@@ -801,7 +801,7 @@ export class GraphWebview extends WebviewBase<State> {
 
 			const cancellation = new CancellationTokenSource();
 			this._searchCancellation = cancellation;
-			const commitFilter = this.container.storage.getWorkspace('graph:commitFilter');
+			const commitFilter = this.container.storage.getWorkspace('graph:commitFilter')?.[this.repository.id];
 
 			try {
 				search = await this.repository.searchCommits(e.search, {
@@ -880,7 +880,14 @@ export class GraphWebview extends WebviewBase<State> {
 	}
 
 	private onCommitFilterSelectionChanged(e: UpdateCommitFilterSelectionParams) {
-		void this.container.storage.storeWorkspace('graph:commitFilter', e.commitFilter);
+		if (this.repository == null) return;
+		let storedCommitFilter = this.container.storage.getWorkspace('graph:commitFilter');
+		storedCommitFilter = updateRecordValue(
+			storedCommitFilter,
+			this.repository.id,
+			e.commitFilter,
+		);
+		void this.container.storage.storeWorkspace('graph:commitFilter', storedCommitFilter);
 		// Reset search and selections in graph when commit filter changes
 		this.setSelectedRows(undefined);
 		this.resetSearchState();
@@ -1393,7 +1400,7 @@ export class GraphWebview extends WebviewBase<State> {
 		const ref =
 			this._selectedId == null || this._selectedId === GitRevision.uncommitted ? 'HEAD' : this._selectedId;
 
-		const commitFilter = this.container.storage.getWorkspace('graph:commitFilter');
+		const commitFilter = this.container.storage.getWorkspace('graph:commitFilter')?.[this.repository.id];
 
 		const dataPromise = this.container.git.getCommitsForGraph(
 			this.repository.path,

--- a/src/plus/webviews/graph/protocol.ts
+++ b/src/plus/webviews/graph/protocol.ts
@@ -67,6 +67,9 @@ export interface State {
 
 export interface GraphCommitFilterState {
 	currentBranchOnly?: boolean;
+	hideRemotes?: boolean;
+	hideStashes?: boolean;
+	hideTags?: boolean;
 }
 
 export type GraphWorkingTreeStats = WorkDirStats;

--- a/src/plus/webviews/graph/protocol.ts
+++ b/src/plus/webviews/graph/protocol.ts
@@ -58,6 +58,7 @@ export interface State {
 	searchResults?: DidSearchParams['results'];
 	hiddenRefs?: GraphHiddenRefs;
 	commitFilter?: GraphCommitFilterState;
+	isVirtual?: boolean;
 
 	// Props below are computed in the webview (not passed)
 	activeRow?: string;

--- a/src/plus/webviews/graph/protocol.ts
+++ b/src/plus/webviews/graph/protocol.ts
@@ -57,10 +57,15 @@ export interface State {
 	workingTreeStats?: GraphWorkingTreeStats;
 	searchResults?: DidSearchParams['results'];
 	hiddenRefs?: GraphHiddenRefs;
+	commitFilter?: GraphCommitFilterState;
 
 	// Props below are computed in the webview (not passed)
 	activeRow?: string;
 	theming?: { cssVariables: CssVariables; themeOpacityFactor: number };
+}
+
+export interface GraphCommitFilterState {
+	currentBranchOnly?: boolean;
 }
 
 export type GraphWorkingTreeStats = WorkDirStats;
@@ -191,6 +196,13 @@ export interface UpdateSelectedRepositoryParams {
 }
 export const UpdateSelectedRepositoryCommandType = new IpcCommandType<UpdateSelectedRepositoryParams>(
 	'graph/selectedRepository/update',
+);
+
+export interface UpdateCommitFilterSelectionParams {
+	commitFilter: GraphCommitFilterState
+}
+export const UpdateCommitFilterSelectionCommandType = new IpcCommandType<UpdateCommitFilterSelectionParams>(
+	'graph/commitFilterSelection/update',
 );
 
 export interface UpdateSelectionParams {

--- a/src/plus/webviews/graph/protocol.ts
+++ b/src/plus/webviews/graph/protocol.ts
@@ -200,7 +200,7 @@ export const UpdateSelectedRepositoryCommandType = new IpcCommandType<UpdateSele
 );
 
 export interface UpdateCommitFilterSelectionParams {
-	commitFilter: GraphCommitFilterState
+	commitFilter: GraphCommitFilterState;
 }
 export const UpdateCommitFilterSelectionCommandType = new IpcCommandType<UpdateCommitFilterSelectionParams>(
 	'graph/commitFilterSelection/update',

--- a/src/storage.ts
+++ b/src/storage.ts
@@ -248,6 +248,9 @@ export interface StoredGraphColumn {
 
 export interface StoredGraphCommitFilterState {
 	currentBranchOnly?: boolean;
+	hideRemotes?: boolean;
+	hideStashes?: boolean;
+	hideTags?: boolean;
 }
 
 export type StoredGraphRefType = 'head' | 'remote' | 'tag';

--- a/src/storage.ts
+++ b/src/storage.ts
@@ -190,6 +190,9 @@ export interface WorkspaceStorage {
 		banners: {
 			dismissed?: Record<string, boolean>;
 		};
+		commitFilter: {
+			currentBranchOnly?: boolean;
+		}
 		columns?: Record<string, StoredGraphColumn>;
 		hiddenRefs?: Record<string, StoredGraphHiddenRef>;
 	};

--- a/src/storage.ts
+++ b/src/storage.ts
@@ -190,9 +190,7 @@ export interface WorkspaceStorage {
 		banners: {
 			dismissed?: Record<string, boolean>;
 		};
-		commitFilter: {
-			currentBranchOnly?: boolean;
-		}
+		commitFilter: Record<string, StoredGraphCommitFilterState>;
 		columns?: Record<string, StoredGraphColumn>;
 		hiddenRefs?: Record<string, StoredGraphHiddenRef>;
 	};
@@ -246,6 +244,10 @@ export interface StoredBranchComparisons {
 export interface StoredGraphColumn {
 	isHidden?: boolean;
 	width?: number;
+}
+
+export interface StoredGraphCommitFilterState {
+	currentBranchOnly?: boolean;
 }
 
 export type StoredGraphRefType = 'head' | 'remote' | 'tag';

--- a/src/webviews/apps/plus/graph/GraphWrapper.tsx
+++ b/src/webviews/apps/plus/graph/GraphWrapper.tsx
@@ -933,14 +933,13 @@ export function GraphWrapper({
 								key={`commitfilter-actioncombo-item-all`}
 								aria-selected={undefined}
 								disabled={isVirtual}
-								onClick={() => handleSelectCommitFilter(
-									{ currentBranchOnly: !commitFilter?.currentBranchOnly }
-								)}
+								onClick={() =>
+									handleSelectCommitFilter({ currentBranchOnly: !commitFilter?.currentBranchOnly })
+								}
 							>
 								{!isVirtual && commitFilter?.currentBranchOnly
 									? 'Show All Commits'
-									: 'Show Current Branch Commits Only'
-								}
+									: 'Show Current Branch Commits Only'}
 							</button>
 						</div>
 					</div>

--- a/src/webviews/apps/plus/graph/GraphWrapper.tsx
+++ b/src/webviews/apps/plus/graph/GraphWrapper.tsx
@@ -152,7 +152,6 @@ export function GraphWrapper({
 
 	const [rows, setRows] = useState(state.rows ?? []);
 	const [avatars, setAvatars] = useState(state.avatars);
-	const [commitFilter, setCommitFilter] = useState(state.commitFilter);
 	const [refsMetadata, setRefsMetadata] = useState(state.refsMetadata);
 	const [repos, setRepos] = useState(state.repositories ?? []);
 	const [repo, setRepo] = useState<GraphRepository | undefined>(
@@ -177,8 +176,10 @@ export function GraphWrapper({
 	const [subscription, setSubscription] = useState<Subscription | undefined>(state.subscription);
 	// repo selection UI
 	const [repoExpanded, setRepoExpanded] = useState(false);
-	// commit filter UI
+	// commit filter state
+	const [commitFilter, setCommitFilter] = useState(state.commitFilter);
 	const [commitFilterExpanded, setCommitFilterExpanded] = useState(false);
+	const [isVirtual, setIsVirtual] = useState(state.isVirtual ?? false);
 	// Number of true values in the commitFilter object
 	const commitFilterCount = Object.values(commitFilter ?? {}).filter(Boolean).length;
 	// search state
@@ -269,6 +270,7 @@ export function GraphWrapper({
 				setContext(state.context);
 				setAvatars(state.avatars ?? {});
 				setCommitFilter(state.commitFilter ?? {});
+				setIsVirtual(state.isVirtual ?? false);
 				setRefsMetadata(state.refsMetadata);
 				setPagingHasMore(state.paging?.hasMore ?? false);
 				setRepos(state.repositories ?? []);
@@ -930,11 +932,12 @@ export function GraphWrapper({
 								id={`commitfilter-actioncombo-item-all`}
 								key={`commitfilter-actioncombo-item-all`}
 								aria-selected={undefined}
+								disabled={isVirtual}
 								onClick={() => handleSelectCommitFilter(
 									{ currentBranchOnly: !commitFilter?.currentBranchOnly }
 								)}
 							>
-								{commitFilter?.currentBranchOnly
+								{!isVirtual && commitFilter?.currentBranchOnly
 									? 'Show All Commits'
 									: 'Show Current Branch Commits Only'
 								}

--- a/src/webviews/apps/plus/graph/GraphWrapper.tsx
+++ b/src/webviews/apps/plus/graph/GraphWrapper.tsx
@@ -937,7 +937,7 @@ export function GraphWrapper({
 									handleSelectCommitFilter({ currentBranchOnly: !commitFilter?.currentBranchOnly })
 								}
 							>
-								{!isVirtual && commitFilter?.currentBranchOnly
+								{isVirtual || commitFilter?.currentBranchOnly
 									? 'Show All Commits'
 									: 'Show Current Branch Commits Only'}
 							</button>
@@ -949,9 +949,10 @@ export function GraphWrapper({
 								id={`commitfilter-actioncombo-item-hide-stashes`}
 								key={`commitfilter-actioncombo-item-hide-stashes`}
 								aria-selected={undefined}
+								disabled={isVirtual}
 								onClick={() => handleSelectCommitFilter({ hideStashes: !commitFilter?.hideStashes })}
 							>
-								{commitFilter?.hideStashes ? 'Show Stashes' : 'Hide Stashes'}
+								{isVirtual || commitFilter?.hideStashes ? 'Show Stashes' : 'Hide Stashes'}
 							</button>
 							<button
 								type="button"

--- a/src/webviews/apps/plus/graph/GraphWrapper.tsx
+++ b/src/webviews/apps/plus/graph/GraphWrapper.tsx
@@ -941,6 +941,30 @@ export function GraphWrapper({
 									? 'Show All Commits'
 									: 'Show Current Branch Commits Only'}
 							</button>
+							<button
+								type="button"
+								className="actioncombo__item"
+								role="option"
+								data-value={'commitfilter-actioncombo-item-hide-stashes'}
+								id={`commitfilter-actioncombo-item-hide-stashes`}
+								key={`commitfilter-actioncombo-item-hide-stashes`}
+								aria-selected={undefined}
+								onClick={() => handleSelectCommitFilter({ hideStashes: !commitFilter?.hideStashes })}
+							>
+								{commitFilter?.hideStashes ? 'Show Stashes' : 'Hide Stashes'}
+							</button>
+							<button
+								type="button"
+								className="actioncombo__item"
+								role="option"
+								data-value={'commitfilter-actioncombo-item-hide-tags'}
+								id={`commitfilter-actioncombo-item-hide-tags`}
+								key={`commitfilter-actioncombo-item-hide-tags`}
+								aria-selected={undefined}
+								onClick={() => handleSelectCommitFilter({ hideTags: !commitFilter?.hideTags })}
+							>
+								{commitFilter?.hideTags ? 'Show Tags' : 'Hide Tags'}
+							</button>
 						</div>
 					</div>
 					{isAccessAllowed && rows.length > 0 && (

--- a/src/webviews/apps/plus/graph/graph.tsx
+++ b/src/webviews/apps/plus/graph/graph.tsx
@@ -37,6 +37,7 @@ import {
 	SearchCommandType,
 	SearchOpenInViewCommandType,
 	UpdateColumnsCommandType,
+	UpdateCommitFilterSelectionCommandType,
 	UpdateRefsVisibilityCommandType,
 	UpdateSelectedRepositoryCommandType as UpdateRepositorySelectionCommandType,
 	UpdateSelectionCommandType,
@@ -90,6 +91,10 @@ export class GraphApp extends App<State> {
 					onRefsVisibilityChange={(refs: GraphHiddenRef[], visible: boolean) =>
 						this.onRefsVisibilityChanged(refs, visible)
 					}
+					onSelectCommitFilter={debounce<GraphApp['onCommitFilterSelectionChanged']>(
+						filter => this.onCommitFilterSelectionChanged(filter),
+						250,
+					)}
 					onSelectRepository={debounce<GraphApp['onRepositorySelectionChanged']>(
 						path => this.onRepositorySelectionChanged(path),
 						250,
@@ -393,6 +398,12 @@ export class GraphApp extends App<State> {
 	private onDoubleClickRef(ref: GraphRef) {
 		this.sendCommand(DoubleClickedRefCommandType, {
 			ref: ref,
+		});
+	}
+
+	private onCommitFilterSelectionChanged(commitFilter: any) {
+		this.sendCommand(UpdateCommitFilterSelectionCommandType, {
+			commitFilter: commitFilter,
 		});
 	}
 


### PR DESCRIPTION
Adds a filter for showing the current branch only. Preliminary hard-coded UX has a button on the graph status bar at the bottom for toggling it.

Limitations:
- Won't work with the GitHub provider just yet (need to figure out how to apply filters with GitHub API)
- When it's turned on, we currently won't show any stashes (needs further investigation as the way we currently pull stashes and inject them into the Git call makes it tricky).