### PR TITLE
153 - Rows are grayed out fairly frequently when VSCode loses the focus (Gitlens side)

### DIFF
--- a/src/plus/webviews/graph/graphWebview.ts
+++ b/src/plus/webviews/graph/graphWebview.ts
@@ -101,7 +101,8 @@ import type {
 	UpdateColumnsParams,
 	UpdateRefsVisibilityParams,
 	UpdateSelectedRepositoryParams,
-	UpdateSelectionParams} from './protocol';
+	UpdateSelectionParams
+} from './protocol';
 import {
 	DidChangeAvatarsNotificationType,
 	DidChangeColumnsNotificationType,

--- a/src/plus/webviews/graph/graphWebview.ts
+++ b/src/plus/webviews/graph/graphWebview.ts
@@ -101,8 +101,7 @@ import type {
 	UpdateColumnsParams,
 	UpdateRefsVisibilityParams,
 	UpdateSelectedRepositoryParams,
-	UpdateSelectionParams,
-} from './protocol';
+	UpdateSelectionParams} from './protocol';
 import {
 	DidChangeAvatarsNotificationType,
 	DidChangeColumnsNotificationType,
@@ -113,6 +112,7 @@ import {
 	DidChangeRowsNotificationType,
 	DidChangeSelectionNotificationType,
 	DidChangeSubscriptionNotificationType,
+	DidChangeWindowFocusNotificationType,
 	DidChangeWorkingTreeNotificationType,
 	DidEnsureRowNotificationType,
 	DidFetchNotificationType,
@@ -201,6 +201,7 @@ export class GraphWebview extends WebviewBase<State> {
 	private _lastFetchedDisposable: Disposable | undefined;
 
 	private trialBanner?: boolean;
+	private isWindowFocused: boolean = true;
 
 	constructor(container: Container) {
 		super(
@@ -254,6 +255,11 @@ export class GraphWebview extends WebviewBase<State> {
 				},
 			),
 		);
+	}
+
+	protected override onWindowFocusChanged(focused: boolean): void {
+		this.isWindowFocused = focused;
+		void this.notifyDidChangeWindowFocus();
 	}
 
 	protected override get options(): WebviewPanelOptions & WebviewOptions {
@@ -936,6 +942,18 @@ export class GraphWebview extends WebviewBase<State> {
 		void this._notifyDidChangeStateDebounced();
 	}
 
+	@debug()
+	private async notifyDidChangeWindowFocus(): Promise<boolean> {
+		if (!this.isReady || !this.visible) {
+			this.addPendingIpcNotification(DidChangeWindowFocusNotificationType);
+			return false;
+		}
+
+		return this.notify(DidChangeWindowFocusNotificationType, {
+			focused: this.isWindowFocused,
+		});
+	}
+
 	private _notifyDidChangeAvatarsDebounced: Deferrable<GraphWebview['notifyDidChangeAvatars']> | undefined =
 		undefined;
 
@@ -1135,6 +1153,7 @@ export class GraphWebview extends WebviewBase<State> {
 		[DidChangeSelectionNotificationType, this.notifyDidChangeSelection],
 		[DidChangeSubscriptionNotificationType, this.notifyDidChangeSubscription],
 		[DidChangeWorkingTreeNotificationType, this.notifyDidChangeWorkingTree],
+		[DidChangeWindowFocusNotificationType, this.notifyDidChangeWindowFocus],
 	]);
 
 	private addPendingIpcNotification(type: IpcNotificationType<any>, msg?: IpcMessage) {
@@ -1450,6 +1469,7 @@ export class GraphWebview extends WebviewBase<State> {
 		const branch = await this.repository.getBranch();
 
 		return {
+			windowFocused: this.isWindowFocused,
 			trialBanner: this.trialBanner,
 			repositories: formatRepositories(this.container.git.openRepositories),
 			selectedRepository: this.repository.path,

--- a/src/plus/webviews/graph/protocol.ts
+++ b/src/plus/webviews/graph/protocol.ts
@@ -38,6 +38,7 @@ export type GraphMissingRefsMetadata = Record</*id*/ string, /*missingType*/ Gra
 export type GraphPullRequestMetadata = PullRequestMetadata;
 
 export interface State {
+	windowFocused?: boolean,
 	repositories?: GraphRepository[];
 	selectedRepository?: string;
 	selectedRepositoryVisibility?: RepositoryVisibility;
@@ -245,6 +246,14 @@ export interface DidChangeColumnsParams {
 }
 export const DidChangeColumnsNotificationType = new IpcNotificationType<DidChangeColumnsParams>(
 	'graph/columns/didChange',
+	true,
+);
+
+export interface DidChangeWindowFocusParams {
+	focused: boolean;
+}
+export const DidChangeWindowFocusNotificationType= new IpcNotificationType<DidChangeWindowFocusParams>(
+	'graph/window/focus/didChange',
 	true,
 );
 

--- a/src/plus/webviews/graph/protocol.ts
+++ b/src/plus/webviews/graph/protocol.ts
@@ -252,7 +252,7 @@ export const DidChangeColumnsNotificationType = new IpcNotificationType<DidChang
 export interface DidChangeWindowFocusParams {
 	focused: boolean;
 }
-export const DidChangeWindowFocusNotificationType= new IpcNotificationType<DidChangeWindowFocusParams>(
+export const DidChangeWindowFocusNotificationType = new IpcNotificationType<DidChangeWindowFocusParams>(
 	'graph/window/focus/didChange',
 	true,
 );

--- a/src/webviews/apps/plus/graph/GraphWrapper.tsx
+++ b/src/webviews/apps/plus/graph/GraphWrapper.tsx
@@ -31,8 +31,7 @@ import type {
 	GraphSearchResultsError,
 	InternalNotificationType,
 	State,
-	UpdateStateCallback,
-} from '../../../../plus/webviews/graph/protocol';
+	UpdateStateCallback} from '../../../../plus/webviews/graph/protocol';
 import {
 	DidChangeAvatarsNotificationType,
 	DidChangeColumnsNotificationType,
@@ -42,6 +41,7 @@ import {
 	DidChangeRowsNotificationType,
 	DidChangeSelectionNotificationType,
 	DidChangeSubscriptionNotificationType,
+	DidChangeWindowFocusNotificationType,
 	DidChangeWorkingTreeNotificationType,
 	DidFetchNotificationType,
 	DidSearchNotificationType,
@@ -169,6 +169,7 @@ export function GraphWrapper({
 	const [styleProps, setStyleProps] = useState(state.theming);
 	const [branchName, setBranchName] = useState(state.branchName);
 	const [lastFetched, setLastFetched] = useState(state.lastFetched);
+	const [windowFocused, setWindowFocused] = useState(state.windowFocused);
 	// account
 	const [showAccount, setShowAccount] = useState(state.trialBanner);
 	const [isAccessAllowed, setIsAccessAllowed] = useState(state.allowed ?? false);
@@ -210,6 +211,9 @@ export function GraphWrapper({
 				break;
 			case DidChangeAvatarsNotificationType:
 				setAvatars(state.avatars);
+				break;
+			case DidChangeWindowFocusNotificationType:
+				setWindowFocused(state.windowFocused);
 				break;
 			case DidChangeRefsMetadataNotificationType:
 				setRefsMetadata(state.refsMetadata);
@@ -288,6 +292,10 @@ export function GraphWrapper({
 	}
 
 	useEffect(() => subscriber?.(updateState), []);
+
+	useEffect(() => {
+		graphRef.current?.setContainerWindowFocused(windowFocused || false);
+	}, [windowFocused]);
 
 	useEffect(() => {
 		if (searchResultsError != null || searchResults == null || searchResults.count === 0 || searchQuery == null) {

--- a/src/webviews/apps/plus/graph/GraphWrapper.tsx
+++ b/src/webviews/apps/plus/graph/GraphWrapper.tsx
@@ -294,10 +294,6 @@ export function GraphWrapper({
 	useEffect(() => subscriber?.(updateState), []);
 
 	useEffect(() => {
-		graphRef.current?.setContainerWindowFocused(windowFocused || false);
-	}, [windowFocused]);
-
-	useEffect(() => {
 		if (searchResultsError != null || searchResults == null || searchResults.count === 0 || searchQuery == null) {
 			return;
 		}
@@ -844,6 +840,7 @@ export function GraphWrapper({
 							scrollRowPadding={graphConfig?.scrollRowPadding}
 							showGhostRefsOnRowHover={graphConfig?.showGhostRefsOnRowHover}
 							showRemoteNamesOnRefs={graphConfig?.showRemoteNamesOnRefs}
+							isContainerWindowFocused={windowFocused}
 							isLoadingRows={isLoading}
 							isSelectedBySha={selectedRows}
 							nonce={nonce}

--- a/src/webviews/apps/plus/graph/graph.tsx
+++ b/src/webviews/apps/plus/graph/graph.tsx
@@ -13,8 +13,7 @@ import type {
 	GraphRepository,
 	InternalNotificationType,
 	State,
-	UpdateStateCallback,
-} from '../../../../plus/webviews/graph/protocol';
+	UpdateStateCallback} from '../../../../plus/webviews/graph/protocol';
 import {
 	DidChangeAvatarsNotificationType,
 	DidChangeColumnsNotificationType,
@@ -25,6 +24,7 @@ import {
 	DidChangeRowsNotificationType,
 	DidChangeSelectionNotificationType,
 	DidChangeSubscriptionNotificationType,
+	DidChangeWindowFocusNotificationType,
 	DidChangeWorkingTreeNotificationType,
 	DidEnsureRowNotificationType,
 	DidFetchNotificationType,
@@ -140,6 +140,13 @@ export class GraphApp extends App<State> {
 			case DidChangeAvatarsNotificationType.method:
 				onIpc(DidChangeAvatarsNotificationType, msg, (params, type) => {
 					this.state.avatars = params.avatars;
+					this.setState(this.state, type);
+				});
+				break;
+
+			case DidChangeWindowFocusNotificationType.method:
+				onIpc(DidChangeWindowFocusNotificationType, msg, (params, type) => {
+					this.state.windowFocused = params.focused;
 					this.setState(this.state, type);
 				});
 				break;

--- a/src/webviews/webviewBase.ts
+++ b/src/webviews/webviewBase.ts
@@ -51,10 +51,7 @@ export abstract class WebviewBase<State> implements Disposable {
 		showCommand: Commands,
 	) {
 		this._originalTitle = this._title = title;
-		this.disposables.push(
-			registerCommand(showCommand, this.onShowCommand, this),
-			window.onDidChangeWindowState(this.onWindowStateChanged, this),
-		);
+		this.disposables.push(registerCommand(showCommand, this.onShowCommand, this));
 	}
 
 	dispose() {
@@ -121,6 +118,7 @@ export abstract class WebviewBase<State> implements Disposable {
 				this._panel.webview.onDidReceiveMessage(this.onMessageReceivedCore, this),
 				...(this.onInitializing?.() ?? []),
 				...(this.registerCommands?.() ?? []),
+				window.onDidChangeWindowState(this.onWindowStateChanged, this),
 			);
 
 			this._panel.webview.html = await this.getHtml(this._panel.webview);


### PR DESCRIPTION
# Summary of changes
- Added new notification to know the VS Code window focus state. In that way, we can notify the graph component to disable the hover behavior of the refs when Gitlens loses the focus. 

# Notes
- This PR works with Graph component side changes: https://github.com/gitkraken/GitKrakenComponents/pull/157

# Task
https://github.com/gitkraken/GitKrakenComponents/issues/153
