### PR TITLE
Add graph setting for auto-dimming merge commit rows

### DIFF
--- a/package.json
+++ b/package.json
@@ -2236,6 +2236,13 @@
 						"scope": "window",
 						"order": 24
 					},
+					"gitlens.graph.dimMergeCommits": {
+						"type": "boolean",
+						"default": false,
+						"markdownDescription": "Specifies whether to always dim rows with merge commits in the _Commit Graph_",
+						"scope": "window",
+						"order": 25
+					},
 					"gitlens.graph.commitOrdering": {
 						"type": "string",
 						"default": "date",

--- a/src/config.ts
+++ b/src/config.ts
@@ -387,6 +387,7 @@ export interface GraphConfig {
 	dateFormat: DateTimeFormat | string | null;
 	dateStyle: DateStyle | null;
 	defaultItemLimit: number;
+	dimMergeCommits: boolean;
 	highlightRowsOnRefHover: boolean;
 	scrollRowPadding: number;
 	showDetailsView: 'open' | 'selection' | false;

--- a/src/plus/webviews/graph/graphWebview.ts
+++ b/src/plus/webviews/graph/graphWebview.ts
@@ -529,6 +529,7 @@ export class GraphWebview extends WebviewBase<State> {
 			configuration.changed(e, 'graph.avatars') ||
 			configuration.changed(e, 'graph.dateFormat') ||
 			configuration.changed(e, 'graph.dateStyle') ||
+			configuration.changed(e, 'graph.dimMergeCommits') ||
 			configuration.changed(e, 'graph.highlightRowsOnRefHover') ||
 			configuration.changed(e, 'graph.scrollRowPadding') ||
 			configuration.changed(e, 'graph.showGhostRefsOnRowHover') ||
@@ -1453,6 +1454,7 @@ export class GraphWebview extends WebviewBase<State> {
 			dateFormat:
 				configuration.get('graph.dateFormat') ?? configuration.get('defaultDateFormat') ?? 'short+short',
 			dateStyle: configuration.get('graph.dateStyle') ?? configuration.get('defaultDateStyle'),
+			dimMergeCommits: configuration.get('graph.dimMergeCommits'),
 			enableMultiSelection: false,
 			highlightRowsOnRefHover: configuration.get('graph.highlightRowsOnRefHover'),
 			scrollRowPadding: configuration.get('graph.scrollRowPadding'),

--- a/src/plus/webviews/graph/protocol.ts
+++ b/src/plus/webviews/graph/protocol.ts
@@ -107,6 +107,7 @@ export interface GraphComponentConfig {
 	avatars?: boolean;
 	dateFormat: DateTimeFormat | string;
 	dateStyle: DateStyle;
+	dimMergeCommits?: boolean;
 	enableMultiSelection?: boolean;
 	highlightRowsOnRefHover?: boolean;
 	scrollRowPadding?: number;

--- a/src/webviews/apps/plus/graph/GraphWrapper.tsx
+++ b/src/webviews/apps/plus/graph/GraphWrapper.tsx
@@ -941,6 +941,7 @@ export function GraphWrapper({
 							columnsSettings={columns}
 							contexts={context}
 							cssVariables={styleProps?.cssVariables}
+							dimMergeCommits={graphConfig?.dimMergeCommits}
 							enableMultiSelection={graphConfig?.enableMultiSelection}
 							excludeRefsById={excludeRefsById}
 							excludeByType={excludeTypes}

--- a/src/webviews/apps/settings/partials/commit-graph.html
+++ b/src/webviews/apps/settings/partials/commit-graph.html
@@ -135,6 +135,20 @@
 					<div class="setting">
 						<div class="setting__input">
 							<input
+								id="graph.dimMergeCommits"
+								name="graph.dimMergeCommits"
+								type="checkbox"
+								data-setting
+							/>
+							<label for="graph.dimMergeCommits"
+								>Always dim merge commit rows</label
+							>
+						</div>
+					</div>
+
+					<div class="setting">
+						<div class="setting__input">
+							<input
 								id="graph.showRemoteNames"
 								name="graph.showRemoteNames"
 								type="checkbox"


### PR DESCRIPTION
Adds a graph setting for always dimming merge commit rows on the commit graph. Defaulted to off.