### PR TITLE
Add "dim merge commit rows" to filter dropdown

### DIFF
--- a/package.json
+++ b/package.json
@@ -2239,7 +2239,7 @@
 					"gitlens.graph.dimMergeCommits": {
 						"type": "boolean",
 						"default": false,
-						"markdownDescription": "Specifies whether to always dim rows with merge commits in the _Commit Graph_",
+						"markdownDescription": "Specifies whether to dim rows with merge commits in the _Commit Graph_",
 						"scope": "window",
 						"order": 25
 					},

--- a/src/plus/webviews/graph/graphWebview.ts
+++ b/src/plus/webviews/graph/graphWebview.ts
@@ -75,6 +75,7 @@ import { WebviewBase } from '../../../webviews/webviewBase';
 import type { SubscriptionChangeEvent } from '../../subscription/subscriptionService';
 import { arePlusFeaturesEnabled, ensurePlusFeaturesEnabled } from '../../subscription/utils';
 import type {
+	DimMergeCommitsParams,
 	DismissBannerParams,
 	DoubleClickedRefParams,
 	EnsureRowParams,
@@ -121,6 +122,7 @@ import {
 	DidEnsureRowNotificationType,
 	DidFetchNotificationType,
 	DidSearchNotificationType,
+	DimMergeCommitsCommandType,
 	DismissBannerCommandType,
 	DoubleClickedRefCommandType,
 	EnsureRowCommandType,
@@ -404,6 +406,9 @@ export class GraphWebview extends WebviewBase<State> {
 
 	protected override onMessageReceived(e: IpcMessage) {
 		switch (e.method) {
+			case DimMergeCommitsCommandType.method:
+				onIpc(DimMergeCommitsCommandType, e, params => this.dimMergeCommits(params));
+				break;
 			case DismissBannerCommandType.method:
 				onIpc(DismissBannerCommandType, e, params => this.dismissBanner(params));
 				break;
@@ -595,6 +600,10 @@ export class GraphWebview extends WebviewBase<State> {
 
 		this._theme = theme;
 		this.updateState();
+	}
+
+	private dimMergeCommits(e: DimMergeCommitsParams) {
+		void configuration.updateEffective('graph.dimMergeCommits', e.dim);
 	}
 
 	private dismissBanner(e: DismissBannerParams) {

--- a/src/plus/webviews/graph/protocol.ts
+++ b/src/plus/webviews/graph/protocol.ts
@@ -140,6 +140,11 @@ export interface UpdateStateCallback {
 }
 
 // Commands
+export interface DimMergeCommitsParams {
+	dim: boolean;
+}
+export const DimMergeCommitsCommandType = new IpcCommandType<DimMergeCommitsParams>('graph/dimMergeCommits');
+
 export interface DismissBannerParams {
 	key: 'preview' | 'trial';
 }

--- a/src/webviews/apps/plus/graph/GraphWrapper.tsx
+++ b/src/webviews/apps/plus/graph/GraphWrapper.tsx
@@ -339,6 +339,10 @@ export function GraphWrapper({
 			return true;
 		}
 
+		if (graphConfig?.dimMergeCommits) {
+			return true;
+		}
+
 		if (excludeTypes == null) {
 			return false;
 		}

--- a/src/webviews/apps/plus/graph/GraphWrapper.tsx
+++ b/src/webviews/apps/plus/graph/GraphWrapper.tsx
@@ -67,6 +67,7 @@ export interface GraphWrapperProps {
 	subscriber: (callback: UpdateStateCallback) => () => void;
 	onSelectRepository?: (repository: GraphRepository) => void;
 	onColumnsChange?: (colsSettings: GraphColumnsConfig) => void;
+	onDimMergeCommits?: (dim: boolean) => void;
 	onDoubleClickRef?: (ref: GraphRef) => void;
 	onMissingAvatars?: (emails: { [email: string]: string }) => void;
 	onMissingRefsMetadata?: (metadata: GraphMissingRefsMetadata) => void;
@@ -141,6 +142,7 @@ export function GraphWrapper({
 	state,
 	onSelectRepository,
 	onColumnsChange,
+	onDimMergeCommits,
 	onDoubleClickRef,
 	onEnsureRowPromise,
 	onMissingAvatars,
@@ -491,11 +493,14 @@ export function GraphWrapper({
 
 		const value = $el.value;
 		const isLocalBranches = ['branch-all', 'branch-current'].includes(value);
-		if (!isLocalBranches && !['remotes', 'stashes', 'tags'].includes(value)) return;
+		if (!isLocalBranches && !['remotes', 'stashes', 'tags', 'mergeCommits'].includes(value)) return;
+		const isChecked = $el.checked;
+		if (value === 'mergeCommits') {
+			onDimMergeCommits?.(isChecked);
+			return;
+		}
 
 		const key = value as keyof GraphExcludeTypes;
-		const isChecked = $el.checked;
-
 		const currentFilter = excludeTypes?.[key];
 		if ((currentFilter == null && isChecked) || (currentFilter != null && currentFilter !== isChecked)) {
 			setExcludeTypes({
@@ -912,6 +917,15 @@ export function GraphWrapper({
 											defaultChecked={excludeTypes?.tags ?? false}
 										>
 											Hide Tags
+										</VSCodeCheckbox>
+									</MenuItem>
+									<MenuItem role="none">
+										<VSCodeCheckbox
+											value="mergeCommits"
+											onChange={handleExcludeTypeChange}
+											defaultChecked={graphConfig?.dimMergeCommits ?? false}
+										>
+											Dim Merge Commit Rows
 										</VSCodeCheckbox>
 									</MenuItem>
 								</MenuList>

--- a/src/webviews/apps/plus/graph/graph.tsx
+++ b/src/webviews/apps/plus/graph/graph.tsx
@@ -30,6 +30,7 @@ import {
 	DidEnsureRowNotificationType,
 	DidFetchNotificationType,
 	DidSearchNotificationType,
+	DimMergeCommitsCommandType,
 	DismissBannerCommandType,
 	DoubleClickedRefCommandType,
 	EnsureRowCommandType,
@@ -91,6 +92,7 @@ export class GraphApp extends App<State> {
 						settings => this.onColumnsChanged(settings),
 						250,
 					)}
+					onDimMergeCommits={dim => this.onDimMergeCommits(dim)}
 					onRefsVisibilityChange={(refs: GraphExcludedRef[], visible: boolean) =>
 						this.onRefsVisibilityChanged(refs, visible)
 					}
@@ -409,6 +411,12 @@ export class GraphApp extends App<State> {
 		this.sendCommand(UpdateRefsVisibilityCommandType, {
 			refs: refs,
 			visible: visible,
+		});
+	}
+
+	private onDimMergeCommits(dim: boolean) {
+		this.sendCommand(DimMergeCommitsCommandType, {
+			dim: dim,
 		});
 	}
 

--- a/src/webviews/apps/settings/partials/commit-graph.html
+++ b/src/webviews/apps/settings/partials/commit-graph.html
@@ -141,7 +141,7 @@
 								data-setting
 							/>
 							<label for="graph.dimMergeCommits"
-								>Always dim merge commit rows</label
+								>Dim merge commit rows</label
 							>
 						</div>
 					</div>


### PR DESCRIPTION
Adds the option to "dim merge commit rows", which is already in graph settings, to the filter dropdown for easier access/toggling.

Notes/questions:
- Removed "always" from the wording on the setting.
- Going through the command system to do this, would love feedback if there's a simpler way to set it up.
- Having this item checked activates the indicator on the filter icon, just like having any other item in that dropdown checked. Not sure if we want this, as this is technically not a "filter" in the same sense as the other options.