### PR TITLE
Add line/range on remote from commands

### DIFF
--- a/src/commands/openFileOnRemote.ts
+++ b/src/commands/openFileOnRemote.ts
@@ -100,7 +100,7 @@ export class OpenFileOnRemoteCommand extends ActiveEditorCommand {
 		}
 
 		if (context.command === Commands.OpenFileOnRemoteFrom || context.command === Commands.CopyRemoteFileUrlFrom) {
-			args = { ...args, pickBranchOrTag: true, range: false };
+			args = { ...args, pickBranchOrTag: true };
 		}
 
 		return this.execute(context.editor, uri, args);


### PR DESCRIPTION
Add ability to include line (or range) on `Copy Remote File URL From...` and `Open File on Remote From...` commands.

Closes #2399
