### PR TITLE
Graph: add setting to show status of local branch relative to its upstream

### DIFF
--- a/package.json
+++ b/package.json
@@ -2243,6 +2243,13 @@
 						"scope": "window",
 						"order": 25
 					},
+					"gitlens.graph.showUpstreamStatus": {
+						"type": "boolean",
+						"default": false,
+						"markdownDescription": "Specifies whether to show a local branch's upstream status in the _Commit Graph_",
+						"scope": "window",
+						"order": 26
+					},
 					"gitlens.graph.commitOrdering": {
 						"type": "string",
 						"default": "date",

--- a/src/config.ts
+++ b/src/config.ts
@@ -393,6 +393,7 @@ export interface GraphConfig {
 	showDetailsView: 'open' | 'selection' | false;
 	showGhostRefsOnRowHover: boolean;
 	showRemoteNames: boolean;
+	showUpstreamStatus: boolean;
 	pageItemLimit: number;
 	searchItemLimit: number;
 	statusBar: {

--- a/src/plus/webviews/graph/graphWebview.ts
+++ b/src/plus/webviews/graph/graphWebview.ts
@@ -546,7 +546,8 @@ export class GraphWebview extends WebviewBase<State> {
 			configuration.changed(e, 'graph.highlightRowsOnRefHover') ||
 			configuration.changed(e, 'graph.scrollRowPadding') ||
 			configuration.changed(e, 'graph.showGhostRefsOnRowHover') ||
-			configuration.changed(e, 'graph.showRemoteNames')
+			configuration.changed(e, 'graph.showRemoteNames') ||
+			configuration.changed(e, 'graph.showUpstreamStatus')
 		) {
 			void this.notifyDidChangeConfiguration();
 		}
@@ -1561,6 +1562,7 @@ export class GraphWebview extends WebviewBase<State> {
 			scrollRowPadding: configuration.get('graph.scrollRowPadding'),
 			showGhostRefsOnRowHover: configuration.get('graph.showGhostRefsOnRowHover'),
 			showRemoteNamesOnRefs: configuration.get('graph.showRemoteNames'),
+			showUpstreamStatus: configuration.get('graph.showUpstreamStatus'),
 			idLength: configuration.get('advanced.abbreviatedShaLength'),
 		};
 		return config;

--- a/src/plus/webviews/graph/graphWebview.ts
+++ b/src/plus/webviews/graph/graphWebview.ts
@@ -787,14 +787,9 @@ export class GraphWebview extends WebviewBase<State> {
 					return;
 				}
 
-				// Remote owner is the first part before the /.
-				const upstreamOwner = upstream.name.split('/')[0];
-				// Name is everything in the string after th first /.
-				const upstreamName = upstream.name.substring(upstreamOwner.length + 1);
-
 				const upstreamMetadata: GraphUpstreamMetadata = {
-					name: upstreamName,
-					owner: upstreamOwner,
+					name: getBranchNameWithoutRemote(upstream.name),
+					owner: getRemoteNameFromBranchName(upstream.name),
 					ahead: branch.state.ahead,
 					behind: branch.state.behind,
 				};

--- a/src/plus/webviews/graph/graphWebview.ts
+++ b/src/plus/webviews/graph/graphWebview.ts
@@ -779,10 +779,14 @@ export class GraphWebview extends WebviewBase<State> {
 					?.values?.[0];
 				const upstream = branch?.upstream;
 
-				if (upstream == null) return;
+				if (upstream == null || upstream == undefined) {
+					metadata.upstream = null;
+					this._refsMetadata.set(id, metadata);
+					return;
+				}
 
 				if (upstream?.missing) {
-					metadata.upstream = null;
+					metadata.upstream = undefined;
 					this._refsMetadata.set(id, metadata);
 					return;
 				}

--- a/src/plus/webviews/graph/graphWebview.ts
+++ b/src/plus/webviews/graph/graphWebview.ts
@@ -779,14 +779,8 @@ export class GraphWebview extends WebviewBase<State> {
 					?.values?.[0];
 				const upstream = branch?.upstream;
 
-				if (upstream == null || upstream == undefined) {
+				if (upstream == null || upstream == undefined || upstream.missing) {
 					metadata.upstream = null;
-					this._refsMetadata.set(id, metadata);
-					return;
-				}
-
-				if (upstream?.missing) {
-					metadata.upstream = undefined;
 					this._refsMetadata.set(id, metadata);
 					return;
 				}

--- a/src/plus/webviews/graph/protocol.ts
+++ b/src/plus/webviews/graph/protocol.ts
@@ -16,6 +16,7 @@ import type {
 	RefMetadataType,
 	Remote,
 	Tag,
+	UpstreamMetadata,
 	WorkDirStats,
 } from '@gitkraken/gitkraken-components';
 import type { DateStyle } from '../../../config';
@@ -33,6 +34,7 @@ export type GraphSelectedRows = Record</*id*/ string, true>;
 export type GraphAvatars = Record</*email*/ string, /*url*/ string>;
 
 export type GraphRefMetadata = RefMetadata | null;
+export type GraphUpstreamMetadata = UpstreamMetadata | null;
 export type GraphRefsMetadata = Record</* id */ string, GraphRefMetadata>;
 export type GraphHostingServiceType = HostingServiceType;
 export type GraphMissingRefsMetadataType = RefMetadataType;

--- a/src/plus/webviews/graph/protocol.ts
+++ b/src/plus/webviews/graph/protocol.ts
@@ -117,6 +117,7 @@ export interface GraphComponentConfig {
 	scrollRowPadding?: number;
 	showGhostRefsOnRowHover?: boolean;
 	showRemoteNamesOnRefs?: boolean;
+	showUpstreamStatus?: boolean;
 	idLength?: number;
 }
 

--- a/src/webviews/apps/plus/graph/GraphWrapper.tsx
+++ b/src/webviews/apps/plus/graph/GraphWrapper.tsx
@@ -109,6 +109,8 @@ const createIconElements = (): { [key: string]: ReactElement<any> } => {
 		'pull-request',
 		'show',
 		'hide',
+		'upstream-ahead',
+		'upstream-behind',
 	];
 	const elementLibrary: { [key: string]: ReactElement<any> } = {};
 	iconList.forEach(iconKey => {

--- a/src/webviews/apps/plus/graph/GraphWrapper.tsx
+++ b/src/webviews/apps/plus/graph/GraphWrapper.tsx
@@ -1037,6 +1037,7 @@ export function GraphWrapper({
 							platform={clientPlatform}
 							refMetadataById={refsMetadata}
 							shaLength={graphConfig?.idLength}
+							showUpstreamStatus={graphConfig?.showUpstreamStatus}
 							themeOpacityFactor={styleProps?.themeOpacityFactor}
 							useAuthorInitialsForAvatars={!graphConfig?.avatars}
 							workDirStats={workingTreeStats}

--- a/src/webviews/apps/plus/graph/GraphWrapper.tsx
+++ b/src/webviews/apps/plus/graph/GraphWrapper.tsx
@@ -109,12 +109,19 @@ const createIconElements = (): { [key: string]: ReactElement<any> } => {
 		'pull-request',
 		'show',
 		'hide',
+	];
+
+	const miniIconList = [
 		'upstream-ahead',
 		'upstream-behind',
 	];
+
 	const elementLibrary: { [key: string]: ReactElement<any> } = {};
 	iconList.forEach(iconKey => {
 		elementLibrary[iconKey] = createElement('span', { className: `graph-icon icon--${iconKey}` });
+	});
+	miniIconList.forEach(iconKey => {
+		elementLibrary[iconKey] = createElement('span', { className: `graph-icon mini-icon icon--${iconKey}` });
 	});
 	return elementLibrary;
 };

--- a/src/webviews/apps/plus/graph/graph.scss
+++ b/src/webviews/apps/plus/graph/graph.scss
@@ -474,6 +474,20 @@ button:not([disabled]),
 			content: '\ea64';
 		}
 	}
+	&--upstream-ahead {
+		&::before {
+			// codicon-arrow-up
+			font-family: codicon;
+			content: '\eaa1';
+		}
+	}
+	&--upstream-behind {
+		&::before {
+			// codicon-arrow-down
+			font-family: codicon;
+			content: '\ea9a';
+		}
+	}
 }
 
 .titlebar {

--- a/src/webviews/apps/plus/graph/graph.scss
+++ b/src/webviews/apps/plus/graph/graph.scss
@@ -374,7 +374,7 @@ button:not([disabled]),
 	letter-spacing: normal;
 
 	&.mini-icon {
-		font-size: 10px;
+		font-size: 1rem;
 		line-height: 1.6rem;
 	}
 }

--- a/src/webviews/apps/plus/graph/graph.scss
+++ b/src/webviews/apps/plus/graph/graph.scss
@@ -372,6 +372,11 @@ button:not([disabled]),
 	vertical-align: middle;
 	line-height: 2rem;
 	letter-spacing: normal;
+
+	&.mini-icon {
+		font-size: 10px;
+		line-height: 1.6rem;
+	}
 }
 
 .icon {

--- a/src/webviews/apps/settings/partials/commit-graph.html
+++ b/src/webviews/apps/settings/partials/commit-graph.html
@@ -160,6 +160,20 @@
 
 					<div class="setting">
 						<div class="setting__input">
+							<input
+								id="graph.showUpstreamStatus"
+								name="graph.showUpstreamStatus"
+								type="checkbox"
+								data-setting
+							/>
+							<label for="graph.showUpstreamStatus"
+								>Show upstream status on local branches with remotes</label
+							>
+						</div>
+					</div>
+
+					<div class="setting">
+						<div class="setting__input">
 							<input id="graph.avatars" name="graph.avatars" type="checkbox" data-setting />
 							<label for="graph.avatars">Use author and remote avatars</label>
 						</div>


### PR DESCRIPTION
![image](https://user-images.githubusercontent.com/67011668/211656047-f1296a1c-5815-4d06-a8c1-04fa43f6259d.png)

Adds a graph setting (default: off) to show stats on local branch refs in the graph relative to upstream when an upstream exists. These can be fetched dynamically (they use the same system as avatars).