### PR TITLE
Add setting to toggle PR icons in Graph

### DIFF
--- a/package.json
+++ b/package.json
@@ -12731,7 +12731,7 @@
 		"vscode:prepublish": "yarn run bundle"
 	},
 	"dependencies": {
-		"@gitkraken/gitkraken-components": "1.1.0-rc.22",
+		"@gitkraken/gitkraken-components": "2.0.0",
 		"@microsoft/fast-element": "1.11.0",
 		"@microsoft/fast-react-wrapper": "0.3.16-0",
 		"@octokit/core": "4.1.0",

--- a/package.json
+++ b/package.json
@@ -2246,7 +2246,7 @@
 					"gitlens.graph.showUpstreamStatus": {
 						"type": "boolean",
 						"default": false,
-						"markdownDescription": "Specifies whether to show a local branch's upstream status in the _Commit Graph_. Requires a connection to a supported remote service (e.g. GitHub)",
+						"markdownDescription": "Specifies whether to show a local branch's upstream status in the _Commit Graph_",
 						"scope": "window",
 						"order": 26
 					},

--- a/package.json
+++ b/package.json
@@ -2250,6 +2250,13 @@
 						"scope": "window",
 						"order": 26
 					},
+					"gitlens.graph.showPullRequests": {
+						"type": "boolean",
+						"default": false,
+						"markdownDescription": "Specifies whether to show associated pull requests on remote branches in the _Commit Graph_",
+						"scope": "window",
+						"order": 27
+					},
 					"gitlens.graph.commitOrdering": {
 						"type": "string",
 						"default": "date",

--- a/package.json
+++ b/package.json
@@ -2246,14 +2246,14 @@
 					"gitlens.graph.showUpstreamStatus": {
 						"type": "boolean",
 						"default": false,
-						"markdownDescription": "Specifies whether to show a local branch's upstream status in the _Commit Graph_",
+						"markdownDescription": "Specifies whether to show a local branch's upstream status in the _Commit Graph_. Requires a connection to a supported remote service (e.g. GitHub)",
 						"scope": "window",
 						"order": 26
 					},
 					"gitlens.graph.pullRequests.enabled": {
 						"type": "boolean",
 						"default": false,
-						"markdownDescription": "Specifies whether to show associated pull requests on remote branches in the _Commit Graph_",
+						"markdownDescription": "Specifies whether to show associated pull requests on remote branches in the _Commit Graph_. Requires a connection to a supported remote service (e.g. GitHub)",
 						"scope": "window",
 						"order": 27
 					},

--- a/package.json
+++ b/package.json
@@ -2250,7 +2250,7 @@
 						"scope": "window",
 						"order": 26
 					},
-					"gitlens.graph.showPullRequests": {
+					"gitlens.graph.pullRequests.enabled": {
 						"type": "boolean",
 						"default": false,
 						"markdownDescription": "Specifies whether to show associated pull requests on remote branches in the _Commit Graph_",

--- a/src/config.ts
+++ b/src/config.ts
@@ -392,7 +392,9 @@ export interface GraphConfig {
 	scrollRowPadding: number;
 	showDetailsView: 'open' | 'selection' | false;
 	showGhostRefsOnRowHover: boolean;
-	showPullRequests: boolean;
+	pullRequests: {
+		enabled: boolean;
+	};
 	showRemoteNames: boolean;
 	showUpstreamStatus: boolean;
 	pageItemLimit: number;

--- a/src/config.ts
+++ b/src/config.ts
@@ -392,6 +392,7 @@ export interface GraphConfig {
 	scrollRowPadding: number;
 	showDetailsView: 'open' | 'selection' | false;
 	showGhostRefsOnRowHover: boolean;
+	showPullRequests: boolean;
 	showRemoteNames: boolean;
 	showUpstreamStatus: boolean;
 	pageItemLimit: number;

--- a/src/plus/webviews/graph/graphWebview.ts
+++ b/src/plus/webviews/graph/graphWebview.ts
@@ -548,7 +548,7 @@ export class GraphWebview extends WebviewBase<State> {
 			configuration.changed(e, 'graph.highlightRowsOnRefHover') ||
 			configuration.changed(e, 'graph.scrollRowPadding') ||
 			configuration.changed(e, 'graph.showGhostRefsOnRowHover') ||
-			configuration.changed(e, 'graph.showPullRequests') ||
+			configuration.changed(e, 'graph.pullRequests.enabled') ||
 			configuration.changed(e, 'graph.showRemoteNames') ||
 			configuration.changed(e, 'graph.showUpstreamStatus')
 		) {
@@ -1572,7 +1572,7 @@ export class GraphWebview extends WebviewBase<State> {
 
 	private getActiveRefMetadataTypes(): GraphRefMetadataType[] {
 		const types: GraphRefMetadataType[] = [];
-		if (configuration.get('graph.showPullRequests')) {
+		if (configuration.get('graph.pullRequests.enabled')) {
 			types.push(GraphRefMetadataTypes.PullRequest as GraphRefMetadataType);
 		}
 

--- a/src/plus/webviews/graph/graphWebview.ts
+++ b/src/plus/webviews/graph/graphWebview.ts
@@ -135,6 +135,7 @@ import {
 	GraphRefMetadataTypes,
 	SearchCommandType,
 	SearchOpenInViewCommandType,
+	supportedRefMetadataTypes,
 	UpdateColumnsCommandType,
 	UpdateExcludeTypeCommandType,
 	UpdateIncludeOnlyRefsCommandType,
@@ -742,7 +743,7 @@ export class GraphWebview extends WebviewBase<State> {
 			}
 
 			for (const type of missingTypes) {
-				if (!Object.values(GraphRefMetadataTypes).includes(type)) {
+				if (!supportedRefMetadataTypes.includes(type)) {
 					(metadata as any)[type] = null;
 					this._refsMetadata.set(id, metadata);
 
@@ -1554,11 +1555,11 @@ export class GraphWebview extends WebviewBase<State> {
 
 	private getComponentConfig(): GraphComponentConfig {
 		const config: GraphComponentConfig = {
-			enabledRefMetadataTypes: this.getEnabledRefMetadataTypes(),
 			avatars: configuration.get('graph.avatars'),
 			dateFormat:
 				configuration.get('graph.dateFormat') ?? configuration.get('defaultDateFormat') ?? 'short+short',
 			dateStyle: configuration.get('graph.dateStyle') ?? configuration.get('defaultDateStyle'),
+			enabledRefMetadataTypes: this.getEnabledRefMetadataTypes(),
 			dimMergeCommits: configuration.get('graph.dimMergeCommits'),
 			enableMultiSelection: false,
 			highlightRowsOnRefHover: configuration.get('graph.highlightRowsOnRefHover'),

--- a/src/plus/webviews/graph/graphWebview.ts
+++ b/src/plus/webviews/graph/graphWebview.ts
@@ -1554,7 +1554,7 @@ export class GraphWebview extends WebviewBase<State> {
 
 	private getComponentConfig(): GraphComponentConfig {
 		const config: GraphComponentConfig = {
-			activeRefMetadataTypes: this.getActiveRefMetadataTypes(),
+			enabledRefMetadataTypes: this.getEnabledRefMetadataTypes(),
 			avatars: configuration.get('graph.avatars'),
 			dateFormat:
 				configuration.get('graph.dateFormat') ?? configuration.get('defaultDateFormat') ?? 'short+short',
@@ -1570,7 +1570,7 @@ export class GraphWebview extends WebviewBase<State> {
 		return config;
 	}
 
-	private getActiveRefMetadataTypes(): GraphRefMetadataType[] {
+	private getEnabledRefMetadataTypes(): GraphRefMetadataType[] {
 		const types: GraphRefMetadataType[] = [];
 		if (configuration.get('graph.pullRequests.enabled')) {
 			types.push(GraphRefMetadataTypes.PullRequest as GraphRefMetadataType);

--- a/src/plus/webviews/graph/protocol.ts
+++ b/src/plus/webviews/graph/protocol.ts
@@ -114,7 +114,7 @@ export type GraphTag = Tag;
 export type GraphBranch = Head;
 
 export interface GraphComponentConfig {
-	activeRefMetadataTypes?: GraphRefMetadataType[];
+	enabledRefMetadataTypes?: GraphRefMetadataType[];
 	avatars?: boolean;
 	dateFormat: DateTimeFormat | string;
 	dateStyle: DateStyle;

--- a/src/plus/webviews/graph/protocol.ts
+++ b/src/plus/webviews/graph/protocol.ts
@@ -37,9 +37,15 @@ export type GraphRefMetadata = RefMetadata | null;
 export type GraphUpstreamMetadata = UpstreamMetadata | null;
 export type GraphRefsMetadata = Record</* id */ string, GraphRefMetadata>;
 export type GraphHostingServiceType = HostingServiceType;
+export type GraphRefMetadataType = RefMetadataType;
 export type GraphMissingRefsMetadataType = RefMetadataType;
 export type GraphMissingRefsMetadata = Record</*id*/ string, /*missingType*/ GraphMissingRefsMetadataType[]>;
 export type GraphPullRequestMetadata = PullRequestMetadata;
+
+export const GraphRefMetadataTypes = {
+	Upstream: 'upstream',
+	PullRequest: 'pullRequests',
+};
 
 export interface State {
 	windowFocused?: boolean;
@@ -108,6 +114,7 @@ export type GraphTag = Tag;
 export type GraphBranch = Head;
 
 export interface GraphComponentConfig {
+	activeRefMetadataTypes?: GraphRefMetadataType[];
 	avatars?: boolean;
 	dateFormat: DateTimeFormat | string;
 	dateStyle: DateStyle;
@@ -117,7 +124,6 @@ export interface GraphComponentConfig {
 	scrollRowPadding?: number;
 	showGhostRefsOnRowHover?: boolean;
 	showRemoteNamesOnRefs?: boolean;
-	showUpstreamStatus?: boolean;
 	idLength?: number;
 }
 

--- a/src/plus/webviews/graph/protocol.ts
+++ b/src/plus/webviews/graph/protocol.ts
@@ -42,10 +42,12 @@ export type GraphMissingRefsMetadataType = RefMetadataType;
 export type GraphMissingRefsMetadata = Record</*id*/ string, /*missingType*/ GraphMissingRefsMetadataType[]>;
 export type GraphPullRequestMetadata = PullRequestMetadata;
 
-export const GraphRefMetadataTypes = {
-	Upstream: 'upstream',
-	PullRequest: 'pullRequests',
-};
+export enum GraphRefMetadataTypes {
+	Upstream = 'upstream',
+	PullRequest = 'pullRequests',
+}
+
+export const supportedRefMetadataTypes: GraphRefMetadataType[] = Object.values(GraphRefMetadataTypes);
 
 export interface State {
 	windowFocused?: boolean;
@@ -114,11 +116,11 @@ export type GraphTag = Tag;
 export type GraphBranch = Head;
 
 export interface GraphComponentConfig {
-	enabledRefMetadataTypes?: GraphRefMetadataType[];
 	avatars?: boolean;
 	dateFormat: DateTimeFormat | string;
 	dateStyle: DateStyle;
 	dimMergeCommits?: boolean;
+	enabledRefMetadataTypes?: GraphRefMetadataType[];
 	enableMultiSelection?: boolean;
 	highlightRowsOnRefHover?: boolean;
 	scrollRowPadding?: number;

--- a/src/webviews/apps/plus/graph/GraphWrapper.tsx
+++ b/src/webviews/apps/plus/graph/GraphWrapper.tsx
@@ -1006,12 +1006,12 @@ export function GraphWrapper({
 					<>
 						<GraphContainer
 							ref={graphRef}
-							enabledRefMetadataTypes={graphConfig?.enabledRefMetadataTypes}
 							avatarUrlByEmail={avatars}
 							columnsSettings={columns}
 							contexts={context}
 							cssVariables={styleProps?.cssVariables}
 							dimMergeCommits={graphConfig?.dimMergeCommits}
+							enabledRefMetadataTypes={graphConfig?.enabledRefMetadataTypes}
 							enableMultiSelection={graphConfig?.enableMultiSelection}
 							excludeRefsById={excludeRefsById}
 							excludeByType={excludeTypes}

--- a/src/webviews/apps/plus/graph/GraphWrapper.tsx
+++ b/src/webviews/apps/plus/graph/GraphWrapper.tsx
@@ -1006,7 +1006,7 @@ export function GraphWrapper({
 					<>
 						<GraphContainer
 							ref={graphRef}
-							activeRefMetadataTypes={graphConfig?.activeRefMetadataTypes}
+							enabledRefMetadataTypes={graphConfig?.enabledRefMetadataTypes}
 							avatarUrlByEmail={avatars}
 							columnsSettings={columns}
 							contexts={context}

--- a/src/webviews/apps/plus/graph/GraphWrapper.tsx
+++ b/src/webviews/apps/plus/graph/GraphWrapper.tsx
@@ -1006,6 +1006,7 @@ export function GraphWrapper({
 					<>
 						<GraphContainer
 							ref={graphRef}
+							activeRefMetadataTypes={graphConfig?.activeRefMetadataTypes}
 							avatarUrlByEmail={avatars}
 							columnsSettings={columns}
 							contexts={context}
@@ -1041,7 +1042,6 @@ export function GraphWrapper({
 							platform={clientPlatform}
 							refMetadataById={refsMetadata}
 							shaLength={graphConfig?.idLength}
-							showUpstreamStatus={graphConfig?.showUpstreamStatus}
 							themeOpacityFactor={styleProps?.themeOpacityFactor}
 							useAuthorInitialsForAvatars={!graphConfig?.avatars}
 							workDirStats={workingTreeStats}

--- a/src/webviews/apps/settings/partials/commit-graph.html
+++ b/src/webviews/apps/settings/partials/commit-graph.html
@@ -173,12 +173,12 @@
 					<div class="setting">
 						<div class="setting__input">
 							<input
-								id="graph.showPullRequests"
-								name="graph.showPullRequests"
+								id="graph.pullRequests.enabled"
+								name="graph.pullRequests.enabled"
 								type="checkbox"
 								data-setting
 							/>
-							<label for="graph.showPullRequests"
+							<label for="graph.pullRequests.enabled"
 								>Show associated pull requests on remote branches</label
 							>
 						</div>

--- a/src/webviews/apps/settings/partials/commit-graph.html
+++ b/src/webviews/apps/settings/partials/commit-graph.html
@@ -168,6 +168,9 @@
 								>Show upstream status on local branches with remotes</label
 							>
 						</div>
+						<p class="setting__hint hidden" data-visibility="graph.showUpstreamStatus">
+							<i class="icon icon__info"></i>Requires a connection to a supported remote service (e.g. GitHub)
+						</p>
 					</div>
 
 					<div class="setting">
@@ -182,6 +185,9 @@
 								>Show associated pull requests on remote branches</label
 							>
 						</div>
+						<p class="setting__hint hidden" data-visibility="graph.pullRequests.enabled">
+							<i class="icon icon__info"></i>Requires a connection to a supported remote service (e.g. GitHub)
+						</p>
 					</div>
 
 					<div class="setting">

--- a/src/webviews/apps/settings/partials/commit-graph.html
+++ b/src/webviews/apps/settings/partials/commit-graph.html
@@ -168,9 +168,6 @@
 								>Show upstream status on local branches with remotes</label
 							>
 						</div>
-						<p class="setting__hint hidden" data-visibility="graph.showUpstreamStatus">
-							<i class="icon icon__info"></i>Requires a connection to a supported remote service (e.g. GitHub)
-						</p>
 					</div>
 
 					<div class="setting">

--- a/src/webviews/apps/settings/partials/commit-graph.html
+++ b/src/webviews/apps/settings/partials/commit-graph.html
@@ -172,6 +172,20 @@
 
 					<div class="setting">
 						<div class="setting__input">
+							<input
+								id="graph.showPullRequests"
+								name="graph.showPullRequests"
+								type="checkbox"
+								data-setting
+							/>
+							<label for="graph.showPullRequests"
+								>Show associated pull requests on remote branches</label
+							>
+						</div>
+					</div>
+
+					<div class="setting">
+						<div class="setting__input">
 							<input id="graph.avatars" name="graph.avatars" type="checkbox" data-setting />
 							<label for="graph.avatars">Use author and remote avatars</label>
 						</div>

--- a/yarn.lock
+++ b/yarn.lock
@@ -295,10 +295,10 @@
   resolved "https://registry.yarnpkg.com/@gar/promisify/-/promisify-1.1.3.tgz#555193ab2e3bb3b6adc3d551c9c030d9e860daf6"
   integrity sha512-k2Ty1JcVojjJFwrg/ThKi2ujJ7XNLYaFGNB/bWT9wGR+oSMJHMa5w+CUq6p/pVrKeNNgA7pCqEcjSnHVoqJQFw==
 
-"@gitkraken/gitkraken-components@1.1.0-rc.22":
-  version "1.1.0-rc.22"
-  resolved "https://registry.yarnpkg.com/@gitkraken/gitkraken-components/-/gitkraken-components-1.1.0-rc.22.tgz#6a5fa32dff603fe4561e092508678dc54f62a185"
-  integrity sha512-e7oqU9ibjC11aKs9Z6POjwq1+exk+lIj9nxUDBxGIwVMidfaowaMIH7j7x2tM3we1rdROqsg/sXMImrFbMm6fA==
+"@gitkraken/gitkraken-components@2.0.0":
+  version "2.0.0"
+  resolved "https://registry.yarnpkg.com/@gitkraken/gitkraken-components/-/gitkraken-components-2.0.0.tgz#1a1cbb2ef3873a412b693381ea56869a018e697c"
+  integrity sha512-3caeyF2imEIwZSCwDAf8f5bsxzVZ+0kmL1lZww3CANFlDnhgK8LRU3QkdnuW/PICwZYEpOJop3/0myVBwE3Ieg==
   dependencies:
     "@axosoft/react-virtualized" "9.22.3-gitkraken.3"
     classnames "^2.3.2"


### PR DESCRIPTION
We had a setting to enable/disable upstream status for local branches in the graph. This adds a setting to toggle the other metadata type: Pull Requests.

This also combines all the active metadata from settings into a single array to send to the graph. This requires a graph library update after the breaking change lands: https://github.com/gitkraken/GitKrakenComponents/pull/189

Once that merges, the dependency will be updated in this PR and it can leave draft state.