### PR TITLE
App context menu opens to WIP row on graph

### DIFF
--- a/package.json
+++ b/package.json
@@ -6581,6 +6581,11 @@
 				"icon": "$(eye)"
 			},
 			{
+				"command": "gitlens.graph.openSCM",
+				"title": "Open Source Control",
+				"category": "GitLens"
+			},
+			{
 				"command": "gitlens.graph.openCommitOnRemote",
 				"title": "Open Commit on Remote",
 				"category": "GitLens",
@@ -6617,6 +6622,12 @@
 				"title": "Undo Commit",
 				"category": "GitLens",
 				"icon": "$(discard)"
+			},
+			{
+				"command": "gitlens.graph.saveStash",
+				"title": "Stash All Changes",
+				"category": "GitLens",
+				"icon": "$(gitlens-stash-save)"
 			},
 			{
 				"command": "gitlens.graph.applyStash",
@@ -11328,8 +11339,13 @@
 				},
 				{
 					"command": "gitlens.graph.showInDetailsView",
-					"when": "webviewItem =~ /gitlens:(commit|stash)\\b/",
+					"when": "webviewItem =~ /gitlens:(commit|stash|wip)\\b/",
 					"group": "3_gitlens_explore@0"
+				},
+				{
+					"command": "gitlens.graph.openSCM",
+					"when": "webviewItem == gitlens:wip",
+					"group": "3_gitlens_explore@1"
 				},
 				{
 					"command": "gitlens.graph.openCommitOnRemote",
@@ -11351,6 +11367,11 @@
 					"command": "gitlens.graph.deleteStash",
 					"when": "!gitlens:readonly && !gitlens:untrusted && !gitlens:hasVirtualFolders && webviewItem == gitlens:stash",
 					"group": "1_gitlens_actions@2"
+				},
+				{
+					"command": "gitlens.graph.saveStash",
+					"when": "!gitlens:readonly && !gitlens:untrusted && !gitlens:hasVirtualFolders && webviewItem == gitlens:wip",
+					"group": "1_gitlens_actions@3"
 				},
 				{
 					"command": "gitlens.graph.switchToTag",

--- a/src/plus/webviews/graph/graphWebview.ts
+++ b/src/plus/webviews/graph/graphWebview.ts
@@ -1622,7 +1622,7 @@ export class GraphWebview extends WebviewBase<State> {
 			context: serializeWebviewItemContext<GraphItemContext>({
 				webviewItem: 'gitlens:wip',
 				webviewItemValue: {
-					type: 'revision',
+					type: 'commit',
 					ref:
 						this.getRevisionReference(
 							this.repository.path,
@@ -2385,8 +2385,7 @@ export type GraphItemRefContextValue =
 	| GraphBranchContextValue
 	| GraphCommitContextValue
 	| GraphStashContextValue
-	| GraphTagContextValue
-	| GraphRevisionContextValue;
+	| GraphTagContextValue;
 
 export type GraphItemRefGroupContext<T = GraphItemRefGroupContextValue> = WebviewItemGroupContext<T>;
 export interface GraphItemRefGroupContextValue {
@@ -2431,11 +2430,6 @@ export interface GraphStashContextValue {
 export interface GraphTagContextValue {
 	type: 'tag';
 	ref: GitTagReference;
-}
-
-export interface GraphRevisionContextValue {
-	type: 'revision';
-	ref: GitRevisionReference;
 }
 
 function isGraphItemContext(item: unknown): item is GraphItemContext {

--- a/src/plus/webviews/graph/graphWebview.ts
+++ b/src/plus/webviews/graph/graphWebview.ts
@@ -1623,13 +1623,11 @@ export class GraphWebview extends WebviewBase<State> {
 				webviewItem: 'gitlens:wip',
 				webviewItemValue: {
 					type: 'commit',
-					ref:
-						this.getRevisionReference(
-							this.repository.path,
-							GitRevision.uncommitted,
-							GitGraphRowType.Working,
-						) ||
-						GitReference.create(GitRevision.uncommitted, this.repository.path, { refType: 'revision' }),
+					ref: this.getRevisionReference(
+						this.repository.path,
+						GitRevision.uncommitted,
+						GitGraphRowType.Working,
+					)!,
 				},
 			}),
 		};


### PR DESCRIPTION
Closes: #2419 

Adds three context menu options to work-in-progress row on graph to stash changes, open in commit details, and open SCM:

![WIP context menu](https://user-images.githubusercontent.com/67011668/213559733-75de6aa4-8c6a-463b-a136-598b4c51008d.gif)


