### PR TITLE
Graph: add support for activity column

### DIFF
--- a/package.json
+++ b/package.json
@@ -6954,6 +6954,16 @@
 				"command": "gitlens.graph.columnShaOff",
 				"title": "Hide SHA",
 				"category": "GitLens"
+			},
+			{
+				"command": "gitlens.graph.columnActivityOn",
+				"title": "Show Activity",
+				"category": "GitLens"
+			},
+			{
+				"command": "gitlens.graph.columnActivityOff",
+				"title": "Hide Activity",
+				"category": "GitLens"
 			}
 		],
 		"icons": {
@@ -9003,6 +9013,14 @@
 				},
 				{
 					"command": "gitlens.graph.columnShaOff",
+					"when": "false"
+				},
+				{
+					"command": "gitlens.graph.columnActivityOn",
+					"when": "false"
+				},
+				{
+					"command": "gitlens.graph.columnActivityOff",
 					"when": "false"
 				},
 				{
@@ -11737,6 +11755,16 @@
 					"command": "gitlens.graph.columnShaOff",
 					"when": "webviewItem =~ /gitlens:graph:columns\\b/ && webviewItemValue =~ /^(?:(?!\\bsha\\b).)*$/",
 					"group": "1_columns@3"
+				},
+				{
+					"command": "gitlens.graph.columnActivityOn",
+					"when": "webviewItem =~ /gitlens:graph:columns\\b/ && webviewItemValue =~ /\\bactivity\\b/",
+					"group": "1_columns@4"
+				},
+				{
+					"command": "gitlens.graph.columnActivityOff",
+					"when": "webviewItem =~ /gitlens:graph:columns\\b/ && webviewItemValue =~ /^(?:(?!\\bactivity\\b).)*$/",
+					"group": "1_columns@4"
 				}
 			],
 			"gitlens/commit/browse": [

--- a/package.json
+++ b/package.json
@@ -13113,7 +13113,7 @@
 		"vscode:prepublish": "yarn run bundle"
 	},
 	"dependencies": {
-		"@gitkraken/gitkraken-components": "5.0.0",
+		"@gitkraken/gitkraken-components": "6.0.0",
 		"@microsoft/fast-element": "1.11.0",
 		"@microsoft/fast-react-wrapper": "0.3.16-0",
 		"@octokit/core": "4.2.0",

--- a/package.json
+++ b/package.json
@@ -6956,13 +6956,13 @@
 				"category": "GitLens"
 			},
 			{
-				"command": "gitlens.graph.columnActivityOn",
-				"title": "Show Activity",
+				"command": "gitlens.graph.columnChangesOn",
+				"title": "Show Changes",
 				"category": "GitLens"
 			},
 			{
-				"command": "gitlens.graph.columnActivityOff",
-				"title": "Hide Activity",
+				"command": "gitlens.graph.columnChangesOff",
+				"title": "Hide Changes",
 				"category": "GitLens"
 			}
 		],
@@ -9016,11 +9016,11 @@
 					"when": "false"
 				},
 				{
-					"command": "gitlens.graph.columnActivityOn",
+					"command": "gitlens.graph.columnChangesOn",
 					"when": "false"
 				},
 				{
-					"command": "gitlens.graph.columnActivityOff",
+					"command": "gitlens.graph.columnChangesOff",
 					"when": "false"
 				},
 				{
@@ -11757,13 +11757,13 @@
 					"group": "1_columns@3"
 				},
 				{
-					"command": "gitlens.graph.columnActivityOn",
-					"when": "webviewItem =~ /gitlens:graph:columns\\b/ && webviewItemValue =~ /\\bactivity\\b/",
+					"command": "gitlens.graph.columnChangesOn",
+					"when": "webviewItem =~ /gitlens:graph:columns\\b/ && webviewItemValue =~ /\\bchanges\\b/",
 					"group": "1_columns@4"
 				},
 				{
-					"command": "gitlens.graph.columnActivityOff",
-					"when": "webviewItem =~ /gitlens:graph:columns\\b/ && webviewItemValue =~ /^(?:(?!\\bactivity\\b).)*$/",
+					"command": "gitlens.graph.columnChangesOff",
+					"when": "webviewItem =~ /gitlens:graph:columns\\b/ && webviewItemValue =~ /^(?:(?!\\bchanges\\b).)*$/",
 					"group": "1_columns@4"
 				}
 			],

--- a/src/plus/webviews/graph/graphWebview.ts
+++ b/src/plus/webviews/graph/graphWebview.ts
@@ -174,7 +174,7 @@ const defaultGraphColumnsSettings: GraphColumnsSettings = {
 	author: { width: 130, isHidden: false },
 	datetime: { width: 130, isHidden: false },
 	sha: { width: 130, isHidden: false },
-	changes: { width: 130, isHidden: false },
+	changes: { width: 130, isHidden: true },
 };
 
 export class GraphWebview extends WebviewBase<State> {

--- a/src/plus/webviews/graph/graphWebview.ts
+++ b/src/plus/webviews/graph/graphWebview.ts
@@ -174,7 +174,7 @@ const defaultGraphColumnsSettings: GraphColumnsSettings = {
 	author: { width: 130, isHidden: false },
 	datetime: { width: 130, isHidden: false },
 	sha: { width: 130, isHidden: false },
-	activity: { width: 130, isHidden: false },
+	changes: { width: 130, isHidden: false },
 };
 
 export class GraphWebview extends WebviewBase<State> {
@@ -413,8 +413,8 @@ export class GraphWebview extends WebviewBase<State> {
 			registerCommand('gitlens.graph.columnDateTimeOff', () => this.toggleColumn('datetime', false)),
 			registerCommand('gitlens.graph.columnShaOn', () => this.toggleColumn('sha', true)),
 			registerCommand('gitlens.graph.columnShaOff', () => this.toggleColumn('sha', false)),
-			registerCommand('gitlens.graph.columnActivityOn', () => this.toggleColumn('activity', true)),
-			registerCommand('gitlens.graph.columnActivityOff', () => this.toggleColumn('activity', false)),
+			registerCommand('gitlens.graph.columnChangesOn', () => this.toggleColumn('changes', true)),
+			registerCommand('gitlens.graph.columnChangesOff', () => this.toggleColumn('changes', false)),
 
 			registerCommand('gitlens.graph.copyDeepLinkToBranch', this.copyDeepLinkToBranch, this),
 			registerCommand('gitlens.graph.copyDeepLinkToCommit', this.copyDeepLinkToCommit, this),
@@ -1784,7 +1784,7 @@ export class GraphWebview extends WebviewBase<State> {
 			this.repository.path,
 			this._panel!.webview.asWebviewUri.bind(this._panel!.webview),
 			{
-				include: { stats: configuration.get('graph.experimental.minimap.enabled') || !columnSettings.activity.isHidden },
+				include: { stats: configuration.get('graph.experimental.minimap.enabled') || !columnSettings.changes.isHidden },
 				limit: limit,
 				ref: ref,
 			},

--- a/src/plus/webviews/graph/graphWebview.ts
+++ b/src/plus/webviews/graph/graphWebview.ts
@@ -174,6 +174,7 @@ const defaultGraphColumnsSettings: GraphColumnsSettings = {
 	author: { width: 130, isHidden: false },
 	datetime: { width: 130, isHidden: false },
 	sha: { width: 130, isHidden: false },
+	activity: { width: 130, isHidden: false },
 };
 
 export class GraphWebview extends WebviewBase<State> {
@@ -412,6 +413,8 @@ export class GraphWebview extends WebviewBase<State> {
 			registerCommand('gitlens.graph.columnDateTimeOff', () => this.toggleColumn('datetime', false)),
 			registerCommand('gitlens.graph.columnShaOn', () => this.toggleColumn('sha', true)),
 			registerCommand('gitlens.graph.columnShaOff', () => this.toggleColumn('sha', false)),
+			registerCommand('gitlens.graph.columnActivityOn', () => this.toggleColumn('activity', true)),
+			registerCommand('gitlens.graph.columnActivityOff', () => this.toggleColumn('activity', false)),
 
 			registerCommand('gitlens.graph.copyDeepLinkToBranch', this.copyDeepLinkToBranch, this),
 			registerCommand('gitlens.graph.copyDeepLinkToCommit', this.copyDeepLinkToCommit, this),
@@ -1774,11 +1777,14 @@ export class GraphWebview extends WebviewBase<State> {
 		const ref =
 			this._selectedId == null || this._selectedId === GitRevision.uncommitted ? 'HEAD' : this._selectedId;
 
+		const columns = this.getColumns();
+		const columnSettings = this.getColumnSettings(columns);
+
 		const dataPromise = this.container.git.getCommitsForGraph(
 			this.repository.path,
 			this._panel!.webview.asWebviewUri.bind(this._panel!.webview),
 			{
-				include: { stats: configuration.get('graph.experimental.minimap.enabled') },
+				include: { stats: configuration.get('graph.experimental.minimap.enabled') || !columnSettings.activity.isHidden },
 				limit: limit,
 				ref: ref,
 			},
@@ -1807,8 +1813,6 @@ export class GraphWebview extends WebviewBase<State> {
 			this.setSelectedRows(data.id);
 		}
 
-		const columns = this.getColumns();
-
 		const lastFetched = await this.repository.getLastFetched();
 		const branch = await this.repository.getBranch();
 
@@ -1834,7 +1838,7 @@ export class GraphWebview extends WebviewBase<State> {
 							hasMore: data.paging?.hasMore ?? false,
 					  }
 					: undefined,
-			columns: this.getColumnSettings(columns),
+			columns: columnSettings,
 			config: this.getComponentConfig(),
 			context: {
 				header: this.getColumnHeaderContext(columns),

--- a/src/webviews/apps/plus/graph/graph.scss
+++ b/src/webviews/apps/plus/graph/graph.scss
@@ -33,6 +33,12 @@ body {
 			border-color: var(--vscode-scrollbarSlider-background);
 		}
 	}
+
+	--color-graph-stats-added: var(--vscode-gitDecoration-addedResourceForeground);
+	--color-graph-stats-deleted: var(--vscode-gitDecoration-deletedResourceForeground);
+	--color-graph-stats-files: var(--vscode-gitDecoration-modifiedResourceForeground);
+	--graph-stats-bar-height: 40%;
+	--graph-stats-bar-border-radius: 5px;
 }
 
 ::-webkit-scrollbar-corner {

--- a/src/webviews/apps/plus/graph/graph.tsx
+++ b/src/webviews/apps/plus/graph/graph.tsx
@@ -465,8 +465,8 @@ export class GraphApp extends App<State> {
 		bodyStyle.setProperty('--color-graph-minimap-remoteMarker', opacity(branchMarker, 30));
 		bodyStyle.setProperty('--color-graph-scroll-marker-remote-branches', opacity(branchMarker, 60));
 
-		bodyStyle.setProperty('--color-graph-stats-deleted', '#ff0000');
-		bodyStyle.setProperty('--color-graph-stats-added', '#00ff00');
+		bodyStyle.setProperty('--color-graph-stats-deleted', '#c45478');
+		bodyStyle.setProperty('--color-graph-stats-added', '#558152');
 		bodyStyle.setProperty('--color-graph-stats-files', '#b4b466');
 
 		bodyStyle.setProperty(

--- a/src/webviews/apps/plus/graph/graph.tsx
+++ b/src/webviews/apps/plus/graph/graph.tsx
@@ -432,13 +432,6 @@ export class GraphApp extends App<State> {
 			resultColor.luminance(themeLuminance(0.6)).toString(),
 		);
 
-		color = e.computedStyle.getPropertyValue('--vscode-gitDecoration-deletedResourceForeground').trim();
-		bodyStyle.setProperty('--color-graph-stats-deleted', color);
-		color = e.computedStyle.getPropertyValue('--vscode-gitDecoration-addedResourceForeground').trim();
-		bodyStyle.setProperty('--color-graph-stats-added', color);
-		color = e.computedStyle.getPropertyValue('--vscode-gitDecoration-modifiedResourceForeground').trim();
-		bodyStyle.setProperty('--color-graph-stats-files', color);
-
 		const pillLabel = foregroundColor.luminance(themeLuminance(e.isLightTheme ? 0 : 1)).toString();
 		const headBackground = headColor.luminance(themeLuminance(e.isLightTheme ? 0.9 : 0.2)).toString();
 		const headBorder = headColor.luminance(themeLuminance(e.isLightTheme ? 0.2 : 0.4)).toString();

--- a/src/webviews/apps/plus/graph/graph.tsx
+++ b/src/webviews/apps/plus/graph/graph.tsx
@@ -572,10 +572,6 @@ export class GraphApp extends App<State> {
 				'--text-accent': computedStyle.getPropertyValue('--color-link-foreground'),
 				'--text-inverse': computedStyle.getPropertyValue('--vscode-input-background'),
 				'--text-bright': computedStyle.getPropertyValue('--vscode-input-background'),
-
-				'--stats-added': computedStyle.getPropertyValue('--color-graph-stats-added'),
-				'--stats-deleted': computedStyle.getPropertyValue('--color-graph-stats-deleted'),
-				'--stats-files': computedStyle.getPropertyValue('--color-graph-stats-files'),
 				...mixedGraphColors,
 			},
 			themeOpacityFactor: parseInt(computedStyle.getPropertyValue('--graph-theme-opacity-factor')) || 1,

--- a/src/webviews/apps/plus/graph/graph.tsx
+++ b/src/webviews/apps/plus/graph/graph.tsx
@@ -465,6 +465,10 @@ export class GraphApp extends App<State> {
 		bodyStyle.setProperty('--color-graph-minimap-remoteMarker', opacity(branchMarker, 30));
 		bodyStyle.setProperty('--color-graph-scroll-marker-remote-branches', opacity(branchMarker, 60));
 
+		bodyStyle.setProperty('--color-graph-stats-deleted', '#ff0000');
+		bodyStyle.setProperty('--color-graph-stats-added', '#00ff00');
+		bodyStyle.setProperty('--color-graph-stats-files', '#b4b466');
+
 		bodyStyle.setProperty(
 			'--color-graph-minimap-tagBackground',
 			tagColor.luminance(themeLuminance(e.isLightTheme ? 0.8 : 0.2)).toString(),
@@ -568,6 +572,10 @@ export class GraphApp extends App<State> {
 				'--text-accent': computedStyle.getPropertyValue('--color-link-foreground'),
 				'--text-inverse': computedStyle.getPropertyValue('--vscode-input-background'),
 				'--text-bright': computedStyle.getPropertyValue('--vscode-input-background'),
+
+				'--stats-added': computedStyle.getPropertyValue('--color-graph-stats-added'),
+				'--stats-deleted': computedStyle.getPropertyValue('--color-graph-stats-deleted'),
+				'--stats-files': computedStyle.getPropertyValue('--color-graph-stats-files'),
 				...mixedGraphColors,
 			},
 			themeOpacityFactor: parseInt(computedStyle.getPropertyValue('--graph-theme-opacity-factor')) || 1,

--- a/src/webviews/apps/plus/graph/graph.tsx
+++ b/src/webviews/apps/plus/graph/graph.tsx
@@ -432,6 +432,13 @@ export class GraphApp extends App<State> {
 			resultColor.luminance(themeLuminance(0.6)).toString(),
 		);
 
+		color = e.computedStyle.getPropertyValue('--vscode-gitDecoration-deletedResourceForeground').trim();
+		bodyStyle.setProperty('--color-graph-stats-deleted', color);
+		color = e.computedStyle.getPropertyValue('--vscode-gitDecoration-addedResourceForeground').trim();
+		bodyStyle.setProperty('--color-graph-stats-added', color);
+		color = e.computedStyle.getPropertyValue('--vscode-gitDecoration-modifiedResourceForeground').trim();
+		bodyStyle.setProperty('--color-graph-stats-files', color);
+
 		const pillLabel = foregroundColor.luminance(themeLuminance(e.isLightTheme ? 0 : 1)).toString();
 		const headBackground = headColor.luminance(themeLuminance(e.isLightTheme ? 0.9 : 0.2)).toString();
 		const headBorder = headColor.luminance(themeLuminance(e.isLightTheme ? 0.2 : 0.4)).toString();
@@ -464,10 +471,6 @@ export class GraphApp extends App<State> {
 		bodyStyle.setProperty('--color-graph-minimap-remoteForeground', pillLabel);
 		bodyStyle.setProperty('--color-graph-minimap-remoteMarker', opacity(branchMarker, 30));
 		bodyStyle.setProperty('--color-graph-scroll-marker-remote-branches', opacity(branchMarker, 60));
-
-		bodyStyle.setProperty('--color-graph-stats-deleted', '#c45478');
-		bodyStyle.setProperty('--color-graph-stats-added', '#558152');
-		bodyStyle.setProperty('--color-graph-stats-files', '#b4b466');
 
 		bodyStyle.setProperty(
 			'--color-graph-minimap-tagBackground',

--- a/yarn.lock
+++ b/yarn.lock
@@ -185,10 +185,10 @@
   resolved "https://registry.yarnpkg.com/@gar/promisify/-/promisify-1.1.3.tgz#555193ab2e3bb3b6adc3d551c9c030d9e860daf6"
   integrity sha512-k2Ty1JcVojjJFwrg/ThKi2ujJ7XNLYaFGNB/bWT9wGR+oSMJHMa5w+CUq6p/pVrKeNNgA7pCqEcjSnHVoqJQFw==
 
-"@gitkraken/gitkraken-components@5.0.0":
-  version "5.0.0"
-  resolved "https://registry.yarnpkg.com/@gitkraken/gitkraken-components/-/gitkraken-components-5.0.0.tgz#2898918a9c83c01941251eb738c28d54c39d7b7f"
-  integrity sha512-S3mavyTM/M5VOn+eUYy/BRGHF8rK3n0s6x2/i+OCilUobchXh5T4NvnDvAQ2cQgkb0Yv9UtiwO/mjsgq5PvKYQ==
+"@gitkraken/gitkraken-components@6.0.0":
+  version "6.0.0"
+  resolved "https://registry.yarnpkg.com/@gitkraken/gitkraken-components/-/gitkraken-components-6.0.0.tgz#fc9333c3057a4f1aafeb4cf968301dd5ed7ab69e"
+  integrity sha512-tcCqDLT03UfqqA1Rkhc0SP0eqnkUbLYGOKIwhWa7liKLTJBWPuFSgyAUqglHQtrXD25jtHDPpktO9GMgHvIIWg==
   dependencies:
     "@axosoft/react-virtualized" "9.22.3-gitkraken.3"
     classnames "2.3.2"


### PR DESCRIPTION
Adds support for the new activity column in the commit graph. Allows the column to be toggled, and sends over colors for the bar visuals in the column.

**Note:** The colors being sent over are hard-coded, until we decide what colors we want to send over and handle theming.

**Note 2:** This cannot be merged until its [dependency PR on the component side](https://github.com/gitkraken/GitKrakenComponents/pull/196) is merged, and the graph library version updated, at which point the PR can leave draft.