### PR TITLE
Deep Linking: Prompt to add repo for deep link when no matching repos found

### DIFF
--- a/src/storage.ts
+++ b/src/storage.ts
@@ -189,13 +189,8 @@ export interface StoredBranchComparisons {
 }
 
 export interface StoredDeepLinkContext {
-	state: number;
-	action?: number;
-	uri?: string | undefined;
-	repoId?: string | undefined;
-	remoteUrl?: string | undefined;
-	targetId?: string | undefined;
-	targetType?: string | undefined;
+	url?: string | undefined;
+	repoPath?: string | undefined;
 }
 
 export interface StoredGraphColumn {

--- a/src/storage.ts
+++ b/src/storage.ts
@@ -119,6 +119,7 @@ export type DeprecatedGlobalStorage = {
 
 export type GlobalStorage = {
 	avatars: [string, StoredAvatar][];
+	'deepLinks:pending': StoredDeepLinkContext;
 	'home:actions:completed': CompletedActions[];
 	'home:steps:completed': string[];
 	'home:sections:dismissed': string[];
@@ -185,6 +186,16 @@ export interface StoredBranchComparison {
 
 export interface StoredBranchComparisons {
 	[id: string]: string | StoredBranchComparison;
+}
+
+export interface StoredDeepLinkContext {
+	state: number;
+	action?: number;
+	uri?: string | undefined;
+	repoId?: string | undefined;
+	remoteUrl?: string | undefined;
+	targetId?: string | undefined;
+	targetType?: string | undefined;
 }
 
 export interface StoredGraphColumn {

--- a/src/uris/deepLinks/deepLink.ts
+++ b/src/uris/deepLinks/deepLink.ts
@@ -2,7 +2,6 @@ import type { Uri } from 'vscode';
 import type { GitReference } from '../../git/models/reference';
 import type { GitRemote } from '../../git/models/remote';
 import type { Repository } from '../../git/models/repository';
-import { OpenWorkspaceLocation } from '../../system/utils';
 
 export const enum UriTypes {
 	DeepLink = 'link',
@@ -81,7 +80,6 @@ export const enum DeepLinkServiceState {
 	Idle,
 	RepoMatch,
 	CloneOrAddRepo,
-	OpenedRepo,
 	OpeningRepo,
 	AddedRepoMatch,
 	RemoteMatch,
@@ -96,12 +94,14 @@ export const enum DeepLinkServiceAction {
 	DeepLinkEventFired,
 	DeepLinkCancelled,
 	DeepLinkResolved,
+	DeepLinkStored,
 	DeepLinkErrored,
 	OpenRepo,
 	RepoMatchedWithId,
 	RepoMatchedWithRemoteUrl,
 	RepoMatchFailed,
 	RepoAdded,
+	RepoOpened,
 	RemoteMatched,
 	RemoteMatchFailed,
 	RemoteAdded,
@@ -111,22 +111,9 @@ export const enum DeepLinkServiceAction {
 	TargetFetched,
 }
 
-export enum DeepLinkRepoOpenAction {
-	OpenInCurrentWindow = 'Open in Current Window',
-	OpenInNewWindow = 'Open in New Window',
-	AddToWorkspace = 'Add to Workspace',
-	Cancel = 'Cancel',
-}
-
-export const deepLinkRepoOpenActionToOpenWorkspaceLocation = {
-	[DeepLinkRepoOpenAction.OpenInCurrentWindow]: OpenWorkspaceLocation.CurrentWindow,
-	[DeepLinkRepoOpenAction.OpenInNewWindow]: OpenWorkspaceLocation.NewWindow,
-	[DeepLinkRepoOpenAction.AddToWorkspace]: OpenWorkspaceLocation.AddToWorkspace,
-};
-
 export interface DeepLinkServiceContext {
 	state: DeepLinkServiceState;
-	uri?: string | undefined;
+	url?: string | undefined;
 	repoId?: string | undefined;
 	repo?: Repository | undefined;
 	remoteUrl?: string | undefined;
@@ -147,8 +134,10 @@ export const deepLinkStateTransitionTable: { [state: string]: { [action: string]
 	},
 	[DeepLinkServiceState.CloneOrAddRepo]: {
 		[DeepLinkServiceAction.OpenRepo]: DeepLinkServiceState.OpeningRepo,
+		[DeepLinkServiceAction.RepoOpened]: DeepLinkServiceState.RemoteMatch,
 		[DeepLinkServiceAction.DeepLinkErrored]: DeepLinkServiceState.Idle,
 		[DeepLinkServiceAction.DeepLinkCancelled]: DeepLinkServiceState.Idle,
+		[DeepLinkServiceAction.DeepLinkStored]: DeepLinkServiceState.Idle,
 	},
 	[DeepLinkServiceState.OpeningRepo]: {
 		[DeepLinkServiceAction.RepoAdded]: DeepLinkServiceState.AddedRepoMatch,

--- a/src/uris/deepLinks/deepLink.ts
+++ b/src/uris/deepLinks/deepLink.ts
@@ -111,6 +111,11 @@ export const enum DeepLinkServiceAction {
 	TargetFetched,
 }
 
+export const enum DeepLinkRepoOpenType {
+	Folder = 'folder',
+	Workspace = 'workspace',
+}
+
 export interface DeepLinkServiceContext {
 	state: DeepLinkServiceState;
 	url?: string | undefined;


### PR DESCRIPTION
Expands the deep link service to include a prompt to add the repo using three options (open in current window, open in new window, add to workspace) when a matching repo is not found while resolving a deep link. When a repo is chosen, a notification will indicate that the repo is being opened to resolve the deep link, and can be cancelled.

Includes pending state storage and recall for when adding the repo requires a new instance of the deep link service to continue resolving the link (such as when opening in the current window).