### PR TITLE
2495 Cannot use gitlens+ feature on public repo in some folders

### DIFF
--- a/package.json
+++ b/package.json
@@ -4488,7 +4488,7 @@
 			},
 			{
 				"command": "gitlens.plus.resetRepositoryAccess",
-				"title": "Reset Repository Access",
+				"title": "Reset Repository Access Cache",
 				"category": "GitLens+"
 			},
 			{

--- a/package.json
+++ b/package.json
@@ -4487,6 +4487,16 @@
 				"category": "GitLens+"
 			},
 			{
+				"command": "gitlens.plus.resetRepositoryAccess",
+				"title": "Reset Repository Access",
+				"category": "GitLens+"
+			},
+			{
+				"command": "gitlens.plus.refreshRepositoryAccess",
+				"title": "Refresh Repository Access",
+				"category": "GitLens+"
+			},
+			{
 				"command": "gitlens.getStarted",
 				"title": "Get Started",
 				"category": "GitLens"
@@ -7436,6 +7446,14 @@
 				{
 					"command": "gitlens.plus.reset",
 					"when": "gitlens:debugging"
+				},
+				{
+					"command": "gitlens.plus.resetRepositoryAccess",
+					"when": "gitlens:plus"
+				},
+				{
+					"command": "gitlens.plus.refreshRepositoryAccess",
+					"when": "gitlens:plus"
 				},
 				{
 					"command": "gitlens.showGraphPage",

--- a/src/git/gitProvider.ts
+++ b/src/git/gitProvider.ts
@@ -98,6 +98,12 @@ export const enum RepositoryVisibility {
 	Local = 'local',
 }
 
+export interface RepositoryVisibilityInfo {
+	visibility: RepositoryVisibility;
+	timestamp: number;
+	remotesHash?: string;
+}
+
 export interface GitProvider extends Disposable {
 	get onDidChangeRepository(): Event<RepositoryChangeEvent>;
 	get onDidCloseRepository(): Event<RepositoryCloseEvent>;
@@ -118,7 +124,7 @@ export interface GitProvider extends Disposable {
 	openRepositoryInitWatcher?(): RepositoryInitWatcher;
 
 	supports(feature: Features): Promise<boolean>;
-	visibility(repoPath: string): Promise<RepositoryVisibility>;
+	visibility(repoPath: string, remotes?: GitRemote[]): Promise<[RepositoryVisibility, string | undefined]>;
 
 	getOpenScmRepositories(): Promise<ScmRepository[]>;
 	getScmRepository(repoPath: string): Promise<ScmRepository | undefined>;

--- a/src/git/gitProvider.ts
+++ b/src/git/gitProvider.ts
@@ -124,7 +124,7 @@ export interface GitProvider extends Disposable {
 	openRepositoryInitWatcher?(): RepositoryInitWatcher;
 
 	supports(feature: Features): Promise<boolean>;
-	visibility(repoPath: string, remotes?: GitRemote[]): Promise<[RepositoryVisibility, string | undefined]>;
+	visibility(repoPath: string, remotes?: GitRemote[]): Promise<[visibility: RepositoryVisibility, cacheKey: string | undefined]>;
 
 	getOpenScmRepositories(): Promise<ScmRepository[]>;
 	getScmRepository(repoPath: string): Promise<ScmRepository | undefined>;

--- a/src/git/gitProviderService.ts
+++ b/src/git/gitProviderService.ts
@@ -151,7 +151,7 @@ export class GitProviderService implements Disposable {
 		this._etag = Date.now();
 
 		this._accessCache.clear();
-		this._repoesVisibilityCache = undefined;
+		this._reposVisibilityCache = undefined;
 
 		this._onDidChangeRepositories.fire({ added: added ?? [], removed: removed ?? [], etag: this._etag });
 
@@ -718,7 +718,7 @@ export class GitProviderService implements Disposable {
 		return provider.supports(feature);
 	}
 
-	private _repoesVisibilityCache: RepositoriesVisibility | undefined;
+	private _reposVisibilityCache: RepositoriesVisibility | undefined;
 	private _repoVisibilityCache: Map<string, RepositoryVisibilityInfo> | undefined;
 
 	private ensureRepoVisibilityCache(): void {
@@ -811,12 +811,12 @@ export class GitProviderService implements Disposable {
 	visibility(repoPath: string | Uri): Promise<RepositoryVisibility>;
 	async visibility(repoPath?: string | Uri): Promise<RepositoriesVisibility | RepositoryVisibility> {
 		if (repoPath == null) {
-			let visibility = this._repoesVisibilityCache;
+			let visibility = this._reposVisibilityCache;
 			if (visibility == null) {
 				visibility = await this.visibilityCore();
 				this.container.telemetry.setGlobalAttribute('repositories.visibility', visibility);
 				this.container.telemetry.sendEvent('repositories/visibility');
-				this._repoesVisibilityCache = visibility;
+				this._reposVisibilityCache = visibility;
 			}
 			return visibility;
 		}

--- a/src/git/models/remote.ts
+++ b/src/git/models/remote.ts
@@ -163,3 +163,13 @@ export function getRemoteIconUri(
 	);
 	return asWebviewUri != null ? asWebviewUri(uri) : uri;
 }
+
+export function getVisibilityCacheKey(remote: GitRemote): string;
+export function getVisibilityCacheKey(remotes: GitRemote[]): string;
+export function getVisibilityCacheKey(remotes: GitRemote | GitRemote[]): string {
+	if (!Array.isArray(remotes)) return remotes.id;
+	return remotes
+		.map(r => r.id)
+		.sort()
+		.join(',');
+}

--- a/src/storage.ts
+++ b/src/storage.ts
@@ -123,6 +123,7 @@ export type DeprecatedGlobalStorage = {
 
 export type GlobalStorage = {
 	avatars: [string, StoredAvatar][];
+	repoVisibility: [string, StoredRepoVisibilityInfo][];
 	'confirm:sendToOpenAI': boolean;
 	'deepLinks:pending': StoredDeepLinkContext;
 	'home:actions:completed': CompletedActions[];
@@ -183,6 +184,14 @@ export interface Stored<T, SchemaVersion extends number = 1> {
 export interface StoredAvatar {
 	uri: string;
 	timestamp: number;
+}
+
+export type StoredRepositoryVisibility = 'private' | 'public' | 'local';
+
+export interface StoredRepoVisibilityInfo {
+	visibility: StoredRepositoryVisibility;
+	timestamp: number;
+	remotesHash?: string;
 }
 
 export interface StoredBranchComparison {


### PR DESCRIPTION
Fixes: #2495

- Stores a cache of repo visibility that lives longer than the per-session cache
- Adds commands to reset the cache, either for open repos or for all repos