### PR TITLE
Add settings for additional graph minimap marker types

### DIFF
--- a/package.json
+++ b/package.json
@@ -2385,6 +2385,34 @@
 						"markdownDescription": "Specifies whether to show an experimental minimap of commit activity above the _Commit Graph_",
 						"scope": "window",
 						"order": 100
+					},
+					"gitlens.graph.experimental.minimap.additionalTypes": {
+						"type": "array",
+						"default": [
+							"localBranches",
+							"stashes"
+						],
+						"items": {
+							"type": "string",
+							"enum": [
+								"localBranches",
+								"remoteBranches",
+								"tags",
+								"stashes"
+							],
+							"enumDescriptions": [
+								"Marks the location of local branches",
+								"Marks the location of remote branches",
+								"Marks the location of tags",
+								"Marks the location of stashes"
+							]
+						},
+						"minItems": 0,
+						"maxItems": 4,
+						"uniqueItems": true,
+						"markdownDescription": "Specifies additional markers to show on the minimap in the _Commit Graph_",
+						"scope": "window",
+						"order": 101
 					}
 				}
 			},

--- a/package.json
+++ b/package.json
@@ -2226,20 +2226,18 @@
 					"gitlens.graph.scrollMarkers.additionalTypes": {
 						"type": "array",
 						"default": [
-							"head",
-							"localBranches"
+							"localBranches",
+							"stashes"
 						],
 						"items": {
 							"type": "string",
 							"enum": [
-								"head",
 								"localBranches",
 								"remoteBranches",
 								"tags",
 								"stashes"
 							],
 							"enumDescriptions": [
-								"Marks the location of the current HEAD and its upstream",
 								"Marks the location of local branches",
 								"Marks the location of remote branches",
 								"Marks the location of tags",
@@ -2247,7 +2245,7 @@
 							]
 						},
 						"minItems": 0,
-						"maxItems": 5,
+						"maxItems": 4,
 						"uniqueItems": true,
 						"markdownDescription": "Specifies additional markers to show on the scrollbar in the _Commit Graph_",
 						"scope": "window",

--- a/src/config.ts
+++ b/src/config.ts
@@ -299,6 +299,16 @@ export const enum GraphScrollMarkerTypes {
 	Tags = 'tags',
 }
 
+export const enum GraphMinimapTypes {
+	Selection = 'selection',
+	Head = 'head',
+	LocalBranches = 'localBranches',
+	RemoteBranches = 'remoteBranches',
+	Highlights = 'highlights',
+	Stashes = 'stashes',
+	Tags = 'tags',
+}
+
 export const enum GravatarDefaultStyle {
 	Faces = 'wavatar',
 	Geometric = 'identicon',
@@ -406,6 +416,7 @@ export interface GraphConfig {
 	experimental: {
 		minimap: {
 			enabled: boolean;
+			additionalTypes: GraphMinimapTypes[];
 		};
 	};
 	highlightRowsOnRefHover: boolean;

--- a/src/plus/webviews/graph/graphWebview.ts
+++ b/src/plus/webviews/graph/graphWebview.ts
@@ -1672,13 +1672,10 @@ export class GraphWebview extends WebviewBase<State> {
 		const markers: GraphScrollMarkerTypes[] = [
 			GraphScrollMarkerTypes.Selection,
 			GraphScrollMarkerTypes.Highlights,
+			GraphScrollMarkerTypes.Head,
+			GraphScrollMarkerTypes.Upstream,
 			...(configuration.get('graph.scrollMarkers.additionalTypes') as unknown as GraphScrollMarkerTypes[]),
 		];
-
-		// Head and upstream are under the same setting, but separate markers in the component
-		if (markers.includes(GraphScrollMarkerTypes.Head)) {
-			markers.push(GraphScrollMarkerTypes.Upstream);
-		}
 
 		return markers;
 	}

--- a/src/plus/webviews/graph/graphWebview.ts
+++ b/src/plus/webviews/graph/graphWebview.ts
@@ -1692,7 +1692,9 @@ export class GraphWebview extends WebviewBase<State> {
 			GraphMinimapMarkerTypes.Highlights,
 			GraphMinimapMarkerTypes.Head,
 			GraphMinimapMarkerTypes.Upstream,
-			...(configuration.get('graph.experimental.minimap.additionalTypes') as unknown as GraphMinimapMarkerTypes[]),
+			...(configuration.get(
+				'graph.experimental.minimap.additionalTypes',
+			) as unknown as GraphMinimapMarkerTypes[]),
 		];
 
 		return markers;

--- a/src/plus/webviews/graph/graphWebview.ts
+++ b/src/plus/webviews/graph/graphWebview.ts
@@ -145,6 +145,7 @@ import {
 	GetMissingAvatarsCommandType,
 	GetMissingRefsMetadataCommandType,
 	GetMoreRowsCommandType,
+	GraphMinimapMarkerTypes,
 	GraphRefMetadataTypes,
 	GraphScrollMarkerTypes,
 	SearchCommandType,
@@ -612,7 +613,8 @@ export class GraphWebview extends WebviewBase<State> {
 			configuration.changed(e, 'graph.pullRequests.enabled') ||
 			configuration.changed(e, 'graph.showRemoteNames') ||
 			configuration.changed(e, 'graph.showUpstreamStatus') ||
-			configuration.changed(e, 'graph.experimental.minimap.enabled')
+			configuration.changed(e, 'graph.experimental.minimap.enabled') ||
+			configuration.changed(e, 'graph.experimental.minimap.additionalTypes')
 		) {
 			void this.notifyDidChangeConfiguration();
 
@@ -1656,6 +1658,7 @@ export class GraphWebview extends WebviewBase<State> {
 			enableMultiSelection: false,
 			highlightRowsOnRefHover: configuration.get('graph.highlightRowsOnRefHover'),
 			minimap: configuration.get('graph.experimental.minimap.enabled'),
+			enabledMinimapMarkerTypes: this.getEnabledGraphMinimapMarkers(),
 			scrollRowPadding: configuration.get('graph.scrollRowPadding'),
 			enabledScrollMarkerTypes: this.getEnabledGraphScrollMarkers(),
 			showGhostRefsOnRowHover: configuration.get('graph.showGhostRefsOnRowHover'),
@@ -1675,6 +1678,21 @@ export class GraphWebview extends WebviewBase<State> {
 			GraphScrollMarkerTypes.Head,
 			GraphScrollMarkerTypes.Upstream,
 			...(configuration.get('graph.scrollMarkers.additionalTypes') as unknown as GraphScrollMarkerTypes[]),
+		];
+
+		return markers;
+	}
+
+	private getEnabledGraphMinimapMarkers(): GraphMinimapMarkerTypes[] {
+		const markersEnabled = configuration.get('graph.experimental.minimap.enabled');
+		if (!markersEnabled) return [];
+
+		const markers: GraphMinimapMarkerTypes[] = [
+			GraphMinimapMarkerTypes.Selection,
+			GraphMinimapMarkerTypes.Highlights,
+			GraphMinimapMarkerTypes.Head,
+			GraphMinimapMarkerTypes.Upstream,
+			...(configuration.get('graph.experimental.minimap.additionalTypes') as unknown as GraphMinimapMarkerTypes[]),
 		];
 
 		return markers;

--- a/src/plus/webviews/graph/protocol.ts
+++ b/src/plus/webviews/graph/protocol.ts
@@ -61,6 +61,17 @@ export const enum GraphScrollMarkerTypes {
 	Upstream = 'upstream',
 }
 
+export const enum GraphMinimapMarkerTypes {
+	Selection = 'selection',
+	Head = 'head',
+	Highlights = 'highlights',
+	LocalBranches = 'localBranches',
+	RemoteBranches = 'remoteBranches',
+	Stashes = 'stashes',
+	Tags = 'tags',
+	Upstream = 'upstream',
+}
+
 export const supportedRefMetadataTypes: GraphRefMetadataType[] = Object.values(GraphRefMetadataTypes);
 
 export type GraphCommitDateTimeSource = CommitDateTimeSource;
@@ -149,6 +160,7 @@ export interface GraphComponentConfig {
 	enableMultiSelection?: boolean;
 	highlightRowsOnRefHover?: boolean;
 	minimap?: boolean;
+	enabledMinimapMarkerTypes?: GraphMinimapMarkerTypes[];
 	scrollRowPadding?: number;
 	enabledScrollMarkerTypes?: GraphScrollMarkerTypes[];
 	showGhostRefsOnRowHover?: boolean;


### PR DESCRIPTION
This PR accomplishes the following:
- Updates the "always-on" markers for rich scrollbar and minimap to HEAD/Upstream, Current Selection, Search Results (Highlights)
- Updates the "default" markers on rich scrollbar and minimap to Local Branches/Stashes.
- Adds a new setting `gitlens.graph.experimental.minimap.additionalTypes` to set up additional markers for the minimap (default are Local Branches and Stashes, and Remote Branches and Tags are available as well).
- The setting is available in User Settings and updating it should immediately update the markers in the minimap to reflect the new settings.