### PR TITLE
Skips caching when getting main repo for worktree creation

### DIFF
--- a/src/commands/git/worktree.ts
+++ b/src/commands/git/worktree.ts
@@ -228,7 +228,7 @@ export class WorktreeGitCommand extends QuickCommand<State> {
 			}
 
 			// Ensure we use the "main" repository if we are in a worktree already
-			state.repo = await state.repo.getMainRepository();
+			state.repo = await state.repo.getMainRepository({ detectNested: false, force: true });
 			assertStateStepRepository(state);
 
 			const result = yield* ensureAccessStep(state, context, PlusFeatures.Worktrees);

--- a/src/commands/git/worktree.ts
+++ b/src/commands/git/worktree.ts
@@ -228,7 +228,7 @@ export class WorktreeGitCommand extends QuickCommand<State> {
 			}
 
 			// Ensure we use the "main" repository if we are in a worktree already
-			state.repo = await state.repo.getMainRepository({ detectNested: false, force: true });
+			state.repo = await state.repo.getMainRepository();
 			assertStateStepRepository(state);
 
 			const result = yield* ensureAccessStep(state, context, PlusFeatures.Worktrees);

--- a/src/git/gitProviderService.ts
+++ b/src/git/gitProviderService.ts
@@ -2103,7 +2103,7 @@ export class GitProviderService implements Disposable {
 	@log<GitProviderService['getOrOpenRepository']>({ exit: r => `returned ${r?.path}` })
 	async getOrOpenRepository(
 		uri: Uri,
-		options?: { closeOnOpen?: boolean; detectNested?: boolean },
+		options?: { closeOnOpen?: boolean; detectNested?: boolean; force?: boolean },
 	): Promise<Repository | undefined> {
 		const scope = getLogScope();
 
@@ -2116,14 +2116,14 @@ export class GitProviderService implements Disposable {
 		const detectNested = options?.detectNested ?? configuration.get('detectNestedRepositories', uri);
 		if (!detectNested) {
 			if (repository != null) return repository;
-		} else if (this._visitedPaths.has(path)) {
+		} else if (!options?.force && this._visitedPaths.has(path)) {
 			return repository;
 		} else {
 			const stats = await workspace.fs.stat(uri);
 			// If the uri isn't a directory, go up one level
 			if ((stats.type & FileType.Directory) !== FileType.Directory) {
 				uri = Uri.joinPath(uri, '..');
-				if (this._visitedPaths.has(getBestPath(uri))) return repository;
+				if (!options?.force && this._visitedPaths.has(getBestPath(uri))) return repository;
 			}
 
 			isDirectory = true;

--- a/src/git/models/repository.ts
+++ b/src/git/models/repository.ts
@@ -647,12 +647,16 @@ export class Repository implements Disposable {
 
 	@gate()
 	@log<Repository['getMainRepository']>({ exit: r => `returned ${r?.path}` })
-	async getMainRepository(options?: { detectNested?: boolean; force?: boolean }): Promise<Repository | undefined> {
+	async getMainRepository(): Promise<Repository | undefined> {
 		const gitDir = await this.getGitDir();
 		if (gitDir?.commonUri == null) return this;
 
 		// If the repository isn't already opened, then open it as a "closed" repo (won't show up in the UI)
-		return this.container.git.getOrOpenRepository(gitDir.commonUri, { ...options, closeOnOpen: true });
+		return this.container.git.getOrOpenRepository(gitDir.commonUri, {
+			detectNested: false,
+			force: true,
+			closeOnOpen: true,
+		});
 	}
 
 	getMergeStatus(): Promise<GitMergeStatus | undefined> {

--- a/src/git/models/repository.ts
+++ b/src/git/models/repository.ts
@@ -647,12 +647,12 @@ export class Repository implements Disposable {
 
 	@gate()
 	@log<Repository['getMainRepository']>({ exit: r => `returned ${r?.path}` })
-	async getMainRepository(): Promise<Repository | undefined> {
+	async getMainRepository(options?: { detectNested?: boolean; force?: boolean }): Promise<Repository | undefined> {
 		const gitDir = await this.getGitDir();
 		if (gitDir?.commonUri == null) return this;
 
 		// If the repository isn't already opened, then open it as a "closed" repo (won't show up in the UI)
-		return this.container.git.getOrOpenRepository(gitDir.commonUri, { closeOnOpen: true });
+		return this.container.git.getOrOpenRepository(gitDir.commonUri, { ...options, closeOnOpen: true });
 	}
 
 	getMergeStatus(): Promise<GitMergeStatus | undefined> {


### PR DESCRIPTION
Issue repro steps:
1. Turn the `gitlens.detectNestedRepositories` setting on
1. Using git command line, create a worktree in the `.git` folder of a repo
2. Open that worktree
4. Attempt to create a new worktree while inside that worktree

Expected: You are able to create a new wotkree
Actual: You get a missing repository error in the debug output.
