### PR TITLE
Sends upstream id on a local branch ref to graph

### DIFF
--- a/package.json
+++ b/package.json
@@ -13407,7 +13407,7 @@
 		"vscode:prepublish": "yarn run bundle"
 	},
 	"dependencies": {
-		"@gitkraken/gitkraken-components": "7.3.0",
+		"@gitkraken/gitkraken-components": "8.0.0",
 		"@microsoft/fast-element": "1.11.0",
 		"@microsoft/fast-react-wrapper": "0.3.16-0",
 		"@octokit/core": "4.2.0",

--- a/src/env/node/git/localGitProvider.ts
+++ b/src/env/node/git/localGitProvider.ts
@@ -2006,12 +2006,12 @@ export class LocalGitProvider implements GitProvider, Disposable {
 							name: tip,
 							isCurrentHead: head,
 							context: serializeWebviewItemContext<GraphItemRefContext>(context),
-							...(branch?.upstream && {
-								upstream: {
-									name: branch.upstream.name,
-									id: getBranchId(repoPath, true, branch.upstream.name),
-								},
-							}),
+							upstream: branch?.upstream != null
+							  ? {
+								  name: branch.upstream.name,
+								  id: getBranchId(repoPath, true, branch.upstream.name),
+								}
+							  : undefined,
 						};
 						refHeads.push(refHead);
 						if (branch?.upstream?.name != null) {

--- a/src/env/node/git/localGitProvider.ts
+++ b/src/env/node/git/localGitProvider.ts
@@ -2006,7 +2006,12 @@ export class LocalGitProvider implements GitProvider, Disposable {
 							name: tip,
 							isCurrentHead: head,
 							context: serializeWebviewItemContext<GraphItemRefContext>(context),
-							upstream: branch?.upstream?.name,
+							...(branch?.upstream && {
+								upstream: {
+									name: branch.upstream.name,
+									id: getBranchId(repoPath, true, branch.upstream.name),
+								},
+							}),
 						};
 						refHeads.push(refHead);
 						if (branch?.upstream?.name != null) {

--- a/src/plus/github/githubGitProvider.ts
+++ b/src/plus/github/githubGitProvider.ts
@@ -1286,7 +1286,12 @@ export class GitHubGitProvider implements GitProvider, Disposable {
 						name: headBranch.name,
 						isCurrentHead: true,
 						context: serializeWebviewItemContext<GraphItemRefContext>(context),
-						upstream: headBranch.upstream?.name,
+						...(headBranch.upstream && {
+							upstream: {
+								name: headBranch.upstream.name,
+								id: getBranchId(repoPath, true, headBranch.upstream.name),
+							},
+						}),
 					},
 				];
 

--- a/src/plus/github/githubGitProvider.ts
+++ b/src/plus/github/githubGitProvider.ts
@@ -1286,12 +1286,12 @@ export class GitHubGitProvider implements GitProvider, Disposable {
 						name: headBranch.name,
 						isCurrentHead: true,
 						context: serializeWebviewItemContext<GraphItemRefContext>(context),
-						...(headBranch.upstream && {
-							upstream: {
-								name: headBranch.upstream.name,
-								id: getBranchId(repoPath, true, headBranch.upstream.name),
-							},
-						}),
+						upstream: headBranch.upstream != null
+						? {
+							name: headBranch.upstream.name,
+							id: getBranchId(repoPath, true, headBranch.upstream.name),
+						  }
+						: undefined,
 					},
 				];
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -312,10 +312,10 @@
   resolved "https://registry.yarnpkg.com/@gar/promisify/-/promisify-1.1.3.tgz#555193ab2e3bb3b6adc3d551c9c030d9e860daf6"
   integrity sha512-k2Ty1JcVojjJFwrg/ThKi2ujJ7XNLYaFGNB/bWT9wGR+oSMJHMa5w+CUq6p/pVrKeNNgA7pCqEcjSnHVoqJQFw==
 
-"@gitkraken/gitkraken-components@7.3.0":
-  version "7.3.0"
-  resolved "https://registry.yarnpkg.com/@gitkraken/gitkraken-components/-/gitkraken-components-7.3.0.tgz#fd8f2e8d00e3dc4947997bdf78d0d99632c3b0ff"
-  integrity sha512-LlftWx9c58jA9vMmhhbkBwTtRQ4RA36/BWH6nZ2aggD+L26umChuIBa4aZ25RU6tTlP+QkwGe8Ybu22NULNTCQ==
+"@gitkraken/gitkraken-components@8.0.0":
+  version "8.0.0"
+  resolved "https://registry.yarnpkg.com/@gitkraken/gitkraken-components/-/gitkraken-components-8.0.0.tgz#2ab6830de870eb81a44c805dd295f32cd7bada1d"
+  integrity sha512-cieCMvs8CJg7W/e3Wb4xDRKJjM3JIfnd2BsmSUdI1/g5t9Q2PnVeGgs63gfM7P6JALDq7FgypAamv77VaOijqA==
   dependencies:
     "@axosoft/react-virtualized" "9.22.3-gitkraken.3"
     classnames "2.3.2"


### PR DESCRIPTION
Small change which sends the ID of upstreams along with their name (previously we only sent the upstream name) to local branch refs in the graph, for this feature to work: https://github.com/gitkraken/GitKrakenComponents/pull/205

Once the dependency PR is merged, the graph library published, and the dependency updated here, this PR will leave draft and be ready for review.