### PR TITLE
Adds experimental gutter changes (wip)

### DIFF
--- a/package.json
+++ b/package.json
@@ -58,6 +58,9 @@
 		"onWebviewPanel:gitlens.welcome",
 		"onStartupFinished"
 	],
+	"enabledApiProposals": [
+		"quickDiffProvider"
+	],
 	"capabilities": {
 		"virtualWorkspaces": true,
 		"untrustedWorkspaces": {

--- a/src/@types/vscode.proposed.quickDiffProvider.d.ts
+++ b/src/@types/vscode.proposed.quickDiffProvider.d.ts
@@ -1,0 +1,21 @@
+/*---------------------------------------------------------------------------------------------
+ *  Copyright (c) Microsoft Corporation. All rights reserved.
+ *  Licensed under the MIT License. See License.txt in the project root for license information.
+ *--------------------------------------------------------------------------------------------*/
+
+declare module 'vscode' {
+	// https://github.com/microsoft/vscode/issues/169012
+
+	export namespace window {
+		export function registerQuickDiffProvider(
+			selector: DocumentSelector,
+			quickDiffProvider: QuickDiffProvider,
+			label: string,
+			rootUri?: Uri,
+		): Disposable;
+	}
+
+	interface QuickDiffProvider {
+		label?: string;
+	}
+}

--- a/src/annotations/gutterChangesAnnotationProvider.ts
+++ b/src/annotations/gutterChangesAnnotationProvider.ts
@@ -1,8 +1,9 @@
 import type { CancellationToken, DecorationOptions, Disposable, TextDocument, TextEditor } from 'vscode';
-import { Hover, languages, Position, Range, Selection, TextEditorRevealType } from 'vscode';
+import { Hover, languages, Position, Range, Selection, TextEditorRevealType, window } from 'vscode';
 import type { Container } from '../container';
 import type { GitCommit } from '../git/models/commit';
 import type { GitDiffFile } from '../git/models/diff';
+import { shortenRevision } from '../git/models/reference';
 import { localChangesMessage } from '../hovers/hovers';
 import { configuration } from '../system/configuration';
 import { log } from '../system/decorators/log';
@@ -25,6 +26,7 @@ export interface ChangesAnnotationContext extends AnnotationContext {
 
 export class GutterChangesAnnotationProvider extends AnnotationProviderBase<ChangesAnnotationContext> {
 	private hoverProviderDisposable: Disposable | undefined;
+	private quickdiffProviderDisposable: Disposable | undefined;
 	private sortedHunkStarts: number[] | undefined;
 	private state: { commit: GitCommit | undefined; diffs: GitDiffFile[] } | undefined;
 
@@ -38,6 +40,10 @@ export class GutterChangesAnnotationProvider extends AnnotationProviderBase<Chan
 
 	override clear() {
 		this.state = undefined;
+		if (this.quickdiffProviderDisposable != null) {
+			this.quickdiffProviderDisposable.dispose();
+			this.quickdiffProviderDisposable = undefined;
+		}
 		if (this.hoverProviderDisposable != null) {
 			this.hoverProviderDisposable.dispose();
 			this.hoverProviderDisposable = undefined;
@@ -167,6 +173,22 @@ export class GutterChangesAnnotationProvider extends AnnotationProviderBase<Chan
 				}
 			}
 		}
+
+		const label = `GitLens: Changes from ${shortenRevision(ref2)}`;
+		this.quickdiffProviderDisposable?.dispose();
+		this.quickdiffProviderDisposable = window.registerQuickDiffProvider(
+			{ pattern: this.trackedDocument.uri.fsPath },
+			{
+				label: label,
+				provideOriginalResource: async () =>
+					(await this.container.git.getBestRevisionUri(
+						this.trackedDocument.uri.repoPath,
+						this.trackedDocument.uri.fsPath,
+						ref1 ?? ref2,
+					))!,
+			},
+			label,
+		);
 
 		const diffs = (
 			await Promise.allSettled(


### PR DESCRIPTION
This is an experiment to use the new VS Code `QuickDiffProvider` API proposal.

THIS CANNOT BE MERGED until the VS Code proposal lands.