### PR TITLE
Fixes #2566 hide context menu in output panel

### DIFF
--- a/package.json
+++ b/package.json
@@ -9306,7 +9306,7 @@
 			"editor/context": [
 				{
 					"submenu": "gitlens/editor/context/changes",
-					"when": "editorTextFocus && gitlens:activeFileStatus =~ /tracked/ && config.gitlens.menus.editor.compare",
+					"when": "editorTextFocus && gitlens:activeFileStatus =~ /tracked/ && config.gitlens.menus.editor.compare && activePanel != 'workbench.panel.output'",
 					"group": "2_gitlens@1"
 				},
 				{


### PR DESCRIPTION
Fixes #2566 hide context menu in output panel

maybe be we all modified some line, let my change become not work , so i try open a pr again :) 

- [x] I have followed the guidelines in the Contributing document
- [x] My changes follow the coding style of this project
- [x] My changes build without any errors or warnings
- [x] My changes have been formatted and linted
- [x] My changes include any required corresponding changes to the documentation (including CHANGELOG.md and README.md)
- [x] My changes have been rebased and squashed to the minimal number (typically 1) of relevant commits
- [x] My changes have a descriptive commit message with a short title, including a `Fixes $XXX -` or `Closes #XXX -` prefix to auto-close the issue that your PR addresses
