### PR TITLE
Fixes regressions in #2481 fetching remote

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -47,6 +47,7 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/) and this p
 - Fixes [#2595](https://github.com/gitkraken/vscode-gitlens/issues/2595) - Error when stashing changes
 - Fixes tooltips sometimes failing to show in _Commit Graph_ rows when the Date column is hidden
 - Fixes an issue with incorrectly showing associated pull requests with branches that are partial matches of the true branch the pull request is associated with
+- Fixes [#2587](https://github.com/gitkraken/vscode-gitlens/issues/2587) - Regression in Fetching: Fetching a remote asks to enter remote again
 
 ## [13.4.0] - 2023-03-16
 

--- a/src/constants.ts
+++ b/src/constants.ts
@@ -370,6 +370,8 @@ export type CoreCommands =
 
 export type CoreGitCommands =
 	| 'git.fetch'
+	| 'git.fetchAll'
+	| 'git.fetchPrune'
 	| 'git.publish'
 	| 'git.pull'
 	| 'git.pullRebase'

--- a/src/git/models/repository.ts
+++ b/src/git/models/repository.ts
@@ -578,10 +578,13 @@ export class Repository implements Disposable {
 		remote?: string;
 	}) {
 		try {
-			if (options?.branch != null) {
+			if (options?.branch != null || options?.remote) {
 				await this.container.git.fetch(this.path, options);
 			} else {
-				void (await executeCoreGitCommand('git.fetch', this.path));
+				void (await executeCoreGitCommand(
+					options?.prune ? 'git.fetchPrune' : options?.all ? 'git.fetchAll' : 'git.fetch',
+					this.path,
+				));
 			}
 
 			this.fireChange(RepositoryChange.Unknown);


### PR DESCRIPTION
# Description

<!--
Please include a summary of the changes and which issue will be addressed. Please also include relevant motivation and context.
-->
Fixes some regressions in fetching introduced in #2481:
- Fixes #2587
- It no longer ignores `all` and `prune` flags

# Checklist

<!-- Please check off the following -->

- [x] I have followed the guidelines in the Contributing document
- [x] My changes follow the coding style of this project
- [x] My changes build without any errors or warnings
- [x] My changes have been formatted and linted
- [x] My changes include any required corresponding changes to the documentation (including CHANGELOG.md and README.md)
- [x] My changes have been rebased and squashed to the minimal number (typically 1) of relevant commits
- [x] My changes have a descriptive commit message with a short title, including a `Fixes $XXX -` or `Closes #XXX -` prefix to auto-close the issue that your PR addresses
