### PR TITLE
Graph: Add "publish branch" context item for local branches

### DIFF
--- a/package.json
+++ b/package.json
@@ -6975,6 +6975,13 @@
 				"enablement": "!operationInProgress"
 			},
 			{
+				"command": "gitlens.graph.publishBranch",
+				"title": "Publish Branch",
+				"category": "GitLens",
+				"icon": "$(cloud-upload)",
+				"enablement": "!operationInProgress"
+			},
+			{
 				"command": "gitlens.graph.rebaseOntoBranch",
 				"title": "Rebase Current Branch onto Branch...",
 				"category": "GitLens",
@@ -9178,6 +9185,10 @@
 				},
 				{
 					"command": "gitlens.graph.mergeBranchInto",
+					"when": "false"
+				},
+				{
+					"command": "gitlens.graph.publishBranch",
 					"when": "false"
 				},
 				{
@@ -11934,6 +11945,11 @@
 					"when": "gitlens:hasRemotes && webviewItem =~ /gitlens:branch\\b(?=.*?\\b\\+(tracking|remote)\\b)/",
 					"group": "2_gitlens_quickopen@1",
 					"alt": "gitlens.copyRemoteBranchUrl"
+				},
+				{
+					"command": "gitlens.graph.publishBranch",
+					"when": "gitlens:hasRemotes && !gitlens:readonly && !gitlens:untrusted && !gitlens:hasVirtualFolders && webviewItem =~ /gitlens:branch\\b(?!.*?\\b\\+remote\\b)(?!.*?\\b\\+tracking\\b)/",
+					"group": "8_gitlens_actions@13"
 				},
 				{
 					"command": "gitlens.graph.cherryPick",

--- a/src/plus/webviews/graph/graphWebview.ts
+++ b/src/plus/webviews/graph/graphWebview.ts
@@ -308,6 +308,7 @@ export class GraphWebviewProvider implements WebviewProvider<State> {
 			registerCommand('gitlens.graph.push', this.push, this),
 			registerCommand('gitlens.graph.pull', this.pull, this),
 			registerCommand('gitlens.graph.fetch', this.fetch, this),
+			registerCommand('gitlens.graph.publishBranch', this.publishBranch, this),
 			registerCommand('gitlens.graph.switchToAnotherBranch', this.switchToAnother, this),
 
 			registerCommand('gitlens.graph.createBranch', this.createBranch, this),
@@ -2012,6 +2013,16 @@ export class GraphWebviewProvider implements WebviewProvider<State> {
 				remote: ref.upstream?.name,
 				clipboard: clipboard,
 			});
+		}
+
+		return Promise.resolve();
+	}
+
+	@debug()
+	private publishBranch(item?: GraphItemContext) {
+		if (isGraphItemRefContext(item, 'branch')) {
+			const { ref } = item.webviewItemValue;
+			return RepoActions.push(ref.repoPath, undefined, ref);
 		}
 
 		return Promise.resolve();


### PR DESCRIPTION
Adds the ability to "Publish Branch" in the context menu for local branches in the graph without an upstream.

This feature already exists in the Branches view - simply adding similar functionality to the graph.
