### PR TITLE
Adds experimental.OpenAIModel

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,10 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/) and this p
 
 ## [Unreleased]
 
+### Added
+
+- Adds a `gitlens.experimental.openAIModel` setting to specify the OpenAI model to use to generate commit messages when using the `GitLens: Generate Commit Message` command (defaults to `gpt-3.5-turbo`) &mdash; closes [#2636](https://github.com/gitkraken/vscode-gitlens/issues/2636) thanks to [PR #2637](https://github.com/gitkraken/vscode-gitlens/pull/2637) by Daniel Rodríguez ([@sadasant](https://github.com/sadasant))
+
 ## [13.6.0] - 2023-05-11
 
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,7 +8,8 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/) and this p
 
 ### Added
 
-- Adds a `gitlens.experimental.openAIModel` setting to specify the OpenAI model to use to generate commit messages when using the `GitLens: Generate Commit Message` command (defaults to `gpt-3.5-turbo`) &mdash; closes [#2636](https://github.com/gitkraken/vscode-gitlens/issues/2636) thanks to [PR #2637](https://github.com/gitkraken/vscode-gitlens/pull/2637) by Daniel Rodríguez ([@sadasant](https://github.com/sadasant))
+- Adds ability to choose the OpenAI model used for GitLens' experimental AI features &mdash; closes [#2636](https://github.com/gitkraken/vscode-gitlens/issues/2636) thanks to [PR #2637](https://github.com/gitkraken/vscode-gitlens/pull/2637) by Daniel Rodríguez ([@sadasant](https://github.com/sadasant))
+  - Adds a `gitlens.ai.experimental.openai.model` setting to specify the OpenAI model (defaults to `gpt-3.5-turbo`)
 
 ## [13.6.0] - 2023-05-11
 

--- a/README.md
+++ b/README.md
@@ -1194,6 +1194,7 @@ A big thanks to the people that have contributed to this project:
 - David Rees ([@studgeek](https://github.com/studgeek)) &mdash; [contributions](https://github.com/gitkraken/vscode-gitlens/commits?author=studgeek)
 - Rickard ([@rickardp](https://github.com/rickardp)) &mdash; [contributions](https://github.com/gitkraken/vscode-gitlens/commits?author=rickardp)
 - Johannes Rieken ([@jrieken](https://github.com/jrieken)) &mdash; [contributions](https://github.com/gitkraken/vscode-gitlens/commits?author=jrieken)
+- Daniel Rodríguez ([@sadasant](https://github.com/sadasant)) &mdash; [contributions](https://github.com/gitkraken/vscode-gitlens/commits?author=sadasant)
 - Guillaume Rozan ([@rozangu1](https://github.com/rozangu1)) &mdash; [contributions](https://github.com/gitkraken/vscode-gitlens/commits?author=rozangu1)
 - ryenus ([@ryenus](https://github.com/ryenus)) &mdash; [contributions](https://github.com/gitkraken/vscode-gitlens/commits?author=ryenus)
 - Felipe Santos ([@felipecrs](https://github.com/felipecrs)) &mdash; [contributions](https://github.com/gitkraken/vscode-gitlens/commits?author=felipecrs)

--- a/package.json
+++ b/package.json
@@ -2806,6 +2806,43 @@
 				}
 			},
 			{
+				"id": "ai",
+				"title": "AI",
+				"order": 113,
+				"properties": {
+					"gitlens.experimental.generateCommitMessagePrompt": {
+						"type": "string",
+						"default": "Commit messages must have a short description that is less than 50 chars followed by a newline and a more detailed description.\n- Write concisely using an informal tone and avoid specific names from the code",
+						"markdownDescription": "Specifies the prompt to use to tell OpenAI how to structure or format the generated commit message",
+						"scope": "window",
+						"order": 1
+					},
+					"gitlens.ai.experimental.openai.model": {
+						"type": "string",
+						"default": "gpt-3.5-turbo",
+						"enum": [
+							"gpt-3.5-turbo",
+							"gpt-3.5-turbo-0301",
+							"gpt-4",
+							"gpt-4-0314",
+							"gpt-4-32k",
+							"gpt-4-32k-0314"
+						],
+						"enumDescriptions": [
+							"GPT 3.5 Turbo",
+							"GPT 3.5 Turbo (March 1, 2021)",
+							"GPT 4",
+							"GPT 4 (March 14, 2021)",
+							"GPT 4 32k",
+							"GPT 4 32k (March 14, 2021)"
+						],
+						"markdownDescription": "Specifies the OpenAI model to use for GitLens' experimental AI features",
+						"scope": "window",
+						"order": 100
+					}
+				}
+			},
+			{
 				"id": "date-times",
 				"title": "Date & Times",
 				"order": 120,
@@ -3659,20 +3696,6 @@
 						"markdownDescription": "Specifies the amount (percent) of similarity a deleted and added file pair must have to be considered a rename",
 						"scope": "window",
 						"order": 50
-					},
-					"gitlens.experimental.generateCommitMessagePrompt": {
-						"type": "string",
-						"default": "Commit messages must have a short description that is less than 50 chars followed by a newline and a more detailed description.\n- Write concisely using an informal tone and avoid specific names from the code",
-						"markdownDescription": "Specifies the prompt to use to tell OpenAI how to structure or format the generated commit message",
-						"scope": "window",
-						"order": 55
-					},
-					"gitlens.experimental.openAIModel": {
-						"type": "string",
-						"default": "gpt-3.5-turbo",
-						"markdownDescription": "Specifies the OpenAI model to use to generate commit messages when using the `GitLens: Generate Commit Message` command",
-						"scope": "window",
-						"order": 56
 					},
 					"gitlens.advanced.externalDiffTool": {
 						"type": [

--- a/package.json
+++ b/package.json
@@ -3667,6 +3667,13 @@
 						"scope": "window",
 						"order": 55
 					},
+					"gitlens.experimental.openAIModel": {
+						"type": "string",
+						"default": "gpt-3.5-turbo",
+						"markdownDescription": "Specifies the OpenAI model to use to generate commit messages when using the `GitLens: Generate Commit Message` command",
+						"scope": "window",
+						"order": 56
+					},
 					"gitlens.advanced.externalDiffTool": {
 						"type": [
 							"string",

--- a/src/ai/openaiProvider.ts
+++ b/src/ai/openaiProvider.ts
@@ -12,12 +12,15 @@ const maxCodeCharacters = 12000;
 export class OpenAIProvider implements AIProvider {
 	readonly id = 'openai';
 	readonly name = 'OpenAI';
+	private model: OpenAIChatCompletionModels = 'gpt-3.5-turbo';
 
 	constructor(private readonly container: Container) {}
 
 	dispose() {}
 
 	async generateCommitMessage(diff: string, options?: { context?: string }): Promise<string | undefined> {
+		this.model = configuration.get('experimental.openAIModel') || 'gpt-3.5-turbo';
+
 		const openaiApiKey = await getApiKey(this.container.storage);
 		if (openaiApiKey == null) return undefined;
 
@@ -34,7 +37,7 @@ export class OpenAIProvider implements AIProvider {
 		}
 
 		const data: OpenAIChatCompletionRequest = {
-			model: 'gpt-3.5-turbo',
+			model: this.model,
 			messages: [
 				{
 					role: 'system',
@@ -79,6 +82,8 @@ export class OpenAIProvider implements AIProvider {
 	}
 
 	async explainChanges(message: string, diff: string): Promise<string | undefined> {
+		this.model = configuration.get('experimental.openAIModel') || 'gpt-3.5-turbo';
+
 		const openaiApiKey = await getApiKey(this.container.storage);
 		if (openaiApiKey == null) return undefined;
 
@@ -90,7 +95,7 @@ export class OpenAIProvider implements AIProvider {
 		}
 
 		const data: OpenAIChatCompletionRequest = {
-			model: 'gpt-3.5-turbo',
+			model: this.model,
 			messages: [
 				{
 					role: 'system',
@@ -195,8 +200,10 @@ async function getApiKey(storage: Storage): Promise<string | undefined> {
 	return openaiApiKey;
 }
 
+export type OpenAIChatCompletionModels = 'gpt-3.5-turbo' | 'gpt-3.5-turbo-0301' | 'gpt-4' | 'gpt-4-0314' | 'gpt-4-32k' | 'gpt-4-32k-0314';
+
 interface OpenAIChatCompletionRequest {
-	model: 'gpt-3.5-turbo' | 'gpt-3.5-turbo-0301';
+	model: OpenAIChatCompletionModels;
 	messages: { role: 'system' | 'user' | 'assistant'; content: string }[];
 	temperature?: number;
 	top_p?: number;

--- a/src/config.ts
+++ b/src/config.ts
@@ -49,6 +49,7 @@ export interface Config {
 	detectNestedRepositories: boolean;
 	experimental: {
 		generateCommitMessagePrompt: string;
+		openAIModel?: 'gpt-3.5-turbo' | 'gpt-3.5-turbo-0301' | 'gpt-4' | 'gpt-4-0314' | 'gpt-4-32k' | 'gpt-4-32k-0314';
 	};
 	fileAnnotations: {
 		command: string | null;

--- a/src/config.ts
+++ b/src/config.ts
@@ -1,7 +1,15 @@
+import type { OpenAIModels } from './ai/openaiProvider';
 import type { DateTimeFormat } from './system/date';
 import { LogLevel } from './system/logger.constants';
 
 export interface Config {
+	ai: {
+		experimental: {
+			openai: {
+				model?: OpenAIModels;
+			};
+		};
+	};
 	autolinks: AutolinkReference[] | null;
 	blame: {
 		avatars: boolean;
@@ -49,7 +57,6 @@ export interface Config {
 	detectNestedRepositories: boolean;
 	experimental: {
 		generateCommitMessagePrompt: string;
-		openAIModel?: 'gpt-3.5-turbo' | 'gpt-3.5-turbo-0301' | 'gpt-4' | 'gpt-4-0314' | 'gpt-4-32k' | 'gpt-4-32k-0314';
 	};
 	fileAnnotations: {
 		command: string | null;


### PR DESCRIPTION
# Description

Adds a `gitlens.experimental.OpenAIModel` setting to specify the OpenAI model to use to generate commit messages when using the `GitLens: Generate Commit Message` command.

Fixes #2636

# Checklist

<!-- Please check off the following -->

- [x] I have followed the guidelines in the Contributing document
- [x] My changes follow the coding style of this project
- [x] My changes build without any errors or warnings
- [x] My changes have been formatted and linted
- [x] My changes include any required corresponding changes to the documentation (including CHANGELOG.md and README.md)
- [x] My changes have been rebased and squashed to the minimal number (typically 1) of relevant commits
- [x] My changes have a descriptive commit message with a short title, including a `Fixes $XXX -` or `Closes #XXX -` prefix to auto-close the issue that your PR addresses
