### PR TITLE
Closes #302 - Adds Gitlab avatars

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,9 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/) and this p
 
 ## [Unreleased]
 
+### Added
+- Adds GitLab Avatar support — closes [#302](https://github.com/gitkraken/vscode-gitlens/issues/302) via [#2640](https://github.com/gitkraken/vscode-gitlens/pull/2640)
+
 ## [13.5.0] - 2023-04-07
 
 ### Added

--- a/README.md
+++ b/README.md
@@ -1226,6 +1226,7 @@ A big thanks to the people that have contributed to this project:
 - Zyck ([@qzyse2017](https://github.com/qzyse2017)) &mdash; [contributions](https://github.com/gitkraken/vscode-gitlens/commits?author=qzyse2017)
 - Yonatan Greenfeld ([@YonatanGreenfeld](https://github.com/YonatanGreenfeld)) &mdash; [contributions](https://github.com/gitkraken/vscode-gitlens/commits?author=YonatanGreenfeld)
 - WofWca ([@WofWca](https://github.com/WofWca)) &mdash; [contributions](https://github.com/gitkraken/vscode-gitlens/commits?author=WofWca)
+- 🐇 ([@BunnyTheLifeguard](https://github.com/bunnythelifeguard)) &mdash; [contributions](https://github.com/gitkraken/vscode-gitlens/commits?author=bunnythelifeguard)
 
 Also special thanks to the people that have provided support, testing, brainstorming, etc:
 

--- a/src/git/remotes/gitlab.ts
+++ b/src/git/remotes/gitlab.ts
@@ -377,6 +377,17 @@ export class GitLabRemote extends RichRemoteProvider {
 		return Promise.resolve(undefined);
 	}
 }
+const gitLabNoReplyAddressRegex = /^(?:(\d+)-)?([a-zA-Z\d-]{1,39})@users\.noreply\.(.*)$/i;
+
+export function getGitLabNoReplyAddressParts(
+	email: string,
+): { userId: string; login: string; authority: string } | undefined {
+	const match = gitLabNoReplyAddressRegex.exec(email);
+	if (match == null) return undefined;
+
+	const [, userId, login, authority] = match;
+	return { userId: userId, login: login, authority: authority };
+}
 
 export class GitLabAuthenticationProvider implements Disposable, IntegrationAuthenticationProvider {
 	private readonly _disposable: Disposable;


### PR DESCRIPTION
# Description

This refactors the previous Github NoreplyEmail function into a more generic, extendable one while also adding support for Gitlab Avatars.

VSIX package tested successfully, GitLab avatar was displayed in VSCode.

Closes #302 

# Checklist

<!-- Please check off the following -->

- [x] I have followed the guidelines in the Contributing document
- [x] My changes follow the coding style of this project
- [x] My changes build without any errors or warnings
- [x] My changes have been formatted and linted
- [x] My changes include any required corresponding changes to the documentation (including CHANGELOG.md and README.md)
- [x] My changes have been rebased and squashed to the minimal number (typically 1) of relevant commits
- [x] My changes have a descriptive commit message with a short title, including a `Fixes $XXX -` or `Closes #XXX -` prefix to auto-close the issue that your PR addresses
