### PR TITLE
Unlock all graph columns (for moving and hiding)

### DIFF
--- a/package.json
+++ b/package.json
@@ -7236,12 +7236,12 @@
 			},
 			{
 				"command": "gitlens.graph.columnRefOn",
-				"title": "Show Branch/Tag Column",
+				"title": "Show Branch / Tag Column",
 				"category": "GitLens"
 			},
 			{
 				"command": "gitlens.graph.columnRefOff",
-				"title": "Hide Branch/Tag Column",
+				"title": "Hide Branch / Tag Column",
 				"category": "GitLens"
 			},
 			{
@@ -12151,53 +12151,53 @@
 					"group": "1_columns@1"
 				},
 				{
-					"command": "gitlens.graph.columnChangesOn",
-					"when": "webviewItem =~ /gitlens:graph:columns\\b/ && webviewItemValue =~ /\\bhidden:changes\\b/",
-					"group": "1_columns@2"
-				},
-				{
-					"command": "gitlens.graph.columnChangesOff",
-					"when": "webviewItem =~ /gitlens:graph:columns\\b/ && webviewItemValue =~ /^(?:(?!\\b(hidden|only):changes\\b).)*$/",
-					"group": "1_columns@2"
-				},
-				{
-					"command": "gitlens.graph.columnDateTimeOn",
-					"when": "webviewItem =~ /gitlens:graph:columns\\b/ && webviewItemValue =~ /\\bhidden:datetime\\b/",
-					"group": "1_columns@3"
-				},
-				{
-					"command": "gitlens.graph.columnDateTimeOff",
-					"when": "webviewItem =~ /gitlens:graph:columns\\b/ && webviewItemValue =~ /^(?:(?!\\b(hidden|only):datetime\\b).)*$/",
-					"group": "1_columns@3"
-				},
-				{
-					"command": "gitlens.graph.columnGraphOn",
-					"when": "webviewItem =~ /gitlens:graph:columns\\b/ && webviewItemValue =~ /\\bhidden:graph\\b/",
-					"group": "1_columns@4"
-				},
-				{
-					"command": "gitlens.graph.columnGraphOff",
-					"when": "webviewItem =~ /gitlens:graph:columns\\b/ && webviewItemValue =~ /^(?:(?!\\b(hidden|only):graph\\b).)*$/",
-					"group": "1_columns@4"
-				},
-				{
-					"command": "gitlens.graph.columnMessageOn",
-					"when": "webviewItem =~ /gitlens:graph:columns\\b/ && webviewItemValue =~ /\\bhidden:message\\b/",
-					"group": "1_columns@5"
-				},
-				{
-					"command": "gitlens.graph.columnMessageOff",
-					"when": "webviewItem =~ /gitlens:graph:columns\\b/ && webviewItemValue =~ /^(?:(?!\\b(hidden|only):message\\b).)*$/",
-					"group": "1_columns@5"
-				},
-				{
 					"command": "gitlens.graph.columnRefOn",
 					"when": "webviewItem =~ /gitlens:graph:columns\\b/ && webviewItemValue =~ /\\bhidden:ref\\b/",
-					"group": "1_columns@6"
+					"group": "1_columns@2"
 				},
 				{
 					"command": "gitlens.graph.columnRefOff",
 					"when": "webviewItem =~ /gitlens:graph:columns\\b/ && webviewItemValue =~ /^(?:(?!\\b(hidden|only):ref\\b).)*$/",
+					"group": "1_columns@2"
+				},
+				{
+					"command": "gitlens.graph.columnChangesOn",
+					"when": "webviewItem =~ /gitlens:graph:columns\\b/ && webviewItemValue =~ /\\bhidden:changes\\b/",
+					"group": "1_columns@3"
+				},
+				{
+					"command": "gitlens.graph.columnChangesOff",
+					"when": "webviewItem =~ /gitlens:graph:columns\\b/ && webviewItemValue =~ /^(?:(?!\\b(hidden|only):changes\\b).)*$/",
+					"group": "1_columns@3"
+				},
+				{
+					"command": "gitlens.graph.columnMessageOn",
+					"when": "webviewItem =~ /gitlens:graph:columns\\b/ && webviewItemValue =~ /\\bhidden:message\\b/",
+					"group": "1_columns@4"
+				},
+				{
+					"command": "gitlens.graph.columnMessageOff",
+					"when": "webviewItem =~ /gitlens:graph:columns\\b/ && webviewItemValue =~ /^(?:(?!\\b(hidden|only):message\\b).)*$/",
+					"group": "1_columns@4"
+				},
+				{
+					"command": "gitlens.graph.columnDateTimeOn",
+					"when": "webviewItem =~ /gitlens:graph:columns\\b/ && webviewItemValue =~ /\\bhidden:datetime\\b/",
+					"group": "1_columns@5"
+				},
+				{
+					"command": "gitlens.graph.columnDateTimeOff",
+					"when": "webviewItem =~ /gitlens:graph:columns\\b/ && webviewItemValue =~ /^(?:(?!\\b(hidden|only):datetime\\b).)*$/",
+					"group": "1_columns@5"
+				},
+				{
+					"command": "gitlens.graph.columnGraphOn",
+					"when": "webviewItem =~ /gitlens:graph:columns\\b/ && webviewItemValue =~ /\\bhidden:graph\\b/",
+					"group": "1_columns@6"
+				},
+				{
+					"command": "gitlens.graph.columnGraphOff",
+					"when": "webviewItem =~ /gitlens:graph:columns\\b/ && webviewItemValue =~ /^(?:(?!\\b(hidden|only):graph\\b).)*$/",
 					"group": "1_columns@6"
 				},
 				{

--- a/package.json
+++ b/package.json
@@ -13624,7 +13624,7 @@
 		"vscode:prepublish": "yarn run bundle"
 	},
 	"dependencies": {
-		"@gitkraken/gitkraken-components": "8.1.3",
+		"@gitkraken/gitkraken-components": "8.2.0",
 		"@microsoft/fast-element": "1.11.1",
 		"@microsoft/fast-react-wrapper": "0.3.17",
 		"@octokit/core": "4.2.0",

--- a/package.json
+++ b/package.json
@@ -7215,6 +7215,36 @@
 				"category": "GitLens"
 			},
 			{
+				"command": "gitlens.graph.columnGraphOn",
+				"title": "Show Graph Column",
+				"category": "GitLens"
+			},
+			{
+				"command": "gitlens.graph.columnGraphOff",
+				"title": "Hide Graph Column",
+				"category": "GitLens"
+			},
+			{
+				"command": "gitlens.graph.columnMessageOn",
+				"title": "Show Commit Message Column",
+				"category": "GitLens"
+			},
+			{
+				"command": "gitlens.graph.columnMessageOff",
+				"title": "Hide Commit Message Column",
+				"category": "GitLens"
+			},
+			{
+				"command": "gitlens.graph.columnRefOn",
+				"title": "Show Branch/Tag Column",
+				"category": "GitLens"
+			},
+			{
+				"command": "gitlens.graph.columnRefOff",
+				"title": "Hide Branch/Tag Column",
+				"category": "GitLens"
+			},
+			{
 				"command": "gitlens.graph.columnGraphCompact",
 				"title": "Compact Graph Column Layout",
 				"category": "GitLens"
@@ -9338,6 +9368,30 @@
 				},
 				{
 					"command": "gitlens.graph.columnChangesOff",
+					"when": "false"
+				},
+				{
+					"command": "gitlens.graph.columnGraphOn",
+					"when": "false"
+				},
+				{
+					"command": "gitlens.graph.columnGraphOff",
+					"when": "false"
+				},
+				{
+					"command": "gitlens.graph.columnMessageOn",
+					"when": "false"
+				},
+				{
+					"command": "gitlens.graph.columnMessageOff",
+					"when": "false"
+				},
+				{
+					"command": "gitlens.graph.columnRefOn",
+					"when": "false"
+				},
+				{
+					"command": "gitlens.graph.columnRefOff",
 					"when": "false"
 				},
 				{
@@ -12093,7 +12147,7 @@
 				},
 				{
 					"command": "gitlens.graph.columnAuthorOff",
-					"when": "webviewItem =~ /gitlens:graph:columns\\b/ && webviewItemValue =~ /^(?:(?!\\bhidden:author\\b).)*$/",
+					"when": "webviewItem =~ /gitlens:graph:columns\\b/ && webviewItemValue =~ /^(?:(?!\\b(hidden|only):author\\b).)*$/",
 					"group": "1_columns@1"
 				},
 				{
@@ -12103,7 +12157,7 @@
 				},
 				{
 					"command": "gitlens.graph.columnChangesOff",
-					"when": "webviewItem =~ /gitlens:graph:columns\\b/ && webviewItemValue =~ /^(?:(?!\\bhidden:changes\\b).)*$/",
+					"when": "webviewItem =~ /gitlens:graph:columns\\b/ && webviewItemValue =~ /^(?:(?!\\b(hidden|only):changes\\b).)*$/",
 					"group": "1_columns@2"
 				},
 				{
@@ -12113,18 +12167,48 @@
 				},
 				{
 					"command": "gitlens.graph.columnDateTimeOff",
-					"when": "webviewItem =~ /gitlens:graph:columns\\b/ && webviewItemValue =~ /^(?:(?!\\bhidden:datetime\\b).)*$/",
+					"when": "webviewItem =~ /gitlens:graph:columns\\b/ && webviewItemValue =~ /^(?:(?!\\b(hidden|only):datetime\\b).)*$/",
 					"group": "1_columns@3"
+				},
+				{
+					"command": "gitlens.graph.columnGraphOn",
+					"when": "webviewItem =~ /gitlens:graph:columns\\b/ && webviewItemValue =~ /\\bhidden:graph\\b/",
+					"group": "1_columns@4"
+				},
+				{
+					"command": "gitlens.graph.columnGraphOff",
+					"when": "webviewItem =~ /gitlens:graph:columns\\b/ && webviewItemValue =~ /^(?:(?!\\b(hidden|only):graph\\b).)*$/",
+					"group": "1_columns@4"
+				},
+				{
+					"command": "gitlens.graph.columnMessageOn",
+					"when": "webviewItem =~ /gitlens:graph:columns\\b/ && webviewItemValue =~ /\\bhidden:message\\b/",
+					"group": "1_columns@5"
+				},
+				{
+					"command": "gitlens.graph.columnMessageOff",
+					"when": "webviewItem =~ /gitlens:graph:columns\\b/ && webviewItemValue =~ /^(?:(?!\\b(hidden|only):message\\b).)*$/",
+					"group": "1_columns@5"
+				},
+				{
+					"command": "gitlens.graph.columnRefOn",
+					"when": "webviewItem =~ /gitlens:graph:columns\\b/ && webviewItemValue =~ /\\bhidden:ref\\b/",
+					"group": "1_columns@6"
+				},
+				{
+					"command": "gitlens.graph.columnRefOff",
+					"when": "webviewItem =~ /gitlens:graph:columns\\b/ && webviewItemValue =~ /^(?:(?!\\b(hidden|only):ref\\b).)*$/",
+					"group": "1_columns@6"
 				},
 				{
 					"command": "gitlens.graph.columnShaOn",
 					"when": "webviewItem =~ /gitlens:graph:columns\\b/ && webviewItemValue =~ /\\bhidden:sha\\b/",
-					"group": "1_columns@4"
+					"group": "1_columns@7"
 				},
 				{
 					"command": "gitlens.graph.columnShaOff",
-					"when": "webviewItem =~ /gitlens:graph:columns\\b/ && webviewItemValue =~ /^(?:(?!\\bhidden:sha\\b).)*$/",
-					"group": "1_columns@4"
+					"when": "webviewItem =~ /gitlens:graph:columns\\b/ && webviewItemValue =~ /^(?:(?!\\b(hidden|only):sha\\b).)*$/",
+					"group": "1_columns@7"
 				},
 				{
 					"command": "gitlens.graph.columnGraphDefault",

--- a/src/plus/webviews/graph/graphWebview.ts
+++ b/src/plus/webviews/graph/graphWebview.ts
@@ -382,6 +382,12 @@ export class GraphWebviewProvider implements WebviewProvider<State> {
 			registerCommand('gitlens.graph.columnShaOff', () => this.toggleColumn('sha', false)),
 			registerCommand('gitlens.graph.columnChangesOn', () => this.toggleColumn('changes', true)),
 			registerCommand('gitlens.graph.columnChangesOff', () => this.toggleColumn('changes', false)),
+			registerCommand('gitlens.graph.columnGraphOn', () => this.toggleColumn('graph', true)),
+			registerCommand('gitlens.graph.columnGraphOff', () => this.toggleColumn('graph', false)),
+			registerCommand('gitlens.graph.columnMessageOn', () => this.toggleColumn('message', true)),
+			registerCommand('gitlens.graph.columnMessageOff', () => this.toggleColumn('message', false)),
+			registerCommand('gitlens.graph.columnRefOn', () => this.toggleColumn('ref', true)),
+			registerCommand('gitlens.graph.columnRefOff', () => this.toggleColumn('ref', false)),
 			registerCommand('gitlens.graph.columnGraphCompact', () => this.setColumnMode('graph', 'compact')),
 			registerCommand('gitlens.graph.columnGraphDefault', () => this.setColumnMode('graph', undefined)),
 
@@ -1545,15 +1551,30 @@ export class GraphWebviewProvider implements WebviewProvider<State> {
 
 	private getColumnHeaderContext(columnSettings: GraphColumnsSettings): string {
 		const contextItems: string[] = [];
+		// Old column settings that didn't get cleaned up can mess with calculation of only visible column.
+		// All currently used ones are listed here.
+		const validColumns = ['author', 'changes', 'datetime', 'graph', 'message', 'ref', 'sha'];
+
+		let onlyVisibleColumn: string | undefined;
 		for (const [name, settings] of Object.entries(columnSettings)) {
+			if (!validColumns.includes(name)) continue;
 			if (settings.isHidden) {
 				contextItems.push(`hidden:${name}`);
+			} else if (onlyVisibleColumn == null) {
+				onlyVisibleColumn = name;
+			} else {
+				onlyVisibleColumn = undefined;
 			}
 
 			if (settings.mode) {
 				contextItems.push(`${settings.mode}:${name}`);
 			}
 		}
+
+		if (onlyVisibleColumn != null) {
+			contextItems.push(`only:${onlyVisibleColumn}`);
+		}
+
 		return serializeWebviewItemContext<GraphItemContext>({
 			webviewItem: 'gitlens:graph:columns',
 			webviewItemValue: contextItems.join(','),

--- a/yarn.lock
+++ b/yarn.lock
@@ -202,10 +202,10 @@
   resolved "https://registry.yarnpkg.com/@gar/promisify/-/promisify-1.1.3.tgz#555193ab2e3bb3b6adc3d551c9c030d9e860daf6"
   integrity sha512-k2Ty1JcVojjJFwrg/ThKi2ujJ7XNLYaFGNB/bWT9wGR+oSMJHMa5w+CUq6p/pVrKeNNgA7pCqEcjSnHVoqJQFw==
 
-"@gitkraken/gitkraken-components@8.1.3":
-  version "8.1.3"
-  resolved "https://registry.yarnpkg.com/@gitkraken/gitkraken-components/-/gitkraken-components-8.1.3.tgz#cd8da2450695484616ac53d96343259a3180ad9f"
-  integrity sha512-8dTEBrLgOgAfW8zBi604TfBJ1j2AOKqaZerMlJzqqLUSY11GKrO29wJ6dC/saSN973XTJVOQMgjE80rAIabHVw==
+"@gitkraken/gitkraken-components@8.2.0":
+  version "8.2.0"
+  resolved "https://registry.yarnpkg.com/@gitkraken/gitkraken-components/-/gitkraken-components-8.2.0.tgz#27da91ac6f814a04a3d1cc8aa063cc854a6626f4"
+  integrity sha512-fQ2Kvnduz8PKvJqfCSvQIRkO4b9trwQrNrFiOGfknQqkaPgqPyLGIpP9gbeB7lA+EFngMszIH4G1PejIMq4jZg==
   dependencies:
     "@axosoft/react-virtualized" "9.22.3-gitkraken.3"
     classnames "2.3.2"


### PR DESCRIPTION
This PR unlocks graph columns that were previously locked in so that you can rearrange them and hide them.

The unlocked columns include the Branch/Tag column. the Graph column, and the Commit Message column.

On the graph component side, these columns were unlocked so that they can be  rearranged. On GL side, added commands to the graph header to be able to hide/unhide these columns.

A few caveats:
- Hiding all columns puts the graph into a weird state, so I added a restriction on hide commands that hides the "hide column" option when it's the only visible column.
- To calculate this "only visible column" and add it to the header context, I had to narrow the settings loop to only consider the most recent names of the columns, as there were old column settings that were never cleaned up in my storage. So I added a `validColumns` array.