### PR TITLE
Updates to contribution docs to include extension info

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -106,6 +106,8 @@ yarn run package
 2. Ensure the required [dependencies](#dependencies) are installed
 3. Choose the `Watch & Run` launch configuration from the launch dropdown in the Run and Debug viewlet and press `F5`.
 
+_Note: If you see a pop-up with a message similar to "The task cannot be tracked. Make sure to have a problem matcher defined.", you will need to install the [TypeScript + Webpack Problem Matchers](https://marketplace.visualstudio.com/items?itemName=amodio.tsl-problem-matcher) extension._
+
 #### Using VS Code (desktop webworker)
 
 1. Open the `vscode-gitlens` folder


### PR DESCRIPTION
# Description
When installing and attempting to run the project for the first time, a pop-up was shown by VSCode when trying to run "watch & run". The pop-up said

> The task 'npm: watch' cannot be tracked. Make sure to have a problem matcher defined.

I realized that I was missing [this extension](https://marketplace.visualstudio.com/items?itemName=amodio.tsl-problem-matcher) and thought it would be helpful to others to know in the future.

# Checklist

<!-- Please check off the following -->

- [X] I have followed the guidelines in the Contributing document
- [X] My changes follow the coding style of this project
- [X] My changes build without any errors or warnings
- [X] My changes have been formatted and linted
- [X] My changes include any required corresponding changes to the documentation (including CHANGELOG.md and README.md)
- [X] My changes have been rebased and squashed to the minimal number (typically 1) of relevant commits
- [X] My changes have a descriptive commit message with a short title, including a `Fixes $XXX -` or `Closes #XXX -` prefix to auto-close the issue that your PR addresses
