### PR TITLE
Workspaces Polish

### DIFF
--- a/package.json
+++ b/package.json
@@ -6905,8 +6905,8 @@
 				"enablement": "!operationInProgress"
 			},
 			{
-				"command": "gitlens.views.workspaces.addRepo",
-				"title": "Add Repository to Workspace...",
+				"command": "gitlens.views.workspaces.addRepos",
+				"title": "Add Repositories to Workspace...",
 				"category": "GitLens",
 				"icon": "$(add)"
 			},
@@ -9433,7 +9433,7 @@
 					"when": "false"
 				},
 				{
-					"command": "gitlens.views.workspaces.addRepo",
+					"command": "gitlens.views.workspaces.addRepos",
 					"when": "false"
 				},
 				{
@@ -11058,7 +11058,7 @@
 					"group": "inline@1"
 				},
 				{
-					"command": "gitlens.views.workspaces.addRepo",
+					"command": "gitlens.views.workspaces.addRepos",
 					"when": "viewItem =~ /gitlens:workspace\\b(?=.*?\\b\\+cloud\\b)/",
 					"group": "inline@2"
 				},
@@ -11104,7 +11104,7 @@
 					"group": "1_gitlens_actions@2"
 				},
 				{
-					"command": "gitlens.views.workspaces.addRepo",
+					"command": "gitlens.views.workspaces.addRepos",
 					"when": "viewItem =~ /gitlens:workspace\\b(?=.*?\\b\\+cloud\\b)/",
 					"group": "1_gitlens_actions@3"
 				},

--- a/src/plus/workspaces/models.ts
+++ b/src/plus/workspaces/models.ts
@@ -174,6 +174,11 @@ export const cloudWorkspaceProviderInputTypeToRemoteProviderId = {
 	[CloudWorkspaceProviderInputType.GitLabSelfHosted]: 'gitlab',
 };
 
+export enum WorkspaceAddRepositoriesChoice {
+	CurrentWindow = 'Current Window',
+	ParentFolder = 'Parent Folder',
+}
+
 export const defaultWorkspaceCount = 100;
 export const defaultWorkspaceRepoCount = 100;
 

--- a/src/plus/workspaces/models.ts
+++ b/src/plus/workspaces/models.ts
@@ -10,7 +10,18 @@ export type CodeWorkspaceFileContents = {
 	settings: { [key: string]: any };
 };
 
-export type WorkspaceRepositoriesByName = Map<string, Repository>;
+export type WorkspaceRepositoriesByName = Map<string, RepositoryMatch>;
+
+export interface RepositoryMatch {
+	repository: Repository;
+	descriptor: CloudWorkspaceRepositoryDescriptor | LocalWorkspaceRepositoryDescriptor;
+}
+
+export interface RemoteDescriptor {
+	provider: string;
+	owner: string;
+	repoName: string;
+}
 
 export interface GetWorkspacesResponse {
 	cloudWorkspaces: GKCloudWorkspace[];
@@ -124,6 +135,7 @@ export interface CloudWorkspaceRepositoryDescriptor {
 	provider_organization_id: string;
 	provider_organization_name: string;
 	url: string;
+	workspaceId: string;
 }
 
 export enum CloudWorkspaceProviderInputType {
@@ -538,6 +550,7 @@ export interface LocalWorkspaceRepositoryPath {
 export interface LocalWorkspaceRepositoryDescriptor extends LocalWorkspaceRepositoryPath {
 	id?: undefined;
 	name: string;
+	workspaceId: string;
 }
 
 export interface CloudWorkspaceFileData {

--- a/src/plus/workspaces/workspacesService.ts
+++ b/src/plus/workspaces/workspacesService.ts
@@ -626,13 +626,13 @@ export class WorkspacesService implements Disposable {
 				[
 					{
 						label: 'Choose repositories from the current window',
-						description: 'Choose repositories from the current window',
+						description: undefined,
 						choice: WorkspaceAddRepositoriesChoice.CurrentWindow,
 						picked: true,
 					},
 					{
 						label: 'Choose repositories from a folder',
-						description: 'Choose repositories from a folder',
+						description: undefined,
 						choice: WorkspaceAddRepositoriesChoice.ParentFolder,
 					},
 				],

--- a/src/plus/workspaces/workspacesService.ts
+++ b/src/plus/workspaces/workspacesService.ts
@@ -385,7 +385,7 @@ export class WorkspacesService implements Disposable {
 		const disposables: Disposable[] = [];
 
 		let workspaceName: string | undefined;
-		let workspaceDescription = '';
+		let workspaceDescription : string | undefined;
 
 		let hostUrl: string | undefined;
 		let azureOrganizationName: string | undefined;
@@ -432,12 +432,17 @@ export class WorkspacesService implements Disposable {
 
 			if (!workspaceName) return;
 
-			workspaceDescription = await new Promise<string>(resolve => {
+			workspaceDescription = await new Promise<string | undefined>(resolve => {
 				disposables.push(
-					input.onDidHide(() => resolve('')),
+					input.onDidHide(() => resolve(undefined)),
 					input.onDidAccept(() => {
 						const value = input.value.trim();
-						resolve(value || '');
+						if (!value) {
+							input.validationMessage = 'Please enter a non-empty description for the workspace';
+							return;
+						}
+
+						resolve(value);
 					}),
 				);
 
@@ -447,6 +452,8 @@ export class WorkspacesService implements Disposable {
 				input.prompt = 'Enter your workspace description';
 				input.show();
 			});
+
+			if (!workspaceDescription) return;
 
 			if (workspaceProvider == null) {
 				workspaceProvider = await new Promise<CloudWorkspaceProviderInputType | undefined>(resolve => {

--- a/src/views/nodes/repositoriesNode.ts
+++ b/src/views/nodes/repositoriesNode.ts
@@ -1,5 +1,5 @@
-import type { TextEditor } from 'vscode';
-import { Disposable, TreeItem, TreeItemCollapsibleState, window } from 'vscode';
+import type { TextEditor} from 'vscode';
+import { Disposable , TreeItem, TreeItemCollapsibleState, window, workspace } from 'vscode';
 import type { RepositoriesChangeEvent } from '../../git/gitProviderService';
 import { GitUri, unknownGitUri } from '../../git/gitUri';
 import { gate } from '../../system/decorators/gate';
@@ -55,6 +55,11 @@ export class RepositoriesNode extends SubscribeableViewNode<ViewsWithRepositorie
 			isInWorkspacesView ? 'Current Window' : 'Repositories',
 			isInWorkspacesView ? TreeItemCollapsibleState.Collapsed : TreeItemCollapsibleState.Expanded,
 		);
+
+		if (isInWorkspacesView) {
+			item.description = workspace.name ?? (workspace.workspaceFolders?.[0]?.name ?? '');
+		}
+
 		let contextValue: string = ContextValues.Repositories;
 		if (isInWorkspacesView) {
 			contextValue += '+workspaces';

--- a/src/views/nodes/repositoriesNode.ts
+++ b/src/views/nodes/repositoriesNode.ts
@@ -1,5 +1,5 @@
-import type { TextEditor} from 'vscode';
-import { Disposable , TreeItem, TreeItemCollapsibleState, window, workspace } from 'vscode';
+import type { TextEditor } from 'vscode';
+import { Disposable, TreeItem, TreeItemCollapsibleState, window, workspace } from 'vscode';
 import type { RepositoriesChangeEvent } from '../../git/gitProviderService';
 import { GitUri, unknownGitUri } from '../../git/gitUri';
 import { gate } from '../../system/decorators/gate';
@@ -57,7 +57,7 @@ export class RepositoriesNode extends SubscribeableViewNode<ViewsWithRepositorie
 		);
 
 		if (isInWorkspacesView) {
-			item.description = workspace.name ?? (workspace.workspaceFolders?.[0]?.name ?? '');
+			item.description = workspace.name ?? workspace.workspaceFolders?.[0]?.name ?? '';
 		}
 
 		let contextValue: string = ContextValues.Repositories;

--- a/src/views/workspacesView.ts
+++ b/src/views/workspacesView.ts
@@ -189,8 +189,8 @@ export class WorkspacesView extends ViewBase<WorkspacesViewNode, WorkspacesViewC
 				},
 				this,
 			),
-			registerViewCommand(this.getQualifiedCommand('addRepo'), async (node: WorkspaceNode) => {
-				await this.container.workspaces.addCloudWorkspaceRepo(node.workspaceId);
+			registerViewCommand(this.getQualifiedCommand('addRepos'), async (node: WorkspaceNode) => {
+				await this.container.workspaces.addCloudWorkspaceRepos(node.workspaceId);
 				void node.getParent()?.triggerChange(true);
 			}),
 			registerViewCommand(


### PR DESCRIPTION
- Workspace repo descriptors now have their workspaceId on them (further code improvements to come from this, several places we can remove workspace id as input)

- Fixed a bug with creating a workspace with no description (we now require it)

- For the "current window" repo list in the view, added the workspace name or first repo name as a description to the item

- Unified the code for matching and resolving repos from descriptors. We were doing it separately in many places.

- Unified the code for parsing the provider, owner and name from a remote.

- Unified the logic for adding repositories to a workspace. The same function is now called when creating a workspace or adding repos to it.

- Filters out repos already in a workspace when adding to it

- "add repo to workspace" is now "add repos to workspace" and you can select multiple from the quickpick

- Added a quickpick when adding repos to a workspace which allows you to choose to add from the current window or from a folder

