### PR TITLE
2728 Submodule commit graph will not open in the panel layout

### DIFF
--- a/src/commands/showView.ts
+++ b/src/commands/showView.ts
@@ -27,11 +27,13 @@ export class ShowViewCommand extends Command {
 		]);
 	}
 
-	protected override preExecute(context: CommandContext) {
-		return this.execute(context.command as Commands);
+	protected override preExecute(context: CommandContext, ...args: any[]) {
+		return this.execute(context, ...args);
 	}
 
-	async execute(command: Commands) {
+	async execute(context: CommandContext, ...args: any[]) {
+		const command = context.command as Commands;
+		let commandArgs = args;
 		switch (command) {
 			case Commands.ShowBranchesView:
 				return this.container.branchesView.show();
@@ -48,7 +50,10 @@ export class ShowViewCommand extends Command {
 			case Commands.ShowAccountView:
 				return this.container.accountView.show();
 			case Commands.ShowGraphView:
-				return this.container.graphView.show();
+				if (context.type === 'scm' && context.scm !== undefined) {
+					commandArgs = [context.scm, ...args];
+				}
+				return this.container.graphView.show(undefined, ...commandArgs);
 			case Commands.ShowLineHistoryView:
 				return this.container.lineHistoryView.show();
 			case Commands.ShowRemotesView:

--- a/src/commands/showView.ts
+++ b/src/commands/showView.ts
@@ -50,8 +50,9 @@ export class ShowViewCommand extends Command {
 			case Commands.ShowAccountView:
 				return this.container.accountView.show();
 			case Commands.ShowGraphView:
-				if (context.type === 'scm' && context.scm !== undefined) {
-					commandArgs = [context.scm, ...args];
+				if (context.type === 'scm' && context.scm?.rootUri != null) {
+					const repo = this.container.git.getRepository(context.scm.rootUri);
+					commandArgs = repo != null ? [repo, ...args] : args;
 				}
 				return this.container.graphView.show(undefined, ...commandArgs);
 			case Commands.ShowLineHistoryView:

--- a/src/plus/webviews/graph/graphWebview.ts
+++ b/src/plus/webviews/graph/graphWebview.ts
@@ -283,15 +283,12 @@ export class GraphWebviewProvider implements WebviewProvider<State> {
 		...args: [Repository, { ref: GitReference }, { state: Partial<State> }] | unknown[]
 	): Promise<boolean> {
 		this._firstSelection = true;
-		let repositorySet = false;
 
 		const [arg] = args;
 		if (isRepository(arg)) {
 			this.repository = arg;
-			repositorySet = true;
 		} else if (hasGitReference(arg)) {
 			this.repository = this.container.git.getRepository(arg.ref.repoPath);
-			repositorySet = true;
 
 			let id = arg.ref.ref;
 			if (!isSha(id)) {
@@ -310,24 +307,25 @@ export class GraphWebviewProvider implements WebviewProvider<State> {
 
 				void this.onGetMoreRows({ id: id }, true);
 			}
-		} else if (isSerializedState<State>(arg) && arg.state.selectedRepository != null) {
-			this.repository = this.container.git.getRepository(arg.state.selectedRepository);
-			repositorySet = true;
-		} else if (this.container.git.repositoryCount > 0) {
-			const [contexts] = parseCommandContext(Commands.ShowGraph, undefined, ...args);
-			const context = Array.isArray(contexts) ? contexts[0] : contexts;
-
-			if (context.type === 'scm' && context.scm.rootUri != null) {
-				this.repository = this.container.git.getRepository(context.scm.rootUri);
-				repositorySet = true;
-			} else if (context.type === 'viewItem' && context.node instanceof RepositoryFolderNode) {
-				this.repository = context.node.repo;
-				repositorySet = true;
+		} else {
+			if (isSerializedState<State>(arg) && arg.state.selectedRepository != null) {
+				this.repository = this.container.git.getRepository(arg.state.selectedRepository);
 			}
-		}
 
-		if (repositorySet && this.repository != null && !loading && this.host.ready) {
-			this.updateState();
+			if (this.repository == null && this.container.git.repositoryCount > 1) {
+				const [contexts] = parseCommandContext(Commands.ShowGraph, undefined, ...args);
+				const context = Array.isArray(contexts) ? contexts[0] : contexts;
+
+				if (context.type === 'scm' && context.scm.rootUri != null) {
+					this.repository = this.container.git.getRepository(context.scm.rootUri);
+				} else if (context.type === 'viewItem' && context.node instanceof RepositoryFolderNode) {
+					this.repository = context.node.repo;
+				}
+
+				if (this.repository != null && !loading && this.host.ready) {
+					this.updateState();
+				}
+			}
 		}
 
 		return true;


### PR DESCRIPTION
Completes #2728

Command args were being lost in the intermediary logic when parsing the "Show Graph" command and the graph is in a view (aka Panel Layout, rather than Editor Layout).

Updates the `showView` pre-execution and execution steps to send the args through (and in case it's an SCM node, pack the node into args since the graph logic will parse it again anyway).