### PR TITLE
Adds info button to Workspaces View title with link to help page

### DIFF
--- a/package.json
+++ b/package.json
@@ -6903,6 +6903,12 @@
 				"icon": "$(add)"
 			},
 			{
+				"command": "gitlens.views.workspaces.info",
+				"title": "Learn more about GitKraken Workspaces...",
+				"category": "GitLens",
+				"icon": "$(info)"
+			},
+			{
 				"command": "gitlens.views.workspaces.convert",
 				"title": "Convert to Cloud Workspace...",
 				"category": "GitLens",
@@ -9451,6 +9457,10 @@
 					"when": "false"
 				},
 				{
+					"command": "gitlens.views.workspaces.info",
+					"when": "false"
+				},
+				{
 					"command": "gitlens.views.workspaces.convert",
 					"when": "false"
 				},
@@ -10928,6 +10938,11 @@
 					"command": "gitlens.views.timeline.refresh",
 					"when": "view =~ /^gitlens\\.views\\.timeline/",
 					"group": "navigation@99"
+				},
+				{
+					"command": "gitlens.views.workspaces.info",
+					"when": "view =~ /^gitlens\\.views\\.workspaces/",
+					"group": "navigation@2"
 				},
 				{
 					"command": "gitlens.views.workspaces.create",

--- a/package.json
+++ b/package.json
@@ -10942,7 +10942,7 @@
 				{
 					"command": "gitlens.views.workspaces.info",
 					"when": "view =~ /^gitlens\\.views\\.workspaces/",
-					"group": "navigation@2"
+					"group": "8_info@1"
 				},
 				{
 					"command": "gitlens.views.workspaces.create",

--- a/src/constants.ts
+++ b/src/constants.ts
@@ -399,6 +399,7 @@ export type TreeViewCommands = `gitlens.views.${
 			| `setFilesLayoutTo${'Auto' | 'List' | 'Tree'}`
 			| `setShowAvatars${'On' | 'Off'}`}`
 	| `workspaces.${
+			| 'info'
 			| 'copy'
 			| 'refresh'
 			| 'addRepos'

--- a/src/views/workspacesView.ts
+++ b/src/views/workspacesView.ts
@@ -1,5 +1,5 @@
 import type { Disposable } from 'vscode';
-import { ProgressLocation, window } from 'vscode';
+import { env, ProgressLocation, Uri, window } from 'vscode';
 import type { WorkspacesViewConfig } from '../config';
 import { Commands } from '../constants';
 import type { Container } from '../container';
@@ -56,6 +56,11 @@ export class WorkspacesView extends ViewBase<'workspaces', WorkspacesViewNode, W
 		void this.container.viewCommands;
 
 		return [
+			registerViewCommand(
+				this.getQualifiedCommand('info'),
+				() => env.openExternal(Uri.parse('https://help.gitkraken.com/gitlens/side-bar/#workspaces-☁%ef%b8%8f')),
+				this,
+			),
 			registerViewCommand(
 				this.getQualifiedCommand('copy'),
 				() => executeCommand(Commands.ViewsCopy, this.activeSelection, this.selection),


### PR DESCRIPTION
Adds a button to the title of the Workspaces View that takes you to the help link to learn more about workspaces.

![image](https://github.com/gitkraken/vscode-gitlens/assets/67011668/7c5c2680-c419-4da9-afa7-c6f34fce39f8)
