### PR TITLE
Improves linking between GK and Local Workspaces

### DIFF
--- a/package.json
+++ b/package.json
@@ -4238,6 +4238,15 @@
 				}
 			},
 			{
+				"id": "gitlens.decorations.workspaceCurrentForegroundColor",
+				"description": "Specifies the decoration foreground color of workspaces which are currently open as a Code Workspace file",
+				"defaults": {
+					"dark": "#35b15e",
+					"light": "#35b15e",
+					"highContrast": "#4dff88"
+				}
+			},
+			{
 				"id": "gitlens.decorations.workspaceRepoOpenForegroundColor",
 				"description": "Specifies the decoration foreground color of workspace repos which are open in the current workspace",
 				"defaults": {
@@ -6933,10 +6942,22 @@
 				"icon": "$(location)"
 			},
 			{
-				"command": "gitlens.views.workspaces.open",
-				"title": "Open as VS Code Workspace...",
+				"command": "gitlens.views.workspaces.createLocal",
+				"title": "Create VS Code Workspace...",
 				"category": "GitLens",
 				"icon": "$(empty-window)"
+			},
+			{
+				"command": "gitlens.views.workspaces.openLocal",
+				"title": "Open VS Code Workspace in Current Window...",
+				"category": "GitLens",
+				"icon": "$(window)"
+			},
+			{
+				"command": "gitlens.views.workspaces.openLocalNewWindow",
+				"title": "Open VS Code Workspace in New Window...",
+				"category": "GitLens",
+				"icon": "$(window)"
 			},
 			{
 				"command": "gitlens.views.workspaces.repo.locate",
@@ -9485,7 +9506,15 @@
 					"when": "false"
 				},
 				{
-					"command": "gitlens.views.workspaces.open",
+					"command": "gitlens.views.workspaces.createLocal",
+					"when": "false"
+				},
+				{
+					"command": "gitlens.views.workspaces.openLocal",
+					"when": "false"
+				},
+				{
+					"command": "gitlens.views.workspaces.openLocalNewWindow",
 					"when": "false"
 				},
 				{
@@ -11117,9 +11146,15 @@
 					"group": "inline@2"
 				},
 				{
-					"command": "gitlens.views.workspaces.open",
-					"when": "viewItem =~ /gitlens:workspace\\b(?=.*?\\b\\+(cloud|local)\\b)/",
+					"command": "gitlens.views.workspaces.createLocal",
+					"when": "viewItem =~ /gitlens:workspace\\b(?=.*?\\b\\+(cloud|local)\\b)(?!.*?\\b\\+current\\b)(?!.*?\\b\\+hasPath\\b)/",
 					"group": "inline@3"
+				},
+				{
+					"command": "gitlens.views.workspaces.openLocalNewWindow",
+					"when": "viewItem =~ /gitlens:workspace\\b(?=.*?\\b\\+(cloud|local)\\b)(?!.*?\\b\\+current\\b)(?=.*?\\b\\+hasPath\\b)/",
+					"group": "inline@3",
+					"alt": "gitlens.views.workspaces.openLocal"
 				},
 				{
 					"command": "gitlens.views.workspaces.addRepos",
@@ -11132,9 +11167,19 @@
 					"group": "1_gitlens_actions@2"
 				},
 				{
-					"command": "gitlens.views.workspaces.open",
+					"command": "gitlens.views.workspaces.createLocal",
 					"when": "viewItem =~ /gitlens:workspace\\b(?=.*?\\b\\+(cloud|local)\\b)/",
 					"group": "2_gitlens_quickopen@3"
+				},
+				{
+					"command": "gitlens.views.workspaces.openLocal",
+					"when": "viewItem =~ /gitlens:workspace\\b(?=.*?\\b\\+(cloud|local)\\b)(?!.*?\\b\\+current\\b)(?=.*?\\b\\+hasPath\\b)/",
+					"group": "2_gitlens_quickopen@4"
+				},
+				{
+					"command": "gitlens.views.workspaces.openLocalNewWindow",
+					"when": "viewItem =~ /gitlens:workspace\\b(?=.*?\\b\\+(cloud|local)\\b)(?!.*?\\b\\+current\\b)(?=.*?\\b\\+hasPath\\b)/",
+					"group": "2_gitlens_quickopen@5"
 				},
 				{
 					"command": "gitlens.views.workspaces.delete",

--- a/src/constants.ts
+++ b/src/constants.ts
@@ -74,6 +74,7 @@ export type Colors =
 	| `${typeof extensionPrefix}.decorations.modifiedForegroundColor`
 	| `${typeof extensionPrefix}.decorations.renamedForegroundColor`
 	| `${typeof extensionPrefix}.decorations.untrackedForegroundColor`
+	| `${typeof extensionPrefix}.decorations.workspaceCurrentForegroundColor`
 	| `${typeof extensionPrefix}.decorations.workspaceRepoMissingForegroundColor`
 	| `${typeof extensionPrefix}.decorations.workspaceRepoOpenForegroundColor`
 	| `${typeof extensionPrefix}.decorations.worktreeView.hasUncommittedChangesForegroundColor`
@@ -405,9 +406,11 @@ export type TreeViewCommands = `gitlens.views.${
 			| 'addRepos'
 			| 'convert'
 			| 'create'
+			| 'createLocal'
 			| 'delete'
 			| 'locateAllRepos'
-			| 'open'
+			| 'openLocal'
+			| 'openLocalNewWindow'
 			| `repo.${'locate' | 'open' | 'openInNewWindow' | 'addToWindow' | 'remove'}`}`
 	| `worktrees.${
 			| 'copy'

--- a/src/env/browser/pathMapping/workspacesWebPathMappingProvider.ts
+++ b/src/env/browser/pathMapping/workspacesWebPathMappingProvider.ts
@@ -11,6 +11,17 @@ export class WorkspacesWebPathMappingProvider implements WorkspacesPathMappingPr
 		return undefined;
 	}
 
+	async removeCloudWorkspaceCodeWorkspaceFilePath(_cloudWorkspaceId: string): Promise<void> {}
+
+	async writeCloudWorkspaceCodeWorkspaceFilePathToMap(
+		_cloudWorkspaceId: string,
+		_codeWorkspaceFilePath: string,
+	): Promise<void> {}
+
+	async confirmCloudWorkspaceCodeWorkspaceFilePath(_cloudWorkspaceId: string): Promise<boolean> {
+		return false;
+	}
+
 	async writeCloudWorkspaceRepoDiskPathToMap(
 		_cloudWorkspaceId: string,
 		_repoId: string,

--- a/src/env/browser/pathMapping/workspacesWebPathMappingProvider.ts
+++ b/src/env/browser/pathMapping/workspacesWebPathMappingProvider.ts
@@ -1,5 +1,5 @@
 import { Uri } from 'vscode';
-import type { LocalWorkspaceFileData } from '../../../plus/workspaces/models';
+import type { LocalWorkspaceFileData, WorkspaceSyncSetting } from '../../../plus/workspaces/models';
 import type { WorkspacesPathMappingProvider } from '../../../plus/workspaces/workspacesPathMappingProvider';
 
 export class WorkspacesWebPathMappingProvider implements WorkspacesPathMappingProvider {
@@ -24,14 +24,7 @@ export class WorkspacesWebPathMappingProvider implements WorkspacesPathMappingPr
 	async writeCodeWorkspaceFile(
 		_uri: Uri,
 		_workspaceRepoFilePaths: string[],
-		_options?: { workspaceId?: string },
-	): Promise<boolean> {
-		return false;
-	}
-
-	async confirmCloudWorkspaceCodeWorkspaceFileMatch(
-		_cloudWorkspaceId: string,
-		_codeWorkspaceFilePath: string,
+		_options?: { workspaceId?: string; workspaceSyncSetting?: WorkspaceSyncSetting },
 	): Promise<boolean> {
 		return false;
 	}

--- a/src/env/browser/pathMapping/workspacesWebPathMappingProvider.ts
+++ b/src/env/browser/pathMapping/workspacesWebPathMappingProvider.ts
@@ -7,7 +7,11 @@ export class WorkspacesWebPathMappingProvider implements WorkspacesPathMappingPr
 		return undefined;
 	}
 
-	async writeCloudWorkspaceDiskPathToMap(
+	async getCloudWorkspaceCodeWorkspacePath(_cloudWorkspaceId: string): Promise<string | undefined> {
+		return undefined;
+	}
+
+	async writeCloudWorkspaceRepoDiskPathToMap(
 		_cloudWorkspaceId: string,
 		_repoId: string,
 		_repoLocalPath: string,
@@ -21,6 +25,13 @@ export class WorkspacesWebPathMappingProvider implements WorkspacesPathMappingPr
 		_uri: Uri,
 		_workspaceRepoFilePaths: string[],
 		_options?: { workspaceId?: string },
+	): Promise<boolean> {
+		return false;
+	}
+
+	async confirmCloudWorkspaceCodeWorkspaceFileMatch(
+		_cloudWorkspaceId: string,
+		_codeWorkspaceFilePath: string,
 	): Promise<boolean> {
 		return false;
 	}

--- a/src/env/node/pathMapping/repositoryLocalPathMappingProvider.ts
+++ b/src/env/node/pathMapping/repositoryLocalPathMappingProvider.ts
@@ -93,8 +93,10 @@ export class RepositoryLocalPathMappingProvider implements RepositoryPathMapping
 			this._localRepoDataMap = {};
 		}
 
-		if (this._localRepoDataMap[key] == null || this._localRepoDataMap[key].paths == null) {
+		if (this._localRepoDataMap[key] == null) {
 			this._localRepoDataMap[key] = { paths: [localPath] };
+		} else if (this._localRepoDataMap[key].paths == null) {
+			this._localRepoDataMap[key].paths = [localPath];
 		} else if (!this._localRepoDataMap[key].paths.includes(localPath)) {
 			this._localRepoDataMap[key].paths.push(localPath);
 		}

--- a/src/env/node/pathMapping/workspacesLocalPathMappingProvider.ts
+++ b/src/env/node/pathMapping/workspacesLocalPathMappingProvider.ts
@@ -41,13 +41,13 @@ export class WorkspacesLocalPathMappingProvider implements WorkspacesPathMapping
 	}
 
 	async getCloudWorkspaceRepoPath(cloudWorkspaceId: string, repoId: string): Promise<string | undefined> {
-		const cloudWorkspaceRepoPathMap = await this.getCloudWorkspacePathMap();
-		return cloudWorkspaceRepoPathMap[cloudWorkspaceId]?.repoPaths?.[repoId];
+		const cloudWorkspacePathMap = await this.getCloudWorkspacePathMap();
+		return cloudWorkspacePathMap[cloudWorkspaceId]?.repoPaths?.[repoId];
 	}
 
 	async getCloudWorkspaceCodeWorkspacePath(cloudWorkspaceId: string): Promise<string | undefined> {
-		const cloudWorkspaceRepoPathMap = await this.getCloudWorkspacePathMap();
-		return cloudWorkspaceRepoPathMap[cloudWorkspaceId]?.externalLinks?.['.code-workspace'];
+		const cloudWorkspacePathMap = await this.getCloudWorkspacePathMap();
+		return cloudWorkspacePathMap[cloudWorkspaceId]?.externalLinks?.['.code-workspace'];
 	}
 
 	async writeCloudWorkspaceRepoDiskPathToMap(

--- a/src/plus/workspaces/models.ts
+++ b/src/plus/workspaces/models.ts
@@ -1,9 +1,16 @@
+import type { Disposable } from '../../api/gitlens';
 import type { Container } from '../../container';
 import type { Repository } from '../../git/models/repository';
 
 export enum WorkspaceType {
 	Local = 'local',
 	Cloud = 'cloud',
+}
+
+export enum WorkspaceSyncSetting {
+	Never = 'never',
+	Always = 'always',
+	Ask = 'ask',
 }
 
 export type CodeWorkspaceFileContents = {
@@ -50,8 +57,10 @@ export interface GetCloudWorkspaceRepositoriesResponse {
 export class CloudWorkspace {
 	readonly type = WorkspaceType.Cloud;
 
-	private _repositories: CloudWorkspaceRepositoryDescriptor[] | undefined;
+	private _repositoryDescriptors: CloudWorkspaceRepositoryDescriptor[] | undefined;
+	private _repositoriesByName: WorkspaceRepositoriesByName | undefined;
 	private _localPath: string | undefined;
+	private _disposable: Disposable;
 
 	constructor(
 		private readonly container: Container,
@@ -63,8 +72,13 @@ export class CloudWorkspace {
 		repositories?: CloudWorkspaceRepositoryDescriptor[],
 		localPath?: string,
 	) {
-		this._repositories = repositories;
+		this._repositoryDescriptors = repositories;
 		this._localPath = localPath;
+		this._disposable = this.container.git.onDidChangeRepositories(this.resetRepositoriesByName, this);
+	}
+
+	dispose() {
+		this._disposable.dispose();
 	}
 
 	get shared(): boolean {
@@ -75,12 +89,28 @@ export class CloudWorkspace {
 		return this._localPath;
 	}
 
-	async getRepositoryDescriptors(): Promise<CloudWorkspaceRepositoryDescriptor[]> {
-		if (this._repositories == null) {
-			this._repositories = await this.container.workspaces.getCloudWorkspaceRepositories(this.id);
+	resetRepositoriesByName() {
+		this._repositoriesByName = undefined;
+	}
+
+	async getRepositoriesByName(options?: { force?: boolean }): Promise<WorkspaceRepositoriesByName> {
+		if (this._repositoriesByName == null || options?.force) {
+			this._repositoriesByName = await this.container.workspaces.resolveWorkspaceRepositoriesByName(this.id, {
+				resolveFromPath: true,
+				usePathMapping: true,
+			});
 		}
 
-		return this._repositories;
+		return this._repositoriesByName;
+	}
+
+	async getRepositoryDescriptors(options?: { force?: boolean }): Promise<CloudWorkspaceRepositoryDescriptor[]> {
+		if (this._repositoryDescriptors == null || options?.force) {
+			this._repositoryDescriptors = await this.container.workspaces.getCloudWorkspaceRepositories(this.id);
+			this.resetRepositoriesByName();
+		}
+
+		return this._repositoryDescriptors;
 	}
 
 	async getRepositoryDescriptor(name: string): Promise<CloudWorkspaceRepositoryDescriptor | undefined> {
@@ -89,18 +119,21 @@ export class CloudWorkspace {
 
 	// TODO@axosoft-ramint this should be the entry point, not a backdoor to update the cache
 	addRepositories(repositories: CloudWorkspaceRepositoryDescriptor[]): void {
-		if (this._repositories == null) {
-			this._repositories = repositories;
+		if (this._repositoryDescriptors == null) {
+			this._repositoryDescriptors = repositories;
 		} else {
-			this._repositories = this._repositories.concat(repositories);
+			this._repositoryDescriptors = this._repositoryDescriptors.concat(repositories);
 		}
+
+		this.resetRepositoriesByName();
 	}
 
 	// TODO@axosoft-ramint this should be the entry point, not a backdoor to update the cache
 	removeRepositories(repoNames: string[]): void {
-		if (this._repositories == null) return;
+		if (this._repositoryDescriptors == null) return;
 
-		this._repositories = this._repositories.filter(r => !repoNames.includes(r.name));
+		this._repositoryDescriptors = this._repositoryDescriptors.filter(r => !repoNames.includes(r.name));
+		this.resetRepositoriesByName();
 	}
 
 	setLocalPath(localPath: string): void {
@@ -481,15 +514,23 @@ export class LocalWorkspace {
 	readonly type = WorkspaceType.Local;
 
 	private _localPath: string | undefined;
+	private _repositoriesByName: WorkspaceRepositoriesByName | undefined;
+	private _disposable: Disposable;
 
 	constructor(
+		public readonly container: Container,
 		public readonly id: string,
 		public readonly name: string,
-		private readonly repositories: LocalWorkspaceRepositoryDescriptor[],
+		private readonly repositoryDescriptors: LocalWorkspaceRepositoryDescriptor[],
 		public readonly current: boolean,
 		localPath?: string,
 	) {
 		this._localPath = localPath;
+		this._disposable = this.container.git.onDidChangeRepositories(this.resetRepositoriesByName, this);
+	}
+
+	dispose() {
+		this._disposable.dispose();
 	}
 
 	get shared(): boolean {
@@ -500,12 +541,27 @@ export class LocalWorkspace {
 		return this._localPath;
 	}
 
+	resetRepositoriesByName() {
+		this._repositoriesByName = undefined;
+	}
+
+	async getRepositoriesByName(options?: { force?: boolean }): Promise<WorkspaceRepositoriesByName> {
+		if (this._repositoriesByName == null || options?.force) {
+			this._repositoriesByName = await this.container.workspaces.resolveWorkspaceRepositoriesByName(this.id, {
+				resolveFromPath: true,
+				usePathMapping: true,
+			});
+		}
+
+		return this._repositoriesByName;
+	}
+
 	getRepositoryDescriptors(): Promise<LocalWorkspaceRepositoryDescriptor[]> {
-		return Promise.resolve(this.repositories);
+		return Promise.resolve(this.repositoryDescriptors);
 	}
 
 	getRepositoryDescriptor(name: string): Promise<LocalWorkspaceRepositoryDescriptor | undefined> {
-		return Promise.resolve(this.repositories.find(r => r.name === name));
+		return Promise.resolve(this.repositoryDescriptors.find(r => r.name === name));
 	}
 
 	setLocalPath(localPath: string): void {

--- a/src/plus/workspaces/models.ts
+++ b/src/plus/workspaces/models.ts
@@ -136,7 +136,7 @@ export class CloudWorkspace {
 		this.resetRepositoriesByName();
 	}
 
-	setLocalPath(localPath: string): void {
+	setLocalPath(localPath: string | undefined): void {
 		this._localPath = localPath;
 	}
 }
@@ -564,7 +564,7 @@ export class LocalWorkspace {
 		return Promise.resolve(this.repositoryDescriptors.find(r => r.name === name));
 	}
 
-	setLocalPath(localPath: string): void {
+	setLocalPath(localPath: string | undefined): void {
 		this._localPath = localPath;
 	}
 }

--- a/src/plus/workspaces/models.ts
+++ b/src/plus/workspaces/models.ts
@@ -51,6 +51,7 @@ export class CloudWorkspace {
 	readonly type = WorkspaceType.Cloud;
 
 	private _repositories: CloudWorkspaceRepositoryDescriptor[] | undefined;
+	private _localPath: string | undefined;
 
 	constructor(
 		private readonly container: Container,
@@ -58,13 +59,20 @@ export class CloudWorkspace {
 		public readonly name: string,
 		public readonly organizationId: string | undefined,
 		public readonly provider: CloudWorkspaceProviderType,
+		public readonly current: boolean,
 		repositories?: CloudWorkspaceRepositoryDescriptor[],
+		localPath?: string,
 	) {
 		this._repositories = repositories;
+		this._localPath = localPath;
 	}
 
 	get shared(): boolean {
 		return this.organizationId != null;
+	}
+
+	get localPath(): string | undefined {
+		return this._localPath;
 	}
 
 	async getRepositoryDescriptors(): Promise<CloudWorkspaceRepositoryDescriptor[]> {
@@ -93,6 +101,10 @@ export class CloudWorkspace {
 		if (this._repositories == null) return;
 
 		this._repositories = this._repositories.filter(r => !repoNames.includes(r.name));
+	}
+
+	setLocalPath(localPath: string): void {
+		this._localPath = localPath;
 	}
 }
 
@@ -468,14 +480,24 @@ export interface RemoveWorkspaceRepoDescriptor {
 export class LocalWorkspace {
 	readonly type = WorkspaceType.Local;
 
+	private _localPath: string | undefined;
+
 	constructor(
 		public readonly id: string,
 		public readonly name: string,
 		private readonly repositories: LocalWorkspaceRepositoryDescriptor[],
-	) {}
+		public readonly current: boolean,
+		localPath?: string,
+	) {
+		this._localPath = localPath;
+	}
 
 	get shared(): boolean {
 		return false;
+	}
+
+	get localPath(): string | undefined {
+		return this._localPath;
 	}
 
 	getRepositoryDescriptors(): Promise<LocalWorkspaceRepositoryDescriptor[]> {
@@ -484,6 +506,10 @@ export class LocalWorkspace {
 
 	getRepositoryDescriptor(name: string): Promise<LocalWorkspaceRepositoryDescriptor | undefined> {
 		return Promise.resolve(this.repositories.find(r => r.name === name));
+	}
+
+	setLocalPath(localPath: string): void {
+		this._localPath = localPath;
 	}
 }
 
@@ -519,13 +545,18 @@ export interface CloudWorkspaceFileData {
 }
 
 export type CloudWorkspacesPathMap = {
-	[cloudWorkspaceId: string]: CloudWorkspaceRepoPaths;
+	[cloudWorkspaceId: string]: CloudWorkspacePaths;
 };
 
-export interface CloudWorkspaceRepoPaths {
+export interface CloudWorkspacePaths {
 	repoPaths: CloudWorkspaceRepoPathMap;
+	externalLinks: CloudWorkspaceExternalLinkMap;
 }
 
 export type CloudWorkspaceRepoPathMap = {
 	[repoId: string]: string;
+};
+
+export type CloudWorkspaceExternalLinkMap = {
+	[fileExtenstion: string]: string;
 };

--- a/src/plus/workspaces/workspacesPathMappingProvider.ts
+++ b/src/plus/workspaces/workspacesPathMappingProvider.ts
@@ -1,5 +1,5 @@
 import type { Uri } from 'vscode';
-import type { LocalWorkspaceFileData } from './models';
+import type { LocalWorkspaceFileData, WorkspaceSyncSetting } from './models';
 
 export interface WorkspacesPathMappingProvider {
 	getCloudWorkspaceRepoPath(cloudWorkspaceId: string, repoId: string): Promise<string | undefined>;
@@ -17,11 +17,6 @@ export interface WorkspacesPathMappingProvider {
 	writeCodeWorkspaceFile(
 		uri: Uri,
 		workspaceRepoFilePaths: string[],
-		options?: { workspaceId?: string },
-	): Promise<boolean>;
-
-	confirmCloudWorkspaceCodeWorkspaceFileMatch(
-		cloudWorkspaceId: string,
-		codeWorkspaceFilePath: string,
+		options?: { workspaceId?: string; workspaceSyncSetting?: WorkspaceSyncSetting },
 	): Promise<boolean>;
 }

--- a/src/plus/workspaces/workspacesPathMappingProvider.ts
+++ b/src/plus/workspaces/workspacesPathMappingProvider.ts
@@ -4,7 +4,13 @@ import type { LocalWorkspaceFileData } from './models';
 export interface WorkspacesPathMappingProvider {
 	getCloudWorkspaceRepoPath(cloudWorkspaceId: string, repoId: string): Promise<string | undefined>;
 
-	writeCloudWorkspaceDiskPathToMap(cloudWorkspaceId: string, repoId: string, repoLocalPath: string): Promise<void>;
+	getCloudWorkspaceCodeWorkspacePath(cloudWorkspaceId: string): Promise<string | undefined>;
+
+	writeCloudWorkspaceRepoDiskPathToMap(
+		cloudWorkspaceId: string,
+		repoId: string,
+		repoLocalPath: string,
+	): Promise<void>;
 
 	getLocalWorkspaceData(): Promise<LocalWorkspaceFileData>;
 
@@ -12,5 +18,10 @@ export interface WorkspacesPathMappingProvider {
 		uri: Uri,
 		workspaceRepoFilePaths: string[],
 		options?: { workspaceId?: string },
+	): Promise<boolean>;
+
+	confirmCloudWorkspaceCodeWorkspaceFileMatch(
+		cloudWorkspaceId: string,
+		codeWorkspaceFilePath: string,
 	): Promise<boolean>;
 }

--- a/src/plus/workspaces/workspacesPathMappingProvider.ts
+++ b/src/plus/workspaces/workspacesPathMappingProvider.ts
@@ -6,6 +6,15 @@ export interface WorkspacesPathMappingProvider {
 
 	getCloudWorkspaceCodeWorkspacePath(cloudWorkspaceId: string): Promise<string | undefined>;
 
+	removeCloudWorkspaceCodeWorkspaceFilePath(cloudWorkspaceId: string): Promise<void>;
+
+	writeCloudWorkspaceCodeWorkspaceFilePathToMap(
+		cloudWorkspaceId: string,
+		codeWorkspaceFilePath: string,
+	): Promise<void>;
+
+	confirmCloudWorkspaceCodeWorkspaceFilePath(cloudWorkspaceId: string): Promise<boolean>;
+
 	writeCloudWorkspaceRepoDiskPathToMap(
 		cloudWorkspaceId: string,
 		repoId: string,

--- a/src/views/nodes/workspaceNode.ts
+++ b/src/views/nodes/workspaceNode.ts
@@ -1,6 +1,6 @@
 import { ThemeIcon, TreeItem, TreeItemCollapsibleState, Uri } from 'vscode';
 import { GitUri } from '../../git/gitUri';
-import type { CloudWorkspace, LocalWorkspace, WorkspaceRepositoriesByName } from '../../plus/workspaces/models';
+import type { CloudWorkspace, LocalWorkspace } from '../../plus/workspaces/models';
 import { WorkspaceType } from '../../plus/workspaces/models';
 import { createCommand } from '../../system/command';
 import type { WorkspacesView } from '../workspacesView';
@@ -55,12 +55,7 @@ export class WorkspaceNode extends ViewNode<WorkspacesView> {
 					return this._children;
 				}
 
-				// TODO@eamodio this should not be done here -- it should be done in the workspaces model (when loading the repos)
-				const reposByName: WorkspaceRepositoriesByName =
-					await this.view.container.workspaces.resolveWorkspaceRepositoriesByName(this.workspace.id, {
-						resolveFromPath: true,
-						usePathMapping: true,
-					});
+				const reposByName = await this.workspace.getRepositoriesByName({ force: true });
 
 				for (const descriptor of descriptors) {
 					const repo = reposByName.get(descriptor.name)?.repository;

--- a/src/views/nodes/workspaceNode.ts
+++ b/src/views/nodes/workspaceNode.ts
@@ -1,4 +1,4 @@
-import { ThemeIcon, TreeItem, TreeItemCollapsibleState } from 'vscode';
+import { ThemeIcon, TreeItem, TreeItemCollapsibleState, Uri } from 'vscode';
 import { GitUri } from '../../git/gitUri';
 import type { CloudWorkspace, LocalWorkspace, WorkspaceRepositoriesByName } from '../../plus/workspaces/models';
 import { WorkspaceType } from '../../plus/workspaces/models';
@@ -93,10 +93,18 @@ export class WorkspaceNode extends ViewNode<WorkspacesView> {
 		const item = new TreeItem(this.workspace.name, TreeItemCollapsibleState.Collapsed);
 
 		let contextValue = `${ContextValues.Workspace}`;
+		item.resourceUri = undefined;
 		if (this.workspace.type === WorkspaceType.Cloud) {
 			contextValue += '+cloud';
 		} else {
 			contextValue += '+local';
+		}
+		if (this.workspace.current) {
+			contextValue += '+current';
+			item.resourceUri = Uri.parse('gitlens-view://workspaces/workspace/current');
+		}
+		if (this.workspace.localPath != null) {
+			contextValue += '+hasPath';
 		}
 		item.id = this.id;
 		item.contextValue = contextValue;
@@ -110,7 +118,6 @@ export class WorkspaceNode extends ViewNode<WorkspacesView> {
 				? `\nProvider: ${this.workspace.provider}`
 				: ''
 		}`;
-		item.resourceUri = undefined;
 		return item;
 	}
 

--- a/src/views/viewDecorationProvider.ts
+++ b/src/views/viewDecorationProvider.ts
@@ -62,6 +62,16 @@ export class ViewFileDecorationProvider implements FileDecorationProvider, Dispo
 			}
 		}
 
+		if (type === 'workspace') {
+			if (status === 'current') {
+				return {
+					badge: '●',
+					color: new ThemeColor('gitlens.decorations.workspaceCurrentForegroundColor' satisfies Colors),
+					tooltip: '',
+				};
+			}
+		}
+
 		return undefined;
 	}
 

--- a/src/views/workspacesView.ts
+++ b/src/views/workspacesView.ts
@@ -25,8 +25,6 @@ export class WorkspacesView extends ViewBase<'workspaces', WorkspacesViewNode, W
 
 		this._disposable = Disposable.from(
 			this.container.workspaces.onDidResetWorkspaces(() => void this.ensureRoot().triggerChange(true)),
-			this.container.git.onDidChangeRepositories(() => void this.ensureRoot().triggerChange()),
-			this.container.git.onDidChangeRepository(() => void this.ensureRoot().triggerChange()),
 		);
 		this.description = `PREVIEW\u00a0\u00a0☁️`;
 	}

--- a/src/views/workspacesView.ts
+++ b/src/views/workspacesView.ts
@@ -1,5 +1,4 @@
-import type { Disposable } from 'vscode';
-import { env, ProgressLocation, Uri, window } from 'vscode';
+import { Disposable, env, ProgressLocation, Uri, window } from 'vscode';
 import type { WorkspacesViewConfig } from '../config';
 import { Commands } from '../constants';
 import type { Container } from '../container';
@@ -24,8 +23,10 @@ export class WorkspacesView extends ViewBase<'workspaces', WorkspacesViewNode, W
 	constructor(container: Container) {
 		super(container, 'workspaces', 'Workspaces', 'workspaceView');
 
-		this._disposable = this.container.workspaces.onDidChangeWorkspaces(
-			() => void this.ensureRoot().triggerChange(true),
+		this._disposable = Disposable.from(
+			this.container.workspaces.onDidResetWorkspaces(() => void this.ensureRoot().triggerChange(true)),
+			this.container.git.onDidChangeRepositories(() => void this.ensureRoot().triggerChange()),
+			this.container.git.onDidChangeRepository(() => void this.ensureRoot().triggerChange()),
 		);
 		this.description = `PREVIEW\u00a0\u00a0☁️`;
 	}
@@ -70,7 +71,6 @@ export class WorkspacesView extends ViewBase<'workspaces', WorkspacesViewNode, W
 				this.getQualifiedCommand('refresh'),
 				() => {
 					this.container.workspaces.resetWorkspaces();
-					void this.ensureRoot().triggerChange(true);
 				},
 				this,
 			),

--- a/src/views/workspacesView.ts
+++ b/src/views/workspacesView.ts
@@ -103,10 +103,28 @@ export class WorkspacesView extends ViewBase<'workspaces', WorkspacesViewNode, W
 				this,
 			),
 			registerViewCommand(
-				this.getQualifiedCommand('open'),
+				this.getQualifiedCommand('createLocal'),
 				async (node: WorkspaceNode) => {
-					await this.container.workspaces.saveAsCodeWorkspaceFile(node.workspace.id, node.workspace.type, {
-						open: true,
+					await this.container.workspaces.saveAsCodeWorkspaceFile(node.workspace.id);
+					void this.ensureRoot().triggerChange(true);
+				},
+				this,
+			),
+			registerViewCommand(
+				this.getQualifiedCommand('openLocal'),
+				async (node: WorkspaceNode) => {
+					await this.container.workspaces.openCodeWorkspaceFile(node.workspace.id, {
+						location: OpenWorkspaceLocation.CurrentWindow,
+					});
+					void this.ensureRoot().triggerChange(true);
+				},
+				this,
+			),
+			registerViewCommand(
+				this.getQualifiedCommand('openLocalNewWindow'),
+				async (node: WorkspaceNode) => {
+					await this.container.workspaces.openCodeWorkspaceFile(node.workspace.id, {
+						location: OpenWorkspaceLocation.NewWindow,
 					});
 				},
 				this,


### PR DESCRIPTION
Improves linkage between vscode and cloud workspaces:

- Command next to a GitKraken Workspace in the Workspaces View, previously labeled "open as vscode workspace", split out to several commands: "create vscode workspace". "open vscode workspace (new window)", and "open vscode workspace (current window)".
- When you create a vscode workspace, it saves the GK workspace id in that code workspace file's settings. It also saves the file path of that code-workspace file for that cloud workspace in `cloudWorkspaces.json` in the shared folder (i.e. C`:/Users/(user)/.gk`).
- This changes the command for this cloud workspace from "Create" to "open". From now on, using the command opens the existing workspace at that location.
- When you create the vscode workspace, you now also have the option to enable syncing via three methods: Always, Ask every time or Never.
 - `Always` means whenever a new repo is added to the cloud workspace, it will always automatically add that repo to the linked vscode workspace if it is open.
- `Ask` is similar to above, but it will ask each time if you want to add the new repos to the local workspace.
- `Never` will never do the above syncing.

* Note that the syncing is **one-way** intentionally: we want to be minimally invasive with this syncing for now, so it will only add from cloud to local and only for adding repos, not removing if they were removed from cloud.