### PR TITLE
Fixes #2791 changes to fix contributors link in readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -316,9 +316,9 @@ Want to contribute to GitLens? Follow the [CONTRIBUTING](https://github.com/gitk
 
 Contributions to the documentation are greatly appreciated. If you find any areas that can be improved or have suggestions for new documentation, you can submit them as pull requests to the [GitLens Docs](https://github.com/gitkraken/gitlens-docs) repository.
 
-# Contributors &#x1F64F;&#x2764;
+# Contributors
 
-A big thanks to the people that have contributed to this project:
+A big thanks to the people that have contributed to this project 🙏❤️:
 
 - Zeeshan Adnan ([@zeeshanadnan](https://github.com/zeeshanadnan)) &mdash; [contributions](https://github.com/gitkraken/vscode-gitlens/commits?author=zeeshanadnan)
 - Alex ([@deadmeu](https://github.com/deadmeu)) &mdash; [contributions](https://github.com/gitkraken/vscode-gitlens/commits?author=deadmeu)

--- a/README.md
+++ b/README.md
@@ -33,7 +33,7 @@ See the [FAQ](#is-gitlens-free-to-use 'Jump to FAQ') for more details.
 | [FAQ](#faq 'Jump to FAQ')
 | [Support and Community](#support-and-community 'Jump to Support and Community')
 | [Contributing](#contributing 'Jump to Contributing')
-| [Contributors](#contributors-🙏❤ 'Jump to Contributors')
+| [Contributors](#contributors- 'Jump to Contributors')
 | [License](#license 'Jump to License')
 
 # Discover Powerful Features


### PR DESCRIPTION
Fixes #2791

# Description

While looking into the repo's readme I found that the contributors link was non functional. In my testing it would appear that removing the two emojis at the end of the contributors link allows the link to gain it's intended functionality while not changing anything else about the page.

# Checklist
- [x] I have followed the guidelines in the Contributing document
- [x] My changes follow the coding style of this project
- [x] My changes build without any errors or warnings
- [x] My changes have been formatted and linted
- [x] My changes include any required corresponding changes to the documentation (including CHANGELOG.md and README.md)
- [x] My changes have been rebased and squashed to the minimal number (typically 1) of relevant commits
- [x] My changes have a descriptive commit message with a short title, including a `Fixes $XXX -` or `Closes #XXX -` prefix to auto-close the issue that your PR addresses
