### PR TITLE
Fixes #2641 Support search and open file history change

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,10 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/) and this p
 
 ## [Unreleased]
 
+### Added
+
+- Adds an _Open Changes_ button to commits in the file history quick pick menu &mdash; closes [#2641](https://github.com/gitkraken/vscode-gitlens/issues/2641) thanks to [PR #2800](https://github.com/gitkraken/vscode-gitlens/pull/2800) by Omar Ghazi ([@omarfesal](https://github.com/omarfesal))
+
 ## [14.2.1] - 2023-08-10
 
 ### Added

--- a/README.md
+++ b/README.md
@@ -345,6 +345,7 @@ A big thanks to the people that have contributed to this project 🙏❤️:
 - Cory Forsyth ([@bantic](https://github.com/bantic)) &mdash; [contributions](https://github.com/gitkraken/vscode-gitlens/commits?author=bantic)
 - John Gee ([@shadowspawn](https://github.com/shadowspawn)) &mdash; [contributions](https://github.com/gitkraken/vscode-gitlens/commits?author=shadowspawn)
 - Geoffrey ([@g3offrey](https://github.com/g3offrey)) &mdash; [contributions](https://github.com/gitkraken/vscode-gitlens/commits?author=g3offrey)
+- Omar Ghazi ([@omarfesal](https://github.com/omarfesal)) &mdash; [contributions](https://github.com/gitkraken/vscode-gitlens/commits?author=omarfesal)
 - Neil Ghosh ([@neilghosh](https://github.com/neilghosh)) &mdash; [contributions](https://github.com/gitkraken/vscode-gitlens/commits?author=neilghosh)
 - Guillaume Rozan ([@grozan](https://github.com/grozan)) &mdash; [contributions](https://github.com/gitkraken/vscode-gitlens/commits?author=grozan)
 - Guillem González Vela ([@guillemglez](https://github.com/guillemglez)) &mdash; [contributions](https://github.com/gitkraken/vscode-gitlens/commits?author=guillemglez)

--- a/src/commands/quickCommand.buttons.ts
+++ b/src/commands/quickCommand.buttons.ts
@@ -127,6 +127,11 @@ export const ShowDetailsViewQuickInputButton: QuickInputButton = {
 	tooltip: 'Open Details',
 };
 
+export const OpenChangesViewQuickInputButton: QuickInputButton = {
+	iconPath: new ThemeIcon('compare-changes'),
+	tooltip: 'Open Changes',
+};
+
 export const ShowResultsInSideBarQuickInputButton: QuickInputButton = {
 	iconPath: new ThemeIcon('link-external'),
 	tooltip: 'Show Results in Side Bar',

--- a/src/commands/quickCommand.steps.ts
+++ b/src/commands/quickCommand.steps.ts
@@ -119,6 +119,7 @@ import {
 	createPickStep,
 	endSteps,
 	LoadMoreQuickInputButton,
+	OpenChangesViewQuickInputButton,
 	OpenInNewWindowQuickInputButton,
 	PickCommitQuickInputButton,
 	RevealInSideBarQuickInputButton,
@@ -1067,7 +1068,11 @@ export async function* pickCommitStep<
 							picked != null &&
 								(typeof picked === 'string' ? commit.ref === picked : picked.includes(commit.ref)),
 							{
-								buttons: [ShowDetailsViewQuickInputButton, RevealInSideBarQuickInputButton],
+								buttons: [
+									ShowDetailsViewQuickInputButton,
+									RevealInSideBarQuickInputButton,
+									OpenChangesViewQuickInputButton,
+								],
 								compact: true,
 								icon: true,
 							},
@@ -1101,6 +1106,7 @@ export async function* pickCommitStep<
 		],
 		onDidClickItemButton: (quickpick, button, item) => {
 			if (CommandQuickPickItem.is(item)) return;
+			const fileName = `${item.item.file?.path}`;
 
 			switch (button) {
 				case ShowDetailsViewQuickInputButton:
@@ -1113,6 +1119,9 @@ export async function* pickCommitStep<
 						focus: false,
 						expand: true,
 					});
+					break;
+				case OpenChangesViewQuickInputButton:
+					void CommitActions.openChanges(fileName, item.item, {});
 					break;
 			}
 		},


### PR DESCRIPTION
Fixes #2641

# Description

Add "Show changes button" beside "Reveal in side Bar" while open "Show file history" 

# Checklist

- [x] I have followed the guidelines in the Contributing document
- [x] My changes follow the coding style of this project
- [x] My changes build without any errors or warnings
- [x] My changes have been formatted and linted
- [x] My changes include any required corresponding changes to the documentation (including CHANGELOG.md and README.md)
- [x] My changes have been rebased and squashed to the minimal number (typically 1) of relevant commits
- [x] My changes have a descriptive commit message with a short title, including a `Fixes $XXX -` or `Closes #XXX -` prefix to auto-close the issue that your PR addresses
