### PR TITLE
Move from Gitlens to the library the columns settings button

### DIFF
--- a/package.json
+++ b/package.json
@@ -14629,7 +14629,7 @@
 		"vscode:prepublish": "yarn run bundle"
 	},
 	"dependencies": {
-		"@gitkraken/gitkraken-components": "10.1.8",
+		"@gitkraken/gitkraken-components": "10.1.9",
 		"@microsoft/fast-element": "1.12.0",
 		"@microsoft/fast-react-wrapper": "0.3.18",
 		"@octokit/core": "4.2.4",

--- a/src/webviews/apps/plus/graph/GraphWrapper.tsx
+++ b/src/webviews/apps/plus/graph/GraphWrapper.tsx
@@ -131,6 +131,7 @@ const createIconElements = (): Record<string, ReactElement> => {
 		'message',
 		'changes',
 		'files',
+		'settings',
 	];
 
 	const miniIconList = ['upstream-ahead', 'upstream-behind'];
@@ -1397,6 +1398,7 @@ export function GraphWrapper({
 							onGraphColumnsReOrdered={handleOnGraphColumnsReOrdered}
 							onGraphMouseLeave={minimap.current ? handleOnGraphMouseLeave : undefined}
 							onGraphRowHovered={minimap.current ? handleOnGraphRowHovered : undefined}
+							onSettingsClick={handleToggleColumnSettings}
 							onSelectGraphRows={handleSelectGraphRows}
 							onToggleRefsVisibilityClick={handleOnToggleRefsVisibilityClick}
 							onEmailsMissingAvatarUrls={handleMissingAvatars}
@@ -1416,15 +1418,6 @@ export function GraphWrapper({
 				) : (
 					<p>No repository is selected</p>
 				)}
-				<button
-					className="column-button"
-					type="button"
-					role="button"
-					data-vscode-context={context?.settings || JSON.stringify({ webviewItem: 'gitlens:graph:settings' })}
-					onClick={handleToggleColumnSettings}
-				>
-					<span className="codicon codicon-settings-gear" aria-label="Column Settings"></span>
-				</button>
 			</main>
 		</>
 	);

--- a/src/webviews/apps/plus/graph/graph.scss
+++ b/src/webviews/apps/plus/graph/graph.scss
@@ -411,7 +411,7 @@ button:not([disabled]),
 	}
 }
 
-.column-button {
+.columns-settings {
 	--column-button-height: 19px;
 
 	position: absolute;
@@ -450,6 +450,10 @@ button:not([disabled]),
 		font-size: 1.1rem;
 		position: relative;
 	}
+}
+
+.gk-graph.bs-tooltip {
+	z-index: 1040;
 }
 
 .alert {
@@ -717,7 +721,13 @@ button:not([disabled]),
 			content: '\ea9a';
 		}
 	}
-
+	&--settings {
+		&::before {
+			// codicon-settings-gear
+			font-family: codicon;
+			content: '\eb51';
+		}
+	}
 	&--branch {
 		&::before {
 			// codicon-git-branch

--- a/yarn.lock
+++ b/yarn.lock
@@ -202,10 +202,10 @@
   resolved "https://registry.yarnpkg.com/@eslint/js/-/js-8.44.0.tgz#961a5903c74139390478bdc808bcde3fc45ab7af"
   integrity sha512-Ag+9YM4ocKQx9AarydN0KY2j0ErMHNIocPDrVo8zAE44xLTjEtz81OdR68/cydGtk6m6jDb5Za3r2useMzYmSw==
 
-"@gitkraken/gitkraken-components@10.1.8":
-  version "10.1.8"
-  resolved "https://registry.yarnpkg.com/@gitkraken/gitkraken-components/-/gitkraken-components-10.1.8.tgz#2ee9e70817d51b0928731e57e640ac49f3e7502c"
-  integrity sha512-kq6d+HVlELdFHpIMMgVuopqjX63Jtt7udW7OHbhf1Za/rrlwczX2K1a+wPYEGVQvHjaOrghTVmG/mogNhMQ0qA==
+"@gitkraken/gitkraken-components@10.1.9":
+  version "10.1.9"
+  resolved "https://registry.npmjs.org/@gitkraken/gitkraken-components/-/gitkraken-components-10.1.9.tgz#751a9bce02f46a11facc000fefe7844802a8c9c8"
+  integrity sha512-1NicZneMfzj4zuqtZjlAMho/85+qseqM+cEHLR696qcEV0sp0AmujPTvj4PZCIV/Y7J/j3uKvAMFzBsbgdTi4g==
   dependencies:
     "@axosoft/react-virtualized" "9.22.3-gitkraken.3"
     classnames "2.3.2"


### PR DESCRIPTION
## Summary of changes:
- Removed graph header settings button from Gitlens as now the Graph component can display that button and we have exposed new input properties.

## Notes
- This PR works with GK graph library side changes: https://github.com/gitkraken/GitKrakenComponents/pull/231
- Before merge this PR, we have to update the GK graph library version dependency.

## Tasks
[230](https://github.com/gitkraken/GitKrakenComponents/issues/230)
Internal task: `GK.3665`