### PR TITLE
Fixes #2823 - Handle stdout/stderr Buffers in shell run()

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,7 +11,10 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/) and this p
 - Changes _Compact Graph Column Layout_ context menu command to _Use Compact Graph Column_ for better clarity
 - Changes _Default Graph Column Layout_ context menu command to _Use Expanded Graph Column_ for better clarity
 - Improves remote parsing for better integration support for some edge cases
-- Improves error handling of shell commands in certain cases
+
+### Fixed
+
+- Fixes [#2823](https://github.com/gitkraken/vscode-gitlens/issues/2823) - Handle stdout/stderr Buffers in shell run()
 
 ## [14.1.1] - 2023-07-18
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/) and this p
 - Changes _Compact Graph Column Layout_ context menu command to _Use Compact Graph Column_ for better clarity
 - Changes _Default Graph Column Layout_ context menu command to _Use Expanded Graph Column_ for better clarity
 - Improves remote parsing for better integration support for some edge cases
+- Improves error handling of shell commands in certain cases
 
 ## [14.1.1] - 2023-07-18
 

--- a/README.md
+++ b/README.md
@@ -351,6 +351,7 @@ A big thanks to the people that have contributed to this project 🙏❤️:
 - Vladislav Guleaev ([@vguleaev](https://github.com/vguleaev)) &mdash; [contributions](https://github.com/gitkraken/vscode-gitlens/commits?author=vguleaev)
 - Dmitry Gurovich ([@yrtimiD](https://github.com/yrtimiD)) &mdash; [contributions](https://github.com/gitkraken/vscode-gitlens/commits?author=yrtimiD)
 - hahaaha ([@hahaaha](https://github.com/hahaaha)) &mdash; [contributions](https://github.com/gitkraken/vscode-gitlens/commits?author=hahaaha)
+- Victor Hallberg ([@mogelbrod](https://github.com/mogelbrod)) &mdash; [contributions](https://github.com/gitkraken/vscode-gitlens/commits?author=mogelbrod)
 - Ken Hom ([@kh0m](https://github.com/kh0m)) &mdash; [contributions](https://github.com/gitkraken/vscode-gitlens/commits?author=kh0m)
 - Yukai Huang ([@Yukaii](https://github.com/Yukaii)) &mdash; [contributions](https://github.com/gitkraken/vscode-gitlens/commits?author=Yukaii)
 - Justin Hutchings ([@jhutchings1](https://github.com/jhutchings1)) &mdash; [contributions](https://github.com/gitkraken/vscode-gitlens/commits?author=jhutchings1)

--- a/src/env/node/git/shell.ts
+++ b/src/env/node/git/shell.ts
@@ -245,11 +245,12 @@ export function run<T extends number | string | Buffer>(
 					error.message = `Command output exceeded the allocated stdout buffer. Set 'options.maxBuffer' to a larger value than ${opts.maxBuffer} bytes`;
 				}
 
-				let stdoutDecoded;
-				let stderrDecoded;
+				let stdoutDecoded: string;
+				let stderrDecoded: string;
 				if (encoding === 'utf8' || encoding === 'binary' || encoding === 'buffer') {
-					stdoutDecoded = stdout;
-					stderrDecoded = stderr;
+					// stdout & stderr can be `Buffer` or `string
+					stdoutDecoded = stdout.toString();
+					stderrDecoded = stderr.toString();
 				} else {
 					const decode = (await import(/* webpackChunkName: "encoding" */ 'iconv-lite')).decode;
 					stdoutDecoded = decode(Buffer.from(stdout, 'binary'), encoding);


### PR DESCRIPTION
# Description

Fixes #2823

Handles cases where stdout/stderr are `Buffer`s in the shell `run()` helper:

https://github.com/gitkraken/vscode-gitlens/blob/c20ff5131eeb4b663eb6e191b7de8dab06949a78/src/env/node/git/shell.ts#L248-L258

# Checklist

<!-- Please check off the following -->

- [x] I have followed the guidelines in the Contributing document
- [x] My changes follow the coding style of this project
- [x] My changes build without any errors or warnings
- [x] My changes have been formatted and linted
- [x] My changes include any required corresponding changes to the documentation (including CHANGELOG.md and README.md)
- [x] My changes have been rebased and squashed to the minimal number (typically 1) of relevant commits
- [x] My changes have a descriptive commit message with a short title, including a `Fixes $XXX -` or `Closes #XXX -` prefix to auto-close the issue that your PR addresses
