### PR TITLE
Fixes #708 - Prompt for file path when missing from revision

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,10 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/) and this p
 
 ## [Unreleased]
 
+### Added
+
+- Adds support for opening renamed/deleted files using the _Open File at Revision..._ & _Open File at Revision from..._ commands by showing a quick pick menu if the requested file doesn't exist in the selected revision &mdash; closes [#708](https://github.com/gitkraken/vscode-gitlens/issues/708) thanks to [PR #2825](https://github.com/gitkraken/vscode-gitlens/pull/2825) by Victor Hallberg ([@mogelbrod](https://github.com/mogelbrod))
+
 ### Changed
 
 - Changes blame to show the last modified time of the file for uncommitted changes

--- a/src/commands/diffWithRevision.ts
+++ b/src/commands/diffWithRevision.ts
@@ -56,21 +56,23 @@ export class DiffWithRevisionCommand extends ActiveEditorCommand {
 				'Choose a commit to compare with',
 				{
 					picked: gitUri.sha,
-					keys: ['right', 'alt+right', 'ctrl+right'],
-					onDidPressKey: async (key, item) => {
-						void (await executeCommand<DiffWithCommandArgs>(Commands.DiffWith, {
-							repoPath: gitUri.repoPath,
-							lhs: {
-								sha: item.item.ref,
-								uri: gitUri,
-							},
-							rhs: {
-								sha: '',
-								uri: gitUri,
-							},
-							line: args!.line,
-							showOptions: args!.showOptions,
-						}));
+					keyboard: {
+						keys: ['right', 'alt+right', 'ctrl+right'],
+						onDidPressKey: async (key, item) => {
+							await executeCommand<DiffWithCommandArgs>(Commands.DiffWith, {
+								repoPath: gitUri.repoPath,
+								lhs: {
+									sha: item.item.ref,
+									uri: gitUri,
+								},
+								rhs: {
+									sha: '',
+									uri: gitUri,
+								},
+								line: args!.line,
+								showOptions: args!.showOptions,
+							});
+						},
 					},
 					showOtherReferences: [
 						CommandQuickPickItem.fromCommand('Choose a Branch or Tag...', Commands.DiffWithRevisionFrom),

--- a/src/commands/gitCommands.ts
+++ b/src/commands/gitCommands.ts
@@ -363,6 +363,9 @@ export class GitCommandsCommand extends Command {
 
 				const scope = this.container.keyboard.createScope(mapping);
 				void scope.start();
+				if (step.value != null) {
+					void scope.pause(['left', 'ctrl+left', 'right', 'ctrl+right']);
+				}
 
 				disposables.push(
 					scope,
@@ -404,9 +407,9 @@ export class GitCommandsCommand extends Command {
 						if (scope != null) {
 							// Pause the left/right keyboard commands if there is a value, otherwise the left/right arrows won't work in the input properly
 							if (e.length !== 0) {
-								await scope.pause(['left', 'right']);
+								void scope.pause(['left', 'ctrl+left', 'right', 'ctrl+right']);
 							} else {
-								await scope.resume();
+								void scope.resume();
 							}
 						}
 
@@ -521,6 +524,9 @@ export class GitCommandsCommand extends Command {
 
 				const scope = this.container.keyboard.createScope(mapping);
 				void scope.start();
+				if (step.value != null) {
+					void scope.pause(['left', 'ctrl+left', 'right', 'ctrl+right']);
+				}
 
 				let overrideItems = false;
 
@@ -592,9 +598,9 @@ export class GitCommandsCommand extends Command {
 						if (scope != null) {
 							// Pause the left/right keyboard commands if there is a value, otherwise the left/right arrows won't work in the input properly
 							if (e.length !== 0) {
-								await scope.pause(['left', 'right']);
+								void scope.pause(['left', 'ctrl+left', 'right', 'ctrl+right']);
 							} else {
-								await scope.resume();
+								void scope.resume();
 							}
 						}
 

--- a/src/commands/openFileAtRevision.ts
+++ b/src/commands/openFileAtRevision.ts
@@ -133,14 +133,16 @@ export class OpenFileAtRevisionCommand extends ActiveEditorCommand {
 					`Choose a commit to ${args.annotationType === 'blame' ? 'blame' : 'open'} the file revision from`,
 					{
 						picked: gitUri.sha,
-						keys: ['right', 'alt+right', 'ctrl+right'],
-						onDidPressKey: async (key, item) => {
-							await openFileAtRevision(item.item.file!, item.item, {
-								annotationType: args!.annotationType,
-								line: args!.line,
-								preserveFocus: true,
-								preview: false,
-							});
+						keyboard: {
+							keys: ['right', 'alt+right', 'ctrl+right'],
+							onDidPressKey: async (key, item) => {
+								await openFileAtRevision(item.item.file!, item.item, {
+									annotationType: args!.annotationType,
+									line: args!.line,
+									preserveFocus: true,
+									preview: true,
+								});
+							},
 						},
 						showOtherReferences: [
 							CommandQuickPickItem.fromCommand(

--- a/src/commands/openFileAtRevisionFrom.ts
+++ b/src/commands/openFileAtRevisionFrom.ts
@@ -65,20 +65,19 @@ export class OpenFileAtRevisionFromCommand extends ActiveEditorCommand {
 					'Choose a branch or tag to open the file revision from',
 					{
 						allowEnteringRefs: true,
-						keys: ['right', 'alt+right', 'ctrl+right'],
-						onDidPressKey: async (key, quickpick) => {
-							const [item] = quickpick.activeItems;
-							if (item != null) {
+						keyboard: {
+							keys: ['right', 'alt+right', 'ctrl+right'],
+							onDidPressKey: async (key, item) => {
 								await openFileAtRevision(
 									this.container.git.getRevisionUri(item.ref, gitUri.fsPath, gitUri.repoPath!),
 									{
 										annotationType: args!.annotationType,
 										line: args!.line,
 										preserveFocus: true,
-										preview: false,
+										preview: true,
 									},
 								);
-							}
+							},
 						},
 					},
 				);

--- a/src/env/node/git/git.ts
+++ b/src/env/node/git/git.ts
@@ -539,8 +539,8 @@ export class Git {
 		);
 	}
 
-	async cat_file__size(repoPath: string, object: string): Promise<number> {
-		const data = await this.git<string>({ cwd: repoPath }, 'cat-file', '-s', object);
+	async cat_file__size(repoPath: string, oid: string): Promise<number> {
+		const data = await this.git<string>({ cwd: repoPath }, 'cat-file', '-s', oid);
 		return data.length ? parseInt(data.trim(), 10) : 0;
 	}
 
@@ -1343,13 +1343,13 @@ export class Git {
 
 	async log__find_object(
 		repoPath: string,
-		objectId: string,
+		oid: string,
 		ref: string,
 		ordering: 'date' | 'author-date' | 'topo' | null,
 		file?: string,
 		cancellation?: CancellationToken,
 	) {
-		const params = ['log', '-n1', '--no-renames', '--format=%H', `--find-object=${objectId}`, ref];
+		const params = ['log', '-n1', '--no-renames', '--format=%H', `--find-object=${oid}`, ref];
 
 		if (ordering) {
 			params.push(`--${ordering}-order`);

--- a/src/env/node/git/localGitProvider.ts
+++ b/src/env/node/git/localGitProvider.ts
@@ -4844,9 +4844,10 @@ export class LocalGitProvider implements GitProvider, Disposable {
 			const [result] = parseGitLsFiles(data);
 			if (result == null) return undefined;
 
-			const size = await this.git.cat_file__size(repoPath, result.object);
+			const size = await this.git.cat_file__size(repoPath, result.oid);
 			return {
-				commitSha: ref,
+				ref: ref,
+				oid: result.oid,
 				path: relativePath,
 				size: size,
 				type: 'blob',
@@ -4854,7 +4855,7 @@ export class LocalGitProvider implements GitProvider, Disposable {
 		}
 
 		const data = await this.git.ls_tree(root, ref, relativePath);
-		return parseGitTree(data)[0];
+		return parseGitTree(data, ref)[0];
 	}
 
 	@log()
@@ -4862,7 +4863,7 @@ export class LocalGitProvider implements GitProvider, Disposable {
 		if (repoPath == null) return [];
 
 		const data = await this.git.ls_tree(repoPath, ref);
-		return parseGitTree(data);
+		return parseGitTree(data, ref);
 	}
 
 	@log({ args: { 1: false } })

--- a/src/git/fsProvider.ts
+++ b/src/git/fsProvider.ts
@@ -142,7 +142,7 @@ export class GitFileSystemProvider implements FileSystemProvider, Disposable {
 		const trees = await this.container.git.getTreeForRevision(repoPath, ref);
 
 		// Add a fake root folder so that searches will work
-		searchTree.set('~', { commitSha: '', path: '~', size: 0, type: 'tree' });
+		searchTree.set('~', { ref: '', oid: '', path: '~', size: 0, type: 'tree' });
 		for (const item of trees) {
 			searchTree.set(`~/${item.path}`, item);
 		}

--- a/src/git/models/tree.ts
+++ b/src/git/models/tree.ts
@@ -1,5 +1,6 @@
 export interface GitTreeEntry {
-	commitSha: string;
+	ref: string;
+	oid: string;
 	path: string;
 	size: number;
 	type: 'blob' | 'tree';
@@ -7,7 +8,7 @@ export interface GitTreeEntry {
 
 export interface GitLsFilesEntry {
 	mode: string;
+	oid: string;
 	path: string;
-	object: string;
 	stage: number;
 }

--- a/src/plus/integrations/providers/github/githubGitProvider.ts
+++ b/src/plus/integrations/providers/github/githubGitProvider.ts
@@ -2740,8 +2740,9 @@ export class GitHubGitProvider implements GitProvider, Disposable {
 		if (stats == null) return undefined;
 
 		return {
+			ref: ref,
+			oid: '',
 			path: this.getRelativePath(uri, repoPath),
-			commitSha: ref,
 			size: stats.size,
 			type: (stats.type & FileType.Directory) === FileType.Directory ? 'tree' : 'blob',
 		};
@@ -2772,8 +2773,9 @@ export class GitHubGitProvider implements GitProvider, Disposable {
 			// const stats = await workspace.fs.stat(uri);
 
 			result.push({
+				ref: ref,
+				oid: '',
 				path: this.getRelativePath(path, uri),
-				commitSha: ref,
 				size: 0, // stats?.size,
 				type: (type & FileType.Directory) === FileType.Directory ? 'tree' : 'blob',
 			});

--- a/src/quickpicks/revisionPicker.ts
+++ b/src/quickpicks/revisionPicker.ts
@@ -1,0 +1,58 @@
+// import path from "path";
+import type { Disposable, Uri } from "vscode";
+import { window } from "vscode";
+import { Container } from "../container";
+import type { GitUri } from "../git/gitUri";
+import { filterMap } from "../system/iterable";
+import { getQuickPickIgnoreFocusOut } from "../system/utils";
+
+export async function showRevisionPicker(
+	uri: GitUri,
+	options: {
+		title: string;
+		initialPath?: string;
+	},
+): Promise<Uri | undefined> {
+	const disposables: Disposable[] = [];
+	try {
+		const picker = window.createQuickPick();
+		picker.title = options.title;
+		picker.value = options.initialPath ?? uri.relativePath;
+		picker.placeholder = 'Enter path to file...';
+		picker.matchOnDescription = true;
+		picker.busy = true;
+		picker.ignoreFocusOut = getQuickPickIgnoreFocusOut();
+
+		picker.show();
+
+		const tree = await Container.instance.git.getTreeForRevision(uri.repoPath, uri.sha!);
+		picker.items = Array.from(filterMap(tree, file => {
+			// Exclude directories
+			if (file.type !== 'blob') { return null }
+			return { label: file.path }
+			// FIXME: Remove this unless we opt to show the directory in the description
+			// const parsed = path.parse(file.path)
+			// return { label: parsed.base, description: parsed.dir }
+		}))
+		picker.busy = false;
+
+		const pick = await new Promise<string | undefined>(resolve => {
+			disposables.push(
+				picker,
+				picker.onDidHide(() => resolve(undefined)),
+				picker.onDidAccept(() => {
+					if (picker.activeItems.length === 0) return;
+					resolve(picker.activeItems[0].label);
+				}),
+			);
+		});
+
+		return pick
+			? Container.instance.git.getRevisionUri(uri.sha!, `${uri.repoPath}/${pick}`, uri.repoPath!)
+			: undefined;
+	} finally {
+		disposables.forEach(d => {
+			d.dispose();
+		});
+	}
+}

--- a/src/system/path.ts
+++ b/src/system/path.ts
@@ -221,7 +221,7 @@ export function splitPath(
 	root: string | undefined,
 	splitOnBaseIfMissing: boolean = false,
 	ignoreCase?: boolean,
-): [string, string] {
+): [path: string, root: string] {
 	pathOrUri = getBestPath(pathOrUri);
 
 	if (root) {


### PR DESCRIPTION
# Description

Fixes #708 - Prompt for file path when missing from revision

Improves the `openFileAtRevision()` function by:
- Asking user to enter another path when the requested file doesn't exist in the
  selected revision.
- Showing an error message on subsequent failure (or if an error is thrown).

The above function is used by a number of commands:
- `gitlens.openFileRevision`
- `gitlens.openFileRevisionFrom`
- `gitlens.openRevisionFile`

# Checklist

<!-- Please check off the following -->

- [x] I have followed the guidelines in the Contributing document
- [x] My changes follow the coding style of this project
- [x] My changes build without any errors or warnings
- [x] My changes have been formatted and linted
- [x] My changes include any required corresponding changes to the documentation (including CHANGELOG.md and README.md)
- [x] My changes have been rebased and squashed to the minimal number (typically 1) of relevant commits
- [x] My changes have a descriptive commit message with a short title, including a `Fixes $XXX -` or `Closes #XXX -` prefix to auto-close the issue that your PR addresses
