### PR TITLE
Adds native Pull and Push implementations to experimental Native Git flag

### DIFF
--- a/src/constants.ts
+++ b/src/constants.ts
@@ -600,6 +600,7 @@ export type CoreGitConfiguration =
 	| 'git.enabled'
 	| 'git.fetchOnPull'
 	| 'git.path'
+	| 'git.pullTags'
 	| 'git.repositoryScanIgnoredFolders'
 	| 'git.repositoryScanMaxDepth'
 	| 'git.useForcePushWithLease';

--- a/src/env/node/git/git.ts
+++ b/src/env/node/git/git.ts
@@ -86,6 +86,7 @@ export const GitErrors = {
 	permissionDenied: /Permission.*denied/i,
 	pushRejected: /^error: failed to push some refs to\b/m,
 	rebaseMultipleBranches: /cannot rebase onto multiple branches/i,
+	remoteAhead: /rejected because the remote contains work/i,
 	remoteConnection: /Could not read from remote repository/i,
 	tagConflict: /! \[rejected\].*\(would clobber existing tag\)/m,
 	unmergedFiles: /is not possible because you have unmerged files/i,
@@ -929,7 +930,9 @@ export class Git {
 		} catch (ex) {
 			const msg: string = ex?.toString() ?? '';
 			let reason: PushErrorReason = PushErrorReason.Other;
-			if (GitWarnings.tipBehind.test(msg) || GitWarnings.tipBehind.test(ex.stderr ?? '')) {
+			if (GitErrors.remoteAhead.test(msg) || GitErrors.remoteAhead.test(ex.stderr ?? '')) {
+				reason = PushErrorReason.RemoteAhead;
+			} else if (GitWarnings.tipBehind.test(msg) || GitWarnings.tipBehind.test(ex.stderr ?? '')) {
 				reason = PushErrorReason.TipBehind;
 			} else if (GitErrors.pushRejected.test(msg) || GitErrors.pushRejected.test(ex.stderr ?? '')) {
 				reason = PushErrorReason.PushRejected;

--- a/src/env/node/git/git.ts
+++ b/src/env/node/git/git.ts
@@ -108,7 +108,7 @@ const GitWarnings = {
 	noRemoteRepositorySpecified: /No remote repository specified\./i,
 	remoteConnectionError: /Could not read from remote repository/i,
 	notAGitCommand: /'.+' is not a git command/i,
-	tipBehind: /is behind its remote counterpart/i,
+	tipBehind: /tip of your current branch is behind/i,
 };
 
 function defaultExceptionHandler(ex: Error, cwd: string | undefined, start?: [number, number]): string {
@@ -887,11 +887,14 @@ export class Git {
 		} catch (ex) {
 			const msg: string = ex?.toString() ?? '';
 			let reason: FetchErrorReason = FetchErrorReason.Other;
-			if (GitErrors.noFastForward.test(msg)) {
+			if (GitErrors.noFastForward.test(msg) || GitErrors.noFastForward.test(ex.stderr ?? '')) {
 				reason = FetchErrorReason.NoFastForward;
-			} else if (GitErrors.noRemoteRepositorySpecified.test(msg)) {
+			} else if (
+				GitErrors.noRemoteRepositorySpecified.test(msg) ||
+				GitErrors.noRemoteRepositorySpecified.test(ex.stderr ?? '')
+			) {
 				reason = FetchErrorReason.NoRemote;
-			} else if (GitErrors.remoteConnection.test(msg)) {
+			} else if (GitErrors.remoteConnection.test(msg) || GitErrors.remoteConnection.test(ex.stderr ?? '')) {
 				reason = FetchErrorReason.RemoteConnection;
 			}
 
@@ -926,15 +929,15 @@ export class Git {
 		} catch (ex) {
 			const msg: string = ex?.toString() ?? '';
 			let reason: PushErrorReason = PushErrorReason.Other;
-			if (GitWarnings.tipBehind.test(msg)) {
+			if (GitWarnings.tipBehind.test(msg) || GitWarnings.tipBehind.test(ex.stderr ?? '')) {
 				reason = PushErrorReason.TipBehind;
-			} else if (GitErrors.pushRejected.test(msg)) {
+			} else if (GitErrors.pushRejected.test(msg) || GitErrors.pushRejected.test(ex.stderr ?? '')) {
 				reason = PushErrorReason.PushRejected;
-			} else if (GitErrors.permissionDenied.test(msg)) {
+			} else if (GitErrors.permissionDenied.test(msg) || GitErrors.permissionDenied.test(ex.stderr ?? '')) {
 				reason = PushErrorReason.PermissionDenied;
-			} else if (GitErrors.remoteConnection.test(msg)) {
+			} else if (GitErrors.remoteConnection.test(msg) || GitErrors.remoteConnection.test(ex.stderr ?? '')) {
 				reason = PushErrorReason.RemoteConnection;
-			} else if (GitErrors.noUpstream.test(msg)) {
+			} else if (GitErrors.noUpstream.test(msg) || GitErrors.noUpstream.test(ex.stderr ?? '')) {
 				reason = PushErrorReason.NoUpstream;
 			}
 
@@ -966,25 +969,34 @@ export class Git {
 		} catch (ex) {
 			const msg: string = ex?.toString() ?? '';
 			let reason: PullErrorReason = PullErrorReason.Other;
-			if (GitErrors.conflict.test(msg)) {
+			if (GitErrors.conflict.test(msg) || GitErrors.conflict.test(ex.stdout ?? '')) {
 				reason = PullErrorReason.Conflict;
-			} else if (GitErrors.noUserNameConfigured.test(msg)) {
+			} else if (
+				GitErrors.noUserNameConfigured.test(msg) ||
+				GitErrors.noUserNameConfigured.test(ex.stderr ?? '')
+			) {
 				reason = PullErrorReason.GitIdentity;
-			} else if (GitErrors.remoteConnection.test(msg)) {
+			} else if (GitErrors.remoteConnection.test(msg) || GitErrors.remoteConnection.test(ex.stderr ?? '')) {
 				reason = PullErrorReason.RemoteConnection;
-			} else if (GitErrors.unstagedChanges.test(msg)) {
+			} else if (GitErrors.unstagedChanges.test(msg) || GitErrors.unstagedChanges.test(ex.stderr ?? '')) {
 				reason = PullErrorReason.UnstagedChanges;
-			} else if (GitErrors.unmergedFiles.test(msg)) {
+			} else if (GitErrors.unmergedFiles.test(msg) || GitErrors.unmergedFiles.test(ex.stderr ?? '')) {
 				reason = PullErrorReason.UnmergedFiles;
-			} else if (GitErrors.commitChangesFirst.test(msg)) {
+			} else if (GitErrors.commitChangesFirst.test(msg) || GitErrors.commitChangesFirst.test(ex.stderr ?? '')) {
 				reason = PullErrorReason.UncommittedChanges;
-			} else if (GitErrors.changesWouldBeOverwritten.test(msg)) {
+			} else if (
+				GitErrors.changesWouldBeOverwritten.test(msg) ||
+				GitErrors.changesWouldBeOverwritten.test(ex.stderr ?? '')
+			) {
 				reason = PullErrorReason.OverwrittenChanges;
-			} else if (GitErrors.cantLockRef.test(msg)) {
+			} else if (GitErrors.cantLockRef.test(msg) || GitErrors.cantLockRef.test(ex.stderr ?? '')) {
 				reason = PullErrorReason.RefLocked;
-			} else if (GitErrors.rebaseMultipleBranches.test(msg)) {
+			} else if (
+				GitErrors.rebaseMultipleBranches.test(msg) ||
+				GitErrors.rebaseMultipleBranches.test(ex.stderr ?? '')
+			) {
 				reason = PullErrorReason.RebaseMultipleBranches;
-			} else if (GitErrors.tagConflict.test(msg)) {
+			} else if (GitErrors.tagConflict.test(msg) || GitErrors.tagConflict.test(ex.stderr ?? '')) {
 				reason = PullErrorReason.TagConflict;
 			}
 

--- a/src/env/node/git/git.ts
+++ b/src/env/node/git/git.ts
@@ -971,7 +971,7 @@ export class Git {
 				outputReason = 'due to conflicts.';
 			} else if (GitErrors.noUserNameConfigured.test(msg)) {
 				outputReason = 'because you have not yet set up your Git identity.';
-			} else if (/Could not read from remote repository/.test(ex.stderr || '')) {
+			} else if (GitErrors.remoteConnection.test(msg)) {
 				outputReason = 'because the remote repository could not be reached.';
 			} else if (GitErrors.unstagedChanges.test(msg)) {
 				outputReason = 'because you have unstaged changes.';

--- a/src/env/node/git/git.ts
+++ b/src/env/node/git/git.ts
@@ -932,11 +932,7 @@ export class Git {
 			}
 
 			if (outputReason) {
-				void window.showErrorMessage(
-					`Unable to push ${options?.branch ?? 'the current branch'} ${outputReason}`,
-				);
-
-				return;
+				throw new Error(outputReason);
 			}
 
 			throw ex;
@@ -990,10 +986,7 @@ export class Git {
 			}
 
 			if (outputReason) {
-				void window.showErrorMessage(
-					`Unable to pull ${options.branch ?? 'the current branch'} ${outputReason}`,
-				);
-				return;
+				throw new Error(outputReason);
 			}
 
 			throw ex;

--- a/src/env/node/git/localGitProvider.ts
+++ b/src/env/node/git/localGitProvider.ts
@@ -1181,9 +1181,9 @@ export class LocalGitProvider implements GitProvider, Disposable {
 
 			this.container.events.fire('git:cache:reset', { repoPath: repoPath });
 		} catch (ex) {
+			Logger.error(ex, 'LocalGitProvider.fetch');
 			if (FetchError.is(ex)) {
 				void window.showErrorMessage(ex.message);
-				Logger.error(ex, 'LocalGitProvider.fetch');
 			} else {
 				throw ex;
 			}
@@ -1218,9 +1218,9 @@ export class LocalGitProvider implements GitProvider, Disposable {
 
 			this.container.events.fire('git:cache:reset', { repoPath: repoPath });
 		} catch (ex) {
+			Logger.error(ex, 'LocalGitProvider.push');
 			if (PushError.is(ex)) {
 				void window.showErrorMessage(ex.message);
-				Logger.error(ex, 'LocalGitProvider.push');
 			} else {
 				throw ex;
 			}
@@ -1252,9 +1252,9 @@ export class LocalGitProvider implements GitProvider, Disposable {
 
 			this.container.events.fire('git:cache:reset', { repoPath: repoPath });
 		} catch (ex) {
+			Logger.error(ex, 'LocalGitProvider.pull');
 			if (PullError.is(ex)) {
 				void window.showErrorMessage(ex.message);
-				Logger.error(ex, 'LocalGitProvider.pull');
 			} else {
 				throw ex;
 			}

--- a/src/git/errors.ts
+++ b/src/git/errors.ts
@@ -83,12 +83,13 @@ export class StashPushError extends Error {
 }
 
 export const enum PushErrorReason {
-	TipBehind = 1,
-	PushRejected = 2,
-	PermissionDenied = 3,
-	RemoteConnection = 4,
-	NoUpstream = 5,
-	Other = 6,
+	RemoteAhead = 1,
+	TipBehind = 2,
+	PushRejected = 3,
+	PermissionDenied = 4,
+	RemoteConnection = 5,
+	NoUpstream = 6,
+	Other = 7,
 }
 
 export class PushError extends Error {
@@ -118,6 +119,9 @@ export class PushError extends Error {
 		} else {
 			reason = messageOrReason;
 			switch (reason) {
+				case PushErrorReason.RemoteAhead:
+					message = `${baseMessage} because the remote contains work that you do not have locally. Try doing a fetch first.`;
+					break;
 				case PushErrorReason.TipBehind:
 					message = `${baseMessage} as it is behind its remote counterpart. Try doing a pull first.`;
 					break;

--- a/src/git/errors.ts
+++ b/src/git/errors.ts
@@ -82,6 +82,207 @@ export class StashPushError extends Error {
 	}
 }
 
+export const enum PushErrorReason {
+	TipBehind = 1,
+	PushRejected = 2,
+	PermissionDenied = 3,
+	RemoteConnection = 4,
+	NoUpstream = 5,
+	Other = 6,
+}
+
+export class PushError extends Error {
+	static is(ex: any, reason?: PushErrorReason): ex is PushError {
+		return ex instanceof PushError && (reason == null || ex.reason === reason);
+	}
+
+	readonly original?: Error;
+	readonly reason: PushErrorReason | undefined;
+
+	constructor(reason?: PushErrorReason, original?: Error, branch?: string, remote?: string);
+	constructor(message?: string, original?: Error);
+	constructor(
+		messageOrReason: string | PushErrorReason | undefined,
+		original?: Error,
+		branch?: string,
+		remote?: string,
+	) {
+		let message;
+		const baseMessage = `Unable to push${branch ? ` branch '${branch}'` : ''}${remote ? ` to ${remote}` : ''}`;
+		let reason: PushErrorReason | undefined;
+		if (messageOrReason == null) {
+			message = baseMessage;
+		} else if (typeof messageOrReason === 'string') {
+			message = messageOrReason;
+			reason = undefined;
+		} else {
+			reason = messageOrReason;
+			switch (reason) {
+				case PushErrorReason.TipBehind:
+					message = `${baseMessage} as it is behind its remote counterpart. Try doing a pull first.`;
+					break;
+				case PushErrorReason.PushRejected:
+					message = `${baseMessage} because some refs failed to push or the push was rejected.`;
+					break;
+				case PushErrorReason.PermissionDenied:
+					message = `${baseMessage} because you don't have permission to push to this remote repository.`;
+					break;
+				case PushErrorReason.RemoteConnection:
+					message = `${baseMessage} because the remote repository could not be reached.`;
+					break;
+				case PushErrorReason.NoUpstream:
+					message = `${baseMessage} because it has no upstream branch.`;
+					break;
+				default:
+					message = baseMessage;
+			}
+		}
+		super(message);
+
+		this.original = original;
+		this.reason = reason;
+		Error.captureStackTrace?.(this, PushError);
+	}
+}
+
+export const enum PullErrorReason {
+	Conflict = 1,
+	GitIdentity = 2,
+	RemoteConnection = 3,
+	UnstagedChanges = 4,
+	UnmergedFiles = 5,
+	UncommittedChanges = 6,
+	OverwrittenChanges = 7,
+	RefLocked = 8,
+	RebaseMultipleBranches = 9,
+	TagConflict = 10,
+	Other = 11,
+}
+
+export class PullError extends Error {
+	static is(ex: any, reason?: PullErrorReason): ex is PullError {
+		return ex instanceof PullError && (reason == null || ex.reason === reason);
+	}
+
+	readonly original?: Error;
+	readonly reason: PullErrorReason | undefined;
+
+	constructor(reason?: PullErrorReason, original?: Error, branch?: string, remote?: string);
+	constructor(message?: string, original?: Error);
+	constructor(
+		messageOrReason: string | PullErrorReason | undefined,
+		original?: Error,
+		branch?: string,
+		remote?: string,
+	) {
+		let message;
+		let reason: PullErrorReason | undefined;
+		const baseMessage = `Unable to pull${branch ? ` branch '${branch}'` : ''}${remote ? ` from ${remote}` : ''}`;
+		if (messageOrReason == null) {
+			message = 'Unable to pull';
+		} else if (typeof messageOrReason === 'string') {
+			message = messageOrReason;
+			reason = undefined;
+		} else {
+			reason = messageOrReason;
+			switch (reason) {
+				case PullErrorReason.Conflict:
+					message = `${baseMessage} due to conflicts.`;
+					break;
+				case PullErrorReason.GitIdentity:
+					message = `${baseMessage} because you have not yet set up your Git identity.`;
+					break;
+				case PullErrorReason.RemoteConnection:
+					message = `${baseMessage} because the remote repository could not be reached.`;
+					break;
+				case PullErrorReason.UnstagedChanges:
+					message = `${baseMessage} because you have unstaged changes.`;
+					break;
+				case PullErrorReason.UnmergedFiles:
+					message = `${baseMessage} because you have unmerged files.`;
+					break;
+				case PullErrorReason.UncommittedChanges:
+					message = `${baseMessage} because you have uncommitted changes.`;
+					break;
+				case PullErrorReason.OverwrittenChanges:
+					message = `${baseMessage} because local changes to some files would be overwritten.`;
+					break;
+				case PullErrorReason.RefLocked:
+					message = `${baseMessage} because a local ref could not be updated.`;
+					break;
+				case PullErrorReason.RebaseMultipleBranches:
+					message = `${baseMessage} because you are trying to rebase onto multiple branches.`;
+					break;
+				case PullErrorReason.TagConflict:
+					message = `${baseMessage} because a local tag would be overwritten.`;
+					break;
+				default:
+					message = baseMessage;
+			}
+		}
+		super(message);
+
+		this.original = original;
+		this.reason = reason;
+		Error.captureStackTrace?.(this, PullError);
+	}
+}
+
+export const enum FetchErrorReason {
+	NoFastForward = 1,
+	NoRemote = 2,
+	RemoteConnection = 3,
+	Other = 4,
+}
+
+export class FetchError extends Error {
+	static is(ex: any, reason?: FetchErrorReason): ex is FetchError {
+		return ex instanceof FetchError && (reason == null || ex.reason === reason);
+	}
+
+	readonly original?: Error;
+	readonly reason: FetchErrorReason | undefined;
+
+	constructor(reason?: FetchErrorReason, original?: Error, branch?: string, remote?: string);
+	constructor(message?: string, original?: Error);
+	constructor(
+		messageOrReason: string | FetchErrorReason | undefined,
+		original?: Error,
+		branch?: string,
+		remote?: string,
+	) {
+		let message;
+		const baseMessage = `Unable to fetch${branch ? ` branch '${branch}'` : ''}${remote ? ` from ${remote}` : ''}`;
+		let reason: FetchErrorReason | undefined;
+		if (messageOrReason == null) {
+			message = baseMessage;
+		} else if (typeof messageOrReason === 'string') {
+			message = messageOrReason;
+			reason = undefined;
+		} else {
+			reason = messageOrReason;
+			switch (reason) {
+				case FetchErrorReason.NoFastForward:
+					message = `${baseMessage} as it cannot be fast-forwarded`;
+					break;
+				case FetchErrorReason.NoRemote:
+					message = `${baseMessage} without a remote repository specified.`;
+					break;
+				case FetchErrorReason.RemoteConnection:
+					message = `${baseMessage}. Could not connect to the remote repository.`;
+					break;
+				default:
+					message = baseMessage;
+			}
+		}
+		super(message);
+
+		this.original = original;
+		this.reason = reason;
+		Error.captureStackTrace?.(this, FetchError);
+	}
+}
+
 export class WorkspaceUntrustedError extends Error {
 	constructor() {
 		super('Unable to perform Git operations because the current workspace is untrusted');

--- a/src/git/gitProvider.ts
+++ b/src/git/gitProvider.ts
@@ -163,6 +163,14 @@ export interface GitProvider extends Disposable {
 			remote?: string | undefined;
 		},
 	): Promise<void>;
+	push(
+		repoPath: string,
+		options?: {
+			branch?: GitBranchReference | undefined;
+			force?: boolean | undefined;
+			publish?: { remote: string };
+		},
+	): Promise<void>;
 	findRepositoryUri(uri: Uri, isDirectory?: boolean): Promise<Uri | undefined>;
 	getAheadBehindCommitCount(repoPath: string, refs: string[]): Promise<{ ahead: number; behind: number } | undefined>;
 	/**

--- a/src/git/gitProvider.ts
+++ b/src/git/gitProvider.ts
@@ -163,6 +163,14 @@ export interface GitProvider extends Disposable {
 			remote?: string | undefined;
 		},
 	): Promise<void>;
+	pull(
+		repoPath: string,
+		options?: {
+			branch?: GitBranchReference | undefined;
+			rebase?: boolean | undefined;
+			tags?: boolean | undefined;
+		},
+	): Promise<void>;
 	push(
 		repoPath: string,
 		options?: {

--- a/src/git/gitProviderService.ts
+++ b/src/git/gitProviderService.ts
@@ -1319,6 +1319,13 @@ export class GitProviderService implements Disposable {
 		);
 	}
 
+	@gate()
+	@log()
+	pull(repoPath: string, options?: { branch?: GitBranchReference; rebase?: boolean; tags?: boolean }): Promise<void> {
+		const { provider, path } = this.getProvider(repoPath);
+		return provider.push(path, options);
+	}
+
 	@gate<GitProviderService['pullAll']>(
 		(repos, opts) => `${repos == null ? '' : repos.map(r => r.id).join(',')}|${JSON.stringify(opts)}`,
 	)

--- a/src/git/gitProviderService.ts
+++ b/src/git/gitProviderService.ts
@@ -1344,6 +1344,16 @@ export class GitProviderService implements Disposable {
 		);
 	}
 
+	@gate()
+	@log()
+	push(
+		repoPath: string,
+		options?: { branch?: GitBranchReference; force?: boolean; publish?: { remote: string } },
+	): Promise<void> {
+		const { provider, path } = this.getProvider(repoPath);
+		return provider.push(path, options);
+	}
+
 	@gate<GitProviderService['pushAll']>(repos => `${repos == null ? '' : repos.map(r => r.id).join(',')}`)
 	@log<GitProviderService['pushAll']>({ args: { 0: repos => repos?.map(r => r.name).join(', ') } })
 	async pushAll(

--- a/src/git/gitProviderService.ts
+++ b/src/git/gitProviderService.ts
@@ -1323,7 +1323,7 @@ export class GitProviderService implements Disposable {
 	@log()
 	pull(repoPath: string, options?: { branch?: GitBranchReference; rebase?: boolean; tags?: boolean }): Promise<void> {
 		const { provider, path } = this.getProvider(repoPath);
-		return provider.push(path, options);
+		return provider.pull(path, options);
 	}
 
 	@gate<GitProviderService['pullAll']>(

--- a/src/git/models/branch.ts
+++ b/src/git/models/branch.ts
@@ -11,7 +11,7 @@ import type { RemoteProvider } from '../remotes/remoteProvider';
 import type { RichRemoteProvider } from '../remotes/richRemoteProvider';
 import type { PullRequest, PullRequestState } from './pullRequest';
 import type { GitBranchReference, GitReference } from './reference';
-import { shortenRevision } from './reference';
+import { getBranchTrackingWithoutRemote, shortenRevision } from './reference';
 import type { GitRemote } from './remote';
 import type { Repository } from './repository';
 import { getUpstreamStatus } from './status';
@@ -139,7 +139,7 @@ export class GitBranch implements GitBranchReference {
 
 	@memoize()
 	getTrackingWithoutRemote(): string | undefined {
-		return this.upstream?.name.substring(getRemoteNameSlashIndex(this.upstream.name) + 1);
+		return getBranchTrackingWithoutRemote(this);
 	}
 
 	@memoize()
@@ -220,7 +220,7 @@ export function formatDetachedHeadName(sha: string): string {
 	return `(${shortenRevision(sha)}...)`;
 }
 
-function getRemoteNameSlashIndex(name: string): number {
+export function getRemoteNameSlashIndex(name: string): number {
 	return name.startsWith('remotes/') ? name.indexOf('/', 8) : name.indexOf('/');
 }
 

--- a/src/git/models/reference.ts
+++ b/src/git/models/reference.ts
@@ -1,6 +1,11 @@
 import { GlyphChars } from '../../constants';
 import { configuration } from '../../system/configuration';
-import { getBranchNameWithoutRemote, getRemoteNameFromBranchName, splitBranchNameAndRemote } from './branch';
+import {
+	getBranchNameWithoutRemote,
+	getRemoteNameFromBranchName,
+	getRemoteNameSlashIndex,
+	splitBranchNameAndRemote,
+} from './branch';
 import { deletedOrMissing, uncommitted, uncommittedStaged } from './constants';
 
 const rangeRegex = /^(\S*?)(\.\.\.?)(\S*)\s*$/;
@@ -262,6 +267,10 @@ export function getNameWithoutRemote(ref: GitReference) {
 		return ref.remote ? getBranchNameWithoutRemote(ref.name) : ref.name;
 	}
 	return ref.name;
+}
+
+export function getBranchTrackingWithoutRemote(ref: GitBranchReference) {
+	return ref.upstream?.name.substring(getRemoteNameSlashIndex(ref.upstream.name) + 1);
 }
 
 export function isGitReference(ref: unknown): ref is GitReference {

--- a/src/git/models/repository.ts
+++ b/src/git/models/repository.ts
@@ -807,30 +807,6 @@ export class Repository implements Disposable {
 		}
 	}
 
-	@gate()
-	@log()
-	async push(options?: {
-		force?: boolean;
-		progress?: boolean;
-		reference?: GitReference;
-		publish?: {
-			remote: string;
-		};
-	}) {
-		const { progress, ...opts } = { progress: true, ...options };
-		if (!progress) return this.pushCore(opts);
-
-		return window.withProgress(
-			{
-				location: ProgressLocation.Notification,
-				title: isBranchReference(opts.reference)
-					? `${opts.publish != null ? 'Publishing ' : 'Pushing '}${opts.reference.name}...`
-					: `Pushing ${this.formattedName}...`,
-			},
-			() => this.pushCore(opts),
-		);
-	}
-
 	private async showCreatePullRequestPrompt(remoteName: string, branch: GitBranchReference) {
 		if (!this.container.actionRunners.count('createPullRequest')) return;
 		if (!(await showCreatePullRequestPrompt(branch.name))) return;
@@ -862,6 +838,30 @@ export class Repository implements Disposable {
 		});
 	}
 
+	@gate()
+	@log()
+	async push(options?: {
+		force?: boolean;
+		progress?: boolean;
+		reference?: GitReference;
+		publish?: {
+			remote: string;
+		};
+	}) {
+		const { progress, ...opts } = { progress: true, ...options };
+		if (!progress) return this.pushCore(opts);
+
+		return window.withProgress(
+			{
+				location: ProgressLocation.Notification,
+				title: isBranchReference(opts.reference)
+					? `${opts.publish != null ? 'Publishing ' : 'Pushing '}${opts.reference.name}...`
+					: `Pushing ${this.formattedName}...`,
+			},
+			() => this.pushCore(opts),
+		);
+	}
+
 	private async pushCore(options?: {
 		force?: boolean;
 		reference?: GitReference;
@@ -870,7 +870,14 @@ export class Repository implements Disposable {
 		};
 	}) {
 		try {
-			if (isBranchReference(options?.reference)) {
+			if (configuration.getAny('gitlens.experimental.nativeGit') === true) {
+				const branch = await this.getBranch(options?.reference?.name);
+				await this.container.git.push(this.path, {
+					force: options?.force,
+					branch: isBranchReference(options?.reference) ? options?.reference : branch,
+					...(options?.publish && { publish: options.publish }),
+				});
+			} else if (isBranchReference(options?.reference)) {
 				const repo = await this.container.git.getOrOpenScmRepository(this.path);
 				if (repo == null) return;
 

--- a/src/plus/github/githubGitProvider.ts
+++ b/src/plus/github/githubGitProvider.ts
@@ -487,6 +487,12 @@ export class GitHubGitProvider implements GitProvider, Disposable {
 	): Promise<void> {}
 
 	@log()
+	async pull(
+		_repoPath: string,
+		_options?: { branch?: GitBranchReference; rebase?: boolean; tags?: boolean },
+	): Promise<void> {}
+
+	@log()
 	async push(
 		_repoPath: string,
 		_options?: { branch?: GitBranchReference; force?: boolean; publish?: { remote: string } },

--- a/src/plus/github/githubGitProvider.ts
+++ b/src/plus/github/githubGitProvider.ts
@@ -486,6 +486,12 @@ export class GitHubGitProvider implements GitProvider, Disposable {
 		_options?: { all?: boolean; branch?: GitBranchReference; prune?: boolean; pull?: boolean; remote?: string },
 	): Promise<void> {}
 
+	@log()
+	async push(
+		_repoPath: string,
+		_options?: { branch?: GitBranchReference; force?: boolean; publish?: { remote: string } },
+	): Promise<void> {}
+
 	@gate()
 	@debug()
 	async findRepositoryUri(uri: Uri, _isDirectory?: boolean): Promise<Uri | undefined> {


### PR DESCRIPTION
Adds our own implementations of `pull` and `push` and puts them behind the `gitlens.experimental.nativeGit` flag.