### PR TITLE
Adds a "show only changed files" command to command palette and graph

### DIFF
--- a/package.json
+++ b/package.json
@@ -5280,8 +5280,8 @@
 				"category": "GitLens"
 			},
 			{
-				"command": "gitlens.showOnlyChangedFiles",
-				"title": "Show Only Changed Files",
+				"command": "gitlens.openOnlyChangedFiles",
+				"title": "Open Changed & Close Unchanged Files",
 				"category": "GitLens"
 			},
 			{
@@ -5873,8 +5873,8 @@
 				"category": "GitLens"
 			},
 			{
-				"command": "gitlens.views.showOnlyChangedFiles",
-				"title": "Show Only Changed Files",
+				"command": "gitlens.views.openOnlyChangedFiles",
+				"title": "Open Changed & Close Unchanged Files",
 				"category": "GitLens"
 			},
 			{
@@ -7459,8 +7459,8 @@
 				"category": "GitLens"
 			},
 			{
-				"command": "gitlens.graph.showOnlyChangedFiles",
-				"title": "Show Only Changed Files",
+				"command": "gitlens.graph.openOnlyChangedFiles",
+				"title": "Open Changed & Close Unchanged Files",
 				"category": "GitLens"
 			},
 			{
@@ -8401,7 +8401,7 @@
 					"when": "gitlens:enabled"
 				},
 				{
-					"command": "gitlens.showOnlyChangedFiles",
+					"command": "gitlens.openOnlyChangedFiles",
 					"when": "gitlens:enabled"
 				},
 				{
@@ -8781,7 +8781,7 @@
 					"when": "false"
 				},
 				{
-					"command": "gitlens.views.showOnlyChangedFiles",
+					"command": "gitlens.views.openOnlyChangedFiles",
 					"when": "false"
 				},
 				{
@@ -9877,7 +9877,7 @@
 					"when": "false"
 				},
 				{
-					"command": "gitlens.graph.showOnlyChangedFiles",
+					"command": "gitlens.graph.openOnlyChangedFiles",
 					"when": "false"
 				},
 				{
@@ -10409,7 +10409,7 @@
 					"group": "3_gitlens@2"
 				},
 				{
-					"command": "gitlens.showOnlyChangedFiles",
+					"command": "gitlens.openOnlyChangedFiles",
 					"when": "gitlens:enabled && scmProvider == git && scmResourceGroup =~ /^(workingTree|index)$/ && config.gitlens.menus.scmGroup.openClose",
 					"group": "3_gitlens@2"
 				}
@@ -13144,7 +13144,7 @@
 					"group": "2_gitlens@2"
 				},
 				{
-					"command": "gitlens.views.showOnlyChangedFiles",
+					"command": "gitlens.views.openOnlyChangedFiles",
 					"group": "2_gitlens@3"
 				}
 			],
@@ -13167,7 +13167,7 @@
 					"group": "2_gitlens@2"
 				},
 				{
-					"command": "gitlens.graph.showOnlyChangedFiles",
+					"command": "gitlens.graph.openOnlyChangedFiles",
 					"group": "2_gitlens@3"
 				}
 			],

--- a/package.json
+++ b/package.json
@@ -5280,6 +5280,11 @@
 				"category": "GitLens"
 			},
 			{
+				"command": "gitlens.showOnlyChangedFiles",
+				"title": "Show Only Changed Files",
+				"category": "GitLens"
+			},
+			{
 				"command": "gitlens.openBranchesOnRemote",
 				"title": "Open Branches on Remote",
 				"category": "GitLens",
@@ -5865,6 +5870,11 @@
 			{
 				"command": "gitlens.views.openChangedFileRevisions",
 				"title": "Open Files at Revision",
+				"category": "GitLens"
+			},
+			{
+				"command": "gitlens.views.showOnlyChangedFiles",
+				"title": "Show Only Changed Files",
 				"category": "GitLens"
 			},
 			{
@@ -7449,6 +7459,11 @@
 				"category": "GitLens"
 			},
 			{
+				"command": "gitlens.graph.showOnlyChangedFiles",
+				"title": "Show Only Changed Files",
+				"category": "GitLens"
+			},
+			{
 				"command": "gitlens.graph.addAuthor",
 				"title": "Add as Co-author",
 				"category": "GitLens",
@@ -8386,6 +8401,10 @@
 					"when": "gitlens:enabled"
 				},
 				{
+					"command": "gitlens.showOnlyChangedFiles",
+					"when": "gitlens:enabled"
+				},
+				{
 					"command": "gitlens.openBranchesOnRemote",
 					"when": "gitlens:hasRemotes"
 				},
@@ -8759,6 +8778,10 @@
 				},
 				{
 					"command": "gitlens.views.openChangedFileRevisions",
+					"when": "false"
+				},
+				{
+					"command": "gitlens.views.showOnlyChangedFiles",
 					"when": "false"
 				},
 				{
@@ -9854,6 +9877,10 @@
 					"when": "false"
 				},
 				{
+					"command": "gitlens.graph.showOnlyChangedFiles",
+					"when": "false"
+				},
+				{
 					"command": "gitlens.graph.addAuthor",
 					"when": "false"
 				},
@@ -10378,6 +10405,11 @@
 				},
 				{
 					"command": "gitlens.closeUnchangedFiles",
+					"when": "gitlens:enabled && scmProvider == git && scmResourceGroup =~ /^(workingTree|index)$/ && config.gitlens.menus.scmGroup.openClose",
+					"group": "3_gitlens@2"
+				},
+				{
+					"command": "gitlens.showOnlyChangedFiles",
 					"when": "gitlens:enabled && scmProvider == git && scmResourceGroup =~ /^(workingTree|index)$/ && config.gitlens.menus.scmGroup.openClose",
 					"group": "3_gitlens@2"
 				}
@@ -13110,6 +13142,10 @@
 				{
 					"command": "gitlens.views.openChangedFileRevisions",
 					"group": "2_gitlens@2"
+				},
+				{
+					"command": "gitlens.views.showOnlyChangedFiles",
+					"group": "2_gitlens@3"
 				}
 			],
 			"gitlens/graph/commit/changes": [
@@ -13129,6 +13165,10 @@
 				{
 					"command": "gitlens.graph.openChangedFileRevisions",
 					"group": "2_gitlens@2"
+				},
+				{
+					"command": "gitlens.graph.showOnlyChangedFiles",
+					"group": "2_gitlens@3"
 				}
 			],
 			"gitlens/commit/file/commit": [

--- a/src/commands.ts
+++ b/src/commands.ts
@@ -49,6 +49,7 @@ export * from './commands/resetViewsLayout';
 export * from './commands/searchCommits';
 export * from './commands/showCommitsInView';
 export * from './commands/showLastQuickPick';
+export * from './commands/showOnlyChangedFiles';
 export * from './commands/showQuickBranchHistory';
 export * from './commands/showQuickCommit';
 export * from './commands/showQuickCommitFile';

--- a/src/commands.ts
+++ b/src/commands.ts
@@ -49,7 +49,7 @@ export * from './commands/resetViewsLayout';
 export * from './commands/searchCommits';
 export * from './commands/showCommitsInView';
 export * from './commands/showLastQuickPick';
-export * from './commands/showOnlyChangedFiles';
+export * from './commands/openOnlyChangedFiles';
 export * from './commands/showQuickBranchHistory';
 export * from './commands/showQuickCommit';
 export * from './commands/showQuickCommitFile';

--- a/src/commands/openOnlyChangedFiles.ts
+++ b/src/commands/openOnlyChangedFiles.ts
@@ -11,27 +11,27 @@ import { Logger } from '../system/logger';
 import { findOrOpenEditors } from '../system/utils';
 import { Command } from './base';
 
-export interface ShowOnlyChangedFilesCommandArgs {
+export interface OpenOnlyChangedFilesCommandArgs {
 	uris?: Uri[];
 }
 
 @command()
-export class ShowOnlyChangedFilesCommand extends Command {
+export class OpenOnlyChangedFilesCommand extends Command {
 	constructor(private readonly container: Container) {
-		super(Commands.ShowOnlyChangedFiles);
+		super(Commands.OpenOnlyChangedFiles);
 	}
 
-	async execute(args?: ShowOnlyChangedFilesCommandArgs) {
+	async execute(args?: OpenOnlyChangedFilesCommandArgs) {
 		args = { ...args };
 
 		try {
 			if (args.uris == null) {
-				const repository = await getRepositoryOrShowPicker('Show Only Unchanged Files');
+				const repository = await getRepositoryOrShowPicker('Open Changed & Close Unchanged Files');
 				if (repository == null) return;
 
 				const status = await this.container.git.getStatusForRepo(repository.uri);
 				if (status == null) {
-					void window.showWarningMessage('Unable to show only changed files');
+					void window.showWarningMessage('Unable to open changed & close unchanged files');
 
 					return;
 				}
@@ -78,8 +78,8 @@ export class ShowOnlyChangedFilesCommand extends Command {
 				findOrOpenEditors([...openUris]);
 			}
 		} catch (ex) {
-			Logger.error(ex, 'ShowOnlyChangedFilesCommand');
-			void showGenericErrorMessage('Unable to show only changed files');
+			Logger.error(ex, 'OpenOnlyChangedFilesCommand');
+			void showGenericErrorMessage('Unable to open changed & close unchanged files');
 		}
 	}
 }

--- a/src/commands/quickCommand.steps.ts
+++ b/src/commands/quickCommand.steps.ts
@@ -63,7 +63,7 @@ import {
 	CommitOpenRevisionsCommandQuickPickItem,
 	CommitRestoreFileChangesCommandQuickPickItem,
 	OpenChangedFilesCommandQuickPickItem,
-	ShowOnlyChangedFilesCommandQuickPickItem,
+	OpenOnlyChangedFilesCommandQuickPickItem,
 } from '../quickpicks/items/commits';
 import type { QuickPickSeparator } from '../quickpicks/items/common';
 import { CommandQuickPickItem, createQuickPickSeparator } from '../quickpicks/items/common';
@@ -2388,7 +2388,7 @@ function getShowRepositoryStatusStepItems<
 		);
 
 		items.push(
-			new ShowOnlyChangedFilesCommandQuickPickItem(
+			new OpenOnlyChangedFilesCommandQuickPickItem(
 				computed.stagedAddsAndChanges.concat(computed.unstagedAddsAndChanges),
 			),
 		);
@@ -2402,8 +2402,8 @@ function getShowRepositoryStatusStepItems<
 		);
 
 		items.push(
-			new ShowOnlyChangedFilesCommandQuickPickItem(computed.stagedAddsAndChanges, {
-				label: '$(files) Show Only Staged Files',
+			new OpenOnlyChangedFilesCommandQuickPickItem(computed.stagedAddsAndChanges, {
+				label: '$(files) Open Only Staged Files',
 			}),
 		);
 	}
@@ -2416,8 +2416,8 @@ function getShowRepositoryStatusStepItems<
 		);
 
 		items.push(
-			new ShowOnlyChangedFilesCommandQuickPickItem(computed.unstagedAddsAndChanges, {
-				label: '$(files) Show Only Unstaged Files',
+			new OpenOnlyChangedFilesCommandQuickPickItem(computed.unstagedAddsAndChanges, {
+				label: '$(files) Open Only Unstaged Files',
 			}),
 		);
 	}

--- a/src/commands/quickCommand.steps.ts
+++ b/src/commands/quickCommand.steps.ts
@@ -63,6 +63,7 @@ import {
 	CommitOpenRevisionsCommandQuickPickItem,
 	CommitRestoreFileChangesCommandQuickPickItem,
 	OpenChangedFilesCommandQuickPickItem,
+	ShowOnlyChangedFilesCommandQuickPickItem,
 } from '../quickpicks/items/commits';
 import type { QuickPickSeparator } from '../quickpicks/items/common';
 import { CommandQuickPickItem, createQuickPickSeparator } from '../quickpicks/items/common';
@@ -2385,6 +2386,12 @@ function getShowRepositoryStatusStepItems<
 				computed.stagedAddsAndChanges.concat(computed.unstagedAddsAndChanges),
 			),
 		);
+
+		items.push(
+			new ShowOnlyChangedFilesCommandQuickPickItem(
+				computed.stagedAddsAndChanges.concat(computed.unstagedAddsAndChanges),
+			),
+		);
 	}
 
 	if (computed.staged > 0) {
@@ -2393,12 +2400,24 @@ function getShowRepositoryStatusStepItems<
 				label: '$(files) Open Staged Files',
 			}),
 		);
+
+		items.push(
+			new ShowOnlyChangedFilesCommandQuickPickItem(computed.stagedAddsAndChanges, {
+				label: '$(files) Show Only Staged Files',
+			}),
+		);
 	}
 
 	if (computed.unstaged > 0) {
 		items.push(
 			new OpenChangedFilesCommandQuickPickItem(computed.unstagedAddsAndChanges, {
 				label: '$(files) Open Unstaged Files',
+			}),
+		);
+
+		items.push(
+			new ShowOnlyChangedFilesCommandQuickPickItem(computed.unstagedAddsAndChanges, {
+				label: '$(files) Show Only Unstaged Files',
 			}),
 		);
 	}

--- a/src/commands/showOnlyChangedFiles.ts
+++ b/src/commands/showOnlyChangedFiles.ts
@@ -1,0 +1,85 @@
+import type { Uri } from 'vscode';
+import { TabInputCustom, TabInputNotebook, TabInputNotebookDiff, TabInputText, TabInputTextDiff, window } from 'vscode';
+import { Commands } from '../constants';
+import type { Container } from '../container';
+import { showGenericErrorMessage } from '../messages';
+import { getRepositoryOrShowPicker } from '../quickpicks/repositoryPicker';
+import { filterMap } from '../system/array';
+import { command } from '../system/command';
+import { UriComparer } from '../system/comparers';
+import { Logger } from '../system/logger';
+import { findOrOpenEditors } from '../system/utils';
+import { Command } from './base';
+
+export interface ShowOnlyChangedFilesCommandArgs {
+	uris?: Uri[];
+}
+
+@command()
+export class ShowOnlyChangedFilesCommand extends Command {
+	constructor(private readonly container: Container) {
+		super(Commands.ShowOnlyChangedFiles);
+	}
+
+	async execute(args?: ShowOnlyChangedFilesCommandArgs) {
+		args = { ...args };
+
+		try {
+			if (args.uris == null) {
+				const repository = await getRepositoryOrShowPicker('Show Only Unchanged Files');
+				if (repository == null) return;
+
+				const status = await this.container.git.getStatusForRepo(repository.uri);
+				if (status == null) {
+					void window.showWarningMessage('Unable to show only changed files');
+
+					return;
+				}
+
+				args.uris = filterMap(status.files, f => (f.status !== 'D' ? f.uri : undefined));
+			}
+
+			const hasNoChangedFiles = args.uris.length === 0;
+			const openUris = new Set(args.uris);
+			let inputUri: Uri | undefined = undefined;
+			let matchingUri: Uri | undefined;
+
+			for (const group of window.tabGroups.all) {
+				for (const tab of group.tabs) {
+					if (hasNoChangedFiles) {
+						void window.tabGroups.close(tab, true);
+						continue;
+					}
+
+					if (
+						tab.input instanceof TabInputText ||
+						tab.input instanceof TabInputCustom ||
+						tab.input instanceof TabInputNotebook
+					) {
+						inputUri = tab.input.uri;
+					} else if (tab.input instanceof TabInputTextDiff || tab.input instanceof TabInputNotebookDiff) {
+						inputUri = tab.input.modified;
+					} else {
+						inputUri = undefined;
+					}
+
+					if (inputUri == null) continue;
+					// eslint-disable-next-line no-loop-func
+					matchingUri = args.uris.find(uri => UriComparer.equals(uri, inputUri));
+					if (matchingUri != null) {
+						openUris.delete(matchingUri);
+					} else {
+						void window.tabGroups.close(tab, true);
+					}
+				}
+			}
+
+			if (openUris.size > 0) {
+				findOrOpenEditors([...openUris]);
+			}
+		} catch (ex) {
+			Logger.error(ex, 'ShowOnlyChangedFilesCommand');
+			void showGenericErrorMessage('Unable to show only changed files');
+		}
+	}
+}

--- a/src/constants.ts
+++ b/src/constants.ts
@@ -246,7 +246,7 @@ export const enum Commands {
 	ShowLastQuickPick = 'gitlens.showLastQuickPick',
 	ShowLineCommitInView = 'gitlens.showLineCommitInView',
 	ShowLineHistoryView = 'gitlens.showLineHistoryView',
-	ShowOnlyChangedFiles = 'gitlens.showOnlyChangedFiles',
+	OpenOnlyChangedFiles = 'gitlens.openOnlyChangedFiles',
 	ShowQuickBranchHistory = 'gitlens.showQuickBranchHistory',
 	ShowQuickCommit = 'gitlens.showQuickCommitDetails',
 	ShowQuickCommitFile = 'gitlens.showQuickCommitFileDetails',

--- a/src/constants.ts
+++ b/src/constants.ts
@@ -246,6 +246,7 @@ export const enum Commands {
 	ShowLastQuickPick = 'gitlens.showLastQuickPick',
 	ShowLineCommitInView = 'gitlens.showLineCommitInView',
 	ShowLineHistoryView = 'gitlens.showLineHistoryView',
+	ShowOnlyChangedFiles = 'gitlens.showOnlyChangedFiles',
 	ShowQuickBranchHistory = 'gitlens.showQuickBranchHistory',
 	ShowQuickCommit = 'gitlens.showQuickCommitDetails',
 	ShowQuickCommitFile = 'gitlens.showQuickCommitFileDetails',

--- a/src/git/actions/commit.ts
+++ b/src/git/actions/commit.ts
@@ -6,6 +6,7 @@ import type {
 	DiffWithWorkingCommandArgs,
 	OpenFileOnRemoteCommandArgs,
 	OpenWorkingFileCommandArgs,
+	ShowOnlyChangedFilesCommandArgs,
 	ShowQuickCommitCommandArgs,
 	ShowQuickCommitFileCommandArgs,
 } from '../../commands';
@@ -608,5 +609,24 @@ export async function showInCommitGraph(
 	void (await executeCommand<ShowInCommitGraphCommandArgs>(Commands.ShowInCommitGraph, {
 		ref: getReferenceFromRevision(commit),
 		preserveFocus: options?.preserveFocus,
+	}));
+}
+
+export async function showOnlyChangedFiles(commit: GitCommit): Promise<void> {
+	await commit.ensureFullDetails();
+
+	const files = commit.files ?? [];
+
+	if (files.length > 10) {
+		const result = await window.showWarningMessage(
+			`Are you sure you want to open all ${files.length} files?`,
+			{ title: 'Yes' },
+			{ title: 'No', isCloseAffordance: true },
+		);
+		if (result == null || result.title === 'No') return;
+	}
+
+	void (await executeCommand<ShowOnlyChangedFilesCommandArgs>(Commands.ShowOnlyChangedFiles, {
+		uris: files.filter(f => f.status !== 'D').map(f => f.uri),
 	}));
 }

--- a/src/git/actions/commit.ts
+++ b/src/git/actions/commit.ts
@@ -5,8 +5,8 @@ import type {
 	DiffWithPreviousCommandArgs,
 	DiffWithWorkingCommandArgs,
 	OpenFileOnRemoteCommandArgs,
+	OpenOnlyChangedFilesCommandArgs,
 	OpenWorkingFileCommandArgs,
-	ShowOnlyChangedFilesCommandArgs,
 	ShowQuickCommitCommandArgs,
 	ShowQuickCommitFileCommandArgs,
 } from '../../commands';
@@ -612,7 +612,7 @@ export async function showInCommitGraph(
 	}));
 }
 
-export async function showOnlyChangedFiles(commit: GitCommit): Promise<void> {
+export async function openOnlyChangedFiles(commit: GitCommit): Promise<void> {
 	await commit.ensureFullDetails();
 
 	const files = commit.files ?? [];
@@ -626,7 +626,7 @@ export async function showOnlyChangedFiles(commit: GitCommit): Promise<void> {
 		if (result == null || result.title === 'No') return;
 	}
 
-	void (await executeCommand<ShowOnlyChangedFilesCommandArgs>(Commands.ShowOnlyChangedFiles, {
+	void (await executeCommand<OpenOnlyChangedFilesCommandArgs>(Commands.OpenOnlyChangedFiles, {
 		uris: files.filter(f => f.status !== 'D').map(f => f.uri),
 	}));
 }

--- a/src/plus/webviews/graph/graphWebview.ts
+++ b/src/plus/webviews/graph/graphWebview.ts
@@ -23,8 +23,8 @@ import {
 	openAllChangesWithWorking,
 	openFiles,
 	openFilesAtRevision,
+	openOnlyChangedFiles as openOnlyChangedFilesForCommit,
 	showGraphDetailsView,
-	showOnlyChangedFiles as showOnlyChangedFilesForCommit,
 } from '../../../git/actions/commit';
 import * as ContributorActions from '../../../git/actions/contributor';
 import * as RepoActions from '../../../git/actions/repository';
@@ -448,7 +448,7 @@ export class GraphWebviewProvider implements WebviewProvider<State> {
 			registerCommand('gitlens.graph.copyDeepLinkToTag', this.copyDeepLinkToTag, this),
 
 			registerCommand('gitlens.graph.openChangedFiles', this.openFiles, this),
-			registerCommand('gitlens.graph.showOnlyChangedFiles', this.showOnlyChangedFiles, this),
+			registerCommand('gitlens.graph.openOnlyChangedFiles', this.openOnlyChangedFiles, this),
 			registerCommand('gitlens.graph.openChangedFileDiffs', this.openAllChanges, this),
 			registerCommand('gitlens.graph.openChangedFileDiffsWithWorking', this.openAllChangesWithWorking, this),
 			registerCommand('gitlens.graph.openChangedFileRevisions', this.openRevisions, this),
@@ -2635,11 +2635,11 @@ export class GraphWebviewProvider implements WebviewProvider<State> {
 	}
 
 	@debug()
-	private async showOnlyChangedFiles(item?: GraphItemContext) {
+	private async openOnlyChangedFiles(item?: GraphItemContext) {
 		const commit = await this.getCommitFromGraphItemRef(item);
 		if (commit == null) return;
 
-		return showOnlyChangedFilesForCommit(commit);
+		return openOnlyChangedFilesForCommit(commit);
 	}
 
 	@debug()

--- a/src/plus/webviews/graph/graphWebview.ts
+++ b/src/plus/webviews/graph/graphWebview.ts
@@ -24,6 +24,7 @@ import {
 	openFiles,
 	openFilesAtRevision,
 	showGraphDetailsView,
+	showOnlyChangedFiles as showOnlyChangedFilesForCommit,
 } from '../../../git/actions/commit';
 import * as ContributorActions from '../../../git/actions/contributor';
 import * as RepoActions from '../../../git/actions/repository';
@@ -447,6 +448,7 @@ export class GraphWebviewProvider implements WebviewProvider<State> {
 			registerCommand('gitlens.graph.copyDeepLinkToTag', this.copyDeepLinkToTag, this),
 
 			registerCommand('gitlens.graph.openChangedFiles', this.openFiles, this),
+			registerCommand('gitlens.graph.showOnlyChangedFiles', this.showOnlyChangedFiles, this),
 			registerCommand('gitlens.graph.openChangedFileDiffs', this.openAllChanges, this),
 			registerCommand('gitlens.graph.openChangedFileDiffsWithWorking', this.openAllChangesWithWorking, this),
 			registerCommand('gitlens.graph.openChangedFileRevisions', this.openRevisions, this),
@@ -2630,6 +2632,14 @@ export class GraphWebviewProvider implements WebviewProvider<State> {
 		if (commit == null) return;
 
 		return openFilesAtRevision(commit);
+	}
+
+	@debug()
+	private async showOnlyChangedFiles(item?: GraphItemContext) {
+		const commit = await this.getCommitFromGraphItemRef(item);
+		if (commit == null) return;
+
+		return showOnlyChangedFilesForCommit(commit);
 	}
 
 	@debug()

--- a/src/quickpicks/items/commits.ts
+++ b/src/quickpicks/items/commits.ts
@@ -1,5 +1,6 @@
 import type { QuickPickItem } from 'vscode';
 import { window } from 'vscode';
+import type { ShowOnlyChangedFilesCommandArgs } from '../../commands';
 import type { OpenChangedFilesCommandArgs } from '../../commands/openChangedFiles';
 import { RevealInSideBarQuickInputButton, ShowDetailsViewQuickInputButton } from '../../commands/quickCommand.buttons';
 import type { Keys } from '../../constants';
@@ -417,5 +418,15 @@ export class OpenChangedFilesCommandQuickPickItem extends CommandQuickPickItem {
 		};
 
 		super(item ?? '$(files) Open All Changed Files', Commands.OpenChangedFiles, [commandArgs]);
+	}
+}
+
+export class ShowOnlyChangedFilesCommandQuickPickItem extends CommandQuickPickItem {
+	constructor(files: GitStatusFile[], item?: QuickPickItem) {
+		const commandArgs: ShowOnlyChangedFilesCommandArgs = {
+			uris: files.map(f => f.uri),
+		};
+
+		super(item ?? '$(files) Show Only Changed Files', Commands.ShowOnlyChangedFiles, [commandArgs]);
 	}
 }

--- a/src/quickpicks/items/commits.ts
+++ b/src/quickpicks/items/commits.ts
@@ -1,6 +1,6 @@
 import type { QuickPickItem } from 'vscode';
 import { window } from 'vscode';
-import type { ShowOnlyChangedFilesCommandArgs } from '../../commands';
+import type { OpenOnlyChangedFilesCommandArgs } from '../../commands';
 import type { OpenChangedFilesCommandArgs } from '../../commands/openChangedFiles';
 import { RevealInSideBarQuickInputButton, ShowDetailsViewQuickInputButton } from '../../commands/quickCommand.buttons';
 import type { Keys } from '../../constants';
@@ -421,12 +421,12 @@ export class OpenChangedFilesCommandQuickPickItem extends CommandQuickPickItem {
 	}
 }
 
-export class ShowOnlyChangedFilesCommandQuickPickItem extends CommandQuickPickItem {
+export class OpenOnlyChangedFilesCommandQuickPickItem extends CommandQuickPickItem {
 	constructor(files: GitStatusFile[], item?: QuickPickItem) {
-		const commandArgs: ShowOnlyChangedFilesCommandArgs = {
+		const commandArgs: OpenOnlyChangedFilesCommandArgs = {
 			uris: files.map(f => f.uri),
 		};
 
-		super(item ?? '$(files) Show Only Changed Files', Commands.ShowOnlyChangedFiles, [commandArgs]);
+		super(item ?? '$(files) Open Changed & Close Unchanged Files', Commands.OpenOnlyChangedFiles, [commandArgs]);
 	}
 }


### PR DESCRIPTION
The new command can be accessed via the GitLens Command Palette: `GitLens: Show Only Changed Files` or on the context menu of the graph WIP node.

It simply combines the "open changed files" and "close unchanged files" commands into a single command for convenience.