### PR TITLE
Allows graph "reset to commit" context menu option on branch item

### DIFF
--- a/package.json
+++ b/package.json
@@ -6092,6 +6092,12 @@
 				"enablement": "!operationInProgress"
 			},
 			{
+				"command": "gitlens.views.resetToTip",
+				"title": "Reset Current Branch to Tip...",
+				"category": "GitLens",
+				"enablement": "!operationInProgress"
+			},
+			{
 				"command": "gitlens.views.revert",
 				"title": "Revert Commit...",
 				"category": "GitLens",
@@ -7315,6 +7321,12 @@
 			{
 				"command": "gitlens.graph.resetToCommit",
 				"title": "Reset Current Branch to Commit...",
+				"category": "GitLens",
+				"enablement": "!operationInProgress"
+			},
+			{
+				"command": "gitlens.graph.resetToTip",
+				"title": "Reset Current Branch to Tip...",
 				"category": "GitLens",
 				"enablement": "!operationInProgress"
 			},
@@ -8894,6 +8906,10 @@
 					"when": "false"
 				},
 				{
+					"command": "gitlens.views.resetToTip",
+					"when": "false"
+				},
+				{
 					"command": "gitlens.views.revert",
 					"when": "false"
 				},
@@ -9767,6 +9783,10 @@
 				},
 				{
 					"command": "gitlens.graph.resetToCommit",
+					"when": "false"
+				},
+				{
+					"command": "gitlens.graph.resetToTip",
 					"when": "false"
 				},
 				{
@@ -11560,6 +11580,11 @@
 					"group": "1_gitlens_actions@4"
 				},
 				{
+					"command": "gitlens.views.resetToTip",
+					"when": "!gitlens:readonly && !gitlens:untrusted && !gitlens:hasVirtualFolders && viewItem =~ /gitlens:branch\\b/",
+					"group": "1_gitlens_actions@4"
+				},
+				{
 					"command": "gitlens.views.resetCommit",
 					"when": "!gitlens:readonly && !gitlens:untrusted && !gitlens:hasVirtualFolders && viewItem =~ /gitlens:commit\\b/",
 					"group": "1_gitlens_actions@5"
@@ -12723,6 +12748,11 @@
 				{
 					"command": "gitlens.graph.resetToCommit",
 					"when": "!gitlens:readonly && !gitlens:untrusted && !gitlens:hasVirtualFolders && webviewItem =~ /gitlens:commit\\b/",
+					"group": "1_gitlens_actions@4"
+				},
+				{
+					"command": "gitlens.graph.resetToTip",
+					"when": "!gitlens:readonly && !gitlens:untrusted && !gitlens:hasVirtualFolders && webviewItem =~ /gitlens:branch\\b/",
 					"group": "1_gitlens_actions@4"
 				},
 				{

--- a/src/plus/webviews/graph/graphWebview.ts
+++ b/src/plus/webviews/graph/graphWebview.ts
@@ -379,6 +379,7 @@ export class GraphWebviewProvider implements WebviewProvider<State> {
 			registerCommand('gitlens.graph.rebaseOntoCommit', this.rebase, this),
 			registerCommand('gitlens.graph.resetCommit', this.resetCommit, this),
 			registerCommand('gitlens.graph.resetToCommit', this.resetToCommit, this),
+			registerCommand('gitlens.graph.resetToTip', this.resetToTip, this),
 			registerCommand('gitlens.graph.revert', this.revertCommit, this),
 			registerCommand('gitlens.graph.switchToCommit', this.switchTo, this),
 			registerCommand('gitlens.graph.undoCommit', this.undoCommit, this),
@@ -2360,6 +2361,17 @@ export class GraphWebviewProvider implements WebviewProvider<State> {
 		if (ref == null) return Promise.resolve();
 
 		return RepoActions.reset(ref.repoPath, ref);
+	}
+
+	@debug()
+	private resetToTip(item?: GraphItemContext) {
+		const ref = this.getGraphItemRef(item, 'branch');
+		if (ref == null) return Promise.resolve();
+
+		return RepoActions.reset(
+			ref.repoPath,
+			createReference(ref.ref, ref.repoPath, { refType: 'revision', name: ref.name }),
+		);
 	}
 
 	@debug()

--- a/src/views/viewCommands.ts
+++ b/src/views/viewCommands.ts
@@ -279,6 +279,7 @@ export class ViewCommands {
 
 		registerViewCommand('gitlens.views.resetCommit', this.resetCommit, this);
 		registerViewCommand('gitlens.views.resetToCommit', this.resetToCommit, this);
+		registerViewCommand('gitlens.views.resetToTip', this.resetToTip, this);
 		registerViewCommand('gitlens.views.revert', this.revert, this);
 		registerViewCommand('gitlens.views.undoCommit', this.undoCommit, this);
 
@@ -722,6 +723,16 @@ export class ViewCommands {
 		if (!(node instanceof CommitNode) && !(node instanceof FileRevisionAsCommitNode)) return Promise.resolve();
 
 		return RepoActions.reset(node.repoPath, node.ref);
+	}
+
+	@debug()
+	private resetToTip(node: BranchNode) {
+		if (!(node instanceof BranchNode)) return Promise.resolve();
+
+		return RepoActions.reset(
+			node.repoPath,
+			createReference(node.ref.ref, node.repoPath, { refType: 'revision', name: node.ref.name }),
+		);
 	}
 
 	@debug()


### PR DESCRIPTION
"Reset Current Branch to Commit..." context menu option in the graph would previously only appear when you were over a commit, rather than a branch.

This tiny change allows the option to appear on the context menu of a branch label in the graph, and should reset to the commit that branch is pointing to.