### PR TITLE
Fixes #1651 - search & compare opens file instead of diff

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,11 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/) and this p
 
 ## [Unreleased]
 
+### Changed
+
+- Changes _Search & Compare_ to default to open file instead of diff
+  - Closes [#1651](https://github.com/gitkraken/vscode-gitlens/issues/1651)
+
 ## [14.2.0] - 2023-08-04
 
 ### Added

--- a/README.md
+++ b/README.md
@@ -422,6 +422,7 @@ A big thanks to the people that have contributed to this project 🙏❤️:
 - Zyck ([@qzyse2017](https://github.com/qzyse2017)) &mdash; [contributions](https://github.com/gitkraken/vscode-gitlens/commits?author=qzyse2017)
 - Yonatan Greenfeld ([@YonatanGreenfeld](https://github.com/YonatanGreenfeld)) &mdash; [contributions](https://github.com/gitkraken/vscode-gitlens/commits?author=YonatanGreenfeld)
 - WofWca ([@WofWca](https://github.com/WofWca)) &mdash; [contributions](https://github.com/gitkraken/vscode-gitlens/commits?author=WofWca)
+- Svaught598 ([@Svaught598](https://github.com/svaught598)) &mdash; [contributions](https://github.com/gitkraken/vscode-gitlens/commits?author=Svaught598)
 
 Also special thanks to the people that have provided support, testing, brainstorming, etc:
 

--- a/src/views/nodes/commitFileNode.ts
+++ b/src/views/nodes/commitFileNode.ts
@@ -1,6 +1,6 @@
 import type { Command, Selection } from 'vscode';
 import { MarkdownString, TreeItem, TreeItemCollapsibleState, Uri } from 'vscode';
-import type { DiffWithPreviousCommandArgs } from '../../commands';
+import type { OpenFileAtRevisionCommandArgs } from '../../commands';
 import { Commands, Schemes } from '../../constants';
 import { StatusFileFormatter } from '../../git/formatters/statusFormatter';
 import { GitUri } from '../../git/gitUri';
@@ -161,26 +161,14 @@ export class CommitFileNode<
 	}
 
 	override getCommand(): Command | undefined {
-		let line;
-		if (this.commit.lines.length) {
-			line = this.commit.lines[0].line - 1;
-		} else {
-			line = this._options.selection?.active.line ?? 0;
-		}
-
-		const commandArgs: DiffWithPreviousCommandArgs = {
-			commit: this.commit,
-			uri: GitUri.fromFile(this.file, this.commit.repoPath),
-			line: line,
-			showOptions: {
-				preserveFocus: true,
-				preview: true,
-			},
+		const commandArgs: OpenFileAtRevisionCommandArgs = {
+			revisionUri: GitUri.fromFile(this.file, this.uri.repoPath!, this.ref.ref),
 		};
+
 		return {
-			title: 'Open Changes with Previous Revision',
-			command: Commands.DiffWithPrevious,
-			arguments: [undefined, commandArgs],
+			title: 'Open File',
+			command: Commands.OpenFileAtRevision,
+			arguments: [commandArgs],
 		};
 	}
 }


### PR DESCRIPTION

# Description

Closes #1651. Instead of opening a diff from the _Search & Compare_ view, this opens the current revision's file.

The use case seems to be setting a up the workspace, so line numbers seem to be inconsequential here. Can definitely put that back in if it's needed.

# Checklist

<!-- Please check off the following -->

- [x] I have followed the guidelines in the Contributing document
- [x] My changes follow the coding style of this project
- [x] My changes build without any errors or warnings
- [x] My changes have been formatted and linted
- [x] My changes include any required corresponding changes to the documentation (including CHANGELOG.md and README.md)
- [x] My changes have been rebased and squashed to the minimal number (typically 1) of relevant commits
- [x] My changes have a descriptive commit message with a short title, including a `Fixes $XXX -` or `Closes #XXX -` prefix to auto-close the issue that your PR addresses
