### PR TITLE
Changes description of "open-source" to "source-available"

### DIFF
--- a/LICENSE.plus
+++ b/LICENSE.plus
@@ -5,7 +5,7 @@ Copyright (c) 2021-2023 Axosoft, LLC dba GitKraken ("GitKraken")
 With regard to the software set forth in or under any directory named "plus".
 
 This software and associated documentation files (the "Software") may be
-compiled as part of the gitkraken/vscode-gitlens open source project (the
+compiled as part of the gitkraken/vscode-gitlens source-available project (the
 "GitLens") to the extent the Software is a required component of the GitLens;
 provided, however, that the Software and its functionality may only be used if
 you (and any entity that you represent) have agreed to, and are in compliance

--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 > Supercharge Git and unlock **untapped knowledge** within your repository to better **understand**, **write**, and **review** code. Focus, collaborate, accelerate.
 
-[GitLens](https://gitkraken.com/gitlens?utm_source=gitlens-extension&utm_medium=in-app-links&utm_campaign=gitlens-logo-links 'Learn more about GitLens') is a powerful [open-source](https://github.com/gitkraken/vscode-gitlens 'Open GitLens on GitHub') extension for [Visual Studio Code](https://code.visualstudio.com).
+[GitLens](https://gitkraken.com/gitlens?utm_source=gitlens-extension&utm_medium=in-app-links&utm_campaign=gitlens-logo-links 'Learn more about GitLens') is a powerful [source-available](https://github.com/gitkraken/vscode-gitlens 'Open GitLens on GitHub') extension for [Visual Studio Code](https://code.visualstudio.com).
 
 GitLens supercharges your Git experience in VS Code. Maintaining focus is critical, extra time spent context switching or missing context disrupts your flow. GitLens is the ultimate tool for making Git work for you, designed to improve focus, productivity, and collaboration with a powerful set of tools to help you and your team better understand, write, and review code.
 
@@ -304,7 +304,7 @@ With GitLens Pro, you gain access to priority email support from our customer su
 
 # Contributing
 
-GitLens is an open-source project that greatly benefits from the contributions and feedback from its community.
+GitLens is a source-available project that greatly benefits from the contributions and feedback from its community.
 
 Your contributions, feedback, and engagement in the GitLens community are invaluable, and play a significant role in shaping the future of GitLens. Thank you for your support!
 

--- a/src/plus/LICENSE.plus
+++ b/src/plus/LICENSE.plus
@@ -5,7 +5,7 @@ Copyright (c) 2021-2023 Axosoft, LLC dba GitKraken ("GitKraken")
 With regard to the software set forth in or under any directory named "plus".
 
 This software and associated documentation files (the "Software") may be
-compiled as part of the gitkraken/vscode-gitlens open source project (the
+compiled as part of the gitkraken/vscode-gitlens source-available project (the
 "GitLens") to the extent the Software is a required component of the GitLens;
 provided, however, that the Software and its functionality may only be used if
 you (and any entity that you represent) have agreed to, and are in compliance

--- a/src/webviews/apps/plus/LICENSE.plus
+++ b/src/webviews/apps/plus/LICENSE.plus
@@ -5,7 +5,7 @@ Copyright (c) 2021-2023 Axosoft, LLC dba GitKraken ("GitKraken")
 With regard to the software set forth in or under any directory named "plus".
 
 This software and associated documentation files (the "Software") may be
-compiled as part of the gitkraken/vscode-gitlens open source project (the
+compiled as part of the gitkraken/vscode-gitlens source-available project (the
 "GitLens") to the extent the Software is a required component of the GitLens;
 provided, however, that the Software and its functionality may only be used if
 you (and any entity that you represent) have agreed to, and are in compliance


### PR DESCRIPTION
# Description

The [LICENSE.plus](https://github.com/gitkraken/vscode-gitlens/blob/main/LICENSE.plus) license is [clearly](https://fossid.com/blog/source-available-101-how-to-counter-this-confusing-license-category/) [not](https://fauxpensource.org/) [an](https://opensource.com/article/21/11/open-core-vs-open-source) [open-source license](https://opensource.org/osd/). Therefore GitLens, as a whole, is not an open-source project. This patch corrects the misleading descriptions. (An alternative description would be "proprietary".)

# Checklist

<!-- Please check off the following -->

- [x] I have followed the guidelines in the Contributing document
- [x] My changes follow the coding style of this project
- [x] My changes build without any errors or warnings
- [x] My changes have been formatted and linted
- [x] My changes include any required corresponding changes to the documentation (including CHANGELOG.md and README.md)
- [x] My changes have been rebased and squashed to the minimal number (typically 1) of relevant commits
- [x] My changes have a descriptive commit message with a short title, including a `Fixes $XXX -` or `Closes #XXX -` prefix to auto-close the issue that your PR addresses
