### PR TITLE
2880 Deep Link Bug: When opening vscode as a part of a deep link, sometimes it asks to manually open a repo even if it's already open

### DIFF
--- a/src/git/gitProviderService.ts
+++ b/src/git/gitProviderService.ts
@@ -582,6 +582,9 @@ export class GitProviderService implements Disposable {
 	private _discoveredWorkspaceFolders = new Map<WorkspaceFolder, Promise<Repository[]>>();
 
 	private _isDiscoveringRepositories: Promise<void> | undefined;
+	get isDiscoveringRepositories(): Promise<void> | undefined {
+		return this._isDiscoveringRepositories;
+	}
 
 	@log<GitProviderService['discoverRepositories']>({ args: { 0: folders => folders.length } })
 	async discoverRepositories(folders: readonly WorkspaceFolder[], options?: { force?: boolean }): Promise<void> {

--- a/src/uris/deepLinks/deepLinkService.ts
+++ b/src/uris/deepLinks/deepLinkService.ts
@@ -44,6 +44,10 @@ export class DeepLinkService implements Disposable {
 				if (link == null) return;
 
 				if (this._context.state === DeepLinkServiceState.Idle) {
+					if (this.container.git.isDiscoveringRepositories) {
+						await this.container.git.isDiscoveringRepositories;
+					}
+
 					if (!link.type || (!link.repoId && !link.remoteUrl && !link.repoPath)) {
 						void window.showErrorMessage('Unable to resolve link');
 						Logger.warn(`Unable to resolve link - missing basic properties: ${uri.toString()}`);
@@ -125,6 +129,10 @@ export class DeepLinkService implements Disposable {
 		this.setContextFromDeepLink(link, pendingDeepLink.url);
 
 		let action = DeepLinkServiceAction.OpenRepo;
+
+		if (this.container.git.isDiscoveringRepositories) {
+			await this.container.git.isDiscoveringRepositories;
+		}
 
 		if (pendingDeepLink.repoPath != null) {
 			const repoOpenUri = Uri.parse(pendingDeepLink.repoPath);


### PR DESCRIPTION
Fixes #2880

When opening a deep link to GitLens requires VS Code to open, the deep link service enters a race condition with the git provider service on repo discovery. If the deep link service starts checking for a repo match before the git provider service has had a chance to finish at least some form of repo discovery, you can get situations where the correct repo is already open in the workspace but the service doesn't know it exists, so it asks for the user to manually open it.

This workaround exposes the `isDiscoveringRepositories` promise that the git provider service was previously using internally, and simply has the deep link service wait for it when processing a link.

Ideally the git provider service would expose its repo discovery and workspace folder knowledge in a more robust way (and I'm open to suggestions for building a broader system like that, hence this PR), but this should at least put a dent in the issue if deep links on open are the only place where it's a problem.