### PR TITLE
Hooks deep link service into local repo path mapping

### DIFF
--- a/src/uris/deepLinks/deepLink.ts
+++ b/src/uris/deepLinks/deepLink.ts
@@ -129,6 +129,7 @@ export const enum DeepLinkServiceAction {
 	DeepLinkStored,
 	DeepLinkErrored,
 	OpenRepo,
+	RepoMatchedInLocalMapping,
 	RepoMatchedWithId,
 	RepoMatchedWithPath,
 	RepoMatchedWithRemoteUrl,
@@ -148,6 +149,7 @@ export const enum DeepLinkRepoOpenType {
 	Clone = 'clone',
 	Folder = 'folder',
 	Workspace = 'workspace',
+	Current = 'current',
 }
 
 export interface DeepLinkServiceContext {
@@ -174,6 +176,7 @@ export const deepLinkStateTransitionTable: Record<string, Record<string, DeepLin
 		[DeepLinkServiceAction.RepoMatchedWithId]: DeepLinkServiceState.RemoteMatch,
 		[DeepLinkServiceAction.RepoMatchedWithPath]: DeepLinkServiceState.TargetMatch,
 		[DeepLinkServiceAction.RepoMatchedWithRemoteUrl]: DeepLinkServiceState.TargetMatch,
+		[DeepLinkServiceAction.RepoMatchedInLocalMapping]: DeepLinkServiceState.CloneOrAddRepo,
 		[DeepLinkServiceAction.RepoMatchFailed]: DeepLinkServiceState.CloneOrAddRepo,
 	},
 	[DeepLinkServiceState.CloneOrAddRepo]: {


### PR DESCRIPTION
Fixes #2891

Previously, the deep link service was not leveraging the repo path mapping file, so when you choose a location of a repo it is not saved to the mapping file, and when matching a repo for a deep link it does not try looking up the path in the mapping file.

In this PR:

- After choosing a location for a repo, it is saved to the mapping file for that remote url.
- When opening the deep link, we check the path mapping file if other forms of repo matching fail, and if matches are found, we show them in a quickpick and let the user either choose a path from the list or 'choose a different location' which reverts to manual choice.