### PR TITLE
Improve comparison deep link processing from PRs

### DIFF
--- a/src/uris/deepLinks/deepLinkService.ts
+++ b/src/uris/deepLinks/deepLinkService.ts
@@ -171,14 +171,20 @@ export class DeepLinkService implements Disposable {
 		}
 
 		// If that fails, try matching to any existing remote using its path.
-		if (targetId.includes('/')) {
-			const remotes = await repo.getRemotes();
-			for (const remote of remotes) {
-				if (remote.provider?.owner != null && targetId.startsWith(`${remote.provider.owner}/`)) {
-					branchName = targetId.replace(`${remote.provider.owner}/`, `${remote.name}/`);
-					branch = await repo.getBranch(branchName);
-					if (branch?.sha != null) {
-						return branch.sha;
+		if (targetId.includes(':')) {
+			const [providerRepoInfo, branchBaseName] = targetId.split(':');
+			if (providerRepoInfo != null && branchName != null) {
+				const [owner, repoName] = providerRepoInfo.split('/');
+				if (owner != null && repoName != null) {
+					const remotes = await repo.getRemotes();
+					for (const remote of remotes) {
+						if (remote.provider?.owner === owner) {
+							branchName = `${remote.name}/${branchBaseName}`;
+							branch = await repo.getBranch(branchName);
+							if (branch?.sha != null) {
+								return branch.sha;
+							}
+						}
 					}
 				}
 			}


### PR DESCRIPTION
Fixes #2893

This PR achieves three main improvements to deep link processing for comparison links from PRs (using the web extension):

1. It now also considers the PR remote url in addition to the base url (the base url is the URL of the remote of the branch being merged, and the PR remote url is the url of the remote of the branch being merged into) for remote matching. If you are missing either remote, it offers the ability to add that remote.
2. It now supports branches that use the owner as the remote name. For example, if my branch name was `axosoft-ramint/main`, the matching branch may be `origin/main`. Previously we could not determine that this is the ref we really want; now it tries remote owner matching to resolve to the correct ref/sha.
3. We were doing a hacky workaround in the service by storing ref names as shas - the code was refactored to properly separate sha from id for a ref/target.