### PR TITLE
Fix focus before show quick commit popup

### DIFF
--- a/src/commands/showQuickCommit.ts
+++ b/src/commands/showQuickCommit.ts
@@ -12,7 +12,7 @@ import {
 	showGenericErrorMessage,
 	showLineUncommittedWarningMessage,
 } from '../messages';
-import { command } from '../system/command';
+import { command, executeCoreCommand } from '../system/command';
 import { Logger } from '../system/logger';
 import type { CommandContext } from './base';
 import { ActiveEditorCachedCommand, getCommandUri, isCommandContextViewNodeHasCommit } from './base';
@@ -148,6 +148,7 @@ export class ShowQuickCommitCommand extends ActiveEditorCachedCommand {
 				return;
 			}
 
+			await executeCoreCommand('workbench.action.focusActiveEditorGroup');
 			await executeGitCommand({
 				command: 'show',
 				state: {

--- a/src/commands/showQuickCommitFile.ts
+++ b/src/commands/showQuickCommitFile.ts
@@ -13,7 +13,7 @@ import {
 	showGenericErrorMessage,
 	showLineUncommittedWarningMessage,
 } from '../messages';
-import { command, executeCommand } from '../system/command';
+import { command, executeCommand, executeCoreCommand } from '../system/command';
 import { Logger } from '../system/logger';
 import type { CommandContext } from './base';
 import { ActiveEditorCachedCommand, getCommandUri, isCommandContextViewNodeHasCommit } from './base';
@@ -157,6 +157,7 @@ export class ShowQuickCommitFileCommand extends ActiveEditorCachedCommand {
 					repoPath: args.commit.repoPath,
 				});
 			} else {
+				await executeCoreCommand('workbench.action.focusActiveEditorGroup');
 				await executeGitCommand({
 					command: 'show',
 					state: {

--- a/src/constants.ts
+++ b/src/constants.ts
@@ -565,6 +565,7 @@ export type CoreCommands =
 	| 'workbench.action.closeActiveEditor'
 	| 'workbench.action.closeAllEditors'
 	| 'workbench.action.closePanel'
+	| 'workbench.action.focusActiveEditorGroup'
 	| 'workbench.action.nextEditor'
 	| 'workbench.action.openWalkthrough'
 	| 'workbench.action.toggleMaximizedPanel'


### PR DESCRIPTION

# Description
Fix https://github.com/gitkraken/vscode-gitlens/issues/2906

Because quick commit popup show when click A tag on hovering line popup, vscode do not know what should be focus. So we need hide hovering line popup before show quick commit popup.
<!--
Please include a summary of the changes and which issue will be addressed. Please also include relevant motivation and context.
-->

# Checklist

<!-- Please check off the following -->

- [x] I have followed the guidelines in the Contributing document
- [x] My changes follow the coding style of this project
- [x] My changes build without any errors or warnings
- [x] My changes have been formatted and linted
- [x] My changes include any required corresponding changes to the documentation (including CHANGELOG.md and README.md)
- [x] My changes have been rebased and squashed to the minimal number (typically 1) of relevant commits
- [x] My changes have a descriptive commit message with a short title, including a `Fixes $XXX -` or `Closes #XXX -` prefix to auto-close the issue that your PR addresses
