### PR TITLE
Adds workspace deep link support

### DIFF
--- a/package.json
+++ b/package.json
@@ -5394,6 +5394,12 @@
 				"icon": "$(copy)"
 			},
 			{
+				"command": "gitlens.copyDeepLinkToWorkspace",
+				"title": "Copy Link to Workspace",
+				"category": "GitLens",
+				"icon": "$(copy)"
+			},
+			{
 				"command": "gitlens.copyDeepLinkToTag",
 				"title": "Copy Link to Tag",
 				"category": "GitLens",
@@ -8535,6 +8541,10 @@
 				},
 				{
 					"command": "gitlens.copyDeepLinkToTag",
+					"when": "false"
+				},
+				{
+					"command": "gitlens.copyDeepLinkToWorkspace",
 					"when": "false"
 				},
 				{
@@ -11759,7 +11769,7 @@
 				},
 				{
 					"submenu": "gitlens/share",
-					"when": "viewItem =~ /gitlens:(branch|commit|compare:results(?!:)|remote|repo-folder|repository|stash|tag|file\\b(?=.*?\\b\\+committed\\b))\\b/",
+					"when": "viewItem =~ /gitlens:(branch|commit|compare:results(?!:)|remote|repo-folder|repository|stash|tag|workspace|file\\b(?=.*?\\b\\+committed\\b))\\b/",
 					"group": "7_gitlens_a_share@1"
 				},
 				{
@@ -13183,6 +13193,11 @@
 				{
 					"command": "gitlens.copyDeepLinkToComparison",
 					"when": "viewItem =~ /gitlens:compare:results(?!:)\\b/",
+					"group": "1_gitlens@25"
+				},
+				{
+					"command": "gitlens.copyDeepLinkToWorkspace",
+					"when": "viewItem =~ /gitlens:workspace\\b/",
 					"group": "1_gitlens@25"
 				},
 				{

--- a/src/commands/base.ts
+++ b/src/commands/base.ts
@@ -21,6 +21,7 @@ import { GitRemote } from '../git/models/remote';
 import { Repository } from '../git/models/repository';
 import type { GitTag } from '../git/models/tag';
 import { isTag } from '../git/models/tag';
+import { CloudWorkspace, LocalWorkspace } from '../plus/workspaces/models';
 import { registerCommand } from '../system/command';
 import { sequentialize } from '../system/function';
 import { ViewNode, ViewRefFileNode, ViewRefNode } from '../views/nodes/viewNode';
@@ -210,6 +211,14 @@ export function isCommandContextViewNodeHasTag(
 	if (context.type !== 'viewItem') return false;
 
 	return isTag((context.node as ViewNode & { tag: GitTag }).tag);
+}
+
+export function isCommandContextViewNodeHasWorkspace(
+	context: CommandContext,
+): context is CommandViewNodeContext & { node: ViewNode & { workspace: CloudWorkspace | LocalWorkspace } } {
+	if (context.type !== 'viewItem') return false;
+	const workspace = (context.node as ViewNode & { workspace?: CloudWorkspace | LocalWorkspace }).workspace;
+	return workspace instanceof CloudWorkspace || workspace instanceof LocalWorkspace;
 }
 
 export type CommandContext =

--- a/src/commands/copyDeepLink.ts
+++ b/src/commands/copyDeepLink.ts
@@ -20,6 +20,7 @@ import {
 	isCommandContextViewNodeHasComparison,
 	isCommandContextViewNodeHasRemote,
 	isCommandContextViewNodeHasTag,
+	isCommandContextViewNodeHasWorkspace,
 } from './base';
 
 export interface CopyDeepLinkCommandArgs {
@@ -28,6 +29,7 @@ export interface CopyDeepLinkCommandArgs {
 	compareWithRef?: StoredNamedRef;
 	remote?: string;
 	prePickRemote?: boolean;
+	workspaceId?: string;
 }
 
 @command()
@@ -39,6 +41,7 @@ export class CopyDeepLinkCommand extends ActiveEditorCommand {
 			Commands.CopyDeepLinkToRepo,
 			Commands.CopyDeepLinkToTag,
 			Commands.CopyDeepLinkToComparison,
+			Commands.CopyDeepLinkToWorkspace,
 		]);
 	}
 
@@ -58,6 +61,8 @@ export class CopyDeepLinkCommand extends ActiveEditorCommand {
 					compareRef: context.node.compareRef,
 					compareWithRef: context.node.compareWithRef,
 				};
+			} else if (isCommandContextViewNodeHasWorkspace(context)) {
+				args = { workspaceId: context.node.workspace.id };
 			}
 		}
 
@@ -66,6 +71,16 @@ export class CopyDeepLinkCommand extends ActiveEditorCommand {
 
 	async execute(editor?: TextEditor, uri?: Uri, args?: CopyDeepLinkCommandArgs) {
 		args = { ...args };
+
+		if (args.workspaceId != null) {
+			try {
+				await this.container.deepLinks.copyDeepLinkUrl(args.workspaceId);
+			} catch (ex) {
+				Logger.error(ex, 'CopyDeepLinkCommand');
+				void showGenericErrorMessage('Unable to copy link');
+			}
+			return;
+		}
 
 		let type;
 		let repoPath;

--- a/src/constants.ts
+++ b/src/constants.ts
@@ -124,6 +124,7 @@ export const enum Commands {
 	CopyDeepLinkToComparison = 'gitlens.copyDeepLinkToComparison',
 	CopyDeepLinkToRepo = 'gitlens.copyDeepLinkToRepo',
 	CopyDeepLinkToTag = 'gitlens.copyDeepLinkToTag',
+	CopyDeepLinkToWorkspace = 'gitlens.copyDeepLinkToWorkspace',
 	CopyMessageToClipboard = 'gitlens.copyMessageToClipboard',
 	CopyRemoteBranchesUrl = 'gitlens.copyRemoteBranchesUrl',
 	CopyRemoteBranchUrl = 'gitlens.copyRemoteBranchUrl',


### PR DESCRIPTION
- Updates the base logic for views with a new internal fabricated event for when their children are fully loaded.
- Adds support for workspaces in the deep link processing flow. A workspace deep link is of the format:
 1. GitLens: `vscode://eamodio.gitlens/link/workspace/<workspace id>`
 2. GKDev: `https://gitkraken.dev/link/workspaces/<workspace id>`
- Adds share context menu item to workspaces with the ability to copy a deep link to the workspace to the clipboard.