### PR TITLE
Implemented new property of the GK Graph to format commit messages

### DIFF
--- a/package.json
+++ b/package.json
@@ -15153,7 +15153,7 @@
 		"vscode:prepublish": "yarn run bundle"
 	},
 	"dependencies": {
-		"@gitkraken/gitkraken-components": "10.1.30",
+		"@gitkraken/gitkraken-components": "10.2.0",
 		"@gitkraken/shared-web-components": "0.1.1-rc.15",
 		"@lit/react": "1.0.0",
 		"@microsoft/fast-element": "1.12.0",

--- a/src/env/node/git/localGitProvider.ts
+++ b/src/env/node/git/localGitProvider.ts
@@ -17,7 +17,6 @@ import { getCachedAvatarUri } from '../../../avatars';
 import type { CoreConfiguration, CoreGitConfiguration } from '../../../constants';
 import { GlyphChars, Schemes } from '../../../constants';
 import type { Container } from '../../../container';
-import { emojify } from '../../../emojis';
 import { Features } from '../../../features';
 import { GitErrorHandling } from '../../../git/commandOptions';
 import {
@@ -2390,7 +2389,7 @@ export class LocalGitProvider implements GitProvider, Disposable {
 					author: isCurrentUser ? 'You' : commit.author,
 					email: commit.authorEmail,
 					date: Number(ordering === 'author-date' ? commit.authorDate : commit.committerDate) * 1000,
-					message: emojify(commit.message.trim()),
+					message: commit.message.trim(),
 					// TODO: review logic for stash, wip, etc
 					type: stashCommit != null ? 'stash-node' : parents.length > 1 ? 'merge-node' : 'commit-node',
 					heads: refHeads,

--- a/src/plus/github/githubGitProvider.ts
+++ b/src/plus/github/githubGitProvider.ts
@@ -13,7 +13,6 @@ import { authentication, EventEmitter, FileType, Uri, window, workspace } from '
 import { encodeUtf8Hex } from '@env/hex';
 import { CharCode, Schemes } from '../../constants';
 import type { Container } from '../../container';
-import { emojify } from '../../emojis';
 import {
 	AuthenticationError,
 	AuthenticationErrorReason,
@@ -1533,7 +1532,7 @@ export class GitHubGitProvider implements GitProvider, Disposable {
 				author: commit.author.name,
 				email: commit.author.email ?? '',
 				date: commit.committer.date.getTime(),
-				message: emojify(commit.message && String(commit.message).length ? commit.message : commit.summary),
+				message: commit.message && String(commit.message).length ? commit.message : commit.summary,
 				// TODO: review logic for stash, wip, etc
 				type: commit.parents.length > 1 ? 'merge-node' : 'commit-node',
 				heads: refHeads,

--- a/src/webviews/apps/plus/graph/GraphWrapper.tsx
+++ b/src/webviews/apps/plus/graph/GraphWrapper.tsx
@@ -17,6 +17,7 @@ import type { FormEvent, ReactElement } from 'react';
 import React, { createElement, useEffect, useMemo, useRef, useState } from 'react';
 import { getPlatform } from '@env/platform';
 import type { DateStyle } from '../../../../config';
+import { emojify } from '../../../../emojis';
 import type { SearchQuery } from '../../../../git/search';
 import type {
 	DidEnsureRowParams,
@@ -162,6 +163,10 @@ const iconElementLibrary = createIconElements();
 
 const getIconElementLibrary = (iconKey: string) => {
 	return iconElementLibrary[iconKey];
+};
+
+const formatCommitMessage = (commitMessage: string) => {
+	return emojify(commitMessage);
 };
 
 const getClientPlatform = (): GraphPlatform => {
@@ -1398,6 +1403,7 @@ export function GraphWrapper({
 							excludeRefsById={excludeRefsById}
 							excludeByType={excludeTypes}
 							formatCommitDateTime={getGraphDateFormatter(graphConfig)}
+							formatCommitMessage={formatCommitMessage}
 							getExternalIcon={getIconElementLibrary}
 							graphRows={rows}
 							hasMoreCommits={pagingHasMore}

--- a/src/webviews/apps/tsconfig.json
+++ b/src/webviews/apps/tsconfig.json
@@ -17,6 +17,8 @@
 		"../**/protocol.ts",
 		"../../config.ts",
 		"../../constants.ts",
+		"../../emojis.ts",
+		"../../emojis.generated.ts",
 		"../../features.ts",
 		"../../subscription.ts",
 		"../../system/**/*",

--- a/yarn.lock
+++ b/yarn.lock
@@ -223,10 +223,10 @@
   resolved "https://registry.yarnpkg.com/@floating-ui/utils/-/utils-0.1.6.tgz#22958c042e10b67463997bd6ea7115fe28cbcaf9"
   integrity sha512-OfX7E2oUDYxtBvsuS4e/jSn4Q9Qb6DzgeYtsAdkPZ47znpoNsMgZw0+tVijiv3uGNR6dgNlty6r9rzIzHjtd/A==
 
-"@gitkraken/gitkraken-components@10.1.30":
-  version "10.1.30"
-  resolved "https://registry.yarnpkg.com/@gitkraken/gitkraken-components/-/gitkraken-components-10.1.30.tgz#75c504736a47527e410d93be36cc38a0952568d4"
-  integrity sha512-A7EBIFQUCqptvQxmpt5YMfwnhl4rORAeay82Vtue8jM82jedT3xr7gKltQ1Q87QmKWvPpcgCS6pHwVVfOZrJZg==
+"@gitkraken/gitkraken-components@10.2.0":
+  version "10.2.0"
+  resolved "https://registry.yarnpkg.com/@gitkraken/gitkraken-components/-/gitkraken-components-10.2.0.tgz#3b664b0d5df8bf89aa62cb17c9af7142ba4576a6"
+  integrity sha512-c6dV2JkO0Jqvka9M3UzSv558uQDXeuW4XTcBSvpBZt+0PhWr9FOT9Qs2wuukiSXqGagAdqV6pH5UD/D3jeGH/g==
   dependencies:
     "@axosoft/react-virtualized" "9.22.3-gitkraken.3"
     classnames "2.3.2"


### PR DESCRIPTION
# Description
- Added new property to format commit messages to be in sync with new changes of the `GK Graph`.

See task for more details: https://github.com/gitkraken/GitKrakenComponents/issues/303

# Notes
- Works with dependant PR: https://github.com/gitkraken/GitKrakenComponents/pull/302
- For now, I left this PR as draft until changes related with the `GK Graph` are merged as we need to do a bump of that dependency in `GitLens` side.

# Checklist
- [ ] I have followed the guidelines in the Contributing document
- [ ] My changes follow the coding style of this project
- [ ] My changes build without any errors or warnings
- [ ] My changes have been formatted and linted
- [ ] My changes include any required corresponding changes to the documentation (including CHANGELOG.md and README.md)
- [ ] My changes have been rebased and squashed to the minimal number (typically 1) of relevant commits
- [ ] My changes have a descriptive commit message with a short title, including a `Fixes $XXX -` or `Closes #XXX -` prefix to auto-close the issue that your PR addresses
