### PR TITLE
Fixes #2836 adds sorting by repositories

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,8 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/) and this p
 - Improves the experience of the _Search Commits_ quick pick menu
   - Adds a stateful authors picker to make it much easier to search for commits by specific authors
   - Adds a file and folder picker to make it much easier to search for commits containing specific files or in specific folders
+- Adds ability to sort repositories in the views and quick pick menus &mdash; closes [#2836](https://github.com/gitkraken/vscode-gitlens/issues/2836) thanks to [PR #2991](https://github.com/gitkraken/vscode-gitlens/pull/2991)
+  - Adds a `gitlens.sortRepositoriesBy` setting to specify how repositories are sorted in quick pick menus and viewsby Aidos Kanapyanov ([@aidoskanapyanov](https://github.com/aidoskanapyanov))
 - Adds a _[Show|Hide] Merge Commits_ toggle to the Commits\_ view &mdash; closes [#1399](https://github.com/gitkraken/vscode-gitlens/issues/1399) thanks to [PR #1540](https://github.com/gitkraken/vscode-gitlens/pull/1540) by Shashank Shastri ([@Shashank-Shastri](https://github.com/Shashank-Shastri))
 - Adds a _Filter Commits by Author..._ commands to the _Commits_ view and comparisons context menus to filter commits in the _Commits_ view by specific authors
 - Adds an _Open Comparison on Remote_ command to comparisons in views

--- a/README.md
+++ b/README.md
@@ -361,6 +361,7 @@ A big thanks to the people that have contributed to this project 🙏❤️:
 - jogo- ([@jogo-](https://github.com/jogo-)) &mdash; [contributions](https://github.com/gitkraken/vscode-gitlens/commits?author=jogo-)
 - Nils K ([@septatrix](https://github.com/septatrix)) &mdash; [contributions](https://github.com/gitkraken/vscode-gitlens/commits?author=septatrix)
 - Chris Kaczor ([@ckaczor](https://github.com/ckaczor)) &mdash; [contributions](https://github.com/gitkraken/vscode-gitlens/commits?author=ckaczor)
+- Aidos Kanapyanov ([@aidoskanapyanov](https://github.com/aidoskanapyanov)) &mdash; [contributions](https://github.com/gitkraken/vscode-gitlens/commits?author=aidoskanapyanov)
 - Allan Karlson ([@bees4ever](https://github.com/bees4ever)) &mdash; [contributions](https://github.com/gitkraken/vscode-gitlens/commits?author=bees4ever)
 - Nafiur Rahman Khadem ([@ShafinKhadem](https://github.com/ShafinKhadem)) &mdash; [contributions](https://github.com/gitkraken/vscode-gitlens/commits?author=ShafinKhadem)
 - Mathew King ([@MathewKing](https://github.com/MathewKing)) &mdash; [contributions](https://github.com/gitkraken/vscode-gitlens/commits?author=MathewKing)

--- a/package.json
+++ b/package.json
@@ -1834,6 +1834,26 @@
 						"scope": "window",
 						"order": 40
 					},
+					"gitlens.sortRepositoriesBy": {
+						"type": "string",
+						"default": "lastFetched:desc",
+						"enum": [
+							"name:asc",
+							"name:desc",
+							"lastFetched:asc",
+							"lastFetched:desc"
+						],
+						"enumDescriptions": [
+							"Sorts repositories by name in ascending order",
+							"Sorts repositories by name in descending order",
+							"Sorts repositories by last fetched date in ascending order",
+							"Sorts repositories by last fetched date in descending order",
+							"Sorts repositories by starred first"
+						],
+						"markdownDescription": "Specifies how repositories are sorted in quick pick menus and views",
+						"scope": "window",
+						"order": 41
+					},
 					"gitlens.views.contributors.files.layout": {
 						"type": "string",
 						"default": "auto",

--- a/package.json
+++ b/package.json
@@ -1292,25 +1292,6 @@
 						"scope": "window",
 						"order": 30
 					},
-					"gitlens.sortBranchesBy": {
-						"type": "string",
-						"default": "date:desc",
-						"enum": [
-							"date:desc",
-							"date:asc",
-							"name:asc",
-							"name:desc"
-						],
-						"enumDescriptions": [
-							"Sorts branches by the most recent commit date in descending order",
-							"Sorts branches by the most recent commit date in ascending order",
-							"Sorts branches by name in ascending order",
-							"Sorts branches by name in descending order"
-						],
-						"markdownDescription": "Specifies how branches are sorted in quick pick menus and views",
-						"scope": "window",
-						"order": 40
-					},
 					"gitlens.views.branches.files.layout": {
 						"type": "string",
 						"default": "auto",
@@ -1556,25 +1537,6 @@
 						"scope": "window",
 						"order": 10
 					},
-					"gitlens.sortTagsBy": {
-						"type": "string",
-						"default": "date:desc",
-						"enum": [
-							"date:desc",
-							"date:asc",
-							"name:asc",
-							"name:desc"
-						],
-						"enumDescriptions": [
-							"Sorts tags by date in descending order",
-							"Sorts tags by date in ascending order",
-							"Sorts tags by name in ascending order",
-							"Sorts tags by name in descending order"
-						],
-						"markdownDescription": "Specifies how tags are sorted in quick pick menus and views",
-						"scope": "window",
-						"order": 20
-					},
 					"gitlens.views.tags.files.layout": {
 						"type": "string",
 						"default": "auto",
@@ -1810,49 +1772,6 @@
 						"markdownDescription": "Specifies whether to show pull requests (if any) associated with commits in the _Contributors_ view. Requires a connection to a supported remote service (e.g. GitHub)",
 						"scope": "window",
 						"order": 31
-					},
-					"gitlens.sortContributorsBy": {
-						"type": "string",
-						"default": "count:desc",
-						"enum": [
-							"count:desc",
-							"count:asc",
-							"date:desc",
-							"date:asc",
-							"name:asc",
-							"name:desc"
-						],
-						"enumDescriptions": [
-							"Sorts contributors by commit count in descending order",
-							"Sorts contributors by commit count in ascending order",
-							"Sorts contributors by the most recent commit date in descending order",
-							"Sorts contributors by the most recent commit date in ascending order",
-							"Sorts contributors by name in ascending order",
-							"Sorts contributors by name in descending order"
-						],
-						"markdownDescription": "Specifies how contributors are sorted in quick pick menus and views",
-						"scope": "window",
-						"order": 40
-					},
-					"gitlens.sortRepositoriesBy": {
-						"type": "string",
-						"default": "lastFetched:desc",
-						"enum": [
-							"name:asc",
-							"name:desc",
-							"lastFetched:asc",
-							"lastFetched:desc"
-						],
-						"enumDescriptions": [
-							"Sorts repositories by name in ascending order",
-							"Sorts repositories by name in descending order",
-							"Sorts repositories by last fetched date in ascending order",
-							"Sorts repositories by last fetched date in descending order",
-							"Sorts repositories by starred first"
-						],
-						"markdownDescription": "Specifies how repositories are sorted in quick pick menus and views",
-						"scope": "window",
-						"order": 41
 					},
 					"gitlens.views.contributors.files.layout": {
 						"type": "string",
@@ -3324,9 +3243,98 @@
 				}
 			},
 			{
+				"id": "sorting",
+				"title": "Sorting",
+				"order": 121,
+				"properties": {
+					"gitlens.sortRepositoriesBy": {
+						"type": "string",
+						"default": "discovered",
+						"enum": [
+							"discovered",
+							"lastFetched:desc",
+							"lastFetched:asc",
+							"name:asc",
+							"name:desc"
+						],
+						"enumDescriptions": [
+							"Sorts repositories by discovery or workspace order",
+							"Sorts repositories by last fetched date in descending order",
+							"Sorts repositories by last fetched date in ascending order",
+							"Sorts repositories by name in ascending order",
+							"Sorts repositories by name in descending order"
+						],
+						"markdownDescription": "Specifies how repositories are sorted in quick pick menus and views",
+						"scope": "window",
+						"order": 10
+					},
+					"gitlens.sortBranchesBy": {
+						"type": "string",
+						"default": "date:desc",
+						"enum": [
+							"date:desc",
+							"date:asc",
+							"name:asc",
+							"name:desc"
+						],
+						"enumDescriptions": [
+							"Sorts branches by the most recent commit date in descending order",
+							"Sorts branches by the most recent commit date in ascending order",
+							"Sorts branches by name in ascending order",
+							"Sorts branches by name in descending order"
+						],
+						"markdownDescription": "Specifies how branches are sorted in quick pick menus and views",
+						"scope": "window",
+						"order": 20
+					},
+					"gitlens.sortTagsBy": {
+						"type": "string",
+						"default": "date:desc",
+						"enum": [
+							"date:desc",
+							"date:asc",
+							"name:asc",
+							"name:desc"
+						],
+						"enumDescriptions": [
+							"Sorts tags by date in descending order",
+							"Sorts tags by date in ascending order",
+							"Sorts tags by name in ascending order",
+							"Sorts tags by name in descending order"
+						],
+						"markdownDescription": "Specifies how tags are sorted in quick pick menus and views",
+						"scope": "window",
+						"order": 30
+					},
+					"gitlens.sortContributorsBy": {
+						"type": "string",
+						"default": "count:desc",
+						"enum": [
+							"count:desc",
+							"count:asc",
+							"date:desc",
+							"date:asc",
+							"name:asc",
+							"name:desc"
+						],
+						"enumDescriptions": [
+							"Sorts contributors by commit count in descending order",
+							"Sorts contributors by commit count in ascending order",
+							"Sorts contributors by the most recent commit date in descending order",
+							"Sorts contributors by the most recent commit date in ascending order",
+							"Sorts contributors by name in ascending order",
+							"Sorts contributors by name in descending order"
+						],
+						"markdownDescription": "Specifies how contributors are sorted in quick pick menus and views",
+						"scope": "window",
+						"order": 40
+					}
+				}
+			},
+			{
 				"id": "menus-toolbars",
 				"title": "Menus & Toolbars",
-				"order": 121,
+				"order": 122,
 				"properties": {
 					"gitlens.menus": {
 						"anyOf": [
@@ -3701,7 +3709,7 @@
 			{
 				"id": "keyboard",
 				"title": "Keyboard Shortcuts",
-				"order": 122,
+				"order": 123,
 				"properties": {
 					"gitlens.keymap": {
 						"type": "string",
@@ -3725,7 +3733,7 @@
 			{
 				"id": "modes",
 				"title": "Modes",
-				"order": 123,
+				"order": 124,
 				"properties": {
 					"gitlens.mode.statusBar.enabled": {
 						"type": "boolean",

--- a/src/config.ts
+++ b/src/config.ts
@@ -248,7 +248,7 @@ export const enum CodeLensCommand {
 
 export type CodeLensScopes = 'document' | 'containers' | 'blocks';
 export type ContributorSorting = 'count:desc' | 'count:asc' | 'date:desc' | 'date:asc' | 'name:asc' | 'name:desc';
-export type RepositoriesSorting = 'name:asc' | 'name:desc' | 'lastFetched:asc' | 'lastFetched:desc';
+export type RepositoriesSorting = 'discovered' | 'lastFetched:desc' | 'lastFetched:asc' | 'name:asc' | 'name:desc';
 export type CustomRemoteType =
 	| 'AzureDevOps'
 	| 'Bitbucket'

--- a/src/config.ts
+++ b/src/config.ts
@@ -162,6 +162,7 @@ export interface Config {
 	readonly sortBranchesBy: BranchSorting;
 	readonly sortContributorsBy: ContributorSorting;
 	readonly sortTagsBy: TagSorting;
+	readonly sortRepositoriesBy: RepositoriesSorting;
 	readonly statusBar: {
 		readonly alignment: 'left' | 'right';
 		readonly command: StatusBarCommand;
@@ -247,6 +248,7 @@ export const enum CodeLensCommand {
 
 export type CodeLensScopes = 'document' | 'containers' | 'blocks';
 export type ContributorSorting = 'count:desc' | 'count:asc' | 'date:desc' | 'date:asc' | 'name:asc' | 'name:desc';
+export type RepositoriesSorting = 'name:asc' | 'name:desc' | 'lastFetched:asc' | 'lastFetched:desc';
 export type CustomRemoteType =
 	| 'AzureDevOps'
 	| 'Bitbucket'

--- a/src/views/branchesView.ts
+++ b/src/views/branchesView.ts
@@ -178,7 +178,8 @@ export class BranchesView extends ViewBase<'branches', BranchesViewNode, Branche
 			!configuration.changed(e, 'defaultDateStyle') &&
 			!configuration.changed(e, 'defaultGravatarsStyle') &&
 			!configuration.changed(e, 'defaultTimeFormat') &&
-			!configuration.changed(e, 'sortBranchesBy')
+			!configuration.changed(e, 'sortBranchesBy') &&
+			!configuration.changed(e, 'sortRepositoriesBy')
 		) {
 			return false;
 		}

--- a/src/views/commitsView.ts
+++ b/src/views/commitsView.ts
@@ -300,7 +300,8 @@ export class CommitsView extends ViewBase<'commits', CommitsViewNode, CommitsVie
 			!configuration.changed(e, 'defaultDateStyle') &&
 			!configuration.changed(e, 'defaultGravatarsStyle') &&
 			!configuration.changed(e, 'defaultTimeFormat') &&
-			!configuration.changed(e, 'plusFeatures.enabled')
+			!configuration.changed(e, 'plusFeatures.enabled') &&
+			!configuration.changed(e, 'sortRepositoriesBy')
 		) {
 			return false;
 		}

--- a/src/views/contributorsView.ts
+++ b/src/views/contributorsView.ts
@@ -197,7 +197,8 @@ export class ContributorsView extends ViewBase<'contributors', ContributorsViewN
 			!configuration.changed(e, 'defaultDateStyle') &&
 			!configuration.changed(e, 'defaultGravatarsStyle') &&
 			!configuration.changed(e, 'defaultTimeFormat') &&
-			!configuration.changed(e, 'sortContributorsBy')
+			!configuration.changed(e, 'sortContributorsBy') &&
+			!configuration.changed(e, 'sortRepositoriesBy')
 		) {
 			return false;
 		}

--- a/src/views/nodes/abstract/repositoryFolderNode.ts
+++ b/src/views/nodes/abstract/repositoryFolderNode.ts
@@ -207,7 +207,9 @@ export abstract class RepositoryFolderNode<
 		}
 
 		if (this.changed(e)) {
-			void (this.loaded ? this : this.parent ?? this).triggerChange(true);
+			// If we are sorting by last fetched, then we need to trigger the parent to resort
+			const node = !this.loaded || this.repo.orderByLastFetched ? this.parent ?? this : this;
+			void node.triggerChange(true);
 		}
 	}
 }

--- a/src/views/remotesView.ts
+++ b/src/views/remotesView.ts
@@ -170,7 +170,8 @@ export class RemotesView extends ViewBase<'remotes', RemotesViewNode, RemotesVie
 			!configuration.changed(e, 'defaultGravatarsStyle') &&
 			!configuration.changed(e, 'defaultTimeFormat') &&
 			!configuration.changed(e, 'integrations.enabled') &&
-			!configuration.changed(e, 'sortBranchesBy')
+			!configuration.changed(e, 'sortBranchesBy') &&
+			!configuration.changed(e, 'sortRepositoriesBy')
 		) {
 			return false;
 		}

--- a/src/views/repositoriesView.ts
+++ b/src/views/repositoriesView.ts
@@ -254,7 +254,8 @@ export class RepositoriesView extends ViewBase<'repositories', RepositoriesNode,
 			!configuration.changed(e, 'defaultTimeFormat') &&
 			!configuration.changed(e, 'sortBranchesBy') &&
 			!configuration.changed(e, 'sortContributorsBy') &&
-			!configuration.changed(e, 'sortTagsBy')
+			!configuration.changed(e, 'sortTagsBy') &&
+			!configuration.changed(e, 'sortRepositoriesBy')
 		) {
 			return false;
 		}

--- a/src/views/stashesView.ts
+++ b/src/views/stashesView.ts
@@ -140,7 +140,8 @@ export class StashesView extends ViewBase<'stashes', StashesViewNode, StashesVie
 			!configuration.changed(e, 'defaultDateSource') &&
 			!configuration.changed(e, 'defaultDateStyle') &&
 			!configuration.changed(e, 'defaultGravatarsStyle') &&
-			!configuration.changed(e, 'defaultTimeFormat')
+			!configuration.changed(e, 'defaultTimeFormat') &&
+			!configuration.changed(e, 'sortRepositoriesBy')
 		) {
 			return false;
 		}

--- a/src/views/tagsView.ts
+++ b/src/views/tagsView.ts
@@ -146,7 +146,8 @@ export class TagsView extends ViewBase<'tags', TagsViewNode, TagsViewConfig> {
 			!configuration.changed(e, 'defaultDateStyle') &&
 			!configuration.changed(e, 'defaultGravatarsStyle') &&
 			!configuration.changed(e, 'defaultTimeFormat') &&
-			!configuration.changed(e, 'sortTagsBy')
+			!configuration.changed(e, 'sortTagsBy') &&
+			!configuration.changed(e, 'sortRepositoriesBy')
 		) {
 			return false;
 		}

--- a/src/views/worktreesView.ts
+++ b/src/views/worktreesView.ts
@@ -212,7 +212,8 @@ export class WorktreesView extends ViewBase<'worktrees', WorktreesViewNode, Work
 			!configuration.changed(e, 'defaultDateSource') &&
 			!configuration.changed(e, 'defaultDateStyle') &&
 			!configuration.changed(e, 'defaultGravatarsStyle') &&
-			!configuration.changed(e, 'defaultTimeFormat')
+			!configuration.changed(e, 'defaultTimeFormat') &&
+			!configuration.changed(e, 'sortRepositoriesBy')
 			// !configuration.changed(e, 'sortWorktreesBy')
 		) {
 			return false;

--- a/src/webviews/apps/settings/partials/sorting.html
+++ b/src/webviews/apps/settings/partials/sorting.html
@@ -1,0 +1,70 @@
+<section id="views" class="section--settings section--collapsible">
+	<div class="section__header">
+		<h2>Sorting</h2>
+	</div>
+
+	<div class="section__collapsible">
+		<div class="section__group">
+			<div class="section__content">
+				<div class="setting">
+					<div class="setting__input">
+						<label for="sortRepositoriesBy">Sort repositories</label>
+						<div class="select-container">
+							<select id="sortRepositoriesBy" name="sortRepositoriesBy" data-setting>
+								<option value="dcovered">by discovery or workspace order</option>
+								<option value="lastFetched:desc">by last fetched date, descending</option>
+								<option value="lastFetched:asc">by last fetched date, ascending</option>
+								<option value="name:asc">by name, ascending</option>
+								<option value="name:desc">by name, descending</option>
+							</select>
+						</div>
+					</div>
+				</div>
+
+				<div class="setting">
+					<div class="setting__input">
+						<label for="sortBranchesBy">Sort branches</label>
+						<div class="select-container">
+							<select id="sortBranchesBy" name="sortBranchesBy" data-setting>
+								<option value="date:desc">by recent commit date, descending</option>
+								<option value="date:asc">by recent commit date, ascending</option>
+								<option value="name:asc">by name, ascending</option>
+								<option value="name:desc">by name, descending</option>
+							</select>
+						</div>
+					</div>
+				</div>
+
+				<div class="setting">
+					<div class="setting__input">
+						<label for="sortTagsBy">Sort tags</label>
+						<div class="select-container">
+							<select id="sortTagsBy" name="sortTagsBy" data-setting>
+								<option value="date:desc">by recent commit date, descending</option>
+								<option value="date:asc">by recent commit date, ascending</option>
+								<option value="name:asc">by name, ascending</option>
+								<option value="name:desc">by name, descending</option>
+							</select>
+						</div>
+					</div>
+				</div>
+
+				<div class="setting">
+					<div class="setting__input">
+						<label for="sortContributorsBy">Sort contributors</label>
+						<div class="select-container">
+							<select id="sortContributorsBy" name="sortContributorsBy" data-setting>
+								<option value="count:desc">by commit count, descending</option>
+								<option value="count:asc">by commit count, ascending</option>
+								<option value="date:desc">by recent commit date, descending</option>
+								<option value="date:asc">by recent commit date, ascending</option>
+								<option value="name:asc">by name, ascending</option>
+								<option value="name:desc">by name, descending</option>
+							</select>
+						</div>
+					</div>
+				</div>
+			</div>
+		</div>
+	</div>
+</section>

--- a/src/webviews/apps/settings/partials/views.branches.html
+++ b/src/webviews/apps/settings/partials/views.branches.html
@@ -112,20 +112,6 @@
 
 					<div class="setting">
 						<div class="setting__input">
-							<label for="sortBranchesBy">Sort branches</label>
-							<div class="select-container">
-								<select id="sortBranchesBy" name="sortBranchesBy" data-setting>
-									<option value="date:desc">by recent commit date, descending</option>
-									<option value="date:asc">by recent commit date, ascending</option>
-									<option value="name:asc">by name, ascending</option>
-									<option value="name:desc">by name, descending</option>
-								</select>
-							</div>
-						</div>
-					</div>
-
-					<div class="setting">
-						<div class="setting__input">
 							<label for="views.branches.files.layout">Layout files</label>
 							<div class="select-container">
 								<select

--- a/src/webviews/apps/settings/partials/views.contributors.html
+++ b/src/webviews/apps/settings/partials/views.contributors.html
@@ -80,22 +80,6 @@
 
 					<div class="setting">
 						<div class="setting__input">
-							<label for="sortContributorsBy">Sort contributors</label>
-							<div class="select-container">
-								<select id="sortContributorsBy" name="sortContributorsBy" data-setting>
-									<option value="count:desc">by commit count, descending</option>
-									<option value="count:asc">by commit count, ascending</option>
-									<option value="date:desc">by recent commit date, descending</option>
-									<option value="date:asc">by recent commit date, ascending</option>
-									<option value="name:asc">by name, ascending</option>
-									<option value="name:desc">by name, descending</option>
-								</select>
-							</div>
-						</div>
-					</div>
-
-					<div class="setting">
-						<div class="setting__input">
 							<label for="views.contributors.files.layout">Layout files</label>
 							<div class="select-container">
 								<select

--- a/src/webviews/apps/settings/partials/views.remotes.html
+++ b/src/webviews/apps/settings/partials/views.remotes.html
@@ -97,20 +97,6 @@
 
 					<div class="setting">
 						<div class="setting__input">
-							<label for="sortBranchesBy">Sort branches</label>
-							<div class="select-container">
-								<select id="sortBranchesBy" name="sortBranchesBy" data-setting>
-									<option value="date:desc">by recent commit date, descending</option>
-									<option value="date:asc">by recent commit date, ascending</option>
-									<option value="name:asc">by name, ascending</option>
-									<option value="name:desc">by name, descending</option>
-								</select>
-							</div>
-						</div>
-					</div>
-
-					<div class="setting">
-						<div class="setting__input">
 							<label for="views.remotes.files.layout">Layout files</label>
 							<div class="select-container">
 								<select id="views.remotes.files.layout" name="views.remotes.files.layout" data-setting>

--- a/src/webviews/apps/settings/partials/views.repositories.html
+++ b/src/webviews/apps/settings/partials/views.repositories.html
@@ -374,6 +374,21 @@
 							</div>
 						</div>
 					</div>
+
+					<div class="setting">
+						<div class="setting__input">
+							<label for="sortRepositoriesBy">Sort repositories</label>
+							<div class="select-container">
+								<select id="sortRepositoriesBy" name="sortRepositoriesBy" data-setting>
+									<option value="name:asc">by name, ascending</option>
+									<option value="name:desc">by name, descending</option>
+									<option value="lastFetched:asc">by last fetched date, ascending</option>
+									<option value="lastFetched:desc">by last fetched date, descending</option>
+									<option value="starredFirst">by starred first</option>
+								</select>
+							</div>
+						</div>
+					</div>
 				</div>
 			</div>
 

--- a/src/webviews/apps/settings/partials/views.repositories.html
+++ b/src/webviews/apps/settings/partials/views.repositories.html
@@ -330,66 +330,6 @@
 						</div>
 						<p class="setting__hint">Compacts (flattens) unnecessary nesting when using a tree layouts</p>
 					</div>
-
-					<div class="setting">
-						<div class="setting__input">
-							<label for="sortBranchesBy">Sort branches</label>
-							<div class="select-container">
-								<select id="sortBranchesBy" name="sortBranchesBy" data-setting>
-									<option value="date:desc">by recent commit date, descending</option>
-									<option value="date:asc">by recent commit date, ascending</option>
-									<option value="name:asc">by name, ascending</option>
-									<option value="name:desc">by name, descending</option>
-								</select>
-							</div>
-						</div>
-					</div>
-
-					<div class="setting">
-						<div class="setting__input">
-							<label for="sortContributorsBy">Sort contributors</label>
-							<div class="select-container">
-								<select id="sortContributorsBy" name="sortContributorsBy" data-setting>
-									<option value="count:desc">by commit count, descending</option>
-									<option value="count:asc">by commit count, ascending</option>
-									<option value="date:desc">by recent commit date, descending</option>
-									<option value="date:asc">by recent commit date, ascending</option>
-									<option value="name:asc">by name, ascending</option>
-									<option value="name:desc">by name, descending</option>
-								</select>
-							</div>
-						</div>
-					</div>
-
-					<div class="setting">
-						<div class="setting__input">
-							<label for="sortTagsBy">Sort tags</label>
-							<div class="select-container">
-								<select id="sortTagsBy" name="sortTagsBy" data-setting>
-									<option value="date:desc">by recent commit date, descending</option>
-									<option value="date:asc">by recent commit date, ascending</option>
-									<option value="name:asc">by name, ascending</option>
-									<option value="name:desc">by name, descending</option>
-								</select>
-							</div>
-						</div>
-					</div>
-
-					<div class="setting">
-						<div class="setting__input">
-							<label for="sortRepositoriesBy">Sort repositories</label>
-							<div class="select-container">
-								<select id="sortRepositoriesBy" name="sortRepositoriesBy" data-setting>
-									<option value="name:asc">by name, ascending</option>
-									<option value="name:desc">by name, descending</option>
-									<option value="lastFetched:asc">by last fetched date, ascending</option>
-									<option value="lastFetched:desc">by last fetched date, descending</option>
-									<option value="starredFirst">by starred first</option>
-								</select>
-							</div>
-						</div>
-					</div>
-				</div>
 			</div>
 
 			<div class="section__preview">

--- a/src/webviews/apps/settings/partials/views.tags.html
+++ b/src/webviews/apps/settings/partials/views.tags.html
@@ -38,20 +38,6 @@
 
 					<div class="setting">
 						<div class="setting__input">
-							<label for="sortTagsBy">Sort tags</label>
-							<div class="select-container">
-								<select id="sortTagsBy" name="sortTagsBy" data-setting>
-									<option value="date:desc">by recent commit date, descending</option>
-									<option value="date:asc">by recent commit date, ascending</option>
-									<option value="name:asc">by name, ascending</option>
-									<option value="name:desc">by name, descending</option>
-								</select>
-							</div>
-						</div>
-					</div>
-
-					<div class="setting">
-						<div class="setting__input">
 							<label for="views.tags.files.layout">Layout files</label>
 							<div class="select-container">
 								<select id="views.tags.files.layout" name="views.tags.files.layout" data-setting>

--- a/src/webviews/apps/settings/settings.html
+++ b/src/webviews/apps/settings/settings.html
@@ -100,6 +100,7 @@
 				<%= require('html-loader?{"esModule":false}!./partials/autolinks.html') %>
 				<%= require('html-loader?{"esModule":false}!./partials/terminal-links.html') %>
 				<%= require('html-loader?{"esModule":false}!./partials/dates.html') %>
+				<%= require('html-loader?{"esModule":false}!./partials/sorting.html') %>
 				<%= require('html-loader?{"esModule":false}!./partials/menus.html') %>
 				<%= require('html-loader?{"esModule":false}!./partials/shortcuts.html') %>
 				<%= require('html-loader?{"esModule":false}!./partials/modes.html') %>
@@ -325,6 +326,15 @@
 								href="#dates"
 								title="Jump to Dates & Times settings"
 								>Dates & Times</a
+							>
+						</li>
+						<li>
+							<a
+								class="sidebar__jump-link"
+								data-action="jump"
+								href="#views"
+								title="Jump to Sorting settings"
+								>Sorting</a
 							>
 						</li>
 						<li>


### PR DESCRIPTION
# Description
Adds an option to sort repositories in repositories view via name (asc/desc), last fetched (asc/desc), starred. Solves #2836 

# Demo
https://github.com/gitkraken/vscode-gitlens/assets/65722512/dfbe455b-bfbf-48cc-bb0e-01ceff0c1777

# Checklist
- [x] I have followed the guidelines in the Contributing document
- [x] My changes follow the coding style of this project
- [x] My changes build without any errors or warnings
- [x] My changes have been formatted and linted
- [ ] My changes include any required corresponding changes to the documentation (including CHANGELOG.md and README.md)
- [x] My changes have been rebased and squashed to the minimal number (typically 1) of relevant commits
- [x] My changes have a descriptive commit message with a short title, including a `Fixes $XXX -` or `Closes #XXX -` prefix to auto-close the issue that your PR addresses
