### PR TITLE
Fixes #1913 - Adds setting to change the PR associated to a given commit

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/) and this p
 ### Added
 
 - Adds support for OpenAI's GPT-4 Turbo and latest Anthropic models for GitLens' experimental AI features &mdash; closes [#3005](https://github.com/gitkraken/vscode-gitlens/issues/3005)
+- Adds a `gitlens.sortPullRequestsBy` setting to change which PR is associated with a commit - closes [#1913](https://github.com/gitkraken/vscode-gitlens/issues/1913) thanks to [PR #3024](https://github.com/gitkraken/vscode-gitlens/pull/3024) by Aaron Miller ([@aaron-skydio](https://github.com/aaron-skydio))
 
 ### Changed
 

--- a/package.json
+++ b/package.json
@@ -3416,6 +3416,25 @@
 						"markdownDescription": "Specifies how contributors are sorted in quick pick menus and views",
 						"scope": "window",
 						"order": 40
+					},
+					"gitlens.sortPullRequestsBy": {
+						"type": "string",
+						"default": "updated:desc",
+						"enum": [
+							"updated:desc",
+							"updated:asc",
+							"created:desc",
+							"created:asc"
+						],
+						"enumDescriptions": [
+							"Picks the most recently updated pull request",
+							"Picks the least recently updated pull request",
+							"Picks the most recently created pull request",
+							"Picks the first created pull request"
+						],
+						"markdownDescription": "Specifies how to select the pull request associated with a commit or branch",
+						"scope": "window",
+						"order": 50
 					}
 				}
 			},

--- a/src/config.ts
+++ b/src/config.ts
@@ -169,6 +169,7 @@ export interface Config {
 	readonly sortContributorsBy: ContributorSorting;
 	readonly sortTagsBy: TagSorting;
 	readonly sortRepositoriesBy: RepositoriesSorting;
+	readonly sortPullRequestsBy: PullRequestSorting;
 	readonly statusBar: {
 		readonly alignment: 'left' | 'right';
 		readonly command: StatusBarCommand;
@@ -255,6 +256,7 @@ export const enum CodeLensCommand {
 export type CodeLensScopes = 'document' | 'containers' | 'blocks';
 export type ContributorSorting = 'count:desc' | 'count:asc' | 'date:desc' | 'date:asc' | 'name:asc' | 'name:desc';
 export type RepositoriesSorting = 'discovered' | 'lastFetched:desc' | 'lastFetched:asc' | 'name:asc' | 'name:desc';
+export type PullRequestSorting = 'updated:desc' | 'updated:asc' | 'created:desc' | 'created:asc';
 export type CustomRemoteType =
 	| 'AzureDevOps'
 	| 'Bitbucket'

--- a/src/plus/github/models.ts
+++ b/src/plus/github/models.ts
@@ -87,6 +87,7 @@ export interface GitHubPullRequest {
 	id: string;
 	title: string;
 	state: GitHubPullRequestState;
+	createdAt: string;
 	updatedAt: string;
 	closedAt: string | null;
 	mergedAt: string | null;

--- a/src/webviews/apps/settings/partials/sorting.html
+++ b/src/webviews/apps/settings/partials/sorting.html
@@ -64,6 +64,20 @@
 						</div>
 					</div>
 				</div>
+
+				<div class="setting">
+					<div class="setting__input">
+						<label for="sortPullRequestsBy">Pick the pull request that was</label>
+						<div class="select-container">
+							<select id="sortPullRequestsBy" name="sortPullRequestsBy" data-setting>
+								<option value="updated:desc">most recently updated</option>
+								<option value="updated:asc">least recently updated</option>
+								<option value="created:desc">most recently created</option>
+								<option value="created:asc">first created</option>
+							</select>
+						</div>
+					</div>
+				</div>
 			</div>
 		</div>
 	</div>


### PR DESCRIPTION
---

# Description

<!--
Please include a summary of the changes and which issue will be addressed. Please also include relevant motivation and context.
-->

Currently, the pull request selected for a commit is the most recently updated one.  As mentioned in #1913, this is not always desired, for example when a feature merges to one branch, and then that branch is merged into additional branches.

This adds a setting to order by updated or created time, ascending or descending.  It preserves the other behavior, of preference based on owner and merged status.

# Checklist

<!-- Please check off the following -->

- [x] I have followed the guidelines in the Contributing document
- [x] My changes follow the coding style of this project
- [x] My changes build without any errors or warnings
- [x] My changes have been formatted and linted
- [x] My changes include any required corresponding changes to the documentation (including CHANGELOG.md and README.md)
- [x] My changes have been rebased and squashed to the minimal number (typically 1) of relevant commits
- [x] My changes have a descriptive commit message with a short title, including a `Fixes $XXX -` or `Closes #XXX -` prefix to auto-close the issue that your PR addresses
