### PR TITLE
Fixes #2515 - Adds openFileByRevision command

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/) and this p
 
 - Adds a `gitlens.fileAnnotations.dismissOnEscape` setting to specify whether pressing the `ESC` key dismisses the active file annotations &mdash; closes [#3016](https://github.com/gitkraken/vscode-gitlens/issues/3016)
 - Adds _Copy_ to search results in the _Search & Compare_ view to copy the search query to more easily share or paste queries into the _Commit Graph_
+- Adds support for opening renamed/deleted files using the _Open File at Revision..._ commands by showing a quickpick prompt if the requested file doesn't exist in the selected revision &mdash; thanks to [PR #TODO](https://github.com/gitkraken/vscode-gitlens/pull/3036) by Victor Hallberg ([@mogelbrod](https://github.com/mogelbrod))
 
 ### Fixed
 

--- a/package.json
+++ b/package.json
@@ -6045,6 +6045,12 @@
 				"category": "GitLens"
 			},
 			{
+				"command": "gitlens.openFileByRevision",
+				"title": "Open File by Revision...",
+				"icon": "$(gitlens-open-revision)",
+				"category": "GitLens"
+			},
+			{
 				"command": "gitlens.openAutolinkUrl",
 				"title": "Open Autolink URL",
 				"category": "GitLens",

--- a/src/commands.ts
+++ b/src/commands.ts
@@ -36,6 +36,7 @@ import './commands/openFileFromRemote';
 import './commands/openFileOnRemote';
 import './commands/openFileAtRevision';
 import './commands/openFileAtRevisionFrom';
+import './commands/openFileByRevision';
 import './commands/openOnRemote';
 import './commands/openIssueOnRemote';
 import './commands/openPullRequestOnRemote';

--- a/src/commands/openFileByRevision.ts
+++ b/src/commands/openFileByRevision.ts
@@ -1,0 +1,69 @@
+import type { TextDocumentShowOptions, TextEditor, Uri } from 'vscode';
+import type { FileAnnotationType } from '../config';
+import { Commands } from '../constants';
+import { Container } from '../container';
+import { openFileAtRevision } from '../git/actions/commit';
+import { GitUri } from '../git/gitUri';
+import { showNoRepositoryWarningMessage } from '../messages';
+import { showReferencePicker } from '../quickpicks/referencePicker';
+import { showRevisionPicker } from '../quickpicks/revisionPicker';
+import { command } from '../system/command';
+import { ActiveEditorCommand, getCommandUri } from './base';
+
+export interface OpenFileByRevisionCommandArgs {
+	revisionUri?: Uri;
+
+	line?: number;
+	showOptions?: TextDocumentShowOptions;
+	annotationType?: FileAnnotationType;
+}
+
+@command()
+export class OpenFileByRevisionCommand extends ActiveEditorCommand {
+	constructor(private readonly container: Container) {
+		super([
+			// TODO: Do we want to support these command variations?
+			Commands.OpenFileByRevision /*, Commands.OpenFileByRevisionInDiffLeft, Commands.OpenFileByRevisionInDiffRight*/,
+		]);
+	}
+
+	async execute(editor?: TextEditor, uri?: Uri, args?: OpenFileByRevisionCommandArgs) {
+		uri = getCommandUri(uri, editor);
+		const gitUri = uri ? await GitUri.fromUri(uri) : undefined;
+		// TODO: Should we ask user to select repository if there are multiple in the workspace?
+		const repoPath = gitUri?.repoPath || this.container.git.getBestRepository()?.path
+
+		if (!repoPath) {
+			void showNoRepositoryWarningMessage('Unable to determine repository path');
+			return
+		}
+
+		args = {...args}
+
+		let revisionUri = args.revisionUri
+		if (revisionUri == null) {
+			const pick = await showReferencePicker(
+				repoPath,
+				`Select Branch or Tag to browse for File`,
+				'Choose a branch or tag',
+				// TODO: This option appears to have been removed?
+				// { allowEnteringRefs: true },
+			);
+			if (pick == null) return;
+			revisionUri = GitUri.fromRepoPath(repoPath, pick.ref)
+		}
+
+		const revisionGitUri = await GitUri.fromUri(revisionUri);
+		const file = await showRevisionPicker(Container.instance, revisionGitUri, {
+			title: 'Select File to open',
+		});
+
+		if (!file) return;
+
+		await openFileAtRevision(file, {
+			annotationType: args.annotationType,
+			line: args.line,
+			...args.showOptions,
+		});
+	}
+}

--- a/src/constants.ts
+++ b/src/constants.ts
@@ -189,6 +189,7 @@ export const enum Commands {
 	OpenFileOnRemoteFrom = 'gitlens.openFileOnRemoteFrom',
 	OpenFileAtRevision = 'gitlens.openFileRevision',
 	OpenFileAtRevisionFrom = 'gitlens.openFileRevisionFrom',
+	OpenFileByRevision = 'gitlens.openFileByRevision',
 	OpenFolderHistory = 'gitlens.openFolderHistory',
 	OpenOnRemote = 'gitlens.openOnRemote',
 	OpenIssueOnRemote = 'gitlens.openIssueOnRemote',


### PR DESCRIPTION
# Description

Follow up to https://github.com/gitkraken/vscode-gitlens/pull/2825 which adds a dedicated vscode command that prompts the user for a Git revision (selected via quickpick), and then for a file that exists in aforementioned Git revision.

# Checklist

<!-- Please check off the following -->

- [x] I have followed the guidelines in the Contributing document
- [x] My changes follow the coding style of this project
- [x] My changes build without any errors or warnings
- [x] My changes have been formatted and linted
- [x] My changes include any required corresponding changes to the documentation (including CHANGELOG.md and README.md)
- [x] My changes have been rebased and squashed to the minimal number (typically 1) of relevant commits
- [x] My changes have a descriptive commit message with a short title, including a `Fixes $XXX -` or `Closes #XXX -` prefix to auto-close the issue that your PR addresses
