### PR TITLE
Adds organization switching

### DIFF
--- a/package.json
+++ b/package.json
@@ -4309,6 +4309,19 @@
 				}
 			},
 			{
+				"id": "gitkraken",
+				"title": "GitKraken",
+				"order": 11000,
+				"properties": {
+					"gitlens.gitKraken.activeOrganizationId": {
+						"type": "string",
+						"markdownDescription": "Specifies the ID of the user's active GitKraken organization in GitLens",
+						"scope": "window",
+						"order": 1
+					}
+				}
+			},
+			{
 				"id": "general",
 				"title": "General",
 				"order": 0,

--- a/package.json
+++ b/package.json
@@ -4311,7 +4311,7 @@
 			{
 				"id": "gitkraken",
 				"title": "GitKraken",
-				"order": 11000,
+				"order": 9000,
 				"properties": {
 					"gitlens.gitKraken.activeOrganizationId": {
 						"type": "string",
@@ -8661,7 +8661,7 @@
 				},
 				{
 					"command": "gitlens.gk.switchOrganization",
-					"when": "gitlens:gk:hasMultipleOrganizationOptions"
+					"when": "gitlens:gk:hasOrganizations"
 				},
 				{
 					"command": "gitlens.showPatchDetailsPage",

--- a/package.json
+++ b/package.json
@@ -5102,6 +5102,11 @@
 				"category": "GitLens"
 			},
 			{
+				"command": "gitlens.gk.switchOrganization",
+				"title": "Switch Organization...",
+				"category": "GitLens"
+			},
+			{
 				"command": "gitlens.getStarted",
 				"title": "Get Started",
 				"category": "GitLens"
@@ -8653,6 +8658,10 @@
 				{
 					"command": "gitlens.plus.refreshRepositoryAccess",
 					"when": "gitlens:enabled"
+				},
+				{
+					"command": "gitlens.gk.switchOrganization",
+					"when": "gitlens:gk:hasMultipleOrganizations"
 				},
 				{
 					"command": "gitlens.showPatchDetailsPage",

--- a/package.json
+++ b/package.json
@@ -8661,7 +8661,7 @@
 				},
 				{
 					"command": "gitlens.gk.switchOrganization",
-					"when": "gitlens:gk:hasMultipleOrganizations"
+					"when": "gitlens:gk:hasMultipleOrganizationOptions"
 				},
 				{
 					"command": "gitlens.showPatchDetailsPage",

--- a/src/config.ts
+++ b/src/config.ts
@@ -93,6 +93,9 @@ export interface Config {
 		readonly skipConfirmations: string[];
 		readonly sortBy: GitCommandSorting;
 	};
+	readonly gitKraken: {
+		readonly activeOrganizationId: string | null;
+	};
 	readonly graph: GraphConfig;
 	readonly heatmap: {
 		readonly ageThreshold: number;

--- a/src/constants.ts
+++ b/src/constants.ts
@@ -836,7 +836,7 @@ export type GlobalStorage = {
 	avatars: [string, StoredAvatar][];
 	repoVisibility: [string, StoredRepoVisibilityInfo][];
 	'deepLinks:pending': StoredDeepLinkContext;
-	'gitKraken:organizations': StoredOrganizations;
+	'gk:organizations': StoredOrganizations;
 	pendingWelcomeOnFocus: boolean;
 	pendingWhatsNewOnFocus: boolean;
 	// Don't change this key name ('premium`) as its the stored subscription

--- a/src/constants.ts
+++ b/src/constants.ts
@@ -836,6 +836,7 @@ export type GlobalStorage = {
 	avatars: [string, StoredAvatar][];
 	repoVisibility: [string, StoredRepoVisibilityInfo][];
 	'deepLinks:pending': StoredDeepLinkContext;
+	'gitKraken:organizations': StoredOrganizations;
 	pendingWelcomeOnFocus: boolean;
 	pendingWhatsNewOnFocus: boolean;
 	// Don't change this key name ('premium`) as its the stored subscription
@@ -882,6 +883,18 @@ export type WorkspaceStorage = {
 export interface Stored<T, SchemaVersion extends number = 1> {
 	v: SchemaVersion;
 	data: T;
+}
+
+export interface StoredOrganization {
+	id: string;
+	name: string;
+	role: string;
+}
+
+export interface StoredOrganizations {
+	timestamp: number;
+	userId: string;
+	organizations: StoredOrganization[];
 }
 
 export interface StoredAvatar {

--- a/src/constants.ts
+++ b/src/constants.ts
@@ -171,6 +171,7 @@ export const enum Commands {
 	FetchRepositories = 'gitlens.fetchRepositories',
 	GenerateCommitMessage = 'gitlens.generateCommitMessage',
 	GetStarted = 'gitlens.getStarted',
+	GKSwitchOrganization = 'gitlens.gk.switchOrganization',
 	InviteToLiveShare = 'gitlens.inviteToLiveShare',
 	OpenAutolinkUrl = 'gitlens.openAutolinkUrl',
 	OpenBlamePriorToChange = 'gitlens.openBlamePriorToChange',
@@ -600,6 +601,7 @@ export type ContextKeys =
 	| `${typeof extensionPrefix}:disabledToggleCodeLens`
 	| `${typeof extensionPrefix}:disabled`
 	| `${typeof extensionPrefix}:enabled`
+	| `${typeof extensionPrefix}:gk:hasMultipleOrganizations`
 	| `${typeof extensionPrefix}:hasConnectedRemotes`
 	| `${typeof extensionPrefix}:hasRemotes`
 	| `${typeof extensionPrefix}:hasRichRemotes`

--- a/src/constants.ts
+++ b/src/constants.ts
@@ -601,7 +601,7 @@ export type ContextKeys =
 	| `${typeof extensionPrefix}:disabledToggleCodeLens`
 	| `${typeof extensionPrefix}:disabled`
 	| `${typeof extensionPrefix}:enabled`
-	| `${typeof extensionPrefix}:gk:hasMultipleOrganizationOptions`
+	| `${typeof extensionPrefix}:gk:hasOrganizations`
 	| `${typeof extensionPrefix}:hasConnectedRemotes`
 	| `${typeof extensionPrefix}:hasRemotes`
 	| `${typeof extensionPrefix}:hasRichRemotes`

--- a/src/constants.ts
+++ b/src/constants.ts
@@ -4,6 +4,7 @@ import type { ViewShowBranchComparison } from './config';
 import type { Environment } from './container';
 import type { StoredSearchQuery } from './git/search';
 import type { Subscription } from './plus/gk/account/subscription';
+import type { GKCheckInResponse } from './plus/gk/checkin';
 import type { TrackedUsage, TrackedUsageKeys } from './telemetry/usageTracker';
 
 export const extensionPrefix = 'gitlens';
@@ -601,7 +602,7 @@ export type ContextKeys =
 	| `${typeof extensionPrefix}:disabledToggleCodeLens`
 	| `${typeof extensionPrefix}:disabled`
 	| `${typeof extensionPrefix}:enabled`
-	| `${typeof extensionPrefix}:gk:hasMultipleOrganizations`
+	| `${typeof extensionPrefix}:gk:hasMultipleOrganizationOptions`
 	| `${typeof extensionPrefix}:hasConnectedRemotes`
 	| `${typeof extensionPrefix}:hasRemotes`
 	| `${typeof extensionPrefix}:hasRichRemotes`
@@ -843,6 +844,7 @@ export type GlobalStorage = {
 	pendingWhatsNewOnFocus: boolean;
 	// Don't change this key name ('premium`) as its the stored subscription
 	'premium:subscription': Stored<Subscription & { lastValidatedAt: number | undefined }>;
+	'premium:checkin': StoredCheckinData;
 	'synced:version': string;
 	// Keep the pre-release version separate from the released version
 	'synced:preVersion': string;
@@ -885,6 +887,11 @@ export type WorkspaceStorage = {
 export interface Stored<T, SchemaVersion extends number = 1> {
 	v: SchemaVersion;
 	data: T;
+}
+
+export interface StoredCheckinData {
+	timestamp: number;
+	data: GKCheckInResponse;
 }
 
 export interface StoredOrganization {

--- a/src/container.ts
+++ b/src/container.ts
@@ -21,6 +21,7 @@ import type { RepositoryPathMappingProvider } from './pathMapping/repositoryPath
 import { DraftService } from './plus/drafts/draftsService';
 import { FocusService } from './plus/focus/focusService';
 import { AccountAuthenticationProvider } from './plus/gk/account/authenticationProvider';
+import { OrganizationService } from './plus/gk/account/organizationService';
 import { SubscriptionService } from './plus/gk/account/subscriptionService';
 import { ServerConnection } from './plus/gk/serverConnection';
 import { IntegrationAuthenticationService } from './plus/integrations/authentication/integrationAuthentication';
@@ -605,6 +606,14 @@ export class Container {
 			this._mode = configuration.get('modes')?.[configuration.get('mode.active')];
 		}
 		return this._mode;
+	}
+
+	private _organization: OrganizationService | undefined;
+	get organization() {
+		if (this._organization == null) {
+			this._disposables.push((this._organization = new OrganizationService(this, this._connection)));
+		}
+		return this._organization;
 	}
 
 	private readonly _patchDetailsView: WebviewViewProxy<PatchDetailsWebviewShowingArgs>;

--- a/src/container.ts
+++ b/src/container.ts
@@ -608,12 +608,12 @@ export class Container {
 		return this._mode;
 	}
 
-	private _organization: OrganizationService | undefined;
-	get organization() {
-		if (this._organization == null) {
-			this._disposables.push((this._organization = new OrganizationService(this, this._connection)));
+	private _organizations: OrganizationService | undefined;
+	get organizations() {
+		if (this._organizations == null) {
+			this._disposables.push((this._organizations = new OrganizationService(this, this._connection)));
 		}
-		return this._organization;
+		return this._organizations;
 	}
 
 	private readonly _patchDetailsView: WebviewViewProxy<PatchDetailsWebviewShowingArgs>;

--- a/src/plus/gk/account/organization.ts
+++ b/src/plus/gk/account/organization.ts
@@ -1,0 +1,5 @@
+export interface Organization {
+	readonly id: string;
+	readonly name: string;
+	readonly role: string;
+}

--- a/src/plus/gk/account/organization.ts
+++ b/src/plus/gk/account/organization.ts
@@ -1,5 +1,9 @@
 export interface Organization {
 	readonly id: string;
 	readonly name: string;
-	readonly role: string;
+	readonly role: OrganizationRole;
 }
+
+export type OrganizationRole = 'owner' | 'admin' | 'billing' | 'user';
+
+export type OrganizationsResponse = Organization[];

--- a/src/plus/gk/account/organizationService.ts
+++ b/src/plus/gk/account/organizationService.ts
@@ -66,7 +66,7 @@ export class OrganizationService implements Disposable {
 
 	@gate()
 	async getStoredOrganizations(): Promise<Organization[] | undefined> {
-		const userId = (await this.container.subscription.getSubscription())?.account?.id;
+		const userId = (await this.container.subscription.getSubscription(true))?.account?.id;
 		if (userId == null) return undefined;
 		const storedOrganizations = this.container.storage.get('gk:organizations');
 		if (storedOrganizations == null) return undefined;
@@ -84,7 +84,7 @@ export class OrganizationService implements Disposable {
 	}
 
 	private async storeOrganizations(organizations: Organization[]): Promise<void> {
-		const userId = (await this.container.subscription.getSubscription())?.account?.id;
+		const userId = (await this.container.subscription.getSubscription(true))?.account?.id;
 		if (userId == null) return;
 		return this.container.storage.store('gk:organizations', {
 			timestamp: Date.now(),

--- a/src/plus/gk/account/organizationService.ts
+++ b/src/plus/gk/account/organizationService.ts
@@ -5,6 +5,7 @@ import { Logger } from '../../../system/logger';
 import { getLogScope } from '../../../system/logger.scope';
 import type { ServerConnection } from '../serverConnection';
 import type { Organization } from './organization';
+import type { SubscriptionChangeEvent } from './subscriptionService';
 
 export class OrganizationService implements Disposable {
 	private _disposable: Disposable;
@@ -51,7 +52,9 @@ export class OrganizationService implements Disposable {
 		this._disposable.dispose();
 	}
 
-	onSubscriptionChanged(): void {
-		this._organizations = undefined;
+	private onSubscriptionChanged(e: SubscriptionChangeEvent): void {
+		if (e.current?.account?.id !== e.previous?.account?.id) {
+			this._organizations = undefined;
+		}
 	}
 }

--- a/src/plus/gk/account/organizationService.ts
+++ b/src/plus/gk/account/organizationService.ts
@@ -1,0 +1,57 @@
+import { Disposable, window } from 'vscode';
+import type { Container } from '../../../container';
+import { gate } from '../../../system/decorators/gate';
+import { Logger } from '../../../system/logger';
+import { getLogScope } from '../../../system/logger.scope';
+import type { ServerConnection } from '../serverConnection';
+import type { Organization } from './organization';
+
+export class OrganizationService implements Disposable {
+	private _disposable: Disposable;
+	private _organizations: Organization[] | null | undefined;
+
+	constructor(
+		private readonly container: Container,
+		private readonly connection: ServerConnection,
+	) {
+		this._disposable = Disposable.from(container.subscription.onDidChange(this.onSubscriptionChanged, this));
+		this._organizations = undefined;
+	}
+
+	@gate()
+	async getOrganizations(): Promise<Organization[]> {
+		const scope = getLogScope();
+		if (this._organizations === undefined) {
+			// TODO: Use organizations-light instead once available.
+			const rsp = await this.connection.fetchApi('user/organizations', {
+				method: 'GET',
+			});
+
+			if (!rsp.ok) {
+				debugger;
+				Logger.error('', scope, `Unable to get organizations; status=(${rsp.status}): ${rsp.statusText}`);
+
+				void window.showErrorMessage(`Unable to get organizations; Status: ${rsp.statusText}`, 'OK');
+
+				this._organizations = null;
+			}
+
+			const organizations = await rsp.json();
+			this._organizations = organizations.map((o: any) => ({
+				id: o.id,
+				name: o.name,
+				role: o.role,
+			}));
+		}
+
+		return this._organizations ?? [];
+	}
+
+	dispose(): void {
+		this._disposable.dispose();
+	}
+
+	onSubscriptionChanged(): void {
+		this._organizations = undefined;
+	}
+}

--- a/src/plus/gk/account/organizationService.ts
+++ b/src/plus/gk/account/organizationService.ts
@@ -68,7 +68,7 @@ export class OrganizationService implements Disposable {
 	async getStoredOrganizations(): Promise<Organization[] | undefined> {
 		const userId = (await this.container.subscription.getSubscription())?.account?.id;
 		if (userId == null) return undefined;
-		const storedOrganizations = this.container.storage.get('gitKraken:organizations');
+		const storedOrganizations = this.container.storage.get('gk:organizations');
 		if (storedOrganizations == null) return undefined;
 		const { timestamp, organizations, userId: storedUserId } = storedOrganizations;
 		if (storedUserId !== userId || timestamp + organizationsCacheExpiration < Date.now()) {
@@ -80,13 +80,13 @@ export class OrganizationService implements Disposable {
 	}
 
 	private async clearStoredOrganizations(): Promise<void> {
-		return this.container.storage.delete('gitKraken:organizations');
+		return this.container.storage.delete('gk:organizations');
 	}
 
 	private async storeOrganizations(organizations: Organization[]): Promise<void> {
 		const userId = (await this.container.subscription.getSubscription())?.account?.id;
 		if (userId == null) return;
-		return this.container.storage.store('gitKraken:organizations', {
+		return this.container.storage.store('gk:organizations', {
 			timestamp: Date.now(),
 			organizations: organizations,
 			userId: userId,

--- a/src/plus/gk/account/organizationService.ts
+++ b/src/plus/gk/account/organizationService.ts
@@ -39,14 +39,18 @@ export class OrganizationService implements Disposable {
 				}
 			}
 
-			// TODO: Use organizations-light instead once available.
-			const rsp = await this.connection.fetchApi(
-				'user/organizations-light',
-				{
-					method: 'GET',
-				},
-				{ token: options?.accessToken },
-			);
+			let rsp;
+			try {
+				rsp = await this.connection.fetchApi(
+					'user/organizations-light',
+					{
+						method: 'GET',
+					},
+					{ token: options?.accessToken },
+				);
+			} catch (ex) {
+				return undefined;
+			}
 
 			if (!rsp.ok) {
 				debugger;

--- a/src/plus/gk/account/organizationService.ts
+++ b/src/plus/gk/account/organizationService.ts
@@ -19,18 +19,10 @@ export class OrganizationService implements Disposable {
 		private readonly connection: ServerConnection,
 	) {
 		this._disposable = Disposable.from(container.subscription.onDidChange(this.onSubscriptionChanged, this));
-		const userId = container.subscription.subscriptionAccountId;
-		if (userId != null) {
-			this.loadStoredOrganizations(userId);
-		}
 	}
 
 	dispose(): void {
 		this._disposable.dispose();
-	}
-
-	get organizationCount(): number {
-		return this._organizations?.length ?? 0;
 	}
 
 	@gate()
@@ -40,7 +32,7 @@ export class OrganizationService implements Disposable {
 		userId?: string;
 	}): Promise<Organization[] | null | undefined> {
 		const scope = getLogScope();
-		const userId = options?.userId ?? this.container.subscription.subscriptionAccountId;
+		const userId = options?.userId ?? (await this.container.subscription.getSubscription(true))?.account?.id;
 		if (userId == null) {
 			this.updateOrganizations(undefined);
 			return this._organizations;
@@ -118,6 +110,6 @@ export class OrganizationService implements Disposable {
 
 	private updateOrganizations(organizations: Organization[] | null | undefined): void {
 		this._organizations = organizations;
-		void setContext('gitlens:gk:hasMultipleOrganizationOptions', this.organizationCount > 1);
+		void setContext('gitlens:gk:hasMultipleOrganizationOptions', (organizations ?? []).length > 1);
 	}
 }

--- a/src/plus/gk/account/organizationService.ts
+++ b/src/plus/gk/account/organizationService.ts
@@ -115,6 +115,6 @@ export class OrganizationService implements Disposable {
 
 	private updateOrganizations(organizations: Organization[] | null | undefined): void {
 		this._organizations = organizations;
-		void setContext('gitlens:gk:hasMultipleOrganizationOptions', (organizations ?? []).length > 1);
+		void setContext('gitlens:gk:hasOrganizations', (organizations ?? []).length > 1);
 	}
 }

--- a/src/plus/gk/account/subscription.ts
+++ b/src/plus/gk/account/subscription.ts
@@ -1,5 +1,6 @@
 // NOTE@eamodio This file is referenced in the webviews to we can't use anything vscode or other imports that aren't available in the webviews
 import { getDateDifference } from '../../../system/date';
+import type { Organization } from './organization';
 
 export const enum SubscriptionPlanId {
 	Free = 'free',
@@ -24,6 +25,7 @@ export interface Subscription {
 	state: SubscriptionState;
 
 	lastValidatedAt?: number;
+	readonly activeOrganization?: Organization;
 }
 
 export interface SubscriptionPlan {

--- a/src/plus/gk/account/subscription.ts
+++ b/src/plus/gk/account/subscription.ts
@@ -14,20 +14,18 @@ export type FreeSubscriptionPlans = Extract<SubscriptionPlanId, SubscriptionPlan
 export type PaidSubscriptionPlans = Exclude<SubscriptionPlanId, SubscriptionPlanId.Free | SubscriptionPlanId.FreePlus>;
 export type RequiredSubscriptionPlans = Exclude<SubscriptionPlanId, SubscriptionPlanId.Free>;
 
-export interface Subscription extends BaseSubscription {
-	previewTrial?: SubscriptionPreviewTrial;
-
-	state: SubscriptionState;
-
-	lastValidatedAt?: number;
-}
-
-export interface BaseSubscription {
+export interface Subscription {
 	readonly plan: {
 		readonly actual: SubscriptionPlan;
 		readonly effective: SubscriptionPlan;
 	};
 	account: SubscriptionAccount | undefined;
+	previewTrial?: SubscriptionPreviewTrial;
+
+	state: SubscriptionState;
+
+	lastValidatedAt?: number;
+
 	readonly activeOrganization?: Organization;
 }
 

--- a/src/plus/gk/account/subscription.ts
+++ b/src/plus/gk/account/subscription.ts
@@ -14,17 +14,20 @@ export type FreeSubscriptionPlans = Extract<SubscriptionPlanId, SubscriptionPlan
 export type PaidSubscriptionPlans = Exclude<SubscriptionPlanId, SubscriptionPlanId.Free | SubscriptionPlanId.FreePlus>;
 export type RequiredSubscriptionPlans = Exclude<SubscriptionPlanId, SubscriptionPlanId.Free>;
 
-export interface Subscription {
-	readonly plan: {
-		readonly actual: SubscriptionPlan;
-		readonly effective: SubscriptionPlan;
-	};
-	account: SubscriptionAccount | undefined;
+export interface Subscription extends BaseSubscription {
 	previewTrial?: SubscriptionPreviewTrial;
 
 	state: SubscriptionState;
 
 	lastValidatedAt?: number;
+}
+
+export interface BaseSubscription {
+	readonly plan: {
+		readonly actual: SubscriptionPlan;
+		readonly effective: SubscriptionPlan;
+	};
+	account: SubscriptionAccount | undefined;
 	readonly activeOrganization?: Organization;
 }
 

--- a/src/plus/gk/account/subscriptionService.ts
+++ b/src/plus/gk/account/subscriptionService.ts
@@ -116,12 +116,9 @@ export class SubscriptionService implements Disposable {
 		this._disposable.dispose();
 	}
 
-	async getHasMultipleOrganizationOptions(): Promise<boolean> {
+	async getOrganizationOptionCount(): Promise<number> {
 		const organizations = (await this.container.organization.getOrganizations()) ?? [];
-		if (organizations.length === 0) return false;
-		if (organizations.length > 1) return true;
-
-		return this.getShouldShowOrganizationDefault(organizations);
+		return organizations.length + (this.getShouldShowOrganizationDefault(organizations) ? 1 : 0);
 	}
 
 	private getShouldShowOrganizationDefault(organizations: Organization[]): boolean {
@@ -143,6 +140,7 @@ export class SubscriptionService implements Disposable {
 
 		return (
 			hasSubscriptionWithoutOrganization &&
+			organizations.length > 0 &&
 			!organizations.some(org => !checkinSubscriptionsByOrganizationId.has(org.id))
 		);
 	}
@@ -972,7 +970,7 @@ export class SubscriptionService implements Disposable {
 	}
 
 	private async updateOrganizationContext(): Promise<void> {
-		void setContext('gitlens:gk:hasMultipleOrganizationOptions', await this.getHasMultipleOrganizationOptions());
+		void setContext('gitlens:gk:hasMultipleOrganizationOptions', (await this.getOrganizationOptionCount()) > 1);
 	}
 
 	private async updateAccessContext(cancellation: CancellationToken): Promise<void> {
@@ -1094,7 +1092,7 @@ export class SubscriptionService implements Disposable {
 
 		if (this.getShouldShowOrganizationDefault(organizations)) {
 			picks.push({
-				label: 'None',
+				label: 'Default',
 				org: null,
 			});
 		}

--- a/src/plus/gk/account/subscriptionService.ts
+++ b/src/plus/gk/account/subscriptionService.ts
@@ -194,6 +194,10 @@ export class SubscriptionService implements Disposable {
 		return this._subscription;
 	}
 
+	get subscriptionAccountId(): string | undefined {
+		return this._subscription.account?.id;
+	}
+
 	@debug()
 	async learnAboutPreviewOrTrial() {
 		const subscription = await this.getSubscription();
@@ -640,6 +644,7 @@ export class SubscriptionService implements Disposable {
 				(await this.container.organization.getOrganizations({
 					force: true,
 					accessToken: session.accessToken,
+					userId: session.account.id,
 				})) ?? [];
 		} catch (ex) {
 			Logger.error(ex, scope);
@@ -874,7 +879,6 @@ export class SubscriptionService implements Disposable {
 
 		if (!options?.silent) {
 			this.updateContext();
-			void this.updateOrganizationContext();
 
 			if (previous != null) {
 				this._onDidChange.fire({ current: subscription, previous: previous, etag: this._etag });
@@ -938,11 +942,6 @@ export class SubscriptionService implements Disposable {
 
 		void setContext('gitlens:plus', actual.id != SubscriptionPlanId.Free ? actual.id : undefined);
 		void setContext('gitlens:plus:state', state);
-	}
-
-	private async updateOrganizationContext(): Promise<void> {
-		const organizations = (await this.container.organization.getOrganizations()) ?? [];
-		void setContext('gitlens:gk:hasMultipleOrganizationOptions', organizations.length > 1);
 	}
 
 	private async updateAccessContext(cancellation: CancellationToken): Promise<void> {

--- a/src/plus/gk/account/subscriptionService.ts
+++ b/src/plus/gk/account/subscriptionService.ts
@@ -705,7 +705,7 @@ export class SubscriptionService implements Disposable {
 		}
 
 		if (!force && this._session != null) return this._session;
-		if (this._session === null && !createIfNeeded && !force) return undefined;
+		if (this._session === null && !createIfNeeded) return undefined;
 
 		if (this._sessionPromise === undefined) {
 			this._sessionPromise = this.getOrCreateSession(createIfNeeded).then(

--- a/src/plus/gk/account/subscriptionService.ts
+++ b/src/plus/gk/account/subscriptionService.ts
@@ -183,7 +183,6 @@ export class SubscriptionService implements Disposable {
 			...this.registerCommands(),
 		);
 		this.updateContext();
-		void this.updateOrganizationContext();
 	}
 
 	private onRepositoriesChanged(_e: RepositoriesChangeEvent): void {
@@ -680,6 +679,9 @@ export class SubscriptionService implements Disposable {
 		let chosenOrganizationId: string | null | undefined = configuration.get('gitKraken.activeOrganizationId');
 		if (chosenOrganizationId === '') {
 			chosenOrganizationId = undefined;
+		} else if (chosenOrganizationId != null && !organizations.some(o => o.id === chosenOrganizationId)) {
+			chosenOrganizationId = undefined;
+			void configuration.updateEffective('gitKraken.activeOrganizationId', undefined);
 		}
 		const subscription = getSubscriptionFromCheckIn(data, organizations, chosenOrganizationId);
 		this._lastValidatedDate = new Date();
@@ -897,9 +899,6 @@ export class SubscriptionService implements Disposable {
 		});
 
 		void this.storeSubscription(subscription);
-		if (previous?.account?.id !== subscription.account?.id) {
-			void configuration.updateEffective('gitKraken.activeOrganizationId', undefined);
-		}
 
 		this._subscription = subscription;
 		this._etag = Date.now();

--- a/src/plus/gk/account/subscriptionService.ts
+++ b/src/plus/gk/account/subscriptionService.ts
@@ -194,10 +194,6 @@ export class SubscriptionService implements Disposable {
 		return this._subscription;
 	}
 
-	get subscriptionAccountId(): string | undefined {
-		return this._subscription.account?.id;
-	}
-
 	@debug()
 	async learnAboutPreviewOrTrial() {
 		const subscription = await this.getSubscription();

--- a/src/plus/gk/checkin.ts
+++ b/src/plus/gk/checkin.ts
@@ -1,5 +1,5 @@
 import type { Organization } from './account/organization';
-import type { BaseSubscription, Subscription } from './account/subscription';
+import type { Subscription } from './account/subscription';
 import { getSubscriptionPlan, getSubscriptionPlanPriority, SubscriptionPlanId } from './account/subscription';
 
 export interface GKCheckInResponse {
@@ -48,7 +48,7 @@ export function getSubscriptionFromCheckIn(
 	data: GKCheckInResponse,
 	organizations: Organization[],
 	organizationId?: string,
-): BaseSubscription {
+): Omit<Subscription, 'state' | 'lastValidatedAt'> {
 	const account: Subscription['account'] = {
 		id: data.user.id,
 		name: data.user.name,

--- a/src/plus/gk/checkin.ts
+++ b/src/plus/gk/checkin.ts
@@ -47,7 +47,7 @@ export type GKLicenseType =
 export function getSubscriptionFromCheckIn(
 	data: GKCheckInResponse,
 	organizations: Organization[],
-	organizationId?: string | null,
+	organizationId?: string,
 ): BaseSubscription {
 	const account: Subscription['account'] = {
 		id: data.user.id,
@@ -107,10 +107,7 @@ export function getSubscriptionFromCheckIn(
 			!effectiveLicensesByOrganizationId.has(organization.id),
 	);
 
-	if (organizationId === null) {
-		paidLicenses = paidLicenses.filter(([, license]) => license.organizationId == null);
-		effectiveLicenses = effectiveLicenses.filter(([, license]) => license.organizationId == null);
-	} else if (organizationId != null) {
+	if (organizationId != null) {
 		paidLicenses = paidLicenses.filter(
 			([, license]) => license.organizationId === organizationId || license.organizationId == null,
 		);

--- a/src/plus/gk/checkin.ts
+++ b/src/plus/gk/checkin.ts
@@ -170,11 +170,6 @@ export function getSubscriptionFromCheckIn(
 
 	if (effective == null || getSubscriptionPlanPriority(actual.id) >= getSubscriptionPlanPriority(effective.id)) {
 		effective = { ...actual };
-	} else if (
-		organizationId != null &&
-		getSubscriptionPlanPriority(effective.id) > getSubscriptionPlanPriority(actual.id)
-	) {
-		actual = { ...effective };
 	}
 
 	let activeOrganization: Organization | undefined;

--- a/src/plus/webviews/account/accountWebview.ts
+++ b/src/plus/webviews/account/accountWebview.ts
@@ -80,7 +80,7 @@ export class AccountWebviewProvider implements WebviewProvider<State> {
 		return {
 			subscription: sub,
 			avatar: avatar,
-			organizationsCount: ((await this.container.organization.getOrganizations()) ?? []).length,
+			organizationsCount: this.container.organization.organizationCount,
 		};
 	}
 

--- a/src/plus/webviews/account/accountWebview.ts
+++ b/src/plus/webviews/account/accountWebview.ts
@@ -80,7 +80,7 @@ export class AccountWebviewProvider implements WebviewProvider<State> {
 		return {
 			subscription: sub,
 			avatar: avatar,
-			organizationsCount: await this.container.subscription.getOrganizationOptionCount(),
+			organizationsCount: ((await this.container.organization.getOrganizations()) ?? []).length,
 		};
 	}
 

--- a/src/plus/webviews/account/accountWebview.ts
+++ b/src/plus/webviews/account/accountWebview.ts
@@ -80,7 +80,7 @@ export class AccountWebviewProvider implements WebviewProvider<State> {
 		return {
 			subscription: sub,
 			avatar: avatar,
-			organizationsCount: ((await this.container.organization.getOrganizations()) ?? []).length,
+			organizationsCount: ((await this.container.organizations.getOrganizations()) ?? []).length,
 		};
 	}
 

--- a/src/plus/webviews/account/accountWebview.ts
+++ b/src/plus/webviews/account/accountWebview.ts
@@ -80,7 +80,7 @@ export class AccountWebviewProvider implements WebviewProvider<State> {
 		return {
 			subscription: sub,
 			avatar: avatar,
-			organizationsCount: this.container.organization.organizationCount,
+			organizationsCount: ((await this.container.organization.getOrganizations()) ?? []).length,
 		};
 	}
 

--- a/src/plus/webviews/account/accountWebview.ts
+++ b/src/plus/webviews/account/accountWebview.ts
@@ -68,13 +68,7 @@ export class AccountWebviewProvider implements WebviewProvider<State> {
 	}
 
 	private async getSubscription(subscription?: Subscription) {
-		let sub = subscription ?? (await this.container.subscription.getSubscription(true));
-		if (sub?.account != null && (sub?.activeOrganization == null || subscription == null)) {
-			const activeOrganization = await this.container.subscription.getActiveOrganization({
-				force: subscription == null,
-			});
-			sub = { ...sub, activeOrganization: activeOrganization };
-		}
+		const sub = subscription ?? (await this.container.subscription.getSubscription(true));
 
 		let avatar;
 		if (sub.account?.email) {
@@ -83,12 +77,10 @@ export class AccountWebviewProvider implements WebviewProvider<State> {
 			avatar = `${this.host.getWebRoot() ?? ''}/media/gitlens-logo.webp`;
 		}
 
-		const organizationCount = this.container.organization.organizationCount;
-
 		return {
 			subscription: sub,
 			avatar: avatar,
-			hasMultipleOrganizations: organizationCount != null && organizationCount > 1,
+			hasMultipleOrganizationOptions: await this.container.subscription.getHasMultipleOrganizationOptions(),
 		};
 	}
 
@@ -100,7 +92,7 @@ export class AccountWebviewProvider implements WebviewProvider<State> {
 			webroot: this.host.getWebRoot(),
 			subscription: subscriptionResult.subscription,
 			avatar: subscriptionResult.avatar,
-			hasMultipleOrganizations: subscriptionResult.hasMultipleOrganizations,
+			hasMultipleOrganizationOptions: subscriptionResult.hasMultipleOrganizationOptions,
 		};
 	}
 

--- a/src/plus/webviews/account/accountWebview.ts
+++ b/src/plus/webviews/account/accountWebview.ts
@@ -80,7 +80,7 @@ export class AccountWebviewProvider implements WebviewProvider<State> {
 		return {
 			subscription: sub,
 			avatar: avatar,
-			hasMultipleOrganizationOptions: await this.container.subscription.getHasMultipleOrganizationOptions(),
+			organizationsCount: (await this.container.organization.getOrganizations())?.length ?? 0,
 		};
 	}
 
@@ -92,7 +92,7 @@ export class AccountWebviewProvider implements WebviewProvider<State> {
 			webroot: this.host.getWebRoot(),
 			subscription: subscriptionResult.subscription,
 			avatar: subscriptionResult.avatar,
-			hasMultipleOrganizationOptions: subscriptionResult.hasMultipleOrganizationOptions,
+			organizationsCount: subscriptionResult.organizationsCount,
 		};
 	}
 

--- a/src/plus/webviews/account/accountWebview.ts
+++ b/src/plus/webviews/account/accountWebview.ts
@@ -80,7 +80,7 @@ export class AccountWebviewProvider implements WebviewProvider<State> {
 		return {
 			subscription: sub,
 			avatar: avatar,
-			organizationsCount: (await this.container.organization.getOrganizations())?.length ?? 0,
+			organizationsCount: await this.container.subscription.getOrganizationOptionCount(),
 		};
 	}
 

--- a/src/plus/webviews/account/protocol.ts
+++ b/src/plus/webviews/account/protocol.ts
@@ -6,11 +6,13 @@ export interface State extends WebviewState {
 	webroot?: string;
 	subscription: Subscription;
 	avatar?: string;
+	hasMultipleOrganizations?: boolean;
 }
 
 export interface DidChangeSubscriptionParams {
 	subscription: Subscription;
 	avatar?: string;
+	hasMultipleOrganizations?: boolean;
 }
 export const DidChangeSubscriptionNotificationType = new IpcNotificationType<DidChangeSubscriptionParams>(
 	'subscription/didChange',

--- a/src/plus/webviews/account/protocol.ts
+++ b/src/plus/webviews/account/protocol.ts
@@ -6,13 +6,13 @@ export interface State extends WebviewState {
 	webroot?: string;
 	subscription: Subscription;
 	avatar?: string;
-	hasMultipleOrganizations?: boolean;
+	hasMultipleOrganizationOptions?: boolean;
 }
 
 export interface DidChangeSubscriptionParams {
 	subscription: Subscription;
 	avatar?: string;
-	hasMultipleOrganizations?: boolean;
+	hasMultipleOrganizationOptions?: boolean;
 }
 export const DidChangeSubscriptionNotificationType = new IpcNotificationType<DidChangeSubscriptionParams>(
 	'subscription/didChange',

--- a/src/plus/webviews/account/protocol.ts
+++ b/src/plus/webviews/account/protocol.ts
@@ -6,13 +6,13 @@ export interface State extends WebviewState {
 	webroot?: string;
 	subscription: Subscription;
 	avatar?: string;
-	hasMultipleOrganizationOptions?: boolean;
+	organizationsCount?: number;
 }
 
 export interface DidChangeSubscriptionParams {
 	subscription: Subscription;
 	avatar?: string;
-	hasMultipleOrganizationOptions?: boolean;
+	organizationsCount?: number;
 }
 export const DidChangeSubscriptionNotificationType = new IpcNotificationType<DidChangeSubscriptionParams>(
 	'subscription/didChange',

--- a/src/webviews/apps/plus/account/account.ts
+++ b/src/webviews/apps/plus/account/account.ts
@@ -37,6 +37,7 @@ export class AccountApp extends App<State> {
 				onIpc(DidChangeSubscriptionNotificationType, msg, params => {
 					this.state.subscription = params.subscription;
 					this.state.avatar = params.avatar;
+					this.state.hasMultipleOrganizations = params.hasMultipleOrganizations;
 					this.state.timestamp = Date.now();
 					this.setState(this.state);
 					this.updateState();
@@ -70,13 +71,15 @@ export class AccountApp extends App<State> {
 
 	private updateState() {
 		const days = this.getDaysRemaining();
-		const { subscription, avatar } = this.state;
+		const { subscription, avatar, hasMultipleOrganizations } = this.state;
 
 		const $content = document.getElementById('account-content')! as AccountContent;
 
 		$content.image = avatar ?? '';
 		$content.name = subscription.account?.name ?? '';
 		$content.state = subscription.state;
+		$content.organization = subscription.activeOrganization?.name ?? '';
+		$content.hasMultipleOrganizations = hasMultipleOrganizations ?? false;
 		$content.plan = subscription.plan.effective.name;
 		$content.days = days;
 		$content.trialReactivationCount = subscription.plan.effective.trialReactivationCount;

--- a/src/webviews/apps/plus/account/account.ts
+++ b/src/webviews/apps/plus/account/account.ts
@@ -37,7 +37,7 @@ export class AccountApp extends App<State> {
 				onIpc(DidChangeSubscriptionNotificationType, msg, params => {
 					this.state.subscription = params.subscription;
 					this.state.avatar = params.avatar;
-					this.state.hasMultipleOrganizationOptions = params.hasMultipleOrganizationOptions;
+					this.state.organizationsCount = params.organizationsCount;
 					this.state.timestamp = Date.now();
 					this.setState(this.state);
 					this.updateState();
@@ -71,7 +71,7 @@ export class AccountApp extends App<State> {
 
 	private updateState() {
 		const days = this.getDaysRemaining();
-		const { subscription, avatar, hasMultipleOrganizationOptions } = this.state;
+		const { subscription, avatar, organizationsCount } = this.state;
 
 		const $content = document.getElementById('account-content')! as AccountContent;
 
@@ -79,7 +79,7 @@ export class AccountApp extends App<State> {
 		$content.name = subscription.account?.name ?? '';
 		$content.state = subscription.state;
 		$content.organization = subscription.activeOrganization?.name ?? '';
-		$content.hasMultipleOrganizationOptions = hasMultipleOrganizationOptions ?? false;
+		$content.organizationsCount = organizationsCount ?? 0;
 		$content.plan = subscription.plan.effective.name;
 		$content.days = days;
 		$content.trialReactivationCount = subscription.plan.effective.trialReactivationCount;

--- a/src/webviews/apps/plus/account/account.ts
+++ b/src/webviews/apps/plus/account/account.ts
@@ -37,7 +37,7 @@ export class AccountApp extends App<State> {
 				onIpc(DidChangeSubscriptionNotificationType, msg, params => {
 					this.state.subscription = params.subscription;
 					this.state.avatar = params.avatar;
-					this.state.hasMultipleOrganizations = params.hasMultipleOrganizations;
+					this.state.hasMultipleOrganizationOptions = params.hasMultipleOrganizationOptions;
 					this.state.timestamp = Date.now();
 					this.setState(this.state);
 					this.updateState();
@@ -71,7 +71,7 @@ export class AccountApp extends App<State> {
 
 	private updateState() {
 		const days = this.getDaysRemaining();
-		const { subscription, avatar, hasMultipleOrganizations } = this.state;
+		const { subscription, avatar, hasMultipleOrganizationOptions } = this.state;
 
 		const $content = document.getElementById('account-content')! as AccountContent;
 
@@ -79,7 +79,7 @@ export class AccountApp extends App<State> {
 		$content.name = subscription.account?.name ?? '';
 		$content.state = subscription.state;
 		$content.organization = subscription.activeOrganization?.name ?? '';
-		$content.hasMultipleOrganizations = hasMultipleOrganizations ?? false;
+		$content.hasMultipleOrganizationOptions = hasMultipleOrganizationOptions ?? false;
 		$content.plan = subscription.plan.effective.name;
 		$content.days = days;
 		$content.trialReactivationCount = subscription.plan.effective.trialReactivationCount;

--- a/src/webviews/apps/plus/account/components/account-content.ts
+++ b/src/webviews/apps/plus/account/components/account-content.ts
@@ -61,6 +61,14 @@ export class AccountContent extends LitElement {
 				margin-right: 0.1rem;
 			}
 
+			.account__organization___switch {
+				display: inline-block;
+				position: relative;
+				z-index: 1;
+				padding: 0.3rem;
+				margin: -0.3rem;
+			}
+
 			.account__access {
 				position: relative;
 				margin: 0;
@@ -173,6 +181,7 @@ export class AccountContent extends LitElement {
 								? html`
 										<span>
 											<a
+												class="account__organization___switch"
 												href="command:gitlens.gk.switchOrganization"
 												title="Switch Organization"
 												aria-label="Switch Organization"

--- a/src/webviews/apps/plus/account/components/account-content.ts
+++ b/src/webviews/apps/plus/account/components/account-content.ts
@@ -34,7 +34,7 @@ export class AccountContent extends LitElement {
 
 			.account__media {
 				grid-column: 1;
-				grid-row: 1 / span 2;
+				grid-row: 1 / span 3;
 				display: flex;
 				align-items: center;
 			}
@@ -49,6 +49,16 @@ export class AccountContent extends LitElement {
 				font-size: var(--vscode-font-size);
 				font-weight: 600;
 				margin: 0;
+			}
+
+			.account__organization {
+				position: relative;
+				margin: 0.2rem 0 0.2rem 0;
+				color: var(--color-foreground--65);
+			}
+
+			.account__organization__icon {
+				margin-right: 0.1rem;
 			}
 
 			.account__access {
@@ -76,6 +86,12 @@ export class AccountContent extends LitElement {
 
 	@property()
 	name = '';
+
+	@property()
+	organization = '';
+
+	@property()
+	hasMultipleOrganizations = false;
 
 	@property({ type: Number })
 	days = 0;
@@ -143,6 +159,34 @@ export class AccountContent extends LitElement {
 						: html`<code-icon icon="account" size="34"></code-icon>`}
 				</div>
 				<p class="account__title">${this.name}</p>
+				${this.organization
+					? html` <p class="account__organization">
+							<span class="account__organization__icon"
+								><code-icon
+									icon="organization"
+									title="Organization"
+									aria-label="Organization"
+								></code-icon
+							></span>
+							<span>${this.organization}</span>
+							${this.hasMultipleOrganizations
+								? html`
+										<span>
+											<a
+												href="command:gitlens.gk.switchOrganization"
+												title="Switch Organization"
+												aria-label="Switch Organization"
+												><code-icon
+													icon="chevron-down"
+													title="Switch Organization..."
+													aria-label="Switch Organization"
+												></code-icon
+											></a>
+										</span>
+								  `
+								: null}
+					  </p>`
+					: null}
 				<p class="account__access">${this.planName}${this.daysLeft}</p>
 				<div class="account__signout">
 					<gl-button appearance="toolbar" href="command:gitlens.plus.logout"

--- a/src/webviews/apps/plus/account/components/account-content.ts
+++ b/src/webviews/apps/plus/account/components/account-content.ts
@@ -120,10 +120,10 @@ export class AccountContent extends LitElement {
 	name = '';
 
 	@property()
-	organization = '';
+	organization?: string;
 
-	@property()
-	hasMultipleOrganizationOptions = false;
+	@property({ type: Number })
+	organizationsCount = 0;
 
 	@property({ type: Number })
 	days = 0;
@@ -192,6 +192,10 @@ export class AccountContent extends LitElement {
 				</div>
 				<div class="account__details">
 					<p class="account__title">${this.name}</p>
+					${when(
+						this.organizationsCount === 0,
+						() => html`<p class="account__access">${this.planName}${this.daysLeft}</p>`,
+					)}
 				</div>
 				<div class="account__signout">
 					<gl-button appearance="toolbar" href="command:gitlens.plus.logout"
@@ -199,29 +203,38 @@ export class AccountContent extends LitElement {
 					></gl-button>
 				</div>
 			</div>
-			${this.organization
-				? html` <div class="account account--org">
-						<div class="account__media">
-							<code-icon icon="organization" size="22"></code-icon>
-						</div>
-						<div class="account__details">
-							<p class="account__title">${this.organization}</p>
-							<p class="account__access">${this.planName}${this.daysLeft}</p>
-						</div>
-						${this.hasMultipleOrganizationOptions
-							? html` <div class="account__signout">
-									<span class="account__badge">+1</span>
-									<gl-button appearance="toolbar" href="command:gitlens.gk.switchOrganization"
-										><code-icon
-											icon="arrow-swap"
-											title="Switch Organization"
-											aria-label="Switch Organization"
-										></code-icon
-									></gl-button>
-							  </div>`
-							: nothing}
-				  </div>`
-				: nothing}
+		`;
+	}
+
+	private renderOrganization() {
+		if (!this.hasAccount || !this.organization) {
+			return nothing;
+		}
+
+		return html`
+			<div class="account account--org">
+				<div class="account__media">
+					<code-icon icon="organization" size="22"></code-icon>
+				</div>
+				<div class="account__details">
+					<p class="account__title">${this.organization}</p>
+					<p class="account__access">${this.planName}${this.daysLeft}</p>
+				</div>
+				${when(
+					this.organizationsCount > 1,
+					() =>
+						html`<div class="account__signout">
+							<span class="account__badge">+${this.organizationsCount - 1}</span>
+							<gl-button appearance="toolbar" href="command:gitlens.gk.switchOrganization"
+								><code-icon
+									icon="arrow-swap"
+									title="Switch Organization"
+									aria-label="Switch Organization"
+								></code-icon
+							></gl-button>
+						</div>`,
+				)}
+			</div>
 		`;
 	}
 
@@ -350,6 +363,6 @@ export class AccountContent extends LitElement {
 	}
 
 	override render() {
-		return html`${this.renderAccountInfo()}${this.renderAccountState()}`;
+		return html`${this.renderAccountInfo()}${this.renderOrganization()}${this.renderAccountState()}`;
 	}
 }

--- a/src/webviews/apps/plus/account/components/account-content.ts
+++ b/src/webviews/apps/plus/account/components/account-content.ts
@@ -99,7 +99,7 @@ export class AccountContent extends LitElement {
 	organization = '';
 
 	@property()
-	hasMultipleOrganizations = false;
+	hasMultipleOrganizationOptions = false;
 
 	@property({ type: Number })
 	days = 0;
@@ -177,7 +177,7 @@ export class AccountContent extends LitElement {
 								></code-icon
 							></span>
 							<span>${this.organization}</span>
-							${this.hasMultipleOrganizations
+							${this.hasMultipleOrganizationOptions
 								? html`
 										<span>
 											<a

--- a/src/webviews/apps/plus/account/components/account-content.ts
+++ b/src/webviews/apps/plus/account/components/account-content.ts
@@ -32,11 +32,22 @@ export class AccountContent extends LitElement {
 				margin-bottom: 1.3rem;
 			}
 
+			.account--org {
+				font-size: 0.9em;
+				line-height: 1.2;
+				margin-top: -1rem;
+			}
+
 			.account__media {
 				grid-column: 1;
-				grid-row: 1 / span 3;
+				grid-row: 1 / span 2;
 				display: flex;
 				align-items: center;
+				justify-content: center;
+			}
+
+			.account--org .account__media {
+				color: var(--color-foreground--65);
 			}
 
 			.account__image {
@@ -45,28 +56,22 @@ export class AccountContent extends LitElement {
 				border-radius: 50%;
 			}
 
+			.account__details {
+				grid-row: 1 / span 2;
+				display: flex;
+				flex-direction: column;
+				justify-content: center;
+			}
+
 			.account__title {
-				font-size: var(--vscode-font-size);
+				font-size: 1.5rem;
 				font-weight: 600;
 				margin: 0;
 			}
 
-			.account__organization {
-				position: relative;
-				margin: 0.2rem 0 0.2rem 0;
-				color: var(--color-foreground--65);
-			}
-
-			.account__organization__icon {
-				margin-right: 0.1rem;
-			}
-
-			.account__organization___switch {
-				display: inline-block;
-				position: relative;
-				z-index: 1;
-				padding: 0.3rem;
-				margin: -0.3rem;
+			.account--org .account__title {
+				font-size: 1.2rem;
+				font-weight: normal;
 			}
 
 			.account__access {
@@ -77,6 +82,25 @@ export class AccountContent extends LitElement {
 
 			.account__signout {
 				grid-row: 1 / span 2;
+				display: flex;
+				gap: 0.2rem;
+				flex-direction: row;
+				align-items: center;
+				justify-content: center;
+			}
+
+			.account__badge {
+				display: inline-flex;
+				align-items: center;
+				justify-content: center;
+				width: 2.4rem;
+				height: 2.4rem;
+				line-height: 2.4rem;
+				font-size: 1rem;
+				font-weight: 600;
+				color: var(--color-foreground--65);
+				background-color: var(--vscode-toolbar-hoverBackground);
+				border-radius: 50%;
 			}
 
 			.repo-access {
@@ -166,43 +190,38 @@ export class AccountContent extends LitElement {
 						? html`<img src=${this.image} class="account__image" />`
 						: html`<code-icon icon="account" size="34"></code-icon>`}
 				</div>
-				<p class="account__title">${this.name}</p>
-				${this.organization
-					? html` <p class="account__organization">
-							<span class="account__organization__icon"
-								><code-icon
-									icon="organization"
-									title="Organization"
-									aria-label="Organization"
-								></code-icon
-							></span>
-							<span>${this.organization}</span>
-							${this.hasMultipleOrganizationOptions
-								? html`
-										<span>
-											<a
-												class="account__organization___switch"
-												href="command:gitlens.gk.switchOrganization"
-												title="Switch Organization"
-												aria-label="Switch Organization"
-												><code-icon
-													icon="chevron-down"
-													title="Switch Organization..."
-													aria-label="Switch Organization"
-												></code-icon
-											></a>
-										</span>
-								  `
-								: null}
-					  </p>`
-					: null}
-				<p class="account__access">${this.planName}${this.daysLeft}</p>
+				<div class="account__details">
+					<p class="account__title">${this.name}</p>
+				</div>
 				<div class="account__signout">
 					<gl-button appearance="toolbar" href="command:gitlens.plus.logout"
 						><code-icon icon="sign-out" title="Sign Out" aria-label="Sign Out"></code-icon
 					></gl-button>
 				</div>
 			</div>
+			${this.organization
+				? html` <div class="account account--org">
+						<div class="account__media">
+							<code-icon icon="organization" size="22"></code-icon>
+						</div>
+						<div class="account__details">
+							<p class="account__title">${this.organization}</p>
+							<p class="account__access">${this.planName}${this.daysLeft}</p>
+						</div>
+						${this.hasMultipleOrganizationOptions
+							? html` <div class="account__signout">
+									<span class="account__badge">+1</span>
+									<gl-button appearance="toolbar" href="command:gitlens.gk.switchOrganization"
+										><code-icon
+											icon="arrow-swap"
+											title="Switch Organization"
+											aria-label="Switch Organization"
+										></code-icon
+									></gl-button>
+							  </div>`
+							: nothing}
+				  </div>`
+				: nothing}
 		`;
 	}
 


### PR DESCRIPTION
- Adds a new service route for fetching GK organizations
- Adds an `activeOrganization` property to the active subscription in the Subscription service
- Adds a new command allowing the user to switch organizations (and, by extension, subscriptions)
- Adds new caches and storage for list of organizations, currently selected organization, and checkin response
- Adds new UX in the GitKraken Account view which shows the active organization and a button to switch