### PR TITLE
Fix indefinite line tracker suspension after closing large dirty editor

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/) and this p
 ### Fixed
 
 - Fixes [#2926](https://github.com/gitkraken/vscode-gitlens/issues/2926) in more cases - "Open File at Revision" has incorrect editor label if revision contains path separator &mdash; thanks to [PR #3060](https://github.com/gitkraken/vscode-gitlens/issues/3060) by Ian Chamberlain ([@ian-h-chamberlain](https://github.com/ian-h-chamberlain)
+- Fixes [#3066](https://github.com/gitkraken/vscode-gitlens/issues/3066) - Editing a large file and switching away to another file without saving causes current line blame to disappear; thanks to [PR #3067](https://github.com/gitkraken/vscode-gitlens/pulls/3067) by Brandon Cheng ([@gluxon](https://github.com/gluxon)).
 
 ## [14.6.1] - 2023-12-14
 

--- a/README.md
+++ b/README.md
@@ -427,6 +427,7 @@ A big thanks to the people that have contributed to this project 🙏❤️:
 - WofWca ([@WofWca](https://github.com/WofWca)) &mdash; [contributions](https://github.com/gitkraken/vscode-gitlens/commits?author=WofWca)
 - 不见月 ([@nooooooom](https://github.com/nooooooom)) &mdash; [contributions](https://github.com/gitkraken/vscode-gitlens/commits?author=nooooooom)
 - Ian Chamberlain ([@ian-h-chamberlain](https://github.com/ian-h-chamberlain)) &mdash; [contributions](https://github.com/gitkraken/vscode-gitlens/commits?author=ian-h-chamberlain)
+- Brandon Cheng ([@gluxon](https://github.com/gluxon)) &mdash; [contributions](https://github.com/gitkraken/vscode-gitlens/commits?author=gluxon)`
 
 Also special thanks to the people that have provided support, testing, brainstorming, etc:
 

--- a/src/trackers/gitLineTracker.ts
+++ b/src/trackers/gitLineTracker.ts
@@ -58,6 +58,18 @@ export class GitLineTracker extends LineTracker<GitLineState> {
 		this._subscriptionOnlyWhenActive = undefined;
 	}
 
+	protected override onActiveEditorChanged() {
+		// The GitLineTracker is suspended for performance while users have
+		// dirty changes in a large editor with lines exceeding the
+		// advanced.blame.sizeThresholdAfterEdit config.
+		//
+		// We'll need to resume if the active editor has changed (since the
+		// suspension was for the previous editor). Otherwise the line tracker
+		// would stay suspended after navigating away from the large dirty
+		// document.
+		this.resume();
+	}
+
 	@debug<GitLineTracker['onBlameStateChanged']>({
 		args: {
 			0: e => `editor/doc=${e.editor.document.uri.toString(true)}, blameable=${e.blameable}`,

--- a/src/trackers/lineTracker.ts
+++ b/src/trackers/lineTracker.ts
@@ -44,6 +44,7 @@ export class LineTracker<T> implements Disposable {
 		this._selections = toLineSelections(editor?.selections);
 
 		this.notifyLinesChanged('editor');
+		this.onActiveEditorChanged?.();
 	}
 
 	private onTextEditorSelectionChanged(e: TextEditorSelectionChangeEvent) {
@@ -196,6 +197,12 @@ export class LineTracker<T> implements Disposable {
 		this.onSuspend?.();
 		this.notifyLinesChanged('editor');
 	}
+
+	/**
+	 * Called after the active editor is changed and line tracker state has been
+	 * updated for it.
+	 */
+	protected onActiveEditorChanged?(): void;
 
 	protected fireLinesChanged(e: LinesChangeEvent) {
 		this._onDidChangeActiveLines.fire(e);


### PR DESCRIPTION
# Description

Fixes #3066. See issue link for an in-depth explanation of the bug, steps to reproduce, and a video.

# Checklist

<!-- Please check off the following -->

- [x] I have followed the guidelines in the Contributing document
- [x] My changes follow the coding style of this project
- [x] My changes build without any errors or warnings
- [x] My changes have been formatted and linted
- [x] My changes include any required corresponding changes to the documentation (including CHANGELOG.md and README.md)
- [x] My changes have been rebased and squashed to the minimal number (typically 1) of relevant commits
- [x] My changes have a descriptive commit message with a short title, including a `Fixes $XXX -` or `Closes #XXX -` prefix to auto-close the issue that your PR addresses
