### PR TITLE
Fixes #3090 - Treats .git/gitdir as toplevel on "empty" bare clones

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/) and this p
 - Fixes [#3650](https://github.com/gitkraken/vscode-gitlens/issues/3650) - "Create & Switch to Local Branch" from remote branch no longer prefills local branch name to match remote branch name
 - Fixes [#3651](https://github.com/gitkraken/vscode-gitlens/issues/3651) - "Open on Remote (Web)" does not use tracked branch name
 - Fixes [#3657](https://github.com/gitkraken/vscode-gitlens/issues/3657) - Creating a worktree from within a worktree chooses the wrong path
+- Fixes [#3090](https://github.com/gitkraken/vscode-gitlens/issues/3090) - Manually created empty bare clone repositories in a trusted directory crash worktree view since LocalGitProvider.findRepositoryUri returns just ".git" &mdash; thanks to [PR #3092](https://github.com/gitkraken/vscode-gitlens/pull/3092) by Dawn Hwang ([@hwangh95](https://github.com/hwangh95))
 
 ## [15.6.0] - 2024-10-07
 

--- a/README.md
+++ b/README.md
@@ -450,6 +450,7 @@ A big thanks to the people that have contributed to this project 🙏❤️:
 - bm-w ([@bm-w](https://github.com/bm-w)) &mdash; [contributions](https://github.com/gitkraken/vscode-gitlens/commits?author=bm-w)
 - Tyler Johnson ([@TJohnsonSE](https://github.com/TJohnsonSE)) &mdash; [contributions](https://github.com/gitkraken/vscode-gitlens/commits?author=TJohnsonSE)
 - Jean Pierre ([@jeanp413](https://github.com/jeanp413)) &mdash; [contributions](https://github.com/gitkraken/vscode-gitlens/commits?author=jeanp413)
+- Dawn Hwang ([@hwangh95](https://github.com/hwangh95)) &mdash; [contributions](https://github.com/gitkraken/vscode-gitlens/commits?author=hwangh95)
 
 Also special thanks to the people that have provided support, testing, brainstorming, etc:
 

--- a/src/env/node/git/git.ts
+++ b/src/env/node/git/git.ts
@@ -1813,16 +1813,9 @@ export class Git {
 					'--is-bare-repository',
 				);
 				if (data.trim() === 'true') {
-					// If we are in a bare clone, then the common dir is the git dir
-					data = await this.git<string>(
-						{ cwd: cwd, errors: GitErrorHandling.Ignore },
-						'rev-parse',
-						'--git-common-dir',
-					);
-					data = data.trim();
-					if (data.length) {
-						return [true, normalizePath((data === '.' ? cwd : data).trimStart().replace(/[\r|\n]+$/, ''))];
-					}
+					const result = await this.rev_parse__git_dir(cwd);
+					const repoPath = result?.commonPath ?? result?.path;
+					if (repoPath?.length) return [true, repoPath];
 				}
 			}
 


### PR DESCRIPTION
# Description
There are cases for having bare clones with multiple worktrees in the same folder to manage various versions in a workspace

Currently, however, the only supported way to do this is to have the .git/ files such as HEAD, branches/, refs/, worktrees/, etc in the same folder as your actual worktrees. This makes your workspace very cluttered and is counterproductive to the structured way of multiple worktrees

What many of us prefer is to have an "empty" bare clone with the normal bare clone files within the .git/ folder or another folder labeled .bare and use a .git file with a gitdir reference

This fix will allow for the worktrees view to function the same way it would show on a `git worktree list` command

# Checklist

- [x] I have followed the guidelines in the Contributing document
- [x] My changes follow the coding style of this project
- [x] My changes build without any errors or warnings
- [x] My changes have been formatted and linted
- [x] My changes include any required corresponding changes to the documentation (including CHANGELOG.md and README.md)
- [x] My changes have been rebased and squashed to the minimal number (typically 1) of relevant commits
- [x] My changes have a descriptive commit message with a short title, including a `Fixes $XXX -` or `Closes #XXX -` prefix to auto-close the issue that your PR addresses

Refs: #3090, #2575