### PR TITLE
Adds ability to try to collapse worktrees in views

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,10 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/) and this p
 
 ## [Unreleased]
 
+### Added
+
+- Adds a new `gitlens.views.collapseWorktreesWhenPossible` setting to specify whether to try to collapse the opened worktrees into a single (common) repository in the views when possible
+
 ## [14.9.0] - 2024-03-06
 
 ### Added

--- a/package.json
+++ b/package.json
@@ -578,6 +578,13 @@
 				"title": "Views",
 				"order": 20,
 				"properties": {
+					"gitlens.views.collapseWorktreesWhenPossible": {
+						"type": "boolean",
+						"default": true,
+						"markdownDescription": "Specifies whether to try to collapse the opened worktrees into a single (common) repository in the views when possible",
+						"scope": "window",
+						"order": 1
+					},
 					"gitlens.views.defaultItemLimit": {
 						"type": "number",
 						"default": 10,

--- a/src/commands/ghpr/openOrCreateWorktree.ts
+++ b/src/commands/ghpr/openOrCreateWorktree.ts
@@ -77,7 +77,7 @@ export class OpenOrCreateWorktreeCommand extends Command {
 			return;
 		}
 
-		repo = await repo.getMainRepository();
+		repo = await repo.getCommonRepository();
 		if (repo == null) {
 			void window.showWarningMessage(`Unable to find main repository(${localUri.toString()}) for PR #${number}`);
 			return;

--- a/src/commands/git/worktree.ts
+++ b/src/commands/git/worktree.ts
@@ -291,7 +291,7 @@ export class WorktreeGitCommand extends QuickCommand<State> {
 
 			if (state.subcommand !== 'copy-changes') {
 				// Ensure we use the "main" repository if we are in a worktree already
-				state.repo = (await state.repo.getMainRepository()) ?? state.repo;
+				state.repo = (await state.repo.getCommonRepository()) ?? state.repo;
 			}
 			assertStateStepRepository(state);
 
@@ -977,7 +977,7 @@ export class WorktreeGitCommand extends QuickCommand<State> {
 			} else {
 				let name;
 
-				const repo = (await state.repo.getMainRepository()) ?? state.repo;
+				const repo = (await state.repo.getCommonRepository()) ?? state.repo;
 				if (repo.name !== state.worktree.name) {
 					name = `${repo.name}: ${state.worktree.name}`;
 				} else {

--- a/src/config.ts
+++ b/src/config.ts
@@ -551,6 +551,7 @@ export type SuppressedMessages =
 	| 'suppressBlameInvalidIgnoreRevsFileBadRevisionWarning';
 
 export interface ViewsCommonConfig {
+	readonly collapseWorktreesWhenPossible: boolean;
 	readonly defaultItemLimit: number;
 	readonly formats: {
 		readonly commits: {

--- a/src/git/models/branch.ts
+++ b/src/git/models/branch.ts
@@ -36,6 +36,7 @@ export interface BranchSortOptions {
 	current?: boolean;
 	missingUpstream?: boolean;
 	orderBy?: BranchSorting;
+	openWorktreeBranches?: string[];
 }
 
 export function getBranchId(repoPath: string, remote: boolean, name: string): string {
@@ -251,6 +252,10 @@ export function sortBranches(branches: GitBranch[], options?: BranchSortOptions)
 				(a, b) =>
 					(options.missingUpstream ? (a.upstream?.missing ? -1 : 1) - (b.upstream?.missing ? -1 : 1) : 0) ||
 					(options.current ? (a.current ? -1 : 1) - (b.current ? -1 : 1) : 0) ||
+					(options.openWorktreeBranches
+						? (options.openWorktreeBranches.includes(a.name) ? -1 : 1) -
+						  (options.openWorktreeBranches.includes(b.name) ? -1 : 1)
+						: 0) ||
 					(a.starred ? -1 : 1) - (b.starred ? -1 : 1) ||
 					(b.remote ? -1 : 1) - (a.remote ? -1 : 1) ||
 					(a.date == null ? -1 : a.date.getTime()) - (b.date == null ? -1 : b.date.getTime()),
@@ -260,6 +265,10 @@ export function sortBranches(branches: GitBranch[], options?: BranchSortOptions)
 				(a, b) =>
 					(options.missingUpstream ? (a.upstream?.missing ? -1 : 1) - (b.upstream?.missing ? -1 : 1) : 0) ||
 					(options.current ? (a.current ? -1 : 1) - (b.current ? -1 : 1) : 0) ||
+					(options.openWorktreeBranches
+						? (options.openWorktreeBranches.includes(a.name) ? -1 : 1) -
+						  (options.openWorktreeBranches.includes(b.name) ? -1 : 1)
+						: 0) ||
 					(a.starred ? -1 : 1) - (b.starred ? -1 : 1) ||
 					(a.name === 'main' ? -1 : 1) - (b.name === 'main' ? -1 : 1) ||
 					(a.name === 'master' ? -1 : 1) - (b.name === 'master' ? -1 : 1) ||
@@ -272,6 +281,10 @@ export function sortBranches(branches: GitBranch[], options?: BranchSortOptions)
 				(a, b) =>
 					(options.missingUpstream ? (a.upstream?.missing ? -1 : 1) - (b.upstream?.missing ? -1 : 1) : 0) ||
 					(options.current ? (a.current ? -1 : 1) - (b.current ? -1 : 1) : 0) ||
+					(options.openWorktreeBranches
+						? (options.openWorktreeBranches.includes(a.name) ? -1 : 1) -
+						  (options.openWorktreeBranches.includes(b.name) ? -1 : 1)
+						: 0) ||
 					(a.starred ? -1 : 1) - (b.starred ? -1 : 1) ||
 					(a.name === 'main' ? -1 : 1) - (b.name === 'main' ? -1 : 1) ||
 					(a.name === 'master' ? -1 : 1) - (b.name === 'master' ? -1 : 1) ||
@@ -285,6 +298,10 @@ export function sortBranches(branches: GitBranch[], options?: BranchSortOptions)
 				(a, b) =>
 					(options.missingUpstream ? (a.upstream?.missing ? -1 : 1) - (b.upstream?.missing ? -1 : 1) : 0) ||
 					(options.current ? (a.current ? -1 : 1) - (b.current ? -1 : 1) : 0) ||
+					(options.openWorktreeBranches
+						? (options.openWorktreeBranches.includes(a.name) ? -1 : 1) -
+						  (options.openWorktreeBranches.includes(b.name) ? -1 : 1)
+						: 0) ||
 					(a.starred ? -1 : 1) - (b.starred ? -1 : 1) ||
 					(b.remote ? -1 : 1) - (a.remote ? -1 : 1) ||
 					(b.date == null ? -1 : b.date.getTime()) - (a.date == null ? -1 : a.date.getTime()),

--- a/src/git/models/repository.ts
+++ b/src/git/models/repository.ts
@@ -1296,18 +1296,18 @@ export function isRepository(repository: unknown): repository is Repository {
 	return repository instanceof Repository;
 }
 
-export async function groupRepositories(repositories: Repository[]): Promise<Map<Repository, Repository[]>> {
+export async function groupRepositories(repositories: Repository[]): Promise<Map<Repository, Map<string, Repository>>> {
 	const repos = new Map<string, Repository>(repositories.map(r => [r.id, r]));
 
 	// Group worktree repos under the common repo when the common repo is also in the list
-	const result = new Map<string, { repo: Repository; worktrees: Repository[] }>();
+	const result = new Map<string, { repo: Repository; worktrees: Map<string, Repository> }>();
 	for (const [, repo] of repos) {
 		const commonUri = await repo.getCommonRepositoryUri();
 		if (commonUri == null) {
 			if (result.has(repo.id)) {
 				debugger;
 			}
-			result.set(repo.id, { repo: repo, worktrees: [] });
+			result.set(repo.id, { repo: repo, worktrees: new Map() });
 			continue;
 		}
 
@@ -1317,16 +1317,16 @@ export async function groupRepositories(repositories: Repository[]): Promise<Map
 			if (result.has(repo.id)) {
 				debugger;
 			}
-			result.set(repo.id, { repo: repo, worktrees: [] });
+			result.set(repo.id, { repo: repo, worktrees: new Map() });
 			continue;
 		}
 
 		let r = result.get(commonRepo.id);
 		if (r == null) {
-			r = { repo: commonRepo, worktrees: [] };
+			r = { repo: commonRepo, worktrees: new Map() };
 			result.set(commonRepo.id, r);
 		} else {
-			r.worktrees.push(repo);
+			r.worktrees.set(repo.path, repo);
 		}
 	}
 

--- a/src/git/models/status.ts
+++ b/src/git/models/status.ts
@@ -311,7 +311,7 @@ export function getUpstreamStatus(
 				status += `${status.length === 0 ? '' : separator}${pluralize('commit', state.ahead, {
 					infix: icons ? '$(arrow-up) ' : undefined,
 				})} ahead`;
-				if (suffix.startsWith(` ${upstream.name.split('/')[0]}`)) {
+				if (suffix.includes(upstream.name.split('/')[0])) {
 					status += ' of';
 				}
 			}

--- a/src/plus/webviews/focus/focusWebview.ts
+++ b/src/plus/webviews/focus/focusWebview.ts
@@ -285,7 +285,7 @@ export class FocusWebviewProvider implements WebviewProvider<State> {
 		const repoAndRemote = searchedPullRequest.repoAndRemote;
 		const localUri = repoAndRemote.repo.uri;
 
-		const repo = await repoAndRemote.repo.getMainRepository();
+		const repo = await repoAndRemote.repo.getCommonRepository();
 		if (repo == null) {
 			void window.showWarningMessage(
 				`Unable to find main repository(${localUri.toString()}) for PR #${pullRequest.id}`,

--- a/src/views/commitsView.ts
+++ b/src/views/commitsView.ts
@@ -54,7 +54,7 @@ export class CommitsRepositoryNode extends RepositoryFolderNode<CommitsView, Bra
 					expand: true,
 					limitCommits: !this.splatted,
 					showComparison: this.view.config.showBranchComparison,
-					showCurrent: false,
+					showCurrentOrOpened: false,
 					showMergeCommits: !this.view.state.hideMergeCommits,
 					showTracking: true,
 					authors: authors,

--- a/src/views/nodes/abstract/viewNode.ts
+++ b/src/views/nodes/abstract/viewNode.ts
@@ -138,6 +138,8 @@ export interface AmbientContext {
 	readonly workspace?: CloudWorkspace | LocalWorkspace;
 	readonly wsRepositoryDescriptor?: CloudWorkspaceRepositoryDescriptor | LocalWorkspaceRepositoryDescriptor;
 	readonly worktree?: GitWorktree;
+
+	readonly openWorktreeBranches?: string[];
 }
 
 export function getViewNodeId(type: string, context: AmbientContext): string {

--- a/src/views/nodes/abstract/viewNode.ts
+++ b/src/views/nodes/abstract/viewNode.ts
@@ -139,7 +139,7 @@ export interface AmbientContext {
 	readonly wsRepositoryDescriptor?: CloudWorkspaceRepositoryDescriptor | LocalWorkspaceRepositoryDescriptor;
 	readonly worktree?: GitWorktree;
 
-	readonly openWorktreeBranches?: string[];
+	readonly openWorktreeBranches?: Set<string>;
 }
 
 export function getViewNodeId(type: string, context: AmbientContext): string {

--- a/src/views/nodes/branchNode.ts
+++ b/src/views/nodes/branchNode.ts
@@ -109,7 +109,7 @@ export class BranchNode
 	}
 
 	get opened(): boolean {
-		return this.context.openWorktreeBranches?.includes(this.branch.name) ?? false;
+		return this.context.openWorktreeBranches?.has(this.branch.name) ?? false;
 	}
 
 	get label(): string {

--- a/src/views/nodes/branchOrTagFolderNode.ts
+++ b/src/views/nodes/branchOrTagFolderNode.ts
@@ -38,7 +38,7 @@ export class BranchOrTagFolderNode extends ViewNode<'branch-tag-folder'> {
 		for (const folder of this.root.children.values()) {
 			if (folder.value === undefined) {
 				// If the folder contains the current branch, expand it by default
-				const expand = folder.descendants?.some(n => n.is('branch') && n.current);
+				const expand = folder.descendants?.some(n => n.is('branch') && (n.current || n.opened));
 				children.push(
 					new BranchOrTagFolderNode(
 						this.view,

--- a/src/views/nodes/branchesNode.ts
+++ b/src/views/nodes/branchesNode.ts
@@ -41,6 +41,13 @@ export class BranchesNode extends CacheableChildrenViewNode<'branches', ViewsWit
 			});
 			if (branches.values.length === 0) return [new MessageNode(this.view, this, 'No branches could be found.')];
 
+			// if (configuration.get('views.collapseWorktreesWhenPossible')) {
+			// 	sortBranches(branches.values, {
+			// 		current: true,
+			// 		openWorktreeBranches: this.context.openWorktreeBranches,
+			// 	});
+			// }
+
 			// TODO@eamodio handle paging
 			const branchNodes = branches.values.map(
 				b =>

--- a/src/views/nodes/repositoryNode.ts
+++ b/src/views/nodes/repositoryNode.ts
@@ -157,7 +157,7 @@ export class RepositoryNode extends SubscribeableViewNode<'repository', ViewsWit
 						new BranchNode(this.uri, this.view, this, this.repo, branch, true, {
 							showAsCommits: true,
 							showComparison: false,
-							showCurrent: false,
+							showCurrentOrOpened: false,
 							showStatus: false,
 							showTracking: false,
 						}),

--- a/src/views/viewDecorationProvider.ts
+++ b/src/views/viewDecorationProvider.ts
@@ -21,7 +21,7 @@ export class ViewFileDecorationProvider implements FileDecorationProvider, Dispo
 
 					switch (uri.authority) {
 						case 'branch':
-							return this.provideBranchCurrentDecoration(uri, token);
+							return this.provideBranchDecoration(uri, token);
 						case 'remote':
 							return this.provideRemoteDefaultDecoration(uri, token);
 						case 'status':
@@ -191,10 +191,14 @@ export class ViewFileDecorationProvider implements FileDecorationProvider, Dispo
 		}
 	}
 
-	provideBranchCurrentDecoration(uri: Uri, _token: CancellationToken): FileDecoration | undefined {
-		const [, , status, current] = uri.path.split('/');
+	provideBranchDecoration(uri: Uri, _token: CancellationToken): FileDecoration | undefined {
+		const query = new URLSearchParams(uri.query);
 
-		if (!current) return undefined;
+		const current = Boolean(query.get('current'));
+		const opened = Boolean(query.get('opened'));
+		const status = query.get('status')! as GitBranchStatus;
+
+		if (!current && !opened) return undefined;
 
 		let color;
 		switch (status as GitBranchStatus) {
@@ -218,7 +222,7 @@ export class ViewFileDecorationProvider implements FileDecorationProvider, Dispo
 		return {
 			badge: GlyphChars.Check,
 			color: color,
-			tooltip: 'Current Branch',
+			tooltip: current ? 'Current Branch' : 'Opened Worktree Branch',
 		};
 	}
 


### PR DESCRIPTION
Adds a new `gitlens.views.collapseWorktreesWhenPossible` setting to change how we will try to show the opened worktrees (in a workspace) in many views  -- either as multiple repositories (default and existing behavior) or as a single (common) repository when possible.

Views currently affected: Branches, Remotes, Stashes, Tags, Worktrees, and Contributors (when showing all branches)

The Commit Graph & quickpicks are currently unaffected and should be addressed separately,