### PR TITLE
Updates quick focus PR categorization

### DIFF
--- a/package.json
+++ b/package.json
@@ -16908,7 +16908,7 @@
 	},
 	"dependencies": {
 		"@gitkraken/gitkraken-components": "10.2.13",
-		"@gitkraken/provider-apis": "0.18.1",
+		"@gitkraken/provider-apis": "0.21.0",
 		"@gitkraken/shared-web-components": "0.1.1-rc.15",
 		"@lit/react": "1.0.3",
 		"@microsoft/fast-element": "1.12.0",

--- a/src/cache.ts
+++ b/src/cache.ts
@@ -1,6 +1,7 @@
 // import type { EnrichedAutolink } from './annotations/autolinks';
 import type { Disposable } from './api/gitlens';
 import type { Container } from './container';
+import type { Account } from './git/models/author';
 import type { DefaultBranch } from './git/models/defaultBranch';
 import type { IssueOrPullRequest } from './git/models/issue';
 import type { PullRequest } from './git/models/pullRequest';
@@ -16,6 +17,7 @@ type Caches = {
 	prByBranch: { key: `branch:${string}:${string}`; value: PullRequest };
 	prsBySha: { key: `sha:${string}:${string}`; value: PullRequest };
 	repoMetadata: { key: `repo:${string}`; value: RepositoryMetadata };
+	currentAccount: { key: `id:${string}`; value: Account };
 };
 
 type Cache = keyof Caches;
@@ -135,6 +137,11 @@ export class CacheProvider implements Disposable {
 		return this.get('repoMetadata', `repo:${key}`, etag, cacheable);
 	}
 
+	getCurrentAccount(integration: IntegrationBase, cacheable: Cacheable<Account>): CacheResult<Account> {
+		const { key, etag } = getIntegrationKeyAndEtag(integration);
+		return this.get('currentAccount', `id:${key}`, etag, cacheable);
+	}
+
 	private set<T extends Cache>(
 		cache: T,
 		key: CacheKey<T>,
@@ -189,6 +196,7 @@ function getExpiresAt<T extends Cache>(cache: T, value: CacheValue<T> | undefine
 	switch (cache) {
 		case 'defaultBranch':
 		case 'repoMetadata':
+		case 'currentAccount':
 			return 0; // Never expires
 		case 'issuesOrPrsById':
 		case 'issuesOrPrsByIdAndRepo': {
@@ -222,4 +230,8 @@ function getExpiresAt<T extends Cache>(cache: T, value: CacheValue<T> | undefine
 
 function getResourceKeyAndEtag(resource: ResourceDescriptor, integration?: HostingIntegration | IntegrationBase) {
 	return { key: resource.key, etag: `${resource.key}:${integration?.maybeConnected ?? false}` };
+}
+
+function getIntegrationKeyAndEtag(integration: IntegrationBase) {
+	return { key: integration.id, etag: `${integration.id}:${integration.maybeConnected ?? false}` };
 }

--- a/src/git/models/pullRequest.ts
+++ b/src/git/models/pullRequest.ts
@@ -31,6 +31,15 @@ export const enum PullRequestMergeMethod {
 	Rebase = 'rebase',
 }
 
+export const enum PullRequestReviewState {
+	Approved = 'APPROVED',
+	ChangesRequested = 'CHANGES_REQUESTED',
+	Commented = 'COMMENTED',
+	Dismissed = 'DISMISSED',
+	Pending = 'PENDING',
+	ReviewRequested = 'REVIEW_REQUESTED',
+}
+
 export interface PullRequestRef {
 	owner: string;
 	repo: string;
@@ -53,8 +62,9 @@ export interface PullRequestMember {
 }
 
 export interface PullRequestReviewer {
-	isCodeOwner: boolean;
+	isCodeOwner?: boolean;
 	reviewer: PullRequestMember;
+	state: PullRequestReviewState;
 }
 
 export interface PullRequestShape extends IssueOrPullRequest {
@@ -163,6 +173,7 @@ export class PullRequest implements PullRequestShape {
 		public readonly thumbsUpCount?: number,
 		public readonly reviewDecision?: PullRequestReviewDecision,
 		public readonly reviewRequests?: PullRequestReviewer[],
+		public readonly latestReviews?: PullRequestReviewer[],
 		public readonly assignees?: PullRequestMember[],
 		public readonly statusCheckRollupState?: PullRequestStatusCheckRollupState,
 	) {}

--- a/src/plus/focus/enrichmentService.ts
+++ b/src/plus/focus/enrichmentService.ts
@@ -44,7 +44,7 @@ type EnrichedItemResponse = {
 	userId?: string;
 	type: 'pin' | 'snooze';
 
-	provider: 'azure' | 'bitbucket' | 'github' | 'gitlab' | 'gitkraken';
+	provider: 'azure' | 'bitbucket' | 'github' | 'gitlab' | 'jira' | 'trello' | 'gitkraken';
 	entityType: 'issue' | 'pr';
 	entityId: string;
 	entityUrl: string;

--- a/src/plus/focus/focus.ts
+++ b/src/plus/focus/focus.ts
@@ -35,12 +35,15 @@ import { groupAndSortFocusItems } from './focusProvider';
 
 const actionGroupMap = new Map<FocusActionCategory, string[]>([
 	['mergeable', ['Ready to Merge', 'Ready to merge']],
-	['mergeable-conflicts', ['Resolve Conflicts', 'You need to resolve merge conflicts, before this can be merged']],
+	['unassigned-reviewers', ['Unassigned Reviewers', 'You need to assign reviewers']],
 	['failed-checks', ['Failed Checks', 'You need to resolve the failing checks']],
 	['conflicts', ['Resolve Conflicts', 'You need to resolve merge conflicts']],
-	['needs-review', ['Needs Your Review', `\${author} requested your review`]],
+	['needs-my-review', ['Needs Your Review', `\${author} requested your review`]],
 	['changes-requested', ['Changes Requested', 'Reviewers requested changes before this can be merged']],
+	['reviewer-commented', ['Reviewers Commented', 'Reviewers have commented on this pull request']],
 	['waiting-for-review', ['Waiting for Review', 'Waiting for reviewers to approve this pull request']],
+	['draft', ['Draft', 'Continue working on your draft']],
+	['other', ['Other', 'Other pull requests']],
 ]);
 
 const groupMap = new Map<FocusGroup, [string, ThemeIcon | undefined]>([
@@ -51,6 +54,8 @@ const groupMap = new Map<FocusGroup, [string, ThemeIcon | undefined]>([
 	['needs-attention', ['Needs Your Attention', new ThemeIcon('bell-dot')]], //comment-unresolved
 	['needs-review', ['Needs Your Review', new ThemeIcon('comment-draft')]], // feedback
 	['waiting-for-review', ['Waiting for Review', new ThemeIcon('gitlens-clock')]],
+	['draft', ['Draft', new ThemeIcon('comment-discussion')]],
+	['other', ['Other', new ThemeIcon('question')]],
 	['snoozed', ['Snoozed', new ThemeIcon('bell-slash')]],
 ]);
 

--- a/src/plus/focus/focus.ts
+++ b/src/plus/focus/focus.ts
@@ -312,7 +312,7 @@ export class FocusCommand extends QuickCommand<State> {
 					state.item.id
 				} \u2022 ${fromNow(state.item.updatedDate)}`,
 				detail: interpolate(actionGroupMap.get(state.item.actionableCategory)![1], {
-					author: state.item.author,
+					author: state.item.author!.username,
 				}),
 				iconPath: state.item.author?.avatarUrl != null ? Uri.parse(state.item.author.avatarUrl) : undefined,
 			}),

--- a/src/plus/focus/focus.ts
+++ b/src/plus/focus/focus.ts
@@ -148,7 +148,7 @@ export class FocusCommand extends QuickCommand<State> {
 					break;
 				}
 				case 'open':
-					void openUrl(state.item.url);
+					void openUrl(state.item.url!);
 					break;
 				case 'review':
 				case 'switch': {
@@ -210,8 +210,8 @@ export class FocusCommand extends QuickCommand<State> {
 							}
 
 							buttons.push(
-								i.pinned ? UnpinQuickInputButton : PinQuickInputButton,
-								i.snoozed ? UnsnoozeQuickInputButton : SnoozeQuickInputButton,
+								i.viewer.pinned ? UnpinQuickInputButton : PinQuickInputButton,
+								i.viewer.snoozed ? UnsnoozeQuickInputButton : SnoozeQuickInputButton,
 							);
 
 							return {
@@ -219,11 +219,11 @@ export class FocusCommand extends QuickCommand<State> {
 								// description: `${i.repoAndOwner}#${i.id}, by @${i.author}`,
 								description: `#${i.id} ${i.isNew ? '(New since last view)' : ''}`,
 								detail: `      ${actionGroupMap.get(i.actionableCategory)![0]} \u2022  ${fromNow(
-									i.date,
-								)} by @${i.author} \u2022 ${i.repoAndOwner}`,
+									i.updatedDate,
+								)} by @${i.author!.username} \u2022 ${i.repository.owner.login}/${i.repository.name}`,
 
 								buttons: buttons,
-								iconPath: i.avatarUrl != null ? Uri.parse(i.avatarUrl) : undefined,
+								iconPath: i.author?.avatarUrl != null ? Uri.parse(i.author.avatarUrl) : undefined,
 								item: i,
 								picked: i.id === picked,
 							};
@@ -308,11 +308,13 @@ export class FocusCommand extends QuickCommand<State> {
 		const confirmations: (QuickPickItemOfT<FocusAction> | DirectiveQuickPickItem)[] = [
 			createDirectiveQuickPickItem(Directive.Noop, false, {
 				label: state.item.title,
-				description: `${state.item.repoAndOwner}#${state.item.id} \u2022 ${fromNow(state.item.date)}`,
+				description: `${state.item.repository.owner.login}/${state.item.repository.name}#${
+					state.item.id
+				} \u2022 ${fromNow(state.item.updatedDate)}`,
 				detail: interpolate(actionGroupMap.get(state.item.actionableCategory)![1], {
 					author: state.item.author,
 				}),
-				iconPath: state.item.avatarUrl != null ? Uri.parse(state.item.avatarUrl) : undefined,
+				iconPath: state.item.author?.avatarUrl != null ? Uri.parse(state.item.author.avatarUrl) : undefined,
 			}),
 			createQuickPickSeparator(),
 			createDirectiveQuickPickItem(Directive.Noop, false, {
@@ -402,7 +404,7 @@ export class FocusCommand extends QuickCommand<State> {
 		}
 
 		const step = this.createConfirmStep(
-			`Focus on ${state.item.repoAndOwner}#${state.item.id}`,
+			`Focus on ${state.item.repository.owner.login}/${state.item.repository.name}#${state.item.id}`,
 			confirmations,
 			undefined,
 			{ placeholder: 'Choose an action to perform' },

--- a/src/plus/focus/focusIndicator.ts
+++ b/src/plus/focus/focusIndicator.ts
@@ -162,9 +162,7 @@ export class FocusIndicator implements Disposable {
 								break;
 							case 'blocked': {
 								const action = groupByMap(items, i =>
-									i.actionableCategory === 'failed-checks' ||
-									i.actionableCategory === 'mergeable-conflicts' ||
-									i.actionableCategory === 'conflicts'
+									i.actionableCategory === 'failed-checks' || i.actionableCategory === 'conflicts'
 										? i.actionableCategory
 										: 'blocked',
 								);
@@ -176,18 +174,6 @@ export class FocusIndicator implements Disposable {
 										'pull request',
 										actionGroupItems.length,
 									)} that ${actionGroupItems.length > 1 ? 'have' : 'has'} failed CI checks.`;
-									this._statusBarFocus.tooltip.appendMarkdown(
-										`<span style="color:#FF0000;">$(circle-filled)</span> ${message}`,
-									);
-									item ??= actionGroupItems[0];
-								}
-
-								actionGroupItems = action.get('mergeable-conflicts');
-								if (actionGroupItems?.length) {
-									const message = `You have ${pluralize(
-										'pull request',
-										actionGroupItems.length,
-									)} that can be merged once conflicts are resolved.`;
 									this._statusBarFocus.tooltip.appendMarkdown(
 										`<span style="color:#FF0000;">$(circle-filled)</span> ${message}`,
 									);
@@ -229,10 +215,7 @@ export class FocusIndicator implements Disposable {
 									let label = 'is blocked';
 									if (item.actionableCategory === 'failed-checks') {
 										label = 'failed CI checks';
-									} else if (
-										item.actionableCategory === 'mergeable-conflicts' ||
-										item.actionableCategory === 'conflicts'
-									) {
+									} else if (item.actionableCategory === 'conflicts') {
 										label = 'has conflicts';
 									}
 									topItem ??= { item: item, groupLabel: label };
@@ -244,11 +227,11 @@ export class FocusIndicator implements Disposable {
 									`<span style="color:#FFFF00;">$(circle-filled)</span> You have ${pluralize(
 										'pull request',
 										items.length,
-									)} that ${items.length > 1 ? 'are' : 'is'} waiting for your review.`,
+									)} that ${items.length > 1 ? 'need' : 'needs'} your review.`,
 								);
 								this._statusBarFocus.tooltip.appendMarkdown('\n');
 								this._statusBarFocus.tooltip.appendMarkdown(
-									`<span>[Show all waiting for review](command:gitlens.quickFocus?${encodeURIComponent(
+									`<span>[Show all needing your review](command:gitlens.quickFocus?${encodeURIComponent(
 										JSON.stringify({ state: { initialGroup: 'needs-review' } }),
 									)})</span>`,
 								);

--- a/src/plus/focus/focusProvider.ts
+++ b/src/plus/focus/focusProvider.ts
@@ -5,12 +5,16 @@ import { CancellationError } from '../../errors';
 import type { SearchedIssue } from '../../git/models/issue';
 import type { SearchedPullRequest } from '../../git/models/pullRequest';
 import type { ProviderReference } from '../../git/models/remoteProvider';
-import type { GkProviderId, RepositoryIdentityDescriptor } from '../../gk/models/repositoryIdentities';
 import { configuration } from '../../system/configuration';
 import { getSettledValue } from '../../system/promise';
 import type { UriTypes } from '../../uris/deepLinks/deepLink';
 import { DeepLinkType } from '../../uris/deepLinks/deepLink';
-import { categorizePullRequests, HostingIntegrationId, toProviderPullRequest } from '../integrations/providers/models';
+import type { ProviderActionablePullRequest } from '../integrations/providers/models';
+import {
+	getActionablePullRequests,
+	HostingIntegrationId,
+	toProviderPullRequestWithUniqueId,
+} from '../integrations/providers/models';
 import type { EnrichableItem, EnrichedItem } from './enrichmentService';
 
 export const focusActionCategories = [
@@ -84,35 +88,24 @@ const prActionsMap = new Map<FocusActionCategory, FocusAction[]>([
 	['other', ['switch', 'open']],
 ]);
 
-export type FocusItem = {
+export type FocusItem = ProviderActionablePullRequest & {
 	type: 'pullRequest' | 'issue';
 	provider: ProviderReference;
-	id: string;
-	uniqueId: string;
-	isNew: boolean;
-	title: string;
-	date: Date;
-	author: string;
-	avatarUrl?: string;
-	repoAndOwner?: string;
-	url: string;
-
 	enrichable: EnrichableItem;
-	enriched?: EnrichedItem;
-
+	repoIdentity: {
+		remote: {
+			url?: string;
+		};
+		name: string;
+		provider: {
+			id: string;
+			repoDomain: string;
+			repoName: string;
+		};
+	};
+	isNew: boolean;
 	actionableCategory: FocusActionCategory;
 	suggestedActions: FocusAction[];
-
-	pinned: boolean;
-	snoozed: boolean;
-	sortTime: number;
-
-	repositoryIdentity?: RepositoryIdentityDescriptor;
-	ref?: {
-		branchName: string;
-		sha: string;
-		remoteName: string;
-	};
 };
 
 type CachedFocusPromise<T> = {
@@ -200,7 +193,7 @@ export class FocusProvider implements Disposable {
 	}
 
 	async pin(item: FocusItem) {
-		item.pinned = true;
+		item.viewer.pinned = true;
 		this._onDidChange.fire();
 
 		await this.container.enrichments.pinItem(item.enrichable);
@@ -209,17 +202,19 @@ export class FocusProvider implements Disposable {
 	}
 
 	async unpin(item: FocusItem) {
-		item.pinned = false;
+		item.viewer.pinned = false;
 		this._onDidChange.fire();
 
-		if (item.enriched == null) return;
-		await this.container.enrichments.unpinItem(item.enriched.id);
+		if (item.viewer.enrichedItems == null) return;
+		const pinned = item.viewer.enrichedItems.find(e => e.type === 'pin');
+		if (pinned == null) return;
+		await this.container.enrichments.unpinItem(pinned.id);
 		this._enrichedItems = undefined;
 		this._onDidChange.fire();
 	}
 
 	async snooze(item: FocusItem) {
-		item.snoozed = true;
+		item.viewer.snoozed = true;
 		this._onDidChange.fire();
 
 		await this.container.enrichments.snoozeItem(item.enrichable);
@@ -228,21 +223,23 @@ export class FocusProvider implements Disposable {
 	}
 
 	async unsnooze(item: FocusItem) {
-		item.snoozed = false;
+		item.viewer.snoozed = false;
 		this._onDidChange.fire();
 
-		if (item.enriched == null) return;
-		await this.container.enrichments.unsnoozeItem(item.enriched.id);
+		if (item.viewer.enrichedItems == null) return;
+		const snoozed = item.viewer.enrichedItems.find(e => e.type === 'snooze');
+		if (snoozed == null) return;
+		await this.container.enrichments.unsnoozeItem(snoozed.id);
 		this._enrichedItems = undefined;
 		this._onDidChange.fire();
 	}
 
 	async merge(item: FocusItem): Promise<void> {
-		if (item.uniqueId == null || item.ref?.sha == null) return;
+		if (item.graphQLId == null || item.headRef?.oid == null) return;
 		// TODO: Include other providers.
 		if (item.provider.id !== 'github') return;
 		const integrations = await this.container.integrations.get(HostingIntegrationId.GitHub);
-		await integrations.mergePullRequest({ id: item.uniqueId, headRefSha: item.ref.sha });
+		await integrations.mergePullRequest({ id: item.graphQLId, headRefSha: item.headRef.oid });
 		this.refresh();
 	}
 
@@ -254,7 +251,7 @@ export class FocusProvider implements Disposable {
 	}
 
 	private async getItemBranchDeepLink(item: FocusItem): Promise<Uri | undefined> {
-		if (item.type !== 'pullRequest' || item.ref == null || item.repositoryIdentity?.remote?.url == null)
+		if (item.type !== 'pullRequest' || item.headRef == null || item.repoIdentity?.remote?.url == null)
 			return undefined;
 		const schemeOverride = configuration.get('deepLinks.schemeOverride');
 		const scheme = !schemeOverride ? 'vscode' : schemeOverride === true ? env.uriScheme : schemeOverride;
@@ -265,8 +262,8 @@ export class FocusProvider implements Disposable {
 			Uri.parse(
 				`${scheme}://${this.container.context.extension.id}/${'link' satisfies UriTypes}/${
 					DeepLinkType.Repository
-				}/-/${DeepLinkType.Branch}/${item.ref.branchName}?url=${encodeURIComponent(
-					ensureRemoteUrl(item.repositoryIdentity.remote.url),
+				}/-/${DeepLinkType.Branch}/${item.headRef.name}?url=${encodeURIComponent(
+					ensureRemoteUrl(item.repoIdentity.remote.url),
 				)}&action=switch`,
 			),
 		);
@@ -331,247 +328,84 @@ export class FocusProvider implements Disposable {
 		]);
 
 		if (cancellation?.isCancellationRequested) throw new CancellationError();
-
-		const enrichedItems = new Map(getSettledValue(enrichedItemsResult)?.map(i => [i.entityId, i]));
-
-		const categorized: FocusItem[] = [];
+		let categorized: FocusItem[] = [];
 
 		// TODO: Since this is all repos we probably should order by repos you are a contributor on (or even filter out one you aren't)
-
 		const prs = getSettledValue(prsResult);
-		if (prs != null) {
-			const prsById = new Map(prs.map(pr => [pr.pullRequest.id, pr]));
-			const github = await this.container.integrations.get(HostingIntegrationId.GitHub);
-			const myAccount = await github.getCurrentAccount();
-			if (myAccount?.username != null) {
-				const bucketedPrs = categorizePullRequests(
-					prs.map(pr => toProviderPullRequest(pr.pullRequest)),
-					{ id: myAccount.username },
-				);
-				for (const bucket of Object.values(bucketedPrs)) {
-					const actionCategory = sharedCategoryToFocusActionCategoryMap.get(bucket.id);
-					for (const bucketedPullRequest of bucket.pullRequests) {
-						const pr = prsById.get(bucketedPullRequest.id);
-						const enrichedItem = enrichedItems.get(pr!.pullRequest.nodeId!);
-						categorized.push(this.createFocusItem(actionCategory!, pr!, enrichedItem));
-					}
+		const enrichedItems = getSettledValue(enrichedItemsResult);
+		// Multiple enriched items can have the same entityId. Map by entityId to an array of enriched items.
+		const enrichedItemsByEntityId: { [id: string]: EnrichedItem[] } = {};
+		if (enrichedItems != null) {
+			for (const enrichedItem of enrichedItems) {
+				if (enrichedItem.entityId in enrichedItemsByEntityId) {
+					enrichedItemsByEntityId[enrichedItem.entityId].push(enrichedItem);
+				} else {
+					enrichedItemsByEntityId[enrichedItem.entityId] = [enrichedItem];
 				}
 			}
 		}
 
-		/* if (prs != null) {
-			outer: for (const pr of prs) {
-				if (pr.pullRequest.isDraft) continue;
+		if (prs != null) {
+			const github = await this.container.integrations.get(HostingIntegrationId.GitHub);
+			const myAccount = await github.getCurrentAccount();
+			const inputPrs = prs.map(pr => {
+				const providerPr = toProviderPullRequestWithUniqueId(pr.pullRequest);
+				const enrichable = {
+					type: 'pr',
+					id: providerPr.uuid,
+					url: pr.pullRequest.url,
+					provider: 'github',
+				};
+				const repoIdentity = {
+					remote: { url: pr.pullRequest.refs?.head?.url },
+					name: pr.pullRequest.repository.repo,
+					provider: {
+						id: pr.pullRequest.provider.id,
+						repoDomain: pr.pullRequest.repository.owner,
+						repoName: pr.pullRequest.repository.repo,
+					},
+				};
 
-				const enrichedItem = enrichedItems.get(pr.pullRequest.nodeId!);
+				return {
+					...providerPr,
+					type: 'pullRequest',
+					uuid: providerPr.uuid,
+					provider: pr.pullRequest.provider,
+					enrichable: enrichable,
+					repoIdentity: repoIdentity,
+				};
+			});
 
-				if (pr.reasons.includes('authored')) {
-					if (pr.pullRequest.statusCheckRollupState === PullRequestStatusCheckRollupState.Failed) {
-						categorized.push(this.createFocusItem('failed-checks', pr, enrichedItem));
-						continue;
-					}
-
-					const viewerHasMergeAccess =
-						pr.pullRequest.viewerCanUpdate &&
-						pr.pullRequest.repository.accessLevel != null &&
-						pr.pullRequest.repository.accessLevel >= RepositoryAccessLevel.Write;
-
-					switch (pr.pullRequest.mergeableState) {
-						case PullRequestMergeableState.Mergeable:
-							switch (pr.pullRequest.reviewDecision) {
-								case PullRequestReviewDecision.Approved:
-									if (viewerHasMergeAccess) {
-										categorized.push(this.createFocusItem('mergeable', pr, enrichedItem));
-									} // TODO: should it be on in any group if you can't merge? maybe need to check if you are a contributor to the repo or something
-									continue outer;
-								case PullRequestReviewDecision.ChangesRequested:
-									categorized.push(this.createFocusItem('changes-requested', pr, enrichedItem));
-									continue outer;
-								case PullRequestReviewDecision.ReviewRequired:
-									categorized.push(this.createFocusItem('waiting-for-review', pr, enrichedItem));
-									continue outer;
-								case undefined:
-									if (pr.pullRequest.reviewRequests?.length) {
-										categorized.push(this.createFocusItem('waiting-for-review', pr, enrichedItem));
-										continue outer;
-									} else {
-										categorized.push(this.createFocusItem('waiting-for-review', pr, enrichedItem));
-										continue outer;
-									}
-									break;
-							}
-							break;
-						case PullRequestMergeableState.Conflicting:
-							if (
-								pr.pullRequest.reviewDecision === PullRequestReviewDecision.Approved &&
-								viewerHasMergeAccess
-							) {
-								categorized.push(this.createFocusItem('mergeable-conflicts', pr, enrichedItem));
-							} else {
-								categorized.push(this.createFocusItem('conflicts', pr, enrichedItem));
-							}
-							continue outer;
-					}
-				}
-
-				if (pr.reasons.includes('review-requested')) {
-					// Skip adding if there are failed CI checks
-					if (pr.pullRequest.statusCheckRollupState === PullRequestStatusCheckRollupState.Failed) continue;
-
-					categorized.push(this.createFocusItem('needs-review', pr, enrichedItem));
-					continue;
-				}
-			}
-		} */
-
-		// const issues = getSettledValue(issuesResult);
-		// if (issues != null) {
-		// 	for (const issue of issues.splice(0, 3)) {
-		// 		let next = false;
-
-		// 		const enrichedItem = enrichedItems.get(issue.issue.nodeId!);
-		// 		if (enrichedItem != null) {
-		// 			switch (enrichedItem.type) {
-		// 				case 'pin':
-		// 					addItemToGroup(grouped, 'Pinned', issue);
-		// 					next = true;
-		// 					break;
-		// 				case 'snooze':
-		// 					addItemToGroup(grouped, 'Snoozed', issue);
-		// 					next = true;
-		// 					break;
-		// 			}
-
-		// 			if (next) continue;
-		// 		}
-
-		// 		if (issue.reasons.includes('assigned')) {
-		// 			addItemToGroup(grouped, 'In Progress', issue);
-		// 			continue;
-		// 		}
-		// 	}
-		// }
-
-		// // Sort the grouped map by the order of the Groups array
-		// const sorted = new Map<FocusActionCategory, FocusItem[]>();
-		// for (const group of actionCategories) {
-		// 	const items = categorized.get(group);
-		// 	if (items == null) continue;
-
-		// 	sorted.set(
-		// 		group,
-		// 		items.sort((a, b) => (a.pinned ? -1 : 1) - (b.pinned ? -1 : 1) || b.sortTime - a.sortTime),
-		// 	);
-		// }
+			const actionableItems = getActionablePullRequests(
+				inputPrs,
+				{ id: myAccount!.username! },
+				{ enrichedItemsByUniqueId: enrichedItemsByEntityId },
+			);
+			// Map from shared category label to local actionable category, and get suggested actions
+			categorized = actionableItems.map(item => {
+				const actionableCategory = sharedCategoryToFocusActionCategoryMap.get(item.suggestedActionCategory)!;
+				const suggestedActions = prActionsMap.get(actionableCategory)!;
+				return {
+					...item,
+					isNew:
+						this._groupedIds != null &&
+						!this._groupedIds.has(`${item.uuid}:${focusCategoryToGroupMap.get(actionableCategory)}`),
+					actionableCategory: actionableCategory,
+					suggestedActions: suggestedActions,
+				};
+			}) as FocusItem[];
+		}
 
 		this.updateGroupedIds(categorized);
 		this._onDidRefresh.fire({ items: categorized });
 		return categorized;
 	}
 
-	private createFocusItem(
-		category: FocusActionCategory,
-		item: SearchedPullRequest | SearchedIssue,
-		enriched?: EnrichedItem,
-	): FocusItem {
-		return 'pullRequest' in item
-			? {
-					type: 'pullRequest',
-					provider: item.pullRequest.provider,
-					id: item.pullRequest.id,
-					uniqueId: item.pullRequest.nodeId!,
-					isNew:
-						this._groupedIds != null &&
-						!this._groupedIds.has(`${item.pullRequest.nodeId!}:${focusCategoryToGroupMap.get(category)}`),
-					title: item.pullRequest.title,
-					date: item.pullRequest.updatedDate,
-					author: item.pullRequest.author.name,
-					avatarUrl: item.pullRequest.author.avatarUrl,
-					repoAndOwner: `${item.pullRequest.repository.owner}/${item.pullRequest.repository.repo}`,
-					url: item.pullRequest.url,
-
-					enrichable: {
-						type: 'pr',
-						id: item.pullRequest.nodeId!,
-						url: item.pullRequest.url,
-						provider: 'github',
-					},
-					enriched: enriched,
-
-					actionableCategory: category,
-					suggestedActions: prActionsMap.get(category)!,
-
-					pinned: enriched?.type === 'pin',
-					snoozed: enriched?.type === 'snooze',
-					sortTime: item.pullRequest.updatedDate.getTime(),
-					repositoryIdentity: {
-						remote: { url: item.pullRequest.refs?.head?.url },
-						name: item.pullRequest.repository.repo,
-						provider: {
-							// TODO: fix this typing, set according to item
-							id: 'github' as GkProviderId,
-							repoDomain: item.pullRequest.repository.owner,
-							repoName: item.pullRequest.repository.repo,
-						},
-					},
-					ref:
-						item.pullRequest.refs?.head != null
-							? {
-									branchName: item.pullRequest.refs.head.branch,
-									sha: item.pullRequest.refs.head.sha,
-									remoteName: item.pullRequest.refs.head.owner,
-							  }
-							: undefined,
-			  }
-			: {
-					type: 'issue',
-					provider: item.issue.provider,
-					id: item.issue.id,
-					uniqueId: item.issue.nodeId!,
-					isNew:
-						this._groupedIds != null &&
-						!this._groupedIds.has(`${item.issue.nodeId!}:${focusCategoryToGroupMap.get(category)}`),
-					title: item.issue.title,
-					date: item.issue.updatedDate,
-					author: item.issue.author.name,
-					avatarUrl: item.issue.author.avatarUrl,
-					repoAndOwner: `${item.issue.repository?.owner}/${item.issue.repository?.repo}`,
-					url: item.issue.url,
-
-					enrichable: {
-						type: 'issue',
-						id: item.issue.nodeId!,
-						url: item.issue.url,
-						provider: 'github',
-					},
-					enriched: enriched,
-
-					actionableCategory: category,
-					suggestedActions: [],
-
-					pinned: enriched?.type === 'pin',
-					snoozed: enriched?.type === 'snooze',
-					sortTime: item.issue.updatedDate.getTime(),
-					repositoryIdentity:
-						item.issue.repository != null
-							? {
-									name: item.issue.repository?.repo,
-									provider: {
-										// TODO: fix this typing, set according to item
-										id: 'github' as GkProviderId,
-										repoDomain: item.issue.repository?.owner,
-										repoName: item.issue.repository?.repo,
-									},
-							  }
-							: undefined,
-			  };
-	}
-
 	private updateGroupedIds(items: FocusItem[]) {
 		const groupedIds = new Set<string>();
 		for (const item of items) {
 			const group = focusCategoryToGroupMap.get(item.actionableCategory)!;
-			const key = `${item.uniqueId}:${group}`;
+			const key = `${item.uuid}:${group}`;
 			if (!groupedIds.has(key)) {
 				groupedIds.add(key);
 			}
@@ -591,13 +425,14 @@ export function groupAndSortFocusItems(items?: FocusItem[]) {
 	const snoozedGroup = grouped.get('snoozed')!;
 
 	for (const item of items) {
-		if (item.pinned && !pinnedGroup.some(i => i.uniqueId === item.uniqueId)) {
-			pinnedGroup.push(item);
-		} else if (item.snoozed) {
-			if (!snoozedGroup.some(i => i.uniqueId === item.uniqueId)) {
+		if (item.viewer.snoozed) {
+			if (!snoozedGroup.some(i => i.uuid === item.uuid)) {
 				snoozedGroup.push(item);
 			}
+
 			continue;
+		} else if (item.viewer.pinned && !pinnedGroup.some(i => i.uuid === item.uuid)) {
+			pinnedGroup.push(item);
 		}
 
 		const group = focusCategoryToGroupMap.get(item.actionableCategory)!;
@@ -610,9 +445,9 @@ export function groupAndSortFocusItems(items?: FocusItem[]) {
 export function sortFocusItems(items: FocusItem[]) {
 	return items.sort(
 		(a, b) =>
-			(a.pinned ? -1 : 1) - (b.pinned ? -1 : 1) ||
+			(a.viewer.pinned ? -1 : 1) - (b.viewer.pinned ? -1 : 1) ||
 			focusActionCategories.indexOf(b.actionableCategory) - focusActionCategories.indexOf(a.actionableCategory) ||
-			b.sortTime - a.sortTime,
+			b.updatedDate.getTime() - a.updatedDate.getTime(),
 	);
 }
 

--- a/src/plus/integrations/integration.ts
+++ b/src/plus/integrations/integration.ts
@@ -362,6 +362,29 @@ export abstract class IntegrationBase<
 		resource: T,
 		id: string,
 	): Promise<IssueOrPullRequest | undefined>;
+
+	async getCurrentAccount(options?: { avatarSize?: number }): Promise<Account | undefined> {
+		const connected = this.maybeConnected ?? (await this.isConnected());
+		if (!connected) return undefined;
+
+		const currentAccount = this.container.cache.getCurrentAccount(this, () => ({
+			value: (async () => {
+				try {
+					const account = await this.getProviderCurrentAccount(this._session!, options);
+					this.resetRequestExceptionCount();
+					return account;
+				} catch (ex) {
+					return this.handleProviderException<Account | undefined>(ex, undefined, undefined);
+				}
+			})(),
+		}));
+		return currentAccount;
+	}
+
+	protected abstract getProviderCurrentAccount(
+		session: ProviderAuthenticationSession,
+		options?: { avatarSize?: number },
+	): Promise<Account | undefined>;
 }
 
 export abstract class IssueIntegration<

--- a/src/plus/integrations/integration.ts
+++ b/src/plus/integrations/integration.ts
@@ -364,6 +364,8 @@ export abstract class IntegrationBase<
 	): Promise<IssueOrPullRequest | undefined>;
 
 	async getCurrentAccount(options?: { avatarSize?: number }): Promise<Account | undefined> {
+		const scope = getLogScope();
+
 		const connected = this.maybeConnected ?? (await this.isConnected());
 		if (!connected) return undefined;
 
@@ -374,7 +376,7 @@ export abstract class IntegrationBase<
 					this.resetRequestExceptionCount();
 					return account;
 				} catch (ex) {
-					return this.handleProviderException<Account | undefined>(ex, undefined, undefined);
+					return this.handleProviderException<Account | undefined>(ex, scope, undefined);
 				}
 			})(),
 		}));

--- a/src/plus/integrations/providers/azureDevOps.ts
+++ b/src/plus/integrations/providers/azureDevOps.ts
@@ -60,6 +60,13 @@ export class AzureDevOpsIntegration extends HostingIntegration<
 	}
 
 	// TODO: implement
+	protected override async getProviderCurrentAccount(
+		_session: AuthenticationSession,
+		_options?: { avatarSize?: number },
+	): Promise<Account | undefined> {
+		return Promise.resolve(undefined);
+	}
+
 	protected override async mergeProviderPullRequest(
 		_session: AuthenticationSession,
 		_pr: PullRequest | { id: string; headRefSha: string },

--- a/src/plus/integrations/providers/bitbucket.ts
+++ b/src/plus/integrations/providers/bitbucket.ts
@@ -39,6 +39,13 @@ export class BitbucketIntegration extends HostingIntegration<
 	}
 
 	// TODO: implement
+	protected override async getProviderCurrentAccount(
+		_session: AuthenticationSession,
+		_options?: { avatarSize?: number },
+	): Promise<Account | undefined> {
+		return Promise.resolve(undefined);
+	}
+
 	protected override async mergeProviderPullRequest(
 		_session: AuthenticationSession,
 		_pr: PullRequest | { id: string; headRefSha: string },

--- a/src/plus/integrations/providers/github.ts
+++ b/src/plus/integrations/providers/github.ts
@@ -185,6 +185,16 @@ abstract class GitHubIntegrationBase<ID extends SupportedIntegrationIds> extends
 			}) ?? false
 		);
 	}
+
+	protected override async getProviderCurrentAccount(
+		{ accessToken }: AuthenticationSession,
+		options?: { avatarSize?: number },
+	): Promise<Account | undefined> {
+		return (await this.container.github)?.getCurrentAccount(this, accessToken, {
+			...options,
+			baseUrl: this.apiBaseUrl,
+		});
+	}
 }
 
 export class GitHubIntegration extends GitHubIntegrationBase<HostingIntegrationId.GitHub> {

--- a/src/plus/integrations/providers/github/github.ts
+++ b/src/plus/integrations/providers/github/github.ts
@@ -143,6 +143,16 @@ reviewRequests(first: 10) {
 		}
 	}
 }
+latestReviews (first: 10) {
+	nodes {
+		author {
+			login
+			avatarUrl
+			url
+		}
+		state
+	}
+}
 totalCommentsCount
 commits(last: 1) {
 	nodes {

--- a/src/plus/integrations/providers/gitlab.ts
+++ b/src/plus/integrations/providers/gitlab.ts
@@ -155,6 +155,13 @@ abstract class GitLabIntegrationBase<ID extends SupportedIntegrationIds> extends
 		return Promise.resolve(undefined);
 	}
 
+	protected override async getProviderCurrentAccount(
+		_session: AuthenticationSession,
+		_options?: { avatarSize?: number },
+	): Promise<Account | undefined> {
+		return Promise.resolve(undefined);
+	}
+
 	protected override async mergeProviderPullRequest(
 		_session: AuthenticationSession,
 		_pr: PullRequest | { id: string; headRefSha: string },

--- a/src/plus/integrations/providers/jira.ts
+++ b/src/plus/integrations/providers/jira.ts
@@ -297,6 +297,13 @@ export class JiraIntegration extends IssueIntegration<IssueIntegrationId.Jira> {
 		}
 	}
 
+	protected override async getProviderCurrentAccount(
+		_session: AuthenticationSession,
+		_options?: { avatarSize?: number },
+	): Promise<Account | undefined> {
+		return Promise.resolve(undefined);
+	}
+
 	protected override providerOnDisconnect(): void {
 		this._organizations = undefined;
 		this._projects = undefined;

--- a/src/plus/integrations/providers/models.ts
+++ b/src/plus/integrations/providers/models.ts
@@ -4,9 +4,13 @@ import type {
 	Bitbucket,
 	EnterpriseOptions,
 	GetRepoInput,
+	GitBuildStatusState,
 	GitHub,
 	GitLab,
 	GitPullRequest,
+	GitPullRequestMergeableState,
+	GitPullRequestReviewState,
+	GitPullRequestState,
 	GitRepository,
 	Issue,
 	Jira,
@@ -14,8 +18,17 @@ import type {
 	JiraResource,
 	Trello,
 } from '@gitkraken/provider-apis';
+import { GitProviderUtils } from '@gitkraken/provider-apis';
 import type { Account as UserAccount } from '../../../git/models/author';
-import type { SearchedIssue } from '../../../git/models/issue';
+import type { IssueMember, SearchedIssue } from '../../../git/models/issue';
+import { RepositoryAccessLevel } from '../../../git/models/issue';
+import type { PullRequest, PullRequestMember, PullRequestReviewer } from '../../../git/models/pullRequest';
+import {
+	PullRequestMergeableState,
+	PullRequestReviewDecision,
+	PullRequestReviewState,
+	PullRequestStatusCheckRollupState,
+} from '../../../git/models/pullRequest';
 import type { ProviderReference } from '../../../git/models/remoteProvider';
 
 export type ProviderAccount = Account;
@@ -479,3 +492,174 @@ export function toAccount(account: ProviderAccount, provider: ProviderReference)
 		username: account.username ?? undefined,
 	};
 }
+
+export const toProviderBuildStatusState = {
+	[PullRequestStatusCheckRollupState.Success]: 'SUCCESS' as GitBuildStatusState,
+	[PullRequestStatusCheckRollupState.Failed]: 'FAILED' as GitBuildStatusState,
+	[PullRequestStatusCheckRollupState.Pending]: 'PENDING' as GitBuildStatusState,
+};
+
+export const toProviderPullRequestReviewState = {
+	[PullRequestReviewState.Approved]: 'APPROVED' as GitPullRequestReviewState,
+	[PullRequestReviewState.ChangesRequested]: 'CHANGES_REQUESTED' as GitPullRequestReviewState,
+	[PullRequestReviewState.Commented]: 'COMMENTED' as GitPullRequestReviewState,
+	[PullRequestReviewState.ReviewRequested]: 'REVIEW_REQUESTED' as GitPullRequestReviewState,
+	[PullRequestReviewState.Dismissed]: null,
+	[PullRequestReviewState.Pending]: null,
+};
+
+export const toProviderPullRequestMergeableState = {
+	[PullRequestMergeableState.Mergeable]: 'MERGEABLE' as GitPullRequestMergeableState,
+	[PullRequestMergeableState.Conflicting]: 'CONFLICTS' as GitPullRequestMergeableState,
+	[PullRequestMergeableState.Unknown]: 'UNKNOWN' as GitPullRequestMergeableState,
+};
+
+export function toProviderReviews(reviewers: PullRequestReviewer[]): ProviderPullRequest['reviews'] {
+	return reviewers
+		.filter(r => r.state !== PullRequestReviewState.Dismissed && r.state !== PullRequestReviewState.Pending)
+		.map(reviewer => ({
+			reviewer: toProviderAccount(reviewer.reviewer),
+			state:
+				toProviderPullRequestReviewState[reviewer.state] ?? ('REVIEW_REQUESTED' as GitPullRequestReviewState),
+		}));
+}
+
+export function toProviderReviewDecision(
+	reviewDecision?: PullRequestReviewDecision,
+	reviewers?: PullRequestReviewer[],
+): GitPullRequestReviewState | null {
+	switch (reviewDecision) {
+		case PullRequestReviewDecision.Approved:
+			return 'APPROVED' as GitPullRequestReviewState;
+		case PullRequestReviewDecision.ChangesRequested:
+			return 'CHANGES_REQUESTED' as GitPullRequestReviewState;
+		case PullRequestReviewDecision.ReviewRequired:
+			return 'REVIEW_REQUESTED' as GitPullRequestReviewState;
+		default: {
+			if (reviewers?.some(r => r.state === PullRequestReviewState.ReviewRequested)) {
+				return 'REVIEW_REQUESTED' as GitPullRequestReviewState;
+			} else if (reviewers?.some(r => r.state === PullRequestReviewState.Commented)) {
+				return 'COMMENTED' as GitPullRequestReviewState;
+			}
+			return null;
+		}
+	}
+}
+
+export function toProviderPullRequest(pr: PullRequest): ProviderPullRequest {
+	const prReviews = [...(pr.reviewRequests ?? []), ...(pr.latestReviews ?? [])];
+	return {
+		id: pr.id,
+		graphQLId: pr.nodeId,
+		number: Number.parseInt(pr.id, 10),
+		title: pr.title,
+		url: pr.url,
+		state:
+			pr.state === 'opened'
+				? ('OPEN' as GitPullRequestState)
+				: pr.state === 'closed'
+				  ? ('CLOSED' as GitPullRequestState)
+				  : ('MERGED' as GitPullRequestState),
+		isDraft: pr.isDraft ?? false,
+		createdDate: pr.createdDate,
+		updatedDate: pr.updatedDate,
+		closedDate: pr.closedDate ?? null,
+		mergedDate: pr.mergedDate ?? null,
+		commentCount: pr.commentsCount ?? null,
+		upvoteCount: pr.thumbsUpCount ?? null,
+		commitCount: null,
+		fileCount: null,
+		additions: pr.additions ?? null,
+		deletions: pr.deletions ?? null,
+		author: toProviderAccount(pr.author),
+		assignees: pr.assignees?.map(toProviderAccount) ?? null,
+		baseRef:
+			pr.refs?.base == null
+				? null
+				: {
+						name: pr.refs.base.branch,
+						oid: pr.refs.base.sha,
+				  },
+		headRef:
+			pr.refs?.head == null
+				? null
+				: {
+						name: pr.refs.head.branch,
+						oid: pr.refs.head.sha,
+				  },
+		reviews: toProviderReviews(prReviews),
+		reviewDecision: toProviderReviewDecision(pr.reviewDecision, prReviews),
+		repository:
+			pr.refs?.base != null
+				? {
+						id: pr.refs.base.repo,
+						name: pr.refs.base.repo,
+						owner: {
+							login: pr.refs.base.owner,
+						},
+						remoteInfo: null,
+				  }
+				: {
+						id: '',
+						name: '',
+						owner: {
+							login: '',
+						},
+						remoteInfo: null,
+				  },
+		headRepository:
+			pr.refs?.head != null
+				? {
+						id: pr.refs.head.repo,
+						name: pr.refs.head.repo,
+						owner: {
+							login: pr.refs.head.owner,
+						},
+						remoteInfo: null,
+				  }
+				: null,
+		headCommit:
+			pr.statusCheckRollupState != null
+				? {
+						buildStatuses: [
+							{
+								completedAt: null,
+								description: '',
+								name: '',
+								state: toProviderBuildStatusState[pr.statusCheckRollupState],
+								startedAt: null,
+								stage: null,
+								url: '',
+							},
+						],
+				  }
+				: null,
+		permissions: {
+			canMerge:
+				pr.viewerCanUpdate === true &&
+				pr.repository.accessLevel != null &&
+				pr.repository.accessLevel >= RepositoryAccessLevel.Write,
+			canMergeAndBypassProtections:
+				pr.viewerCanUpdate === true &&
+				pr.repository.accessLevel != null &&
+				pr.repository.accessLevel >= RepositoryAccessLevel.Admin,
+		},
+		mergeableState: pr.mergeableState
+			? toProviderPullRequestMergeableState[pr.mergeableState]
+			: ('UNKNOWN' as GitPullRequestMergeableState),
+	};
+}
+
+export function toProviderAccount(account: PullRequestMember | IssueMember): ProviderAccount {
+	return {
+		avatarUrl: account.avatarUrl ?? null,
+		name: account.name ?? null,
+		url: account.url ?? null,
+		// TODO: Implement these in our own model
+		email: '',
+		username: account.name ?? null,
+		id: account.name ?? null,
+	};
+}
+
+export const categorizePullRequests = GitProviderUtils.groupPullRequestsIntoBuckets;

--- a/src/plus/integrations/providers/models.ts
+++ b/src/plus/integrations/providers/models.ts
@@ -5,13 +5,9 @@ import type {
 	Bitbucket,
 	EnterpriseOptions,
 	GetRepoInput,
-	GitBuildStatusState,
 	GitHub,
 	GitLab,
 	GitPullRequest,
-	GitPullRequestMergeableState,
-	GitPullRequestReviewState,
-	GitPullRequestState,
 	GitRepository,
 	Issue,
 	Jira,
@@ -20,7 +16,13 @@ import type {
 	PullRequestWithUniqueID,
 	Trello,
 } from '@gitkraken/provider-apis';
-import { GitProviderUtils } from '@gitkraken/provider-apis';
+import {
+	GitBuildStatusState,
+	GitProviderUtils,
+	GitPullRequestMergeableState,
+	GitPullRequestReviewState,
+	GitPullRequestState,
+} from '@gitkraken/provider-apis';
 import type { Account as UserAccount } from '../../../git/models/author';
 import type { IssueMember, SearchedIssue } from '../../../git/models/issue';
 import { RepositoryAccessLevel } from '../../../git/models/issue';
@@ -497,24 +499,24 @@ export function toAccount(account: ProviderAccount, provider: ProviderReference)
 }
 
 export const toProviderBuildStatusState = {
-	[PullRequestStatusCheckRollupState.Success]: 'SUCCESS' as GitBuildStatusState,
-	[PullRequestStatusCheckRollupState.Failed]: 'FAILED' as GitBuildStatusState,
-	[PullRequestStatusCheckRollupState.Pending]: 'PENDING' as GitBuildStatusState,
+	[PullRequestStatusCheckRollupState.Success]: GitBuildStatusState.Success,
+	[PullRequestStatusCheckRollupState.Failed]: GitBuildStatusState.Failed,
+	[PullRequestStatusCheckRollupState.Pending]: GitBuildStatusState.Pending,
 };
 
 export const toProviderPullRequestReviewState = {
-	[PullRequestReviewState.Approved]: 'APPROVED' as GitPullRequestReviewState,
-	[PullRequestReviewState.ChangesRequested]: 'CHANGES_REQUESTED' as GitPullRequestReviewState,
-	[PullRequestReviewState.Commented]: 'COMMENTED' as GitPullRequestReviewState,
-	[PullRequestReviewState.ReviewRequested]: 'REVIEW_REQUESTED' as GitPullRequestReviewState,
+	[PullRequestReviewState.Approved]: GitPullRequestReviewState.Approved,
+	[PullRequestReviewState.ChangesRequested]: GitPullRequestReviewState.ChangesRequested,
+	[PullRequestReviewState.Commented]: GitPullRequestReviewState.Commented,
+	[PullRequestReviewState.ReviewRequested]: GitPullRequestReviewState.ReviewRequested,
 	[PullRequestReviewState.Dismissed]: null,
 	[PullRequestReviewState.Pending]: null,
 };
 
 export const toProviderPullRequestMergeableState = {
-	[PullRequestMergeableState.Mergeable]: 'MERGEABLE' as GitPullRequestMergeableState,
-	[PullRequestMergeableState.Conflicting]: 'CONFLICTS' as GitPullRequestMergeableState,
-	[PullRequestMergeableState.Unknown]: 'UNKNOWN' as GitPullRequestMergeableState,
+	[PullRequestMergeableState.Mergeable]: GitPullRequestMergeableState.Mergeable,
+	[PullRequestMergeableState.Conflicting]: GitPullRequestMergeableState.Conflicts,
+	[PullRequestMergeableState.Unknown]: GitPullRequestMergeableState.Unknown,
 };
 
 export function toProviderReviews(reviewers: PullRequestReviewer[]): ProviderPullRequest['reviews'] {
@@ -522,8 +524,7 @@ export function toProviderReviews(reviewers: PullRequestReviewer[]): ProviderPul
 		.filter(r => r.state !== PullRequestReviewState.Dismissed && r.state !== PullRequestReviewState.Pending)
 		.map(reviewer => ({
 			reviewer: toProviderAccount(reviewer.reviewer),
-			state:
-				toProviderPullRequestReviewState[reviewer.state] ?? ('REVIEW_REQUESTED' as GitPullRequestReviewState),
+			state: toProviderPullRequestReviewState[reviewer.state] ?? GitPullRequestReviewState.ReviewRequested,
 		}));
 }
 
@@ -533,16 +534,16 @@ export function toProviderReviewDecision(
 ): GitPullRequestReviewState | null {
 	switch (reviewDecision) {
 		case PullRequestReviewDecision.Approved:
-			return 'APPROVED' as GitPullRequestReviewState;
+			return GitPullRequestReviewState.Approved;
 		case PullRequestReviewDecision.ChangesRequested:
-			return 'CHANGES_REQUESTED' as GitPullRequestReviewState;
+			return GitPullRequestReviewState.ChangesRequested;
 		case PullRequestReviewDecision.ReviewRequired:
-			return 'REVIEW_REQUESTED' as GitPullRequestReviewState;
+			return GitPullRequestReviewState.ReviewRequested;
 		default: {
 			if (reviewers?.some(r => r.state === PullRequestReviewState.ReviewRequested)) {
-				return 'REVIEW_REQUESTED' as GitPullRequestReviewState;
+				return GitPullRequestReviewState.ReviewRequested;
 			} else if (reviewers?.some(r => r.state === PullRequestReviewState.Commented)) {
-				return 'COMMENTED' as GitPullRequestReviewState;
+				return GitPullRequestReviewState.Commented;
 			}
 			return null;
 		}
@@ -559,10 +560,10 @@ export function toProviderPullRequest(pr: PullRequest): ProviderPullRequest {
 		url: pr.url,
 		state:
 			pr.state === 'opened'
-				? ('OPEN' as GitPullRequestState)
+				? GitPullRequestState.Open
 				: pr.state === 'closed'
-				  ? ('CLOSED' as GitPullRequestState)
-				  : ('MERGED' as GitPullRequestState),
+				  ? GitPullRequestState.Closed
+				  : GitPullRequestState.Merged,
 		isDraft: pr.isDraft ?? false,
 		createdDate: pr.createdDate,
 		updatedDate: pr.updatedDate,
@@ -649,7 +650,7 @@ export function toProviderPullRequest(pr: PullRequest): ProviderPullRequest {
 		},
 		mergeableState: pr.mergeableState
 			? toProviderPullRequestMergeableState[pr.mergeableState]
-			: ('UNKNOWN' as GitPullRequestMergeableState),
+			: GitPullRequestMergeableState.Unknown,
 	};
 }
 

--- a/src/plus/integrations/providers/models.ts
+++ b/src/plus/integrations/providers/models.ts
@@ -1,5 +1,6 @@
 import type {
 	Account,
+	ActionablePullRequest,
 	AzureDevOps,
 	Bitbucket,
 	EnterpriseOptions,
@@ -16,6 +17,7 @@ import type {
 	Jira,
 	JiraProject,
 	JiraResource,
+	PullRequestWithUniqueID,
 	Trello,
 } from '@gitkraken/provider-apis';
 import { GitProviderUtils } from '@gitkraken/provider-apis';
@@ -35,6 +37,7 @@ export type ProviderAccount = Account;
 export type ProviderReposInput = (string | number)[] | GetRepoInput[];
 export type ProviderRepoInput = GetRepoInput;
 export type ProviderPullRequest = GitPullRequest;
+export type toProviderPullRequestWithUniqueId = PullRequestWithUniqueID;
 export type ProviderRepository = GitRepository;
 export type ProviderIssue = Issue;
 export type ProviderEnterpriseOptions = EnterpriseOptions;
@@ -590,14 +593,14 @@ export function toProviderPullRequest(pr: PullRequest): ProviderPullRequest {
 		reviews: toProviderReviews(prReviews),
 		reviewDecision: toProviderReviewDecision(pr.reviewDecision, prReviews),
 		repository:
-			pr.refs?.base != null
+			pr.repository != null
 				? {
-						id: pr.refs.base.repo,
-						name: pr.refs.base.repo,
+						id: pr.repository.repo,
+						name: pr.repository.repo,
 						owner: {
-							login: pr.refs.base.owner,
+							login: pr.repository.owner,
 						},
-						remoteInfo: null,
+						remoteInfo: null, // TODO: Add the urls to our model
 				  }
 				: {
 						id: '',
@@ -650,6 +653,13 @@ export function toProviderPullRequest(pr: PullRequest): ProviderPullRequest {
 	};
 }
 
+export function toProviderPullRequestWithUniqueId(pr: PullRequest): PullRequestWithUniqueID {
+	return {
+		...toProviderPullRequest(pr),
+		uuid: pr.nodeId!,
+	};
+}
+
 export function toProviderAccount(account: PullRequestMember | IssueMember): ProviderAccount {
 	return {
 		avatarUrl: account.avatarUrl ?? null,
@@ -662,4 +672,6 @@ export function toProviderAccount(account: PullRequestMember | IssueMember): Pro
 	};
 }
 
-export const categorizePullRequests = GitProviderUtils.groupPullRequestsIntoBuckets;
+export type ProviderActionablePullRequest = ActionablePullRequest;
+
+export const getActionablePullRequests = GitProviderUtils.getActionablePullRequests;

--- a/yarn.lock
+++ b/yarn.lock
@@ -258,11 +258,12 @@
     react-dragula "1.1.17"
     react-onclickoutside "^6.13.0"
 
-"@gitkraken/provider-apis@0.18.1":
-  version "0.18.1"
-  resolved "https://registry.yarnpkg.com/@gitkraken/provider-apis/-/provider-apis-0.18.1.tgz#a1be75457e18367c8571c7d89367506459e39c61"
-  integrity sha512-QVjd12L4Kx0sDkWb5VVpxOI8RlQP8pauS39CaOA61goE6Le9ogYOeJf51082COlkXil3XQ8+bsxCRkfoOHxSHQ==
+"@gitkraken/provider-apis@0.21.0":
+  version "0.21.0"
+  resolved "https://registry.yarnpkg.com/@gitkraken/provider-apis/-/provider-apis-0.21.0.tgz#8e8546796aa6648b5a73ccd9020ed3fbc59244cf"
+  integrity sha512-+r5hVqN2o4cpKVbic4C1b8DUvwixwyChxwE204yjK/THDhX+K40BmqqTkUgRjBalq0p/kaKe2WkIcylLtQNIZg==
   dependencies:
+    js-base64 "3.7.5"
     node-fetch "2.7.0"
 
 "@gitkraken/shared-web-components@0.1.1-rc.15":
@@ -4359,6 +4360,11 @@ jest-worker@^29.7.0:
     merge-stream "^2.0.0"
     supports-color "^8.0.0"
 
+js-base64@3.7.5:
+  version "3.7.5"
+  resolved "https://registry.yarnpkg.com/js-base64/-/js-base64-3.7.5.tgz#21e24cf6b886f76d6f5f165bfcd69cc55b9e3fca"
+  integrity sha512-3MEt5DTINKqfScXKfJFrRbxkrnk2AxPWGBL/ycjz4dK8iqiSJ06UxD8jh8xuh6p10TX4t2+7FsBYVxxQbMg+qA==
+
 js-levenshtein-esm@^1.2.0:
   version "1.2.0"
   resolved "https://registry.yarnpkg.com/js-levenshtein-esm/-/js-levenshtein-esm-1.2.0.tgz#96532c34e0c90df198c9419963c64ca3cf43ae92"
@@ -6749,16 +6755,7 @@ streamx@^2.13.0, streamx@^2.15.0:
   optionalDependencies:
     bare-events "^2.2.0"
 
-"string-width-cjs@npm:string-width@^4.2.0":
-  version "4.2.3"
-  resolved "https://registry.yarnpkg.com/string-width/-/string-width-4.2.3.tgz#269c7117d27b05ad2e536830a8ec895ef9c6d010"
-  integrity sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g==
-  dependencies:
-    emoji-regex "^8.0.0"
-    is-fullwidth-code-point "^3.0.0"
-    strip-ansi "^6.0.1"
-
-"string-width@^1.0.2 || 2 || 3 || 4", string-width@^4.1.0, string-width@^4.2.0, string-width@^4.2.3:
+"string-width-cjs@npm:string-width@^4.2.0", "string-width@^1.0.2 || 2 || 3 || 4", string-width@^4.1.0, string-width@^4.2.0, string-width@^4.2.3:
   version "4.2.3"
   resolved "https://registry.yarnpkg.com/string-width/-/string-width-4.2.3.tgz#269c7117d27b05ad2e536830a8ec895ef9c6d010"
   integrity sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g==
@@ -6818,14 +6815,7 @@ string_decoder@~1.1.1:
   dependencies:
     safe-buffer "~5.1.0"
 
-"strip-ansi-cjs@npm:strip-ansi@^6.0.1":
-  version "6.0.1"
-  resolved "https://registry.yarnpkg.com/strip-ansi/-/strip-ansi-6.0.1.tgz#9e26c63d30f53443e9489495b2105d37b67a85d9"
-  integrity sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==
-  dependencies:
-    ansi-regex "^5.0.1"
-
-strip-ansi@^6.0.0, strip-ansi@^6.0.1:
+"strip-ansi-cjs@npm:strip-ansi@^6.0.1", strip-ansi@^6.0.0, strip-ansi@^6.0.1:
   version "6.0.1"
   resolved "https://registry.yarnpkg.com/strip-ansi/-/strip-ansi-6.0.1.tgz#9e26c63d30f53443e9489495b2105d37b67a85d9"
   integrity sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==
@@ -7567,16 +7557,7 @@ workerpool@6.2.1:
   resolved "https://registry.yarnpkg.com/workerpool/-/workerpool-6.2.1.tgz#46fc150c17d826b86a008e5a4508656777e9c343"
   integrity sha512-ILEIE97kDZvF9Wb9f6h5aXK4swSlKGUcOEGiIYb2OOu/IrDU9iwj0fD//SsA6E5ibwJxpEvhullJY4Sl4GcpAw==
 
-"wrap-ansi-cjs@npm:wrap-ansi@^7.0.0":
-  version "7.0.0"
-  resolved "https://registry.yarnpkg.com/wrap-ansi/-/wrap-ansi-7.0.0.tgz#67e145cff510a6a6984bdf1152911d69d2eb9e43"
-  integrity sha512-YVGIj2kamLSTxw6NsZjoBxfSwsn0ycdesmc4p+Q21c5zPuZ1pl+NfxVdxPtdHvmNVOQ6XSYG4AUtyt/Fi7D16Q==
-  dependencies:
-    ansi-styles "^4.0.0"
-    string-width "^4.1.0"
-    strip-ansi "^6.0.0"
-
-wrap-ansi@^7.0.0:
+"wrap-ansi-cjs@npm:wrap-ansi@^7.0.0", wrap-ansi@^7.0.0:
   version "7.0.0"
   resolved "https://registry.yarnpkg.com/wrap-ansi/-/wrap-ansi-7.0.0.tgz#67e145cff510a6a6984bdf1152911d69d2eb9e43"
   integrity sha512-YVGIj2kamLSTxw6NsZjoBxfSwsn0ycdesmc4p+Q21c5zPuZ1pl+NfxVdxPtdHvmNVOQ6XSYG4AUtyt/Fi7D16Q==


### PR DESCRIPTION
Uses shared provider utility and its corresponding categories rather than our own.

Note: This requires querying github for additional properties we were not previously, in order to supply the library with all the information it needs on a PR to categorize properly.