### PR TITLE
Fixes #3197 - Only emojify standalone emojis

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/) and this p
 
 ### Fixed
 
+- Fixes [#3197](https://github.com/gitkraken/vscode-gitlens/issues/3197) - Only emojify standalone emojis
 - Fixes [#3180](https://github.com/gitkraken/vscode-gitlens/issues/3180) - Focus View feedback button is not working
 - Fixes [#3179](https://github.com/gitkraken/vscode-gitlens/issues/3179) - The checkmarks in cherry pick are not displayed
 

--- a/README.md
+++ b/README.md
@@ -429,6 +429,7 @@ A big thanks to the people that have contributed to this project 🙏❤️:
 - Ian Chamberlain ([@ian-h-chamberlain](https://github.com/ian-h-chamberlain)) &mdash; [contributions](https://github.com/gitkraken/vscode-gitlens/commits?author=ian-h-chamberlain)
 - Brandon Cheng ([@gluxon](https://github.com/gluxon)) &mdash; [contributions](https://github.com/gitkraken/vscode-gitlens/commits?author=gluxon)
 - yutotnh ([@yutotnh](https://github.com/yutotnh)) &mdash; [contributions](https://github.com/gitkraken/vscode-gitlens/commits?author=yutotnh)
+- may ([@m4rch3n1ng](https://github.com/m4rch3n1ng)) &mdash; [contributions](https://github.com/gitkraken/vscode-gitlens/commits?author=m4rch3n1ng)
 
 Also special thanks to the people that have provided support, testing, brainstorming, etc:
 

--- a/src/emojis.ts
+++ b/src/emojis.ts
@@ -1,12 +1,12 @@
 import { emojis as compressed } from './emojis.generated';
 import { decompressFromBase64LZString } from './system/string';
 
-const emojiRegex = /:([-+_a-z0-9]+):/g;
+const emojiRegex = /(^|\s):([-+_a-z0-9]+):($|\s)/g;
 
 let emojis: Record<string, string> | undefined = undefined;
 export function emojify(message: string) {
 	if (emojis == null) {
 		emojis = JSON.parse(decompressFromBase64LZString(compressed));
 	}
-	return message.replace(emojiRegex, (s, code) => emojis![code] || s);
+	return message.replace(emojiRegex, (s, $1, code, $3) => (emojis![code] ? `${$1}${emojis![code]}${$3}` : s));
 }


### PR DESCRIPTION
# Description

Extend the `emojiRegex` to only `emojify` emojis that are delimited by a space (as in `"text :emoji: text"`), or with a line start / line end (as in `":emoji: text"` or `"text :emoji:"`)

(as a side note: i wanted to write a few tests to ensure this works, but i couldn't figure out where to place them so i just left it)

# Checklist

- [x] I have followed the guidelines in the Contributing document
- [x] My changes follow the coding style of this project
- [x] My changes build without any errors or warnings
- [x] My changes have been formatted and linted
- [x] My changes include any required corresponding changes to the documentation (including CHANGELOG.md and README.md)
- [x] My changes have been rebased and squashed to the minimal number (typically 1) of relevant commits
- [x] My changes have a descriptive commit message with a short title, including a `Fixes $XXX -` or `Closes #XXX -` prefix to auto-close the issue that your PR addresses
