### PR TITLE
Add support for Custom Model to OpenAI settings

### DIFF
--- a/package.json
+++ b/package.json
@@ -3321,7 +3321,8 @@
 							"gpt-3.5-turbo",
 							"gpt-3.5-turbo-16k",
 							"gpt-3.5-turbo-0613",
-							"gpt-3.5-turbo-1106"
+							"gpt-3.5-turbo-1106",
+							"custom"
 						],
 						"enumDescriptions": [
 							"GPT-4 Turbo (Latest)",
@@ -3334,7 +3335,8 @@
 							"GPT-3.5 Turbo",
 							"GPT-3.5 Turbo 16k",
 							"GPT-3.5 Turbo (June 13)",
-							"GPT-3.5 Turbo (Nov 6)"
+							"GPT-3.5 Turbo (Nov 6)",
+							"Custom"
 						],
 						"markdownDescription": "Specifies the OpenAI model to use for GitLens' experimental AI features",
 						"scope": "window",
@@ -3346,7 +3348,17 @@
 							"null"
 						],
 						"default": null,
-						"markdownDescription": "Specifies a custom URL to use for access to an OpenAI model via Azure. Azure URLs should be in the following format: https://{your-resource-name}.openai.azure.com/openai/deployments/{deployment-id}/chat/completions?api-version={api-version}",
+						"markdownDescription": "Specifies a custom URL to use for access to an OpenAI-compatible API. URLs could be in any format as long as the API responds in the same way as OpenAI. eg: https://{serverHost}/v1/chat/completions \n\nAzure URLs should be in the following format: https://{your-resource-name}.openai.azure.com/openai/deployments/{deployment-id}/chat/completions?api-version={api-version}",
+						"scope": "window",
+						"order": 102
+					},
+					"gitlens.ai.experimental.openai.customModel": {
+						"type": [
+							"string",
+							"null"
+						],
+						"default": null,
+						"markdownDescription": "Specifies a custom model to use with an OpenAI-compatible API. Only used when the OpenAI model is set to 'Custom'.",
 						"scope": "window",
 						"order": 102
 					},

--- a/src/ai/aiProviderService.ts
+++ b/src/ai/aiProviderService.ts
@@ -218,7 +218,7 @@ async function confirmAIProviderToS(provider: AIProvider, storage: Storage): Pro
 	return false;
 }
 
-export function getMaxCharacters(model: OpenAIModels | AnthropicModels, outputLength: number): number {
+export function getMaxCharacters(model: OpenAIModels | AnthropicModels | string, outputLength: number): number {
 	const tokensPerCharacter = 3.1;
 
 	let tokens;

--- a/src/config.ts
+++ b/src/config.ts
@@ -15,6 +15,7 @@ export interface Config {
 			readonly openai: {
 				readonly model: OpenAIModels | null;
 				readonly url: string | null;
+				readonly customModel: string | null;
 			};
 			readonly anthropic: {
 				readonly model: AnthropicModels | null;

--- a/src/quickpicks/aiModelPicker.ts
+++ b/src/quickpicks/aiModelPicker.ts
@@ -22,6 +22,7 @@ export async function showAIModelPicker(provider?: AIProviders): Promise<ModelQu
 		{ label: 'OpenAI', description: 'GPT-4', provider: 'openai', model: 'gpt-4' },
 		{ label: 'OpenAI', description: 'GPT-4 32k', provider: 'openai', model: 'gpt-4-32k' },
 		{ label: 'OpenAI', description: 'GPT-3.5 Turbo', provider: 'openai', model: 'gpt-3.5-turbo-1106' },
+		{ label: 'OpenAI', description: 'Custom', provider: 'openai', model: 'custom' },
 		{ label: 'Anthropic', kind: QuickPickItemKind.Separator },
 		{ label: 'Anthropic', description: 'Claude 3 Opus', provider: 'anthropic', model: 'claude-3-opus-20240229' },
 		{


### PR DESCRIPTION

---

# Description

This PR adds a new setting to VSCode in the AI section for a custom model name to be sent to an OpenAI-compatible API. A larger PR was in the works until I realized that the existing custom URL functionality would work.

Closes #3223 

# Checklist

<!-- Please check off the following -->

- [x] I have followed the guidelines in the Contributing document
- [x] My changes follow the coding style of this project
- [x] My changes build without any errors or warnings
- [x] My changes have been formatted and linted
- [ ] My changes include any required corresponding changes to the documentation (including CHANGELOG.md and README.md)
- [x] My changes have been rebased and squashed to the minimal number (typically 1) of relevant commits
- [x] My changes have a descriptive commit message with a short title, including a `Fixes $XXX -` or `Closes #XXX -` prefix to auto-close the issue that your PR addresses
