### PR TITLE
Makes Quick Focus and Indicators responsive to GitHub connection/disconnection

### DIFF
--- a/src/plus/focus/focusProvider.ts
+++ b/src/plus/focus/focusProvider.ts
@@ -109,6 +109,8 @@ export interface FocusRefreshEvent {
 	items: FocusItem[];
 }
 
+export const supportedFocusIntegrations = [HostingIntegrationId.GitHub];
+
 export class FocusProvider implements Disposable {
 	private readonly _onDidChange = new EventEmitter<void>();
 	get onDidChange() {
@@ -409,6 +411,17 @@ export class FocusProvider implements Disposable {
 		}
 
 		this._groupedIds = groupedIds;
+	}
+
+	async hasConnectedIntegration(): Promise<boolean> {
+		for (const integrationId of supportedFocusIntegrations) {
+			const integration = await this.container.integrations.get(integrationId);
+			if (integration.maybeConnected ?? (await integration.isConnected())) {
+				return true;
+			}
+		}
+
+		return false;
 	}
 }
 

--- a/src/plus/integrations/providers/github.ts
+++ b/src/plus/integrations/providers/github.ts
@@ -1,4 +1,5 @@
 import type { AuthenticationSession, CancellationToken } from 'vscode';
+import { authentication } from 'vscode';
 import type { Container } from '../../../container';
 import type { Account } from '../../../git/models/author';
 import type { DefaultBranch } from '../../../git/models/defaultBranch';
@@ -208,6 +209,17 @@ export class GitHubIntegration extends GitHubIntegrationBase<HostingIntegrationI
 
 	protected override get apiBaseUrl(): string {
 		return 'https://api.github.com';
+	}
+
+	// TODO: This is a special case for GitHub because we use VSCode's GitHub session, and it can be disconnected
+	// outside of the extension. Remove this once we use our own GitHub auth provider.
+	override async refresh() {
+		const session = await authentication.getSession(this.authProvider.id, this.authProvider.scopes);
+		if (session == null && this.maybeConnected) {
+			void this.disconnect();
+		} else {
+			super.refresh();
+		}
 	}
 }
 


### PR DESCRIPTION
Previously, the quick focus and indicators would get into weird states if you're not connected to GitHub.

This PR addresses that as follows:
- New step in quick focus to confirm you have a supported integration connected, and offer ability to connect if not connected (GitHub only for now, but set to expand to new providers as added)
- New function in Focus Provider to check if a supported integration is connected (GitHub only for now)
- Updated state in Focus Indicator when not connected to GitHub, and a listener which updates the state when integration state changes. Includes a CTA link to connect to GitHub when disconnected.
- Special case logic in GitHub integration refresh to disconnect if we were disconnected in vscode (since our GH integration is controlled by vscode).