### PR TITLE
Add features to DraftService

### DIFF
--- a/package.json
+++ b/package.json
@@ -16927,7 +16927,7 @@
 	},
 	"dependencies": {
 		"@gitkraken/gitkraken-components": "10.2.13",
-		"@gitkraken/provider-apis": "0.21.0",
+		"@gitkraken/provider-apis": "0.22.1",
 		"@gitkraken/shared-web-components": "0.1.1-rc.15",
 		"@lit/react": "1.0.3",
 		"@microsoft/fast-element": "1.12.0",

--- a/src/gk/models/drafts.ts
+++ b/src/gk/models/drafts.ts
@@ -15,7 +15,7 @@ export type DraftRole = 'owner' | 'admin' | 'editor' | 'viewer';
 
 export interface Draft {
 	readonly draftType: 'cloud';
-	readonly type: 'patch' | 'stash' | 'suggested_pr_change';
+	readonly type: DraftType;
 	readonly id: string;
 	readonly createdAt: Date;
 	readonly updatedAt: Date;
@@ -99,6 +99,7 @@ export interface CreateDraftChange {
 	revision: PatchRevisionRange;
 	contents?: string;
 	repository: Repository;
+	prEntityId?: string;
 }
 
 export interface CreateDraftPatchRequestFromChange {
@@ -110,8 +111,10 @@ export interface CreateDraftPatchRequestFromChange {
 
 export type DraftVisibility = 'public' | 'private' | 'invite_only';
 
+export type DraftType = 'patch' | 'stash' | 'suggested_pr_change';
+
 export interface CreateDraftRequest {
-	type: 'patch' | 'stash';
+	type: DraftType;
 	title: string;
 	description?: string;
 	visibility: DraftVisibility;
@@ -123,7 +126,7 @@ export interface CreateDraftResponse {
 }
 
 export interface DraftResponse {
-	readonly type: 'patch' | 'stash';
+	readonly type: DraftType;
 	readonly id: string;
 	readonly createdAt: string;
 	readonly updatedAt: string;
@@ -193,6 +196,7 @@ export interface DraftPatchCreateRequest {
 	baseCommitSha: string;
 	baseBranchName: string;
 	gitRepoData: RepositoryIdentityRequest;
+	prEntityId?: string;
 }
 
 export interface DraftPatchCreateResponse {

--- a/src/plus/integrations/integration.ts
+++ b/src/plus/integrations/integration.ts
@@ -91,7 +91,7 @@ export abstract class IntegrationBase<
 	abstract get name(): string;
 	abstract get domain(): string;
 
-	protected get authProviderDescriptor(): IntegrationAuthenticationSessionDescriptor {
+	get authProviderDescriptor(): IntegrationAuthenticationSessionDescriptor {
 		return { domain: this.domain, scopes: this.authProvider.scopes };
 	}
 

--- a/src/plus/integrations/providers/utils.ts
+++ b/src/plus/integrations/providers/utils.ts
@@ -1,0 +1,35 @@
+import type { EntityIdentifier } from '@gitkraken/provider-apis';
+import { EntityIdentifierProviderType, EntityType, EntityVersion } from '@gitkraken/provider-apis';
+import type { IssueOrPullRequest } from '../../../git/models/issue';
+import { equalsIgnoreCase } from '../../../system/string';
+
+function isGitHubDotCom(domain: string): boolean {
+	return equalsIgnoreCase(domain, 'github.com');
+}
+
+export function getEntityIdentifier(issueOrPullRequest: IssueOrPullRequest): EntityIdentifier {
+	let entityType = EntityType.Issue;
+	if (issueOrPullRequest.type === 'pullrequest') {
+		entityType = EntityType.PullRequest;
+	}
+
+	let provider = EntityIdentifierProviderType.Github;
+	let domain = null;
+	if (!isGitHubDotCom(issueOrPullRequest.provider.domain)) {
+		provider = EntityIdentifierProviderType.GithubEnterprise;
+		domain = issueOrPullRequest.provider.domain;
+	}
+
+	return {
+		provider: provider,
+		entityType: entityType,
+		version: EntityVersion.One,
+		domain: domain,
+		resourceId: null,
+		accountOrOrgId: null,
+		organizationName: null,
+		projectId: null,
+		repoId: null,
+		entityId: issueOrPullRequest.nodeId!,
+	};
+}

--- a/yarn.lock
+++ b/yarn.lock
@@ -258,10 +258,10 @@
     react-dragula "1.1.17"
     react-onclickoutside "^6.13.0"
 
-"@gitkraken/provider-apis@0.21.0":
-  version "0.21.0"
-  resolved "https://registry.yarnpkg.com/@gitkraken/provider-apis/-/provider-apis-0.21.0.tgz#8e8546796aa6648b5a73ccd9020ed3fbc59244cf"
-  integrity sha512-+r5hVqN2o4cpKVbic4C1b8DUvwixwyChxwE204yjK/THDhX+K40BmqqTkUgRjBalq0p/kaKe2WkIcylLtQNIZg==
+"@gitkraken/provider-apis@0.22.1":
+  version "0.22.1"
+  resolved "https://registry.npmjs.org/@gitkraken/provider-apis/-/provider-apis-0.22.1.tgz#a046f5cef6b7eb9a9b7c19df687a2848d98d95ab"
+  integrity sha512-TILYzN6vLBNnyJlCYuKDupzeGJoCzmbf9pGu1DgKNBd1/VtNo+y3GavUcwAmv/SA9ED+Z8sEUae6dLHzlFn1tA==
   dependencies:
     js-base64 "3.7.5"
     node-fetch "2.7.0"
@@ -4362,7 +4362,7 @@ jest-worker@^29.7.0:
 
 js-base64@3.7.5:
   version "3.7.5"
-  resolved "https://registry.yarnpkg.com/js-base64/-/js-base64-3.7.5.tgz#21e24cf6b886f76d6f5f165bfcd69cc55b9e3fca"
+  resolved "https://registry.npmjs.org/js-base64/-/js-base64-3.7.5.tgz#21e24cf6b886f76d6f5f165bfcd69cc55b9e3fca"
   integrity sha512-3MEt5DTINKqfScXKfJFrRbxkrnk2AxPWGBL/ycjz4dK8iqiSJ06UxD8jh8xuh6p10TX4t2+7FsBYVxxQbMg+qA==
 
 js-levenshtein-esm@^1.2.0:


### PR DESCRIPTION
## Moves git-repositories lookup onto drafts

The `/v1/git-repositories/${repoId}` route in `RepositoryIdentityService.getRepositoryIdentity` is deprecated in favor of a route that directly associates it to a draft `/v1/drafts/${draftId}/git-repositories/${repoId}`. The `getRepositoryIdentity` method was moved to `DraftService` and now implements the new route.

The main difference in the `RepositoryIdentityService` functionality, besides removing that method, is that now the methods only interact with `RepositoryIdentityDescriptor` and no longer need to handle `GkRepositoryId`.

## Utility function to create an EntityIdentifier

This converts issues and pull requests into a resource format that our APIs use to uniquely look them up.

## Creating Code Suggestions

Adds new params into DraftService.createDraft to support the `suggested_pr_change` type