### PR TITLE
Adds initial launchpad telemetry

### DIFF
--- a/src/commands/gitCommands.ts
+++ b/src/commands/gitCommands.ts
@@ -218,6 +218,17 @@ export class GitCommandsCommand extends Command {
 				break;
 			case Commands.ShowLaunchpad:
 				args = { command: 'focus', ...args };
+				// TODO: Improve this. Args do not come in with a command property,
+				// but the contextual typing relies on it to recognize the other args.
+				if (args.command === 'focus') {
+					args.source ??= 'commandPalette';
+					this.container.telemetry.sendEvent('launchpad/opened', {
+						source: args.source,
+						group: args.state?.initialGroup ?? null,
+						selectTopItem: args.state?.selectTopItem ?? false,
+					});
+				}
+
 				break;
 		}
 

--- a/src/constants.ts
+++ b/src/constants.ts
@@ -811,7 +811,13 @@ export type TelemetryEvents =
 	| 'usage/track'
 	| 'openReviewMode'
 	| 'codeSuggestionCreated'
-	| 'codeSuggestionViewed';
+	| 'codeSuggestionViewed'
+	| 'launchpad/opened'
+	| 'launchpad/configurationChanged'
+	| 'launchpad/groupToggled'
+	| 'launchpad/actionTaken'
+	| 'launchpad/indicatorHidden'
+	| 'launchpad/indicatorFirstDataReceived';
 
 export type AIProviders = 'anthropic' | 'gemini' | 'openai';
 export type AIModels<Provider extends AIProviders = AIProviders> = Provider extends 'openai'
@@ -879,6 +885,7 @@ export type GlobalStorage = {
 	'views:welcome:visible': boolean;
 	'confirm:draft:storage': boolean;
 	'home:sections:collapsed': string[];
+	'launchpad:indicator:dataReceived': boolean;
 } & { [key in `confirm:ai:tos:${AIProviders}`]: boolean } & {
 	[key in `provider:authentication:skip:${string}`]: boolean;
 } & { [key in `gk:${string}:checkin`]: Stored<StoredGKCheckInResponse> } & {

--- a/src/plus/focus/focusProvider.ts
+++ b/src/plus/focus/focusProvider.ts
@@ -589,6 +589,23 @@ export class FocusProvider implements Disposable {
 
 	private onConfigurationChanged(e: ConfigurationChangeEvent) {
 		if (!configuration.changed(e, 'launchpad')) return;
+		const launchpadConfig = configuration.get('launchpad');
+		this.container.telemetry.sendEvent('launchpad/configurationChanged', {
+			staleThreshold: launchpadConfig.staleThreshold,
+			ignoredRepositories: launchpadConfig.ignoredRepositories,
+			indicatorEnabled: launchpadConfig.indicator.enabled,
+			indicatorOpenInEditor: launchpadConfig.indicator.openInEditor,
+			indicatorIcon: launchpadConfig.indicator.icon,
+			indicatorLabel: launchpadConfig.indicator.label,
+			indicatorUseColors: launchpadConfig.indicator.useColors,
+			indicatorGroups: launchpadConfig.indicator.groups,
+			indicatorPollingEnabled: launchpadConfig.indicator.polling.enabled,
+			indicatorPollingInterval: launchpadConfig.indicator.polling.interval,
+		});
+
+		if (configuration.changed(e, 'launchpad.indicator.enabled') && !launchpadConfig.indicator.enabled) {
+			this.container.telemetry.sendEvent('launchpad/indicatorHidden');
+		}
 
 		if (
 			configuration.changed(e, 'launchpad.ignoredRepositories') ||

--- a/src/webviews/apps/home/home.html
+++ b/src/webviews/apps/home/home.html
@@ -227,7 +227,7 @@
 					<gl-feature-badge placement="left" class="nav-list__access"></gl-feature-badge>
 				</div>
 				<div class="nav-list__item">
-					<a class="nav-list__link" href="command:gitlens.showLaunchpad" aria-label="Open Launchpad"
+					<a class="nav-list__link" href="command:gitlens.showLaunchpad?%7B%22source%22%3A%22home%22%7D" aria-label="Open Launchpad"
 						><code-icon class="nav-list__icon" icon="rocket"></code-icon
 						><gl-tooltip class="nav-list__group" placement="bottom" content="Open Launchpad"
 							><span class="nav-list__label">Launchpad</span

--- a/src/webviews/apps/welcome/welcome.html
+++ b/src/webviews/apps/welcome/welcome.html
@@ -198,7 +198,10 @@
 
 					<section>
 						<h3 class="sticky">
-							<a class="muted" href="command:gitlens.showLaunchpad" aria-label="Open Launchpad"
+							<a
+								class="muted"
+								href="command:gitlens.showLaunchpad?%7B%22source%22%3A%22welcome%22%7D"
+								aria-label="Open Launchpad"
 								><gl-tooltip placement="bottom" content="Open Launchpad"
 									><span>Launchpad</span></gl-tooltip
 								></a


### PR DESCRIPTION
Adds some initial events and payloads relating to launchpad events.

Notes:
1. These payloads can be expanded if more data is needed.
2. We still need an event for "first-time" launchpad interaction. It still needs discussion and is TBD.