### PR TITLE
Adds initial cloud integration and Jira telemetry

### DIFF
--- a/src/constants.ts
+++ b/src/constants.ts
@@ -795,6 +795,8 @@ export const enum Schemes {
 export type TelemetryEvents =
 	| 'account/validation/failed'
 	| 'activate'
+	| 'cloudIntegrations/jiraFirstConnected'
+	| 'cloudIntegrations/settingsOpened'
 	| 'command'
 	| 'command/core'
 	| 'remoteProviders/connected'
@@ -885,6 +887,7 @@ export type GlobalStorage = {
 	'views:welcome:visible': boolean;
 	'confirm:draft:storage': boolean;
 	'home:sections:collapsed': string[];
+	'cloudIntegrations:jira:firstConnect': boolean;
 	'launchpad:indicator:dataReceived': boolean;
 } & { [key in `confirm:ai:tos:${AIProviders}`]: boolean } & {
 	[key in `provider:authentication:skip:${string}`]: boolean;

--- a/src/plus/integrations/integrationService.ts
+++ b/src/plus/integrations/integrationService.ts
@@ -97,6 +97,9 @@ export class IntegrationService implements Disposable {
 	}
 
 	async manageCloudIntegrations() {
+		this.container.telemetry.sendEvent('cloudIntegrations/settingsOpened', {
+			userId: (await this.container.subscription.getSubscription())?.account?.id,
+		});
 		await env.openExternal(this.connection.getGkDevAccountsUri('settings/integrations'));
 		take(
 			window.onDidChangeWindowState,

--- a/src/plus/integrations/providers/jira.ts
+++ b/src/plus/integrations/providers/jira.ts
@@ -258,6 +258,13 @@ export class JiraIntegration extends IssueIntegration<IssueIntegrationId.Jira> {
 	}
 
 	protected override async providerOnConnect(): Promise<void> {
+		const firstConnected = this.container.storage.get('cloudIntegrations:jira:firstConnect') ?? false;
+		if (!firstConnected) {
+			void this.container.storage.store('cloudIntegrations:jira:firstConnect', true);
+			this.container.telemetry.sendEvent('cloudIntegrations/jiraFirstConnected', {
+				userId: (await this.container.subscription.getSubscription())?.account?.id,
+			});
+		}
 		this._autolinks = undefined;
 		if (this._session == null) return;
 


### PR DESCRIPTION
Two events, one to track the first time a user's Jira integration is connected on a machine and the second to track every time a user opens the cloud integration settings on gkdev.