### PR TITLE
Fixes `launchpad/open` event always being sent on extension load

### DIFF
--- a/src/system/command.ts
+++ b/src/system/command.ts
@@ -9,7 +9,7 @@ import { isWebviewContext } from './webview';
 
 export type CommandCallback = Parameters<typeof commands.registerCommand>[1];
 
-type CommandConstructor = new (container: Container) => Command;
+type CommandConstructor = new (container: Container, ...args: any[]) => Command;
 const registrableCommands: CommandConstructor[] = [];
 
 export function command(): ClassDecorator {
@@ -54,7 +54,9 @@ export function registerWebviewCommand(command: string, callback: CommandCallbac
 }
 
 export function registerCommands(container: Container): Disposable[] {
-	return registrableCommands.map(c => new c(container));
+	return registrableCommands.map(c =>
+		c.name === 'FocusCommand' ? new c(container, undefined, true) : new c(container),
+	);
 }
 
 export function asCommand<T extends unknown[]>(


### PR DESCRIPTION
We call the constructor of all registrable events once when mapping them on extension load. This unfortunately causes the `launchpad/open` event to trigger, because we didn't include a `true` value for the `hidden` param in the constructor. This makes an exception for just that event in the mapping, so that the event doesn't trigger.