### PR TITLE
Fix `GitCodeLensProvider.resolveGitAuthors…` "others" pluralization.

### DIFF
--- a/src/codelens/codeLensProvider.ts
+++ b/src/codelens/codeLensProvider.ts
@@ -537,8 +537,11 @@ export class GitCodeLensProvider implements CodeLensProvider {
 
 		const count = blame.authors.size;
 		const author = first(blame.authors.values())?.name ?? 'Unknown';
+		const andOthers = count > 1
+			? ` and ${pluralize('one other', count - 1, { only: true, plural: 'others' })}`
+			: '';
 
-		let title = `${pluralize('author', count, { zero: '?' })} (${author}${count > 1 ? ' and others' : ''})`;
+		let title = `${pluralize('author', count, { zero: '?' })} (${author}${andOthers})`;
 		if (configuration.get('debug')) {
 			title += ` [${lens.languageId}: ${SymbolKind[lens.symbol.kind]}(${lens.range.start.character}-${
 				lens.range.end.character


### PR DESCRIPTION
# Description

Fixes Authors lens to say e.g. “one other” (in full “2 authors (Jane Doe and one other)”) when there are 2 authors (#3295).


# Checklist

<!-- Please check off the following -->

- [x] I have followed the guidelines in the Contributing document
- [x] My changes follow the coding style of this project
- [x] My changes build without any errors or warnings
- [x] My changes have been formatted and linted
- [x] My changes include any required corresponding changes to the documentation (including CHANGELOG.md and README.md)
- [x] My changes have been rebased and squashed to the minimal number (typically 1) of relevant commits
- [x] My changes have a descriptive commit message with a short title, including a `Fixes $XXX -` or `Closes #XXX -` prefix to auto-close the issue that your PR addresses
