### PR TITLE
Saves collapsed groups on launchpad between uses

### DIFF
--- a/src/constants.ts
+++ b/src/constants.ts
@@ -934,6 +934,7 @@ export type GlobalStorage = {
 	'views:welcome:visible': boolean;
 	'confirm:draft:storage': boolean;
 	'home:sections:collapsed': string[];
+	'launchpad:groups:collapsed': StoredFocusGroup[];
 	'launchpad:indicator:hasLoaded': boolean;
 	'launchpad:indicator:hasInteracted': string;
 } & { [key in `confirm:ai:tos:${AIProviders}`]: boolean } & {
@@ -1151,6 +1152,18 @@ export type WalkthroughSteps =
 	| 'code-collab'
 	| 'integrations'
 	| 'more';
+
+export type StoredFocusGroup =
+	| 'current-branch'
+	| 'pinned'
+	| 'mergeable'
+	| 'blocked'
+	| 'follow-up'
+	| 'needs-review'
+	| 'waiting-for-review'
+	| 'draft'
+	| 'other'
+	| 'snoozed';
 
 export type TelemetryGlobalContext = {
 	debugging: boolean;

--- a/src/plus/focus/focus.ts
+++ b/src/plus/focus/focus.ts
@@ -122,6 +122,8 @@ function assertsFocusStepState(state: StepState<State>): asserts state is FocusS
 
 const instanceCounter = getScopedCounter();
 
+const defaultCollapsedGroups: FocusGroup[] = ['draft', 'other', 'snoozed'];
+
 @command()
 export class FocusCommand extends QuickCommand<State> {
 	private readonly source: Source;
@@ -175,11 +177,14 @@ export class FocusCommand extends QuickCommand<State> {
 			await this.container.git.isDiscoveringRepositories;
 		}
 
-		const collapsed = new Map<FocusGroup, boolean>([
-			['draft', true],
-			['other', true],
-			['snoozed', true],
-		]);
+		let storedCollapsed = this.container.storage.get('launchpad:groups:collapsed') satisfies
+			| FocusGroup[]
+			| undefined;
+		if (storedCollapsed == null) {
+			storedCollapsed = defaultCollapsedGroups;
+		}
+
+		const collapsed = new Map<FocusGroup, boolean>(storedCollapsed.map(g => [g, true]));
 		if (state.initialGroup != null) {
 			// set all to true except the initial group
 			for (const [group] of groupMap) {
@@ -342,6 +347,12 @@ export class FocusCommand extends QuickCommand<State> {
 							onDidSelect: () => {
 								const collapsed = !context.collapsed.get(ui);
 								context.collapsed.set(ui, collapsed);
+								if (state.initialGroup == null) {
+									void this.container.storage.store(
+										'launchpad:groups:collapsed',
+										Array.from(context.collapsed.keys()).filter(g => context.collapsed.get(g)),
+									);
+								}
 
 								if (this.container.telemetry.enabled) {
 									updateTelemetryContext(context);


### PR DESCRIPTION
- Stores collapsed groups as a string array in global storage
- Updates this when a user toggles a group, but only when the launchpad wasn't opened to a specific group (when clicking a specific group from the launchpad indicator hover tooltip)