### PR TITLE
Adds first parent toggle to Graph

### DIFF
--- a/package.json
+++ b/package.json
@@ -2824,6 +2824,12 @@
 						"scope": "window",
 						"order": 30
 					},
+					"gitlens.graph.onlyFollowFirstParent": {
+						"type": "boolean",
+						"default": false,
+						"markdownDescription": "Specifies whether to only follow the first parent when showing commits on the _Commit Graph_",
+						"order": 31
+					},
 					"gitlens.graph.dateStyle": {
 						"type": [
 							"string",

--- a/src/config.ts
+++ b/src/config.ts
@@ -377,27 +377,28 @@ export interface GraphConfig {
 	readonly dateStyle: DateStyle | null;
 	readonly defaultItemLimit: number;
 	readonly dimMergeCommits: boolean;
+	readonly highlightRowsOnRefHover: boolean;
+	readonly layout: 'editor' | 'panel';
 	readonly minimap: {
 		readonly enabled: boolean;
 		readonly dataType: 'commits' | 'lines';
 		readonly additionalTypes: GraphMinimapMarkersAdditionalTypes[];
 	};
-	readonly highlightRowsOnRefHover: boolean;
-	readonly layout: 'editor' | 'panel';
-	readonly scrollRowPadding: number;
-	readonly showDetailsView: 'open' | 'selection' | false;
-	readonly showGhostRefsOnRowHover: boolean;
+	readonly onlyFollowFirstParent: boolean;
+	readonly pageItemLimit: number;
+	readonly pullRequests: {
+		readonly enabled: boolean;
+	};
 	readonly scrollMarkers: {
 		readonly enabled: boolean;
 		readonly additionalTypes: GraphScrollMarkersAdditionalTypes[];
 	};
-	readonly pullRequests: {
-		readonly enabled: boolean;
-	};
+	readonly scrollRowPadding: number;
+	readonly searchItemLimit: number;
+	readonly showDetailsView: 'open' | 'selection' | false;
+	readonly showGhostRefsOnRowHover: boolean;
 	readonly showRemoteNames: boolean;
 	readonly showUpstreamStatus: boolean;
-	readonly pageItemLimit: number;
-	readonly searchItemLimit: number;
 	readonly statusBar: {
 		readonly enabled: boolean;
 	};

--- a/src/env/node/git/localGitProvider.ts
+++ b/src/env/node/git/localGitProvider.ts
@@ -2306,6 +2306,7 @@ export class LocalGitProvider implements GitProvider, Disposable {
 		const defaultLimit = options?.limit ?? configuration.get('graph.defaultItemLimit') ?? 5000;
 		const defaultPageLimit = configuration.get('graph.pageItemLimit') ?? 1000;
 		const ordering = configuration.get('graph.commitOrdering', undefined, 'date');
+		const onlyFollowFirstParent = configuration.get('graph.onlyFollowFirstParent', undefined, false);
 
 		const deferStats = options?.include?.stats; // && defaultLimit > 1000;
 
@@ -2370,6 +2371,9 @@ export class LocalGitProvider implements GitProvider, Disposable {
 
 			do {
 				const args = [...parser.arguments, `--${ordering}-order`, '--all'];
+				if (onlyFollowFirstParent) {
+					args.push('--first-parent');
+				}
 				if (cursor?.skip) {
 					args.push(`--skip=${cursor.skip}`);
 				}
@@ -2724,7 +2728,7 @@ export class LocalGitProvider implements GitProvider, Disposable {
 
 				rows.push({
 					sha: commit.sha,
-					parents: parents,
+					parents: onlyFollowFirstParent ? [parents[0]] : parents,
 					author: isCurrentUser ? 'You' : commit.author,
 					email: commit.authorEmail,
 					date: Number(ordering === 'author-date' ? commit.authorDate : commit.committerDate) * 1000,

--- a/src/plus/webviews/graph/graphWebview.ts
+++ b/src/plus/webviews/graph/graphWebview.ts
@@ -131,7 +131,6 @@ import type {
 	SearchParams,
 	State,
 	UpdateColumnsParams,
-	UpdateDimMergeCommitsParams,
 	UpdateExcludeTypeParams,
 	UpdateGraphConfigurationParams,
 	UpdateRefsVisibilityParams,
@@ -163,7 +162,6 @@ import {
 	SearchRequest,
 	supportedRefMetadataTypes,
 	UpdateColumnsCommand,
-	UpdateDimMergeCommitsCommand,
 	UpdateExcludeTypeCommand,
 	UpdateGraphConfigurationCommand,
 	UpdateIncludeOnlyRefsCommand,
@@ -616,9 +614,6 @@ export class GraphWebviewProvider implements WebviewProvider<State, State, Graph
 			case ChooseRepositoryCommand.is(e):
 				void this.onChooseRepository();
 				break;
-			case UpdateDimMergeCommitsCommand.is(e):
-				this.dimMergeCommits(e.params);
-				break;
 			case DoubleClickedCommandType.is(e):
 				void this.onDoubleClick(e.params);
 				break;
@@ -694,6 +689,12 @@ export class GraphWebviewProvider implements WebviewProvider<State, State, Graph
 						void configuration.updateEffective('graph.minimap.additionalTypes', additionalTypes);
 						break;
 					}
+					case 'dimMergeCommits':
+						void configuration.updateEffective('graph.dimMergeCommits', params.changes[key]);
+						break;
+					case 'onlyFollowFirstParent':
+						void configuration.updateEffective('graph.onlyFollowFirstParent', params.changes[key]);
+						break;
 					default:
 						// TODO:@eamodio add more config options as needed
 						debugger;
@@ -748,30 +749,17 @@ export class GraphWebviewProvider implements WebviewProvider<State, State, Graph
 			configuration.changed(e, 'defaultDateFormat') ||
 			configuration.changed(e, 'defaultDateStyle') ||
 			configuration.changed(e, 'advanced.abbreviatedShaLength') ||
-			configuration.changed(e, 'graph.avatars') ||
-			configuration.changed(e, 'graph.dateFormat') ||
-			configuration.changed(e, 'graph.dateStyle') ||
-			configuration.changed(e, 'graph.dimMergeCommits') ||
-			configuration.changed(e, 'graph.highlightRowsOnRefHover') ||
-			configuration.changed(e, 'graph.scrollRowPadding') ||
-			configuration.changed(e, 'graph.scrollMarkers.enabled') ||
-			configuration.changed(e, 'graph.scrollMarkers.additionalTypes') ||
-			configuration.changed(e, 'graph.showGhostRefsOnRowHover') ||
-			configuration.changed(e, 'graph.pullRequests.enabled') ||
-			configuration.changed(e, 'graph.showRemoteNames') ||
-			configuration.changed(e, 'graph.showUpstreamStatus') ||
-			configuration.changed(e, 'graph.minimap.enabled') ||
-			configuration.changed(e, 'graph.minimap.dataType') ||
-			configuration.changed(e, 'graph.minimap.additionalTypes')
+			configuration.changed(e, 'graph')
 		) {
 			void this.notifyDidChangeConfiguration();
 
 			if (
-				(configuration.changed(e, 'graph.minimap.enabled') ||
+				configuration.changed(e, 'graph.onlyFollowFirstParent') ||
+				((configuration.changed(e, 'graph.minimap.enabled') ||
 					configuration.changed(e, 'graph.minimap.dataType')) &&
-				configuration.get('graph.minimap.enabled') &&
-				configuration.get('graph.minimap.dataType') === 'lines' &&
-				!this._graph?.includes?.stats
+					configuration.get('graph.minimap.enabled') &&
+					configuration.get('graph.minimap.dataType') === 'lines' &&
+					!this._graph?.includes?.stats)
 			) {
 				this.updateState();
 			}
@@ -831,10 +819,6 @@ export class GraphWebviewProvider implements WebviewProvider<State, State, Graph
 
 		this._theme = theme;
 		this.updateState();
-	}
-
-	private dimMergeCommits(e: UpdateDimMergeCommitsParams) {
-		void configuration.updateEffective('graph.dimMergeCommits', e.dim);
 	}
 
 	private onColumnsChanged(e: UpdateColumnsParams) {
@@ -1846,6 +1830,7 @@ export class GraphWebviewProvider implements WebviewProvider<State, State, Graph
 			minimap: configuration.get('graph.minimap.enabled'),
 			minimapDataType: configuration.get('graph.minimap.dataType'),
 			minimapMarkerTypes: this.getMinimapMarkerTypes(),
+			onlyFollowFirstParent: configuration.get('graph.onlyFollowFirstParent'),
 			scrollRowPadding: configuration.get('graph.scrollRowPadding'),
 			scrollMarkerTypes: this.getScrollMarkerTypes(),
 			showGhostRefsOnRowHover: configuration.get('graph.showGhostRefsOnRowHover'),

--- a/src/plus/webviews/graph/protocol.ts
+++ b/src/plus/webviews/graph/protocol.ts
@@ -179,6 +179,7 @@ export interface GraphComponentConfig {
 	minimap?: boolean;
 	minimapDataType?: Config['graph']['minimap']['dataType'];
 	minimapMarkerTypes?: GraphMinimapMarkerTypes[];
+	onlyFollowFirstParent?: boolean;
 	scrollMarkerTypes?: GraphScrollMarkerTypes[];
 	scrollRowPadding?: number;
 	showGhostRefsOnRowHover?: boolean;
@@ -261,11 +262,6 @@ export interface UpdateColumnsParams {
 	config: GraphColumnsConfig;
 }
 export const UpdateColumnsCommand = new IpcCommand<UpdateColumnsParams>(scope, 'columns/update');
-
-export interface UpdateDimMergeCommitsParams {
-	dim: boolean;
-}
-export const UpdateDimMergeCommitsCommand = new IpcCommand<UpdateDimMergeCommitsParams>(scope, 'dimMergeCommits');
 
 export interface UpdateRefsVisibilityParams {
 	refs: GraphExcludedRef[];

--- a/src/webviews/apps/plus/graph/graph.tsx
+++ b/src/webviews/apps/plus/graph/graph.tsx
@@ -42,7 +42,6 @@ import {
 	SearchOpenInViewCommand,
 	SearchRequest,
 	UpdateColumnsCommand,
-	UpdateDimMergeCommitsCommand,
 	UpdateExcludeTypeCommand,
 	UpdateGraphConfigurationCommand,
 	UpdateIncludeOnlyRefsCommand,
@@ -99,7 +98,6 @@ export class GraphApp extends App<State> {
 						settings => this.onColumnsChanged(settings),
 						250,
 					)}
-					onDimMergeCommits={dim => this.onDimMergeCommits(dim)}
 					onRefsVisibilityChange={(refs: GraphExcludedRef[], visible: boolean) =>
 						this.onRefsVisibilityChanged(refs, visible)
 					}
@@ -527,12 +525,6 @@ export class GraphApp extends App<State> {
 
 	private onChooseRepository() {
 		this.sendCommand(ChooseRepositoryCommand, undefined);
-	}
-
-	private onDimMergeCommits(dim: boolean) {
-		this.sendCommand(UpdateDimMergeCommitsCommand, {
-			dim: dim,
-		});
 	}
 
 	private onDoubleClickRef(ref: GraphRef, metadata?: GraphRefMetadataItem) {


### PR DESCRIPTION
Closes #3313 - adds a new `Simply Merge History` filter option to the Commit Graph

![image](https://github.com/gitkraken/vscode-gitlens/assets/641685/a6518f4e-ebb3-4893-a9fe-6b70791affe4)
