### PR TITLE
Converts GitHub integration authentication to use gk.dev GLVSC-554

### DIFF
--- a/src/commands/cloudIntegrations.ts
+++ b/src/commands/cloudIntegrations.ts
@@ -1,12 +1,11 @@
-import type { Source } from '../constants';
+import type { Source, SupportedCloudIntegrationIds } from '../constants';
 import { Commands } from '../constants';
 import type { Container } from '../container';
-import type { IssueIntegrationId } from '../plus/integrations/providers/models';
 import { command } from '../system/command';
 import { Command } from './base';
 
 export interface ManageCloudIntegrationsCommandArgs extends Source {
-	integrationId?: IssueIntegrationId.Jira;
+	integrationId?: SupportedCloudIntegrationIds;
 }
 
 @command()

--- a/src/commands/cloudIntegrations.ts
+++ b/src/commands/cloudIntegrations.ts
@@ -16,7 +16,7 @@ export class ManageCloudIntegrationsCommand extends Command {
 
 	async execute(args?: ManageCloudIntegrationsCommandArgs) {
 		await this.container.integrations.manageCloudIntegrations(
-			args?.integrationId,
+			args?.integrationId ? { integrationId: args.integrationId } : undefined,
 			args?.source ? { source: args.source, detail: args?.detail } : undefined,
 		);
 	}

--- a/src/commands/cloudIntegrations.ts
+++ b/src/commands/cloudIntegrations.ts
@@ -1,6 +1,7 @@
-import type { Source, SupportedCloudIntegrationIds } from '../constants';
+import type { Source } from '../constants';
 import { Commands } from '../constants';
 import type { Container } from '../container';
+import type { SupportedCloudIntegrationIds } from '../plus/integrations/authentication/models';
 import { command } from '../system/command';
 import { Command } from './base';
 

--- a/src/commands/remoteProviders.ts
+++ b/src/commands/remoteProviders.ts
@@ -99,13 +99,16 @@ export class ConnectRemoteProviderCommand extends Command {
 
 		if (!connected) {
 			if (isSupportedCloudIntegrationId(integration.id)) {
-				await this.container.integrations.manageCloudIntegrations(integration.id, {
-					source: 'remoteProvider',
-					detail: {
-						action: 'connect',
-						integration: integration.id,
+				await this.container.integrations.manageCloudIntegrations(
+					{ integrationId: integration.id, skipIfConnected: true },
+					{
+						source: 'remoteProvider',
+						detail: {
+							action: 'connect',
+							integration: integration.id,
+						},
 					},
-				});
+				);
 			}
 
 			connected = await integration.connect();

--- a/src/commands/remoteProviders.ts
+++ b/src/commands/remoteProviders.ts
@@ -1,10 +1,11 @@
-import { Commands, isSupportedCloudIntegrationId } from '../constants';
+import { Commands } from '../constants';
 import type { Container } from '../container';
 import type { GitCommit } from '../git/models/commit';
 import type { GitRemote } from '../git/models/remote';
 import { isRemote } from '../git/models/remote';
 import type { Repository } from '../git/models/repository';
 import type { RemoteProvider } from '../git/remotes/remoteProvider';
+import { isSupportedCloudIntegrationId } from '../plus/integrations/authentication/models';
 import { showRepositoryPicker } from '../quickpicks/repositoryPicker';
 import { command } from '../system/command';
 import { first } from '../system/iterable';

--- a/src/constants.ts
+++ b/src/constants.ts
@@ -8,7 +8,7 @@ import type { Environment } from './container';
 import type { StoredSearchQuery } from './git/search';
 import type { Subscription, SubscriptionPlanId, SubscriptionState } from './plus/gk/account/subscription';
 import type { Integration } from './plus/integrations/integration';
-import type { IntegrationId, IssueIntegrationId } from './plus/integrations/providers/models';
+import type { HostingIntegrationId, IntegrationId, IssueIntegrationId } from './plus/integrations/providers/models';
 import type { TelemetryEventData } from './telemetry/telemetry';
 import type { TrackedUsage, TrackedUsageKeys } from './telemetry/usageTracker';
 
@@ -846,6 +846,7 @@ export type Sources =
 	| 'notification'
 	| 'patchDetails'
 	| 'prompt'
+	| 'remoteProvider'
 	| 'settings'
 	| 'timeline'
 	| 'trial-indicator'
@@ -874,6 +875,15 @@ export type SupportedAIModels =
 	| `google:${AIModels<'gemini'>}`
 	| `openai:${AIModels<'openai'>}`
 	| 'vscode';
+
+// export const supportedCloudIntegrationIds = [HostingIntegrationId.GitHub, IssueIntegrationId.Jira];
+// export type SupportedCloudIntegrationIds = (typeof supportedCloudIntegrationIds)[number];
+const supportedCloudIntegrationIds = ['github', 'jira'];
+export type SupportedCloudIntegrationIds = HostingIntegrationId.GitHub | IssueIntegrationId.Jira;
+
+export function isSupportedCloudIntegrationId(id: string): id is SupportedCloudIntegrationIds {
+	return supportedCloudIntegrationIds.includes(id as SupportedCloudIntegrationIds);
+}
 
 export type SecretKeys =
 	| `gitlens.integration.auth:${IntegrationId}|${string}`
@@ -1224,7 +1234,7 @@ export type TelemetryEvents = {
 	};
 	/** Sent when a user chooses to manage the cloud integrations */
 	'cloudIntegrations/settingsOpened': {
-		'integration.id': IssueIntegrationId | undefined;
+		'integration.id': SupportedCloudIntegrationIds | undefined;
 	};
 
 	/** Sent when a code suggestion is archived */

--- a/src/constants.ts
+++ b/src/constants.ts
@@ -887,6 +887,7 @@ export function isSupportedCloudIntegrationId(id: string): id is SupportedCloudI
 
 export type SecretKeys =
 	| `gitlens.integration.auth:${IntegrationId}|${string}`
+	| `gitlens.integration.auth.cloud:${IntegrationId}|${string}`
 	| `gitlens.${AIProviders}.key`
 	| `gitlens.plus.auth:${Environment}`;
 

--- a/src/constants.ts
+++ b/src/constants.ts
@@ -7,8 +7,9 @@ import type { FileAnnotationType, ViewShowBranchComparison } from './config';
 import type { Environment } from './container';
 import type { StoredSearchQuery } from './git/search';
 import type { Subscription, SubscriptionPlanId, SubscriptionState } from './plus/gk/account/subscription';
+import type { SupportedCloudIntegrationIds } from './plus/integrations/authentication/models';
 import type { Integration } from './plus/integrations/integration';
-import type { HostingIntegrationId, IntegrationId, IssueIntegrationId } from './plus/integrations/providers/models';
+import type { IntegrationId } from './plus/integrations/providers/models';
 import type { TelemetryEventData } from './telemetry/telemetry';
 import type { TrackedUsage, TrackedUsageKeys } from './telemetry/usageTracker';
 
@@ -875,13 +876,6 @@ export type SupportedAIModels =
 	| `google:${AIModels<'gemini'>}`
 	| `openai:${AIModels<'openai'>}`
 	| 'vscode';
-
-const supportedCloudIntegrationIds = ['github', 'jira'];
-export type SupportedCloudIntegrationIds = HostingIntegrationId.GitHub | IssueIntegrationId.Jira;
-
-export function isSupportedCloudIntegrationId(id: string): id is SupportedCloudIntegrationIds {
-	return supportedCloudIntegrationIds.includes(id as SupportedCloudIntegrationIds);
-}
 
 export type SecretKeys =
 	| `gitlens.integration.auth:${IntegrationId}|${string}`

--- a/src/constants.ts
+++ b/src/constants.ts
@@ -876,8 +876,6 @@ export type SupportedAIModels =
 	| `openai:${AIModels<'openai'>}`
 	| 'vscode';
 
-// export const supportedCloudIntegrationIds = [HostingIntegrationId.GitHub, IssueIntegrationId.Jira];
-// export type SupportedCloudIntegrationIds = (typeof supportedCloudIntegrationIds)[number];
 const supportedCloudIntegrationIds = ['github', 'jira'];
 export type SupportedCloudIntegrationIds = HostingIntegrationId.GitHub | IssueIntegrationId.Jira;
 

--- a/src/container.ts
+++ b/src/container.ts
@@ -636,7 +636,7 @@ export class Container {
 	private _integrations: IntegrationService | undefined;
 	get integrations(): IntegrationService {
 		if (this._integrations == null) {
-			const authenticationService = new IntegrationAuthenticationService(this, this._connection);
+			const authenticationService = new IntegrationAuthenticationService(this);
 			this._disposables.push(
 				authenticationService,
 				(this._integrations = new IntegrationService(this, authenticationService)),

--- a/src/plus/focus/focus.ts
+++ b/src/plus/focus/focus.ts
@@ -29,7 +29,7 @@ import {
 	UnsnoozeQuickInputButton,
 } from '../../commands/quickCommand.buttons';
 import type { LaunchpadTelemetryContext, Source, Sources, TelemetryEvents } from '../../constants';
-import { isSupportedCloudIntegrationId, previewBadge } from '../../constants';
+import { previewBadge } from '../../constants';
 import type { Container } from '../../container';
 import type { QuickPickItemOfT } from '../../quickpicks/items/common';
 import { createQuickPickItemOfT, createQuickPickSeparator } from '../../quickpicks/items/common';
@@ -39,6 +39,7 @@ import { getScopedCounter } from '../../system/counter';
 import { fromNow } from '../../system/date';
 import { interpolate, pluralize } from '../../system/string';
 import { openUrl } from '../../system/utils';
+import { isSupportedCloudIntegrationId } from '../integrations/authentication/models';
 import type { IntegrationId } from '../integrations/providers/models';
 import {
 	HostingIntegrationId,

--- a/src/plus/focus/focus.ts
+++ b/src/plus/focus/focus.ts
@@ -29,7 +29,7 @@ import {
 	UnsnoozeQuickInputButton,
 } from '../../commands/quickCommand.buttons';
 import type { LaunchpadTelemetryContext, Source, Sources, TelemetryEvents } from '../../constants';
-import { previewBadge } from '../../constants';
+import { isSupportedCloudIntegrationId, previewBadge } from '../../constants';
 import type { Container } from '../../container';
 import type { QuickPickItemOfT } from '../../quickpicks/items/common';
 import { createQuickPickItemOfT, createQuickPickSeparator } from '../../quickpicks/items/common';
@@ -160,6 +160,15 @@ export class FocusCommand extends QuickCommand<State> {
 		const integration = await this.container.integrations.get(id);
 		let connected = integration.maybeConnected ?? (await integration.isConnected());
 		if (!connected) {
+			if (isSupportedCloudIntegrationId(integration.id)) {
+				await this.container.integrations.manageCloudIntegrations(integration.id, {
+					source: 'launchpad',
+					detail: {
+						action: 'connect',
+						integration: integration.id,
+					},
+				});
+			}
 			connected = await integration.connect();
 		}
 

--- a/src/plus/focus/focus.ts
+++ b/src/plus/focus/focus.ts
@@ -161,13 +161,16 @@ export class FocusCommand extends QuickCommand<State> {
 		let connected = integration.maybeConnected ?? (await integration.isConnected());
 		if (!connected) {
 			if (isSupportedCloudIntegrationId(integration.id)) {
-				await this.container.integrations.manageCloudIntegrations(integration.id, {
-					source: 'launchpad',
-					detail: {
-						action: 'connect',
-						integration: integration.id,
+				await this.container.integrations.manageCloudIntegrations(
+					{ integrationId: integration.id },
+					{
+						source: 'launchpad',
+						detail: {
+							action: 'connect',
+							integration: integration.id,
+						},
 					},
-				});
+				);
 			}
 			connected = await integration.connect();
 		}

--- a/src/plus/focus/focusIndicator.ts
+++ b/src/plus/focus/focusIndicator.ts
@@ -567,13 +567,16 @@ export class FocusIndicator implements Disposable {
 						const github = await this.container.integrations?.get(HostingIntegrationId.GitHub);
 						if (github == null) break;
 						if (!(github.maybeConnected ?? (await github.isConnected()))) {
-							await this.container.integrations.manageCloudIntegrations(HostingIntegrationId.GitHub, {
-								source: 'launchpad-indicator',
-								detail: {
-									action: 'connect',
-									integration: HostingIntegrationId.GitHub,
+							await this.container.integrations.manageCloudIntegrations(
+								{ integrationId: HostingIntegrationId.GitHub },
+								{
+									source: 'launchpad-indicator',
+									detail: {
+										action: 'connect',
+										integration: HostingIntegrationId.GitHub,
+									},
 								},
-							});
+							);
 							void github.connect();
 						}
 						break;

--- a/src/plus/focus/focusIndicator.ts
+++ b/src/plus/focus/focusIndicator.ts
@@ -567,6 +567,13 @@ export class FocusIndicator implements Disposable {
 						const github = await this.container.integrations?.get(HostingIntegrationId.GitHub);
 						if (github == null) break;
 						if (!(github.maybeConnected ?? (await github.isConnected()))) {
+							await this.container.integrations.manageCloudIntegrations(HostingIntegrationId.GitHub, {
+								source: 'launchpad-indicator',
+								detail: {
+									action: 'connect',
+									integration: HostingIntegrationId.GitHub,
+								},
+							});
 							void github.connect();
 						}
 						break;

--- a/src/plus/integrations/authentication/azureDevOps.ts
+++ b/src/plus/integrations/authentication/azureDevOps.ts
@@ -1,17 +1,17 @@
 import type { AuthenticationSession, Disposable, QuickInputButton } from 'vscode';
 import { env, ThemeIcon, Uri, window } from 'vscode';
+import type { Container } from '../../../container';
 import { base64 } from '../../../system/string';
-import type {
-	IntegrationAuthenticationProvider,
-	IntegrationAuthenticationSessionDescriptor,
-} from './integrationAuthentication';
+import { HostingIntegrationId } from '../providers/models';
+import type { IntegrationAuthenticationSessionDescriptor } from './integrationAuthentication';
+import { IntegrationAuthenticationProvider } from './integrationAuthentication';
 
-export class AzureDevOpsAuthenticationProvider implements IntegrationAuthenticationProvider {
-	getSessionId(descriptor?: IntegrationAuthenticationSessionDescriptor): string {
-		return descriptor?.domain ?? '';
+export class AzureDevOpsAuthenticationProvider extends IntegrationAuthenticationProvider {
+	constructor(container: Container) {
+		super(container, HostingIntegrationId.AzureDevOps);
 	}
 
-	async createSession(
+	override async createSession(
 		descriptor?: IntegrationAuthenticationSessionDescriptor,
 	): Promise<AuthenticationSession | undefined> {
 		let azureOrganization: string | undefined = descriptor?.organization as string | undefined;
@@ -116,5 +116,9 @@ export class AzureDevOpsAuthenticationProvider implements IntegrationAuthenticat
 				label: '',
 			},
 		};
+	}
+
+	protected override getCompletionInputTitle(): string {
+		throw new Error('Method not implemented');
 	}
 }

--- a/src/plus/integrations/authentication/azureDevOps.ts
+++ b/src/plus/integrations/authentication/azureDevOps.ts
@@ -1,14 +1,13 @@
 import type { AuthenticationSession, Disposable, QuickInputButton } from 'vscode';
 import { env, ThemeIcon, Uri, window } from 'vscode';
-import type { Container } from '../../../container';
 import { base64 } from '../../../system/string';
 import { HostingIntegrationId } from '../providers/models';
 import type { IntegrationAuthenticationSessionDescriptor } from './integrationAuthentication';
 import { IntegrationAuthenticationProvider } from './integrationAuthentication';
 
-export class AzureDevOpsAuthenticationProvider extends IntegrationAuthenticationProvider {
-	constructor(container: Container) {
-		super(container, HostingIntegrationId.AzureDevOps);
+export class AzureDevOpsAuthenticationProvider extends IntegrationAuthenticationProvider<HostingIntegrationId.AzureDevOps> {
+	protected override get authProviderId(): HostingIntegrationId.AzureDevOps {
+		return HostingIntegrationId.AzureDevOps;
 	}
 
 	override async createSession(

--- a/src/plus/integrations/authentication/azureDevOps.ts
+++ b/src/plus/integrations/authentication/azureDevOps.ts
@@ -3,9 +3,9 @@ import { env, ThemeIcon, Uri, window } from 'vscode';
 import { base64 } from '../../../system/string';
 import { HostingIntegrationId } from '../providers/models';
 import type { IntegrationAuthenticationSessionDescriptor } from './integrationAuthentication';
-import { IntegrationAuthenticationProvider } from './integrationAuthentication';
+import { LocalIntegrationAuthenticationProvider } from './integrationAuthentication';
 
-export class AzureDevOpsAuthenticationProvider extends IntegrationAuthenticationProvider<HostingIntegrationId.AzureDevOps> {
+export class AzureDevOpsAuthenticationProvider extends LocalIntegrationAuthenticationProvider<HostingIntegrationId.AzureDevOps> {
 	protected override get authProviderId(): HostingIntegrationId.AzureDevOps {
 		return HostingIntegrationId.AzureDevOps;
 	}
@@ -115,9 +115,5 @@ export class AzureDevOpsAuthenticationProvider extends IntegrationAuthentication
 				label: '',
 			},
 		};
-	}
-
-	protected override getCompletionInputTitle(): string {
-		throw new Error('Method not implemented');
 	}
 }

--- a/src/plus/integrations/authentication/bitbucket.ts
+++ b/src/plus/integrations/authentication/bitbucket.ts
@@ -1,14 +1,13 @@
 import type { AuthenticationSession, Disposable, QuickInputButton } from 'vscode';
 import { env, ThemeIcon, Uri, window } from 'vscode';
-import type { Container } from '../../../container';
 import { base64 } from '../../../system/string';
 import { HostingIntegrationId } from '../providers/models';
 import type { IntegrationAuthenticationSessionDescriptor } from './integrationAuthentication';
 import { IntegrationAuthenticationProvider } from './integrationAuthentication';
 
-export class BitbucketAuthenticationProvider extends IntegrationAuthenticationProvider {
-	constructor(container: Container) {
-		super(container, HostingIntegrationId.Bitbucket);
+export class BitbucketAuthenticationProvider extends IntegrationAuthenticationProvider<HostingIntegrationId.Bitbucket> {
+	protected override get authProviderId(): HostingIntegrationId.Bitbucket {
+		return HostingIntegrationId.Bitbucket;
 	}
 
 	override async createSession(

--- a/src/plus/integrations/authentication/bitbucket.ts
+++ b/src/plus/integrations/authentication/bitbucket.ts
@@ -1,17 +1,17 @@
 import type { AuthenticationSession, Disposable, QuickInputButton } from 'vscode';
 import { env, ThemeIcon, Uri, window } from 'vscode';
+import type { Container } from '../../../container';
 import { base64 } from '../../../system/string';
-import type {
-	IntegrationAuthenticationProvider,
-	IntegrationAuthenticationSessionDescriptor,
-} from './integrationAuthentication';
+import { HostingIntegrationId } from '../providers/models';
+import type { IntegrationAuthenticationSessionDescriptor } from './integrationAuthentication';
+import { IntegrationAuthenticationProvider } from './integrationAuthentication';
 
-export class BitbucketAuthenticationProvider implements IntegrationAuthenticationProvider {
-	getSessionId(descriptor?: IntegrationAuthenticationSessionDescriptor): string {
-		return descriptor?.domain ?? '';
+export class BitbucketAuthenticationProvider extends IntegrationAuthenticationProvider {
+	constructor(container: Container) {
+		super(container, HostingIntegrationId.Bitbucket);
 	}
 
-	async createSession(
+	override async createSession(
 		descriptor?: IntegrationAuthenticationSessionDescriptor,
 	): Promise<AuthenticationSession | undefined> {
 		let bitbucketUsername: string | undefined = descriptor?.username as string | undefined;
@@ -128,5 +128,9 @@ export class BitbucketAuthenticationProvider implements IntegrationAuthenticatio
 				label: '',
 			},
 		};
+	}
+
+	protected override getCompletionInputTitle(): string {
+		throw new Error('Method not implemented');
 	}
 }

--- a/src/plus/integrations/authentication/bitbucket.ts
+++ b/src/plus/integrations/authentication/bitbucket.ts
@@ -3,9 +3,9 @@ import { env, ThemeIcon, Uri, window } from 'vscode';
 import { base64 } from '../../../system/string';
 import { HostingIntegrationId } from '../providers/models';
 import type { IntegrationAuthenticationSessionDescriptor } from './integrationAuthentication';
-import { IntegrationAuthenticationProvider } from './integrationAuthentication';
+import { LocalIntegrationAuthenticationProvider } from './integrationAuthentication';
 
-export class BitbucketAuthenticationProvider extends IntegrationAuthenticationProvider<HostingIntegrationId.Bitbucket> {
+export class BitbucketAuthenticationProvider extends LocalIntegrationAuthenticationProvider<HostingIntegrationId.Bitbucket> {
 	protected override get authProviderId(): HostingIntegrationId.Bitbucket {
 		return HostingIntegrationId.Bitbucket;
 	}
@@ -127,9 +127,5 @@ export class BitbucketAuthenticationProvider extends IntegrationAuthenticationPr
 				label: '',
 			},
 		};
-	}
-
-	protected override getCompletionInputTitle(): string {
-		throw new Error('Method not implemented');
 	}
 }

--- a/src/plus/integrations/authentication/github.ts
+++ b/src/plus/integrations/authentication/github.ts
@@ -1,16 +1,16 @@
 import type { AuthenticationSession, Disposable, QuickInputButton } from 'vscode';
 import { env, ThemeIcon, Uri, window } from 'vscode';
-import type {
-	IntegrationAuthenticationProvider,
-	IntegrationAuthenticationSessionDescriptor,
-} from './integrationAuthentication';
+import type { Container } from '../../../container';
+import { SelfHostedIntegrationId } from '../providers/models';
+import type { IntegrationAuthenticationSessionDescriptor } from './integrationAuthentication';
+import { IntegrationAuthenticationProvider } from './integrationAuthentication';
 
-export class GitHubEnterpriseAuthenticationProvider implements IntegrationAuthenticationProvider {
-	getSessionId(descriptor?: IntegrationAuthenticationSessionDescriptor): string {
-		return descriptor?.domain ?? '';
+export class GitHubEnterpriseAuthenticationProvider extends IntegrationAuthenticationProvider {
+	constructor(container: Container) {
+		super(container, SelfHostedIntegrationId.GitHubEnterprise);
 	}
 
-	async createSession(
+	override async createSession(
 		descriptor?: IntegrationAuthenticationSessionDescriptor,
 	): Promise<AuthenticationSession | undefined> {
 		const input = window.createInputBox();
@@ -74,5 +74,9 @@ export class GitHubEnterpriseAuthenticationProvider implements IntegrationAuthen
 				label: '',
 			},
 		};
+	}
+
+	protected override getCompletionInputTitle(): string {
+		throw new Error('Method not implemented');
 	}
 }

--- a/src/plus/integrations/authentication/github.ts
+++ b/src/plus/integrations/authentication/github.ts
@@ -15,18 +15,14 @@ export class GitHubAuthenticationProvider extends CloudIntegrationAuthentication
 
 	override async getBuiltInExistingSession(
 		descriptor?: IntegrationAuthenticationSessionDescriptor,
-		options?: { authorizeIfNeeded?: boolean; createIfNeeded?: boolean; forceNewSession?: boolean },
 	): Promise<AuthenticationSession | undefined> {
 		if (descriptor == null) return undefined;
 
-		const { createIfNeeded, forceNewSession } = options ?? {};
 		return wrapForForcedInsecureSSL(
 			this.container.integrations.ignoreSSLErrors({ id: this.authProviderId, domain: descriptor?.domain }),
 			() =>
 				authentication.getSession(this.authProviderId, descriptor.scopes, {
-					createIfNone: forceNewSession ? undefined : createIfNeeded,
-					silent: !createIfNeeded && !forceNewSession ? true : undefined,
-					forceNewSession: forceNewSession ? true : undefined,
+					silent: true,
 				}),
 		);
 	}

--- a/src/plus/integrations/authentication/github.ts
+++ b/src/plus/integrations/authentication/github.ts
@@ -13,31 +13,26 @@ export class GitHubAuthenticationProvider extends CloudIntegrationAuthentication
 		return HostingIntegrationId.GitHub;
 	}
 
-	override async createSession(
+	override async getBuiltInExistingSession(
 		descriptor?: IntegrationAuthenticationSessionDescriptor,
 		options?: { authorizeIfNeeded?: boolean; createIfNeeded?: boolean; forceNewSession?: boolean },
 	): Promise<AuthenticationSession | undefined> {
-		if (descriptor != null) {
-			const { createIfNeeded, forceNewSession } = options ?? {};
-			const session = wrapForForcedInsecureSSL(
-				this.container.integrations.ignoreSSLErrors({ id: this.authProviderId, domain: descriptor?.domain }),
-				() =>
-					authentication.getSession(this.authProviderId, descriptor.scopes, {
-						createIfNone: forceNewSession ? undefined : createIfNeeded,
-						silent: !createIfNeeded && !forceNewSession ? true : undefined,
-						forceNewSession: forceNewSession ? true : undefined,
-					}),
-			);
+		if (descriptor == null) return undefined;
 
-			if (session != null) {
-				return session;
-			}
-		}
-		return super.createSession(descriptor, options);
+		const { createIfNeeded, forceNewSession } = options ?? {};
+		return wrapForForcedInsecureSSL(
+			this.container.integrations.ignoreSSLErrors({ id: this.authProviderId, domain: descriptor?.domain }),
+			() =>
+				authentication.getSession(this.authProviderId, descriptor.scopes, {
+					createIfNone: forceNewSession ? undefined : createIfNeeded,
+					silent: !createIfNeeded && !forceNewSession ? true : undefined,
+					forceNewSession: forceNewSession ? true : undefined,
+				}),
+		);
 	}
 
 	protected override getCompletionInputTitle(): string {
-		throw new Error('Method not implemented.');
+		return 'Connect to GitHub';
 	}
 }
 

--- a/src/plus/integrations/authentication/github.ts
+++ b/src/plus/integrations/authentication/github.ts
@@ -3,9 +3,12 @@ import { authentication, env, ThemeIcon, Uri, window } from 'vscode';
 import { wrapForForcedInsecureSSL } from '@env/fetch';
 import { HostingIntegrationId, SelfHostedIntegrationId } from '../providers/models';
 import type { IntegrationAuthenticationSessionDescriptor } from './integrationAuthentication';
-import { IntegrationAuthenticationProvider } from './integrationAuthentication';
+import {
+	CloudIntegrationAuthenticationProvider,
+	LocalIntegrationAuthenticationProvider,
+} from './integrationAuthentication';
 
-export class GitHubAuthenticationProvider extends IntegrationAuthenticationProvider<HostingIntegrationId.GitHub> {
+export class GitHubAuthenticationProvider extends CloudIntegrationAuthenticationProvider<HostingIntegrationId.GitHub> {
 	protected override get authProviderId(): HostingIntegrationId.GitHub {
 		return HostingIntegrationId.GitHub;
 	}
@@ -38,7 +41,7 @@ export class GitHubAuthenticationProvider extends IntegrationAuthenticationProvi
 	}
 }
 
-export class GitHubEnterpriseAuthenticationProvider extends IntegrationAuthenticationProvider<SelfHostedIntegrationId.GitHubEnterprise> {
+export class GitHubEnterpriseAuthenticationProvider extends LocalIntegrationAuthenticationProvider<SelfHostedIntegrationId.GitHubEnterprise> {
 	protected override get authProviderId(): SelfHostedIntegrationId.GitHubEnterprise {
 		return SelfHostedIntegrationId.GitHubEnterprise;
 	}
@@ -107,9 +110,5 @@ export class GitHubEnterpriseAuthenticationProvider extends IntegrationAuthentic
 				label: '',
 			},
 		};
-	}
-
-	protected override getCompletionInputTitle(): string {
-		throw new Error('Method not implemented');
 	}
 }

--- a/src/plus/integrations/authentication/github.ts
+++ b/src/plus/integrations/authentication/github.ts
@@ -1,14 +1,13 @@
 import type { AuthenticationSession, Disposable, QuickInputButton } from 'vscode';
 import { authentication, env, ThemeIcon, Uri, window } from 'vscode';
 import { wrapForForcedInsecureSSL } from '@env/fetch';
-import type { Container } from '../../../container';
 import { HostingIntegrationId, SelfHostedIntegrationId } from '../providers/models';
 import type { IntegrationAuthenticationSessionDescriptor } from './integrationAuthentication';
 import { IntegrationAuthenticationProvider } from './integrationAuthentication';
 
-export class GitHubAuthenticationProvider extends IntegrationAuthenticationProvider {
-	constructor(container: Container) {
-		super(container, HostingIntegrationId.GitHub);
+export class GitHubAuthenticationProvider extends IntegrationAuthenticationProvider<HostingIntegrationId.GitHub> {
+	protected override get authProviderId(): HostingIntegrationId.GitHub {
+		return HostingIntegrationId.GitHub;
 	}
 
 	override async createSession(
@@ -39,9 +38,9 @@ export class GitHubAuthenticationProvider extends IntegrationAuthenticationProvi
 	}
 }
 
-export class GitHubEnterpriseAuthenticationProvider extends IntegrationAuthenticationProvider {
-	constructor(container: Container) {
-		super(container, SelfHostedIntegrationId.GitHubEnterprise);
+export class GitHubEnterpriseAuthenticationProvider extends IntegrationAuthenticationProvider<SelfHostedIntegrationId.GitHubEnterprise> {
+	protected override get authProviderId(): SelfHostedIntegrationId.GitHubEnterprise {
+		return SelfHostedIntegrationId.GitHubEnterprise;
 	}
 
 	override async createSession(

--- a/src/plus/integrations/authentication/gitlab.ts
+++ b/src/plus/integrations/authentication/gitlab.ts
@@ -3,11 +3,11 @@ import { env, ThemeIcon, Uri, window } from 'vscode';
 import type { Container } from '../../../container';
 import type { HostingIntegrationId, SelfHostedIntegrationId } from '../providers/models';
 import type { IntegrationAuthenticationSessionDescriptor } from './integrationAuthentication';
-import { IntegrationAuthenticationProvider } from './integrationAuthentication';
+import { LocalIntegrationAuthenticationProvider } from './integrationAuthentication';
 
 type GitLabId = HostingIntegrationId.GitLab | SelfHostedIntegrationId.GitLabSelfHosted;
 
-export class GitLabAuthenticationProvider extends IntegrationAuthenticationProvider<GitLabId> {
+export class GitLabAuthenticationProvider extends LocalIntegrationAuthenticationProvider<GitLabId> {
 	constructor(
 		container: Container,
 		protected readonly authProviderId: GitLabId,
@@ -80,9 +80,5 @@ export class GitLabAuthenticationProvider extends IntegrationAuthenticationProvi
 				label: '',
 			},
 		};
-	}
-
-	protected override getCompletionInputTitle(): string {
-		throw new Error('Method not implemented');
 	}
 }

--- a/src/plus/integrations/authentication/gitlab.ts
+++ b/src/plus/integrations/authentication/gitlab.ts
@@ -1,9 +1,20 @@
 import type { AuthenticationSession, Disposable, QuickInputButton } from 'vscode';
 import { env, ThemeIcon, Uri, window } from 'vscode';
+import type { Container } from '../../../container';
+import type { HostingIntegrationId, SelfHostedIntegrationId } from '../providers/models';
 import type { IntegrationAuthenticationSessionDescriptor } from './integrationAuthentication';
 import { IntegrationAuthenticationProvider } from './integrationAuthentication';
 
-export class GitLabAuthenticationProvider extends IntegrationAuthenticationProvider {
+type GitLabId = HostingIntegrationId.GitLab | SelfHostedIntegrationId.GitLabSelfHosted;
+
+export class GitLabAuthenticationProvider extends IntegrationAuthenticationProvider<GitLabId> {
+	constructor(
+		container: Container,
+		protected readonly authProviderId: GitLabId,
+	) {
+		super(container);
+	}
+
 	override async createSession(
 		descriptor?: IntegrationAuthenticationSessionDescriptor,
 	): Promise<AuthenticationSession | undefined> {

--- a/src/plus/integrations/authentication/gitlab.ts
+++ b/src/plus/integrations/authentication/gitlab.ts
@@ -1,16 +1,10 @@
 import type { AuthenticationSession, Disposable, QuickInputButton } from 'vscode';
 import { env, ThemeIcon, Uri, window } from 'vscode';
-import type {
-	IntegrationAuthenticationProvider,
-	IntegrationAuthenticationSessionDescriptor,
-} from './integrationAuthentication';
+import type { IntegrationAuthenticationSessionDescriptor } from './integrationAuthentication';
+import { IntegrationAuthenticationProvider } from './integrationAuthentication';
 
-export class GitLabAuthenticationProvider implements IntegrationAuthenticationProvider {
-	getSessionId(descriptor?: IntegrationAuthenticationSessionDescriptor): string {
-		return descriptor?.domain ?? '';
-	}
-
-	async createSession(
+export class GitLabAuthenticationProvider extends IntegrationAuthenticationProvider {
+	override async createSession(
 		descriptor?: IntegrationAuthenticationSessionDescriptor,
 	): Promise<AuthenticationSession | undefined> {
 		const input = window.createInputBox();
@@ -75,5 +69,9 @@ export class GitLabAuthenticationProvider implements IntegrationAuthenticationPr
 				label: '',
 			},
 		};
+	}
+
+	protected override getCompletionInputTitle(): string {
+		throw new Error('Method not implemented');
 	}
 }

--- a/src/plus/integrations/authentication/integrationAuthentication.ts
+++ b/src/plus/integrations/authentication/integrationAuthentication.ts
@@ -136,13 +136,20 @@ export abstract class CloudIntegrationAuthenticationProvider<
 		return Promise.resolve(undefined);
 	}
 
-	protected override async createSession(
+	public override async getSession(
 		descriptor?: IntegrationAuthenticationSessionDescriptor,
-		options?: { authorizeIfNeeded?: boolean },
+		options?: { createIfNeeded?: boolean; forceNewSession?: boolean },
 	): Promise<ProviderAuthenticationSession | undefined> {
 		const existingSession = await this.getBuiltInExistingSession(descriptor);
 		if (existingSession != null) return existingSession;
 
+		return super.getSession(descriptor, options);
+	}
+
+	protected override async createSession(
+		descriptor?: IntegrationAuthenticationSessionDescriptor,
+		options?: { authorizeIfNeeded?: boolean },
+	): Promise<ProviderAuthenticationSession | undefined> {
 		const cloudIntegrations = await this.container.cloudIntegrations;
 		if (cloudIntegrations == null) return undefined;
 

--- a/src/plus/integrations/authentication/integrationAuthentication.ts
+++ b/src/plus/integrations/authentication/integrationAuthentication.ts
@@ -1,6 +1,5 @@
 import type { AuthenticationSession, CancellationToken, Disposable, Uri } from 'vscode';
-import { authentication, CancellationTokenSource, window } from 'vscode';
-import { wrapForForcedInsecureSSL } from '@env/fetch';
+import { CancellationTokenSource, window } from 'vscode';
 import type { Container } from '../../../container';
 import { debug, log } from '../../../system/decorators/log';
 import type { DeferredEventExecutor } from '../../../system/event';
@@ -48,6 +47,13 @@ export abstract class IntegrationAuthenticationProvider {
 	getSessionId(descriptor?: IntegrationAuthenticationSessionDescriptor): string {
 		return descriptor?.domain ?? '';
 	}
+
+	@debug()
+	async deleteSession(descriptor?: IntegrationAuthenticationSessionDescriptor) {
+		const key = this.getSecretKey(this.getSessionId(descriptor));
+		await this.container.storage.deleteSecret(key);
+	}
+
 	async createSession(
 		descriptor?: IntegrationAuthenticationSessionDescriptor,
 		options?: { authorizeIfNeeded?: boolean },
@@ -150,6 +156,76 @@ export abstract class IntegrationAuthenticationProvider {
 			resolve(uri.toString(true));
 		};
 	}
+
+	private getSecretKey(id: string): `gitlens.integration.auth:${IntegrationId}|${string}` {
+		return `gitlens.integration.auth:${this.authProviderId}|${id}`;
+	}
+
+	@debug()
+	private async createAndStoreSession(
+		descriptor?: IntegrationAuthenticationSessionDescriptor,
+	): Promise<AuthenticationSession | undefined> {
+		const session = await this.createSession(descriptor);
+		if (session == null) return undefined;
+
+		const key = this.getSecretKey(this.getSessionId(descriptor));
+		await this.container.storage.storeSecret(key, JSON.stringify(session));
+
+		return session;
+	}
+
+	@debug()
+	async getSession(
+		descriptor?: IntegrationAuthenticationSessionDescriptor,
+		options?: { createIfNeeded?: boolean; forceNewSession?: boolean },
+	): Promise<ProviderAuthenticationSession | undefined> {
+		const key = this.getSecretKey(this.getSessionId(descriptor));
+
+		if (options?.forceNewSession) {
+			await this.container.storage.deleteSecret(key);
+		}
+
+		let storedSession: StoredSession | undefined;
+		try {
+			const sessionJSON = await this.container.storage.getSecret(key);
+			if (sessionJSON) {
+				storedSession = JSON.parse(sessionJSON);
+			}
+		} catch (ex) {
+			try {
+				await this.container.storage.deleteSecret(key);
+			} catch {}
+
+			if (!options?.createIfNeeded) {
+				throw ex;
+			}
+		}
+
+		if (
+			(options?.createIfNeeded && storedSession == null) ||
+			(storedSession?.expiresAt != null && new Date(storedSession.expiresAt).getTime() < Date.now())
+		) {
+			return this.createAndStoreSession(descriptor);
+		}
+
+		return storedSession as ProviderAuthenticationSession | undefined;
+
+		// For unsupported providers
+		// import { authentication } from 'vscode';
+		// import { wrapForForcedInsecureSSL } from '@env/fetch';
+		//
+		// 	if (descriptor == null) return undefined;
+		// 	const { createIfNeeded, forceNewSession } = options ?? {};
+		// 	return wrapForForcedInsecureSSL(
+		// 		this.container.integrations.ignoreSSLErrors({ id: providerId, domain: descriptor?.domain }),
+		// 		() =>
+		// 			authentication.getSession(providerId, descriptor.scopes, {
+		// 				createIfNone: forceNewSession ? undefined : createIfNeeded,
+		// 				silent: !createIfNeeded && !forceNewSession ? true : undefined,
+		// 				forceNewSession: forceNewSession ? true : undefined,
+		// 			}),
+		// 	);
+	}
 }
 
 export class IntegrationAuthenticationService implements Disposable {
@@ -164,89 +240,16 @@ export class IntegrationAuthenticationService implements Disposable {
 		this.providers.clear();
 	}
 
-	@debug()
-	async createSession(
-		providerId: IntegrationId,
-		descriptor?: IntegrationAuthenticationSessionDescriptor,
-	): Promise<AuthenticationSession | undefined> {
-		const provider = await this.ensureProvider(providerId);
-
-		const session = await provider.createSession(descriptor);
-		if (session == null) return undefined;
-
-		const key = this.getSecretKey(providerId, provider.getSessionId(descriptor));
-		await this.container.storage.storeSecret(key, JSON.stringify(session));
-
-		return session;
-	}
-
-	@debug()
-	async getSession(
-		providerId: IntegrationId,
-		descriptor?: IntegrationAuthenticationSessionDescriptor,
-		options?: { createIfNeeded?: boolean; forceNewSession?: boolean },
-	): Promise<ProviderAuthenticationSession | undefined> {
-		if (this.supports(providerId)) {
-			const provider = await this.ensureProvider(providerId);
-
-			const key = this.getSecretKey(providerId, provider.getSessionId(descriptor));
-
-			if (options?.forceNewSession) {
-				await this.container.storage.deleteSecret(key);
-			}
-
-			let storedSession: StoredSession | undefined;
-			try {
-				const sessionJSON = await this.container.storage.getSecret(key);
-				if (sessionJSON) {
-					storedSession = JSON.parse(sessionJSON);
-				}
-			} catch (ex) {
-				try {
-					await this.container.storage.deleteSecret(key);
-				} catch {}
-
-				if (!options?.createIfNeeded) {
-					throw ex;
-				}
-			}
-
-			if (
-				(options?.createIfNeeded && storedSession == null) ||
-				(storedSession?.expiresAt != null && new Date(storedSession.expiresAt).getTime() < Date.now())
-			) {
-				return this.createSession(providerId, descriptor);
-			}
-
-			return storedSession as ProviderAuthenticationSession | undefined;
-		}
-
-		if (descriptor == null) return undefined;
-
-		const { createIfNeeded, forceNewSession } = options ?? {};
-		return wrapForForcedInsecureSSL(
-			this.container.integrations.ignoreSSLErrors({ id: providerId, domain: descriptor?.domain }),
-			() =>
-				authentication.getSession(providerId, descriptor.scopes, {
-					createIfNone: forceNewSession ? undefined : createIfNeeded,
-					silent: !createIfNeeded && !forceNewSession ? true : undefined,
-					forceNewSession: forceNewSession ? true : undefined,
-				}),
-		);
-	}
-
-	@debug()
-	async deleteSession(providerId: IntegrationId, descriptor?: IntegrationAuthenticationSessionDescriptor) {
-		const provider = await this.ensureProvider(providerId);
-
-		const key = this.getSecretKey(providerId, provider.getSessionId(descriptor));
-		await this.container.storage.deleteSecret(key);
+	async get(providerId: IntegrationId): Promise<IntegrationAuthenticationProvider> {
+		return this.ensureProvider(providerId);
 	}
 
 	@log()
 	async reset() {
 		// TODO: This really isn't ideal, since it will only work for "cloud" providers as we won't have any more specific descriptors
-		await Promise.allSettled(supportedIntegrationIds.map(providerId => this.deleteSession(providerId)));
+		await Promise.allSettled(
+			supportedIntegrationIds.map(async providerId => (await this.ensureProvider(providerId)).deleteSession()),
+		);
 	}
 
 	supports(providerId: string): boolean {
@@ -261,10 +264,6 @@ export class IntegrationAuthenticationService implements Disposable {
 			default:
 				return false;
 		}
-	}
-
-	private getSecretKey(providerId: IntegrationId, id: string): `gitlens.integration.auth:${IntegrationId}|${string}` {
-		return `gitlens.integration.auth:${providerId}|${id}`;
 	}
 
 	private async ensureProvider(providerId: IntegrationId): Promise<IntegrationAuthenticationProvider> {

--- a/src/plus/integrations/authentication/integrationAuthentication.ts
+++ b/src/plus/integrations/authentication/integrationAuthentication.ts
@@ -150,6 +150,9 @@ export abstract class CloudIntegrationAuthenticationProvider<
 		descriptor?: IntegrationAuthenticationSessionDescriptor,
 		options?: { authorizeIfNeeded?: boolean },
 	): Promise<ProviderAuthenticationSession | undefined> {
+		const loggedIn = await this.container.subscription.getAuthenticationSession(false);
+		if (!loggedIn) return undefined;
+
 		const cloudIntegrations = await this.container.cloudIntegrations;
 		if (cloudIntegrations == null) return undefined;
 

--- a/src/plus/integrations/authentication/integrationAuthentication.ts
+++ b/src/plus/integrations/authentication/integrationAuthentication.ts
@@ -39,11 +39,10 @@ export interface IntegrationAuthenticationSessionDescriptor {
 	[key: string]: unknown;
 }
 
-export abstract class IntegrationAuthenticationProvider {
-	constructor(
-		protected readonly container: Container,
-		protected readonly authProviderId: IntegrationId,
-	) {}
+export abstract class IntegrationAuthenticationProvider<ID extends IntegrationId = IntegrationId> {
+	constructor(protected readonly container: Container) {}
+
+	protected abstract get authProviderId(): ID;
 
 	getSessionId(descriptor?: IntegrationAuthenticationSessionDescriptor): string {
 		return descriptor?.domain ?? '';
@@ -214,6 +213,13 @@ export abstract class IntegrationAuthenticationProvider {
 }
 
 class BuiltInAuthenticationProvider extends IntegrationAuthenticationProvider {
+	constructor(
+		container: Container,
+		protected readonly authProviderId: IntegrationId,
+	) {
+		super(container);
+	}
+
 	protected override createSession(): Promise<ProviderAuthenticationSession | undefined> {
 		throw new Error('Method `createSession` should never be used in BuiltInAuthenticationProvider');
 	}

--- a/src/plus/integrations/authentication/integrationAuthentication.ts
+++ b/src/plus/integrations/authentication/integrationAuthentication.ts
@@ -293,6 +293,11 @@ export class IntegrationAuthenticationService implements Disposable {
 						await import(/* webpackChunkName: "integrations" */ './bitbucket')
 					).BitbucketAuthenticationProvider(this.container);
 					break;
+				case HostingIntegrationId.GitHub:
+					provider = new (
+						await import(/* webpackChunkName: "integrations" */ './github')
+					).GitHubAuthenticationProvider(this.container);
+					break;
 				case SelfHostedIntegrationId.GitHubEnterprise:
 					provider = new (
 						await import(/* webpackChunkName: "integrations" */ './github')

--- a/src/plus/integrations/authentication/integrationAuthentication.ts
+++ b/src/plus/integrations/authentication/integrationAuthentication.ts
@@ -148,6 +148,12 @@ export abstract class CloudIntegrationAuthenticationProvider<
 
 		let session = await cloudIntegrations.getConnectionSession(this.authProviderId);
 
+		// Make an exception for GitHub because they always return 0
+		if (session?.expiresIn === 0 && this.authProviderId === HostingIntegrationId.GitHub) {
+			// It never expires so don't refresh it frequently:
+			session.expiresIn = 31536000; // 1 year
+		}
+
 		if (session != null && session.expiresIn < 60) {
 			session = await cloudIntegrations.getConnectionSession(this.authProviderId, session.accessToken);
 		}

--- a/src/plus/integrations/authentication/integrationAuthentication.ts
+++ b/src/plus/integrations/authentication/integrationAuthentication.ts
@@ -1,8 +1,11 @@
-import type { AuthenticationSession, Disposable } from 'vscode';
-import { authentication } from 'vscode';
+import type { AuthenticationSession, CancellationToken, Disposable, Uri } from 'vscode';
+import { authentication, CancellationTokenSource, window } from 'vscode';
 import { wrapForForcedInsecureSSL } from '@env/fetch';
 import type { Container } from '../../../container';
 import { debug, log } from '../../../system/decorators/log';
+import type { DeferredEventExecutor } from '../../../system/event';
+import { promisifyDeferred } from '../../../system/event';
+import { openUrl } from '../../../system/utils';
 import type { ServerConnection } from '../../gk/serverConnection';
 import type { IntegrationId } from '../providers/models';
 import {
@@ -36,11 +39,117 @@ export interface IntegrationAuthenticationSessionDescriptor {
 	[key: string]: unknown;
 }
 
-export interface IntegrationAuthenticationProvider {
-	getSessionId(descriptor?: IntegrationAuthenticationSessionDescriptor): string;
-	createSession(
+export abstract class IntegrationAuthenticationProvider {
+	constructor(
+		private readonly container: Container,
+		private readonly authProviderId: IntegrationId,
+	) {}
+
+	getSessionId(descriptor?: IntegrationAuthenticationSessionDescriptor): string {
+		return descriptor?.domain ?? '';
+	}
+	async createSession(
 		descriptor?: IntegrationAuthenticationSessionDescriptor,
-	): Promise<ProviderAuthenticationSession | undefined>;
+		options?: { authorizeIfNeeded?: boolean },
+	): Promise<ProviderAuthenticationSession | undefined> {
+		const cloudIntegrations = await this.container.cloudIntegrations;
+		if (cloudIntegrations == null) return undefined;
+
+		let session = await cloudIntegrations.getConnectionSession(this.authProviderId);
+
+		if (session != null && session.expiresIn < 60) {
+			session = await cloudIntegrations.getConnectionSession(this.authProviderId, session.accessToken);
+		}
+
+		if (!session && options?.authorizeIfNeeded) {
+			const authorizeUrl = (await cloudIntegrations.authorize(this.authProviderId))?.url;
+
+			if (!authorizeUrl) return undefined;
+
+			void (await openUrl(authorizeUrl));
+
+			const cancellation = new CancellationTokenSource();
+			const deferredCallback = promisifyDeferred(
+				this.container.uri.onDidReceiveCloudIntegrationAuthenticationUri,
+				this.getUriHandlerDeferredExecutor(),
+			);
+
+			try {
+				await Promise.race([
+					deferredCallback.promise,
+					this.openCompletionInput(cancellation.token),
+					new Promise<string>((_, reject) =>
+						// eslint-disable-next-line @typescript-eslint/prefer-promise-reject-errors
+						cancellation.token.onCancellationRequested(() => reject('Cancelled')),
+					),
+					new Promise<string>((_, reject) => setTimeout(reject, 120000, 'Cancelled')),
+				]);
+				session = await cloudIntegrations.getConnectionSession(this.authProviderId);
+			} catch {
+				session = undefined;
+			} finally {
+				cancellation.cancel();
+				cancellation.dispose();
+				deferredCallback.cancel();
+			}
+		}
+
+		if (!session) return undefined;
+
+		return {
+			id: this.getSessionId(descriptor),
+			accessToken: session.accessToken,
+			scopes: descriptor?.scopes ?? [],
+			account: {
+				id: '',
+				label: '',
+			},
+			expiresAt: new Date(session.expiresIn * 1000 + Date.now()),
+		};
+	}
+
+	private async openCompletionInput(cancellationToken: CancellationToken) {
+		const input = window.createInputBox();
+		input.ignoreFocusOut = true;
+
+		const disposables: Disposable[] = [];
+
+		try {
+			if (cancellationToken.isCancellationRequested) return;
+
+			await new Promise<string | undefined>(resolve => {
+				disposables.push(
+					cancellationToken.onCancellationRequested(() => input.hide()),
+					input.onDidHide(() => resolve(undefined)),
+					input.onDidAccept(() => resolve(undefined)),
+				);
+
+				input.title = this.getCompletionInputTitle();
+				input.placeholder = 'Please enter the provided authorization code';
+				input.prompt = '';
+
+				input.show();
+			});
+		} finally {
+			input.dispose();
+			disposables.forEach(d => void d.dispose());
+		}
+	}
+
+	protected abstract getCompletionInputTitle(): string;
+
+	private getUriHandlerDeferredExecutor(): DeferredEventExecutor<Uri, string> {
+		return (uri: Uri, resolve, reject) => {
+			const queryParams: URLSearchParams = new URLSearchParams(uri.query);
+			const provider = queryParams.get('provider');
+			if (provider !== this.authProviderId) {
+				reject('Invalid provider');
+				return;
+			}
+
+			resolve(uri.toString(true));
+		};
+	}
 }
 
 export class IntegrationAuthenticationService implements Disposable {
@@ -165,23 +274,23 @@ export class IntegrationAuthenticationService implements Disposable {
 				case HostingIntegrationId.AzureDevOps:
 					provider = new (
 						await import(/* webpackChunkName: "integrations" */ './azureDevOps')
-					).AzureDevOpsAuthenticationProvider();
+					).AzureDevOpsAuthenticationProvider(this.container);
 					break;
 				case HostingIntegrationId.Bitbucket:
 					provider = new (
 						await import(/* webpackChunkName: "integrations" */ './bitbucket')
-					).BitbucketAuthenticationProvider();
+					).BitbucketAuthenticationProvider(this.container);
 					break;
 				case SelfHostedIntegrationId.GitHubEnterprise:
 					provider = new (
 						await import(/* webpackChunkName: "integrations" */ './github')
-					).GitHubEnterpriseAuthenticationProvider();
+					).GitHubEnterpriseAuthenticationProvider(this.container);
 					break;
 				case HostingIntegrationId.GitLab:
 				case SelfHostedIntegrationId.GitLabSelfHosted:
 					provider = new (
 						await import(/* webpackChunkName: "integrations" */ './gitlab')
-					).GitLabAuthenticationProvider();
+					).GitLabAuthenticationProvider(this.container, providerId);
 					break;
 				case IssueIntegrationId.Jira:
 					provider = new (

--- a/src/plus/integrations/authentication/integrationAuthentication.ts
+++ b/src/plus/integrations/authentication/integrationAuthentication.ts
@@ -235,12 +235,12 @@ export abstract class CloudIntegrationAuthenticationProvider<
 		descriptor?: IntegrationAuthenticationSessionDescriptor,
 		options?: { createIfNeeded?: boolean; forceNewSession?: boolean },
 	): Promise<ProviderAuthenticationSession | undefined> {
+		const session = await super.getSession(descriptor, options);
+		if (session != null) return session;
+
 		// by default getBuiltInExistingSession returns undefined
 		// but specific providers can override it to return a session (e.g. GitHub)
-		const existingSession = await this.getBuiltInExistingSession(descriptor);
-		if (existingSession != null) return existingSession;
-
-		return super.getSession(descriptor, options);
+		return this.getBuiltInExistingSession(descriptor);
 	}
 
 	protected override async createSession(

--- a/src/plus/integrations/authentication/integrationAuthentication.ts
+++ b/src/plus/integrations/authentication/integrationAuthentication.ts
@@ -130,10 +130,19 @@ export abstract class LocalIntegrationAuthenticationProvider<
 export abstract class CloudIntegrationAuthenticationProvider<
 	ID extends IntegrationId = IntegrationId,
 > extends IntegrationAuthenticationProviderBase<ID> {
+	protected async getBuiltInExistingSession(
+		_?: IntegrationAuthenticationSessionDescriptor,
+	): Promise<ProviderAuthenticationSession | undefined> {
+		return Promise.resolve(undefined);
+	}
+
 	protected override async createSession(
 		descriptor?: IntegrationAuthenticationSessionDescriptor,
 		options?: { authorizeIfNeeded?: boolean },
 	): Promise<ProviderAuthenticationSession | undefined> {
+		const existingSession = await this.getBuiltInExistingSession(descriptor);
+		if (existingSession != null) return existingSession;
+
 		const cloudIntegrations = await this.container.cloudIntegrations;
 		if (cloudIntegrations == null) return undefined;
 

--- a/src/plus/integrations/authentication/jira.ts
+++ b/src/plus/integrations/authentication/jira.ts
@@ -1,10 +1,9 @@
-import type { Container } from '../../../container';
 import { IssueIntegrationId } from '../providers/models';
 import { IntegrationAuthenticationProvider } from './integrationAuthentication';
 
-export class JiraAuthenticationProvider extends IntegrationAuthenticationProvider {
-	constructor(container: Container) {
-		super(container, IssueIntegrationId.Jira);
+export class JiraAuthenticationProvider extends IntegrationAuthenticationProvider<IssueIntegrationId.Jira> {
+	protected override get authProviderId(): IssueIntegrationId.Jira {
+		return IssueIntegrationId.Jira;
 	}
 
 	protected override getCompletionInputTitle(): string {

--- a/src/plus/integrations/authentication/jira.ts
+++ b/src/plus/integrations/authentication/jira.ts
@@ -1,7 +1,7 @@
 import { IssueIntegrationId } from '../providers/models';
-import { IntegrationAuthenticationProvider } from './integrationAuthentication';
+import { CloudIntegrationAuthenticationProvider } from './integrationAuthentication';
 
-export class JiraAuthenticationProvider extends IntegrationAuthenticationProvider<IssueIntegrationId.Jira> {
+export class JiraAuthenticationProvider extends CloudIntegrationAuthenticationProvider<IssueIntegrationId.Jira> {
 	protected override get authProviderId(): IssueIntegrationId.Jira {
 		return IssueIntegrationId.Jira;
 	}

--- a/src/plus/integrations/authentication/jira.ts
+++ b/src/plus/integrations/authentication/jira.ts
@@ -1,123 +1,13 @@
-import type { CancellationToken, Disposable, Uri } from 'vscode';
-import { CancellationTokenSource, window } from 'vscode';
 import type { Container } from '../../../container';
-import type { DeferredEventExecutor } from '../../../system/event';
-import { promisifyDeferred } from '../../../system/event';
-import { openUrl } from '../../../system/utils';
 import { IssueIntegrationId } from '../providers/models';
-import type {
-	IntegrationAuthenticationProvider,
-	IntegrationAuthenticationSessionDescriptor,
-} from './integrationAuthentication';
-import type { ProviderAuthenticationSession } from './models';
+import { IntegrationAuthenticationProvider } from './integrationAuthentication';
 
-export class JiraAuthenticationProvider implements IntegrationAuthenticationProvider {
-	constructor(private readonly container: Container) {}
-
-	private readonly authProviderId = IssueIntegrationId.Jira;
-
-	getSessionId(descriptor?: IntegrationAuthenticationSessionDescriptor): string {
-		return descriptor?.domain ?? '';
+export class JiraAuthenticationProvider extends IntegrationAuthenticationProvider {
+	constructor(container: Container) {
+		super(container, IssueIntegrationId.Jira);
 	}
 
-	async createSession(
-		descriptor?: IntegrationAuthenticationSessionDescriptor,
-		options?: { authorizeIfNeeded?: boolean },
-	): Promise<ProviderAuthenticationSession | undefined> {
-		const cloudIntegrations = await this.container.cloudIntegrations;
-		if (cloudIntegrations == null) return undefined;
-
-		let session = await cloudIntegrations.getConnectionSession(this.authProviderId);
-
-		if (session != null && session.expiresIn < 60) {
-			session = await cloudIntegrations.getConnectionSession(this.authProviderId, session.accessToken);
-		}
-
-		if (!session && options?.authorizeIfNeeded) {
-			const authorizeJiraUrl = (await cloudIntegrations.authorize(this.authProviderId))?.url;
-
-			if (!authorizeJiraUrl) return undefined;
-
-			void (await openUrl(authorizeJiraUrl));
-
-			const cancellation = new CancellationTokenSource();
-			const deferredCallback = promisifyDeferred(
-				this.container.uri.onDidReceiveCloudIntegrationAuthenticationUri,
-				this.getUriHandlerDeferredExecutor(),
-			);
-
-			try {
-				await Promise.race([
-					deferredCallback.promise,
-					this.openCompletionInput(cancellation.token),
-					new Promise<string>((_, reject) =>
-						// eslint-disable-next-line @typescript-eslint/prefer-promise-reject-errors
-						cancellation.token.onCancellationRequested(() => reject('Cancelled')),
-					),
-					new Promise<string>((_, reject) => setTimeout(reject, 120000, 'Cancelled')),
-				]);
-				session = await cloudIntegrations.getConnectionSession(this.authProviderId);
-			} catch {
-				session = undefined;
-			} finally {
-				cancellation.cancel();
-				cancellation.dispose();
-				deferredCallback.cancel();
-			}
-		}
-
-		if (!session) return undefined;
-
-		return {
-			id: this.getSessionId(descriptor),
-			accessToken: session.accessToken,
-			scopes: descriptor?.scopes ?? [],
-			account: {
-				id: '',
-				label: '',
-			},
-			expiresAt: new Date(session.expiresIn * 1000 + Date.now()),
-		};
-	}
-
-	private async openCompletionInput(cancellationToken: CancellationToken) {
-		const input = window.createInputBox();
-		input.ignoreFocusOut = true;
-
-		const disposables: Disposable[] = [];
-
-		try {
-			if (cancellationToken.isCancellationRequested) return;
-
-			await new Promise<string | undefined>(resolve => {
-				disposables.push(
-					cancellationToken.onCancellationRequested(() => input.hide()),
-					input.onDidHide(() => resolve(undefined)),
-					input.onDidAccept(() => resolve(undefined)),
-				);
-
-				input.title = 'Connect to Jira';
-				input.placeholder = 'Please enter the provided authorization code';
-				input.prompt = '';
-
-				input.show();
-			});
-		} finally {
-			input.dispose();
-			disposables.forEach(d => void d.dispose());
-		}
-	}
-
-	private getUriHandlerDeferredExecutor(): DeferredEventExecutor<Uri, string> {
-		return (uri: Uri, resolve, reject) => {
-			const queryParams: URLSearchParams = new URLSearchParams(uri.query);
-			const provider = queryParams.get('provider');
-			if (provider !== IssueIntegrationId.Jira) {
-				reject('Invalid provider');
-				return;
-			}
-
-			resolve(uri.toString(true));
-		};
+	protected override getCompletionInputTitle(): string {
+		return 'Connect to Jira';
 	}
 }

--- a/src/plus/integrations/authentication/models.ts
+++ b/src/plus/integrations/authentication/models.ts
@@ -30,7 +30,7 @@ export type CloudIntegrationAuthType = 'oauth' | 'pat';
 
 export const CloudIntegrationAuthenticationUriPathPrefix = 'did-authenticate-cloud-integration';
 
-export const supportedCloudIntegrationIds: IntegrationId[] = [IssueIntegrationId.Jira];
+export const supportedCloudIntegrationIds: IntegrationId[] = [IssueIntegrationId.Jira, HostingIntegrationId.GitHub];
 
 export const toIntegrationId: { [key in CloudIntegrationType]: IntegrationId } = {
 	jira: IssueIntegrationId.Jira,

--- a/src/plus/integrations/authentication/models.ts
+++ b/src/plus/integrations/authentication/models.ts
@@ -30,7 +30,12 @@ export type CloudIntegrationAuthType = 'oauth' | 'pat';
 
 export const CloudIntegrationAuthenticationUriPathPrefix = 'did-authenticate-cloud-integration';
 
-export const supportedCloudIntegrationIds: IntegrationId[] = [IssueIntegrationId.Jira, HostingIntegrationId.GitHub];
+export const supportedCloudIntegrationIds = [IssueIntegrationId.Jira, HostingIntegrationId.GitHub];
+export type SupportedCloudIntegrationIds = (typeof supportedCloudIntegrationIds)[number];
+
+export function isSupportedCloudIntegrationId(id: string): id is SupportedCloudIntegrationIds {
+	return supportedCloudIntegrationIds.includes(id as SupportedCloudIntegrationIds);
+}
 
 export const toIntegrationId: { [key in CloudIntegrationType]: IntegrationId } = {
 	jira: IssueIntegrationId.Jira,

--- a/src/plus/integrations/integration.ts
+++ b/src/plus/integrations/integration.ts
@@ -184,7 +184,8 @@ export abstract class IntegrationBase<
 		}
 
 		if (signOut) {
-			void this.authenticationService.deleteSession(this.authProvider.id, this.authProviderDescriptor);
+			const authProvider = await this.authenticationService.get(this.authProvider.id);
+			void authProvider.deleteSession(this.authProviderDescriptor);
 		}
 
 		this.resetRequestExceptionCount();
@@ -268,7 +269,8 @@ export abstract class IntegrationBase<
 
 		let session: ProviderAuthenticationSession | undefined | null;
 		try {
-			session = await this.authenticationService.getSession(this.authProvider.id, this.authProviderDescriptor, {
+			const authProvider = await this.authenticationService.get(this.authProvider.id);
+			session = await authProvider.getSession(this.authProviderDescriptor, {
 				createIfNeeded: createIfNeeded,
 				forceNewSession: forceNewSession,
 			});

--- a/src/plus/integrations/integration.ts
+++ b/src/plus/integrations/integration.ts
@@ -200,6 +200,18 @@ export abstract class IntegrationBase<
 		this.resetRequestExceptionCount();
 		this._session = null;
 
+		if (connected && options?.cloudSessionOnly) {
+			const authProvider = await this.authenticationService.get(this.authProvider.id);
+			this._session = await authProvider.getSession(this.authProviderDescriptor, {
+				createIfNeeded: false,
+				forceNewSession: false,
+			});
+		}
+
+		if (this._session != null) {
+			return;
+		}
+
 		if (connected) {
 			// Don't store the disconnected flag if this only for this current VS Code session (will be re-connected on next restart)
 			if (!options?.currentSessionOnly) {

--- a/src/plus/integrations/integrationService.ts
+++ b/src/plus/integrations/integrationService.ts
@@ -92,7 +92,7 @@ export class IntegrationService implements Disposable {
 			} else {
 				if (!isConnected) continue;
 
-				await integration.disconnect({ silent: true });
+				await integration.disconnect({ silent: true, cloudSessionOnly: true });
 			}
 		}
 	}

--- a/src/plus/integrations/integrationService.ts
+++ b/src/plus/integrations/integrationService.ts
@@ -1,7 +1,7 @@
 import type { AuthenticationSessionsChangeEvent, CancellationToken, Event } from 'vscode';
 import { authentication, Disposable, env, EventEmitter, window } from 'vscode';
 import { isWeb } from '@env/platform';
-import type { Source, SupportedCloudIntegrationIds } from '../../constants';
+import type { Source } from '../../constants';
 import type { Container } from '../../container';
 import type { SearchedIssue } from '../../git/models/issue';
 import type { SearchedPullRequest } from '../../git/models/pullRequest';
@@ -13,7 +13,8 @@ import { take } from '../../system/event';
 import { filterMap, flatten } from '../../system/iterable';
 import type { SubscriptionChangeEvent } from '../gk/account/subscriptionService';
 import type { IntegrationAuthenticationService } from './authentication/integrationAuthentication';
-import { supportedCloudIntegrationIds, toIntegrationId } from './authentication/models';
+import type { SupportedCloudIntegrationIds } from './authentication/models';
+import { isSupportedCloudIntegrationId, supportedCloudIntegrationIds, toIntegrationId } from './authentication/models';
 import type {
 	HostingIntegration,
 	Integration,
@@ -163,7 +164,7 @@ export class IntegrationService implements Disposable {
 		this._connectedCache.add(key);
 		if (this.container.telemetry.enabled) {
 			if (integration.type === 'hosting') {
-				if (supportedCloudIntegrationIds.includes(integration.id)) {
+				if (isSupportedCloudIntegrationId(integration.id)) {
 					this.container.telemetry.sendEvent('cloudIntegrations/hosting/connected', {
 						'hostingProvider.provider': integration.id,
 						'hostingProvider.key': key,
@@ -194,7 +195,7 @@ export class IntegrationService implements Disposable {
 		this._connectedCache.delete(key);
 		if (this.container.telemetry.enabled) {
 			if (integration.type === 'hosting') {
-				if (supportedCloudIntegrationIds.includes(integration.id)) {
+				if (isSupportedCloudIntegrationId(integration.id)) {
 					this.container.telemetry.sendEvent('cloudIntegrations/hosting/disconnected', {
 						'hostingProvider.provider': integration.id,
 						'hostingProvider.key': key,

--- a/src/plus/integrations/integrationService.ts
+++ b/src/plus/integrations/integrationService.ts
@@ -1,7 +1,7 @@
 import type { AuthenticationSessionsChangeEvent, CancellationToken, Event } from 'vscode';
 import { authentication, Disposable, env, EventEmitter, window } from 'vscode';
 import { isWeb } from '@env/platform';
-import type { Source } from '../../constants';
+import type { Source, SupportedCloudIntegrationIds } from '../../constants';
 import type { Container } from '../../container';
 import type { SearchedIssue } from '../../git/models/issue';
 import type { SearchedPullRequest } from '../../git/models/pullRequest';
@@ -107,7 +107,7 @@ export class IntegrationService implements Disposable {
 		}
 	}
 
-	async manageCloudIntegrations(integrationId: IssueIntegrationId.Jira | undefined, source: Source | undefined) {
+	async manageCloudIntegrations(integrationId: SupportedCloudIntegrationIds | undefined, source: Source | undefined) {
 		if (this.container.telemetry.enabled) {
 			this.container.telemetry.sendEvent(
 				'cloudIntegrations/settingsOpened',

--- a/src/plus/integrations/providers/providersApi.ts
+++ b/src/plus/integrations/providers/providersApi.ts
@@ -238,8 +238,9 @@ export class ProvidersApi {
 				? undefined
 				: { domain: provider.domain, scopes: provider.scopes };
 		try {
+			const authProvider = await this.authenticationService.get(provider.id);
 			return (
-				await this.authenticationService.getSession(provider.id, providerDescriptor, {
+				await authProvider.getSession(providerDescriptor, {
 					createIfNeeded: options?.createSessionIfNeeded,
 				})
 			)?.accessToken;


### PR DESCRIPTION
# Description

Introduces a provider for GitHub integration that tries to check for existing GitHub session before accessing an integration on GKDev (GLVSC-554)

# Checklist

<!-- Please check off the following -->

- [x] I have followed the guidelines in the Contributing document
- [x] My changes follow the coding style of this project
- [x] My changes build without any errors or warnings
- [x] My changes have been formatted and linted
- [x] My changes include any required corresponding changes to the documentation (including CHANGELOG.md and README.md)
- [x] My changes have been rebased and squashed to the minimal number (typically 1) of relevant commits
- [x] My changes have a descriptive commit message with a short title, including a `Fixes $XXX -` or `Closes #XXX -` prefix to auto-close the issue that your PR addresses
