### PR TITLE
Fixes the procedure of refreshing an access token in GK integration

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -27,6 +27,7 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/) and this p
 ### Fixed
 
 - Fixes [#3344](https://github.com/gitkraken/vscode-gitlens/issues/3344) - Make changing the AI key easier
+- Fixes fixes issue with Jira integration not refreshing
 
 ## [15.1.0] - 2024-06-05
 

--- a/src/plus/integrations/authentication/cloudIntegrationService.ts
+++ b/src/plus/integrations/authentication/cloudIntegrationService.ts
@@ -35,17 +35,26 @@ export class CloudIntegrationService {
 
 	async getConnectionSession(
 		id: IntegrationId,
-		refresh: boolean = false,
+		refreshToken?: string,
 	): Promise<CloudIntegrationAuthenticationSession | undefined> {
+		const refresh = Boolean(refreshToken);
 		const cloudIntegrationType = toCloudIntegrationType[id];
 		if (cloudIntegrationType == null) {
 			Logger.error(`Unsupported cloud integration type: ${id}`);
 			return undefined;
 		}
+		const reqInitOptions = refreshToken
+			? {
+					method: 'POST',
+					body: JSON.stringify({
+						access_token: refreshToken,
+					}),
+			  }
+			: { method: 'GET' };
 
 		const tokenRsp = await this.connection.fetchGkDevApi(
 			`v1/provider-tokens/${cloudIntegrationType}${refresh ? '/refresh' : ''}`,
-			{ method: refresh ? 'POST' : 'GET' },
+			reqInitOptions,
 			{ organizationId: false },
 		);
 		if (!tokenRsp.ok) {

--- a/src/plus/integrations/authentication/jira.ts
+++ b/src/plus/integrations/authentication/jira.ts
@@ -30,7 +30,7 @@ export class JiraAuthenticationProvider implements IntegrationAuthenticationProv
 		let session = await cloudIntegrations.getConnectionSession(this.authProviderId);
 
 		if (session != null && session.expiresIn < 60) {
-			session = await cloudIntegrations.getConnectionSession(this.authProviderId, true);
+			session = await cloudIntegrations.getConnectionSession(this.authProviderId, session.accessToken);
 		}
 
 		if (!session && options?.authorizeIfNeeded) {


### PR DESCRIPTION
# Description

Looks like the docs indicate that you need to [send an access token in the body](https://dev-docs.gitkraken.dev/#tag/Provider-Connections/operation/post-v1-refresh-provider) for this request. I don't know if it's always been that way or if that's recent, but the route was previously working for us without doing this. We will need to update it (GLVSC-569)

# Checklist

<!-- Please check off the following -->

- [x] I have followed the guidelines in the Contributing document
- [x] My changes follow the coding style of this project
- [x] My changes build without any errors or warnings
- [x] My changes have been formatted and linted
- [ ] My changes include any required corresponding changes to the documentation (including CHANGELOG.md and README.md)
- [ ] My changes have been rebased and squashed to the minimal number (typically 1) of relevant commits
- [ ] My changes have a descriptive commit message with a short title, including a `Fixes $XXX -` or `Closes #XXX -` prefix to auto-close the issue that your PR addresses
