### PR TITLE
Modifies GitLab auth provider to use gk.dev (GLVSC-555)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,7 +10,7 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/) and this p
 
 - Shows GitLab merge requests in the _Launchpad_ when GitLab integration is connected
 - Adds a new "Connect" button to the _Launchpad_ that allows the user to connect additional integrations.
-- Adds `gitlens.experimental.cloudIntegrations.github.enabled` setting to connect GitHub integration using cloud integration of GitKraken account.
+- Adds `gitlens.experimental.cloudIntegrations.enabled` setting to connect GitHub integration using cloud integration of GitKraken account.
 - Adds comparison support to virtual (GitHub) repositories
 
 ### Changed

--- a/package.json
+++ b/package.json
@@ -3427,7 +3427,7 @@
 						"scope": "window",
 						"order": 20
 					},
-					"gitlens.experimental.cloudIntegrations.github.enabled": {
+					"gitlens.experimental.cloudIntegrations.enabled": {
 						"type": "boolean",
 						"default": false,
 						"markdownDescription": "Specifies whether to use the GitKraken cloud integration when authenticating with GitHub",

--- a/src/config.ts
+++ b/src/config.ts
@@ -83,9 +83,7 @@ export interface Config {
 		readonly generateCloudPatchMessagePrompt: string;
 		readonly generateCodeSuggestionMessagePrompt: string;
 		readonly cloudIntegrations: {
-			readonly github: {
-				readonly enabled: boolean;
-			};
+			readonly enabled: boolean;
 		};
 	};
 	readonly fileAnnotations: {

--- a/src/plus/integrations/authentication/gitlab.ts
+++ b/src/plus/integrations/authentication/gitlab.ts
@@ -97,13 +97,4 @@ export class GitLabCloudAuthenticationProvider extends CloudIntegrationAuthentic
 	protected override getCompletionInputTitle(): string {
 		return 'Connect to GitLab';
 	}
-	protected override async restoreSession({ sessionId, ignoreErrors }: { sessionId: string; ignoreErrors: boolean }) {
-		const localSession = await this.readSecret(this.getLocalSecretKey(sessionId), ignoreErrors);
-		if (localSession != null) return localSession;
-
-		return super.restoreSession({
-			sessionId: sessionId,
-			ignoreErrors: ignoreErrors,
-		});
-	}
 }

--- a/src/plus/integrations/authentication/gitlab.ts
+++ b/src/plus/integrations/authentication/gitlab.ts
@@ -1,13 +1,17 @@
 import type { AuthenticationSession, Disposable, QuickInputButton } from 'vscode';
 import { env, ThemeIcon, Uri, window } from 'vscode';
 import type { Container } from '../../../container';
-import type { HostingIntegrationId, SelfHostedIntegrationId } from '../providers/models';
+import type { SelfHostedIntegrationId } from '../providers/models';
+import { HostingIntegrationId } from '../providers/models';
 import type { IntegrationAuthenticationSessionDescriptor } from './integrationAuthentication';
-import { LocalIntegrationAuthenticationProvider } from './integrationAuthentication';
+import {
+	CloudIntegrationAuthenticationProvider,
+	LocalIntegrationAuthenticationProvider,
+} from './integrationAuthentication';
 
 type GitLabId = HostingIntegrationId.GitLab | SelfHostedIntegrationId.GitLabSelfHosted;
 
-export class GitLabAuthenticationProvider extends LocalIntegrationAuthenticationProvider<GitLabId> {
+export class GitLabLocalAuthenticationProvider extends LocalIntegrationAuthenticationProvider<GitLabId> {
 	constructor(
 		container: Container,
 		protected readonly authProviderId: GitLabId,
@@ -82,5 +86,24 @@ export class GitLabAuthenticationProvider extends LocalIntegrationAuthentication
 				label: '',
 			},
 		};
+	}
+}
+
+export class GitLabCloudAuthenticationProvider extends CloudIntegrationAuthenticationProvider<GitLabId> {
+	protected override get authProviderId(): GitLabId {
+		return HostingIntegrationId.GitLab;
+	}
+
+	protected override getCompletionInputTitle(): string {
+		return 'Connect to GitLab';
+	}
+	protected override async restoreSession({ sessionId, ignoreErrors }: { sessionId: string; ignoreErrors: boolean }) {
+		const localSession = await this.readSecret(this.getLocalSecretKey(sessionId), ignoreErrors);
+		if (localSession != null) return localSession;
+
+		return super.restoreSession({
+			sessionId: sessionId,
+			ignoreErrors: ignoreErrors,
+		});
 	}
 }

--- a/src/plus/integrations/authentication/integrationAuthentication.ts
+++ b/src/plus/integrations/authentication/integrationAuthentication.ts
@@ -207,12 +207,8 @@ export abstract class CloudIntegrationAuthenticationProvider<
 		sessionId: string;
 		ignoreErrors: boolean;
 	}): Promise<StoredSession | undefined> {
-		// At first we try to restore the cloud session
-		let session = await this.readSecret(this.getCloudSecretKey(sessionId), ignoreErrors);
-		if (session != null) return session;
-
-		// If no cloud session, we check whether we have a token with the local key
-		session = await this.readSecret(this.getLocalSecretKey(sessionId), ignoreErrors);
+		// At first we try to restore a token with the local key
+		const session = await this.readSecret(this.getLocalSecretKey(sessionId), ignoreErrors);
 		if (session != null) {
 			// Check the `expiresAt` field
 			// If it has an expiresAt property and the key is the old type, then it's a cloud session,
@@ -228,7 +224,8 @@ export abstract class CloudIntegrationAuthenticationProvider<
 			return session;
 		}
 
-		return undefined;
+		// If no local session we try to restore a session with the cloud key
+		return this.readSecret(this.getCloudSecretKey(sessionId), ignoreErrors);
 	}
 
 	public override async getSession(

--- a/src/plus/integrations/authentication/integrationAuthentication.ts
+++ b/src/plus/integrations/authentication/integrationAuthentication.ts
@@ -456,10 +456,18 @@ export class IntegrationAuthenticationService implements Disposable {
 					).GitHubEnterpriseAuthenticationProvider(this.container);
 					break;
 				case HostingIntegrationId.GitLab:
+					provider = isSupportedCloudIntegrationId(HostingIntegrationId.GitLab)
+						? new (
+								await import(/* webpackChunkName: "integrations" */ './gitlab')
+						  ).GitLabCloudAuthenticationProvider(this.container)
+						: new (
+								await import(/* webpackChunkName: "integrations" */ './gitlab')
+						  ).GitLabLocalAuthenticationProvider(this.container, HostingIntegrationId.GitLab);
+					break;
 				case SelfHostedIntegrationId.GitLabSelfHosted:
 					provider = new (
 						await import(/* webpackChunkName: "integrations" */ './gitlab')
-					).GitLabAuthenticationProvider(this.container, providerId);
+					).GitLabLocalAuthenticationProvider(this.container, SelfHostedIntegrationId.GitLabSelfHosted);
 					break;
 				case IssueIntegrationId.Jira:
 					provider = new (

--- a/src/plus/integrations/authentication/integrationAuthentication.ts
+++ b/src/plus/integrations/authentication/integrationAuthentication.ts
@@ -217,20 +217,15 @@ export abstract class CloudIntegrationAuthenticationProvider<
 			// Check the `expiresAt` field
 			// If it has an expiresAt property and the key is the old type, then it's a cloud session,
 			// so delete it from the local key and
-			// store with the "cloud" type key, and then use that one
-			//
+			// store with the "cloud" type key, and then use that one.
+			// Otherwise it's a local session under the local key, so just return it.
 			if (session.expiresAt != null) {
 				await Promise.allSettled([
 					this.deleteSecret(this.getLocalSecretKey(sessionId)),
 					this.writeSecret(this.getCloudSecretKey(sessionId), session),
 				]);
-				return session;
 			}
-			// Otherwise, it is rather unexpected, so I'm deleting it and returning undefined,
-			// This lets us drop local GitHub sessions that were incorrectly saved during testing the intermitent version of this change.
-			return undefined;
-			// However, I'm also thingking about using it rather than deleting:
-			// return session;
+			return session;
 		}
 
 		return undefined;

--- a/src/plus/integrations/authentication/models.ts
+++ b/src/plus/integrations/authentication/models.ts
@@ -32,7 +32,11 @@ export type CloudIntegrationAuthType = 'oauth' | 'pat';
 export const CloudIntegrationAuthenticationUriPathPrefix = 'did-authenticate-cloud-integration';
 
 const supportedCloudIntegrationIds = [IssueIntegrationId.Jira];
-const supportedCloudIntegrationIdsExperimental = [IssueIntegrationId.Jira, HostingIntegrationId.GitHub];
+const supportedCloudIntegrationIdsExperimental = [
+	IssueIntegrationId.Jira,
+	HostingIntegrationId.GitHub,
+	HostingIntegrationId.GitLab,
+];
 
 export type SupportedCloudIntegrationIds = (typeof supportedCloudIntegrationIdsExperimental)[number];
 

--- a/src/plus/integrations/authentication/models.ts
+++ b/src/plus/integrations/authentication/models.ts
@@ -37,14 +37,14 @@ const supportedCloudIntegrationIdsExperimental = [IssueIntegrationId.Jira, Hosti
 export type SupportedCloudIntegrationIds = (typeof supportedCloudIntegrationIdsExperimental)[number];
 
 export function isSupportedCloudIntegrationId(id: string): id is SupportedCloudIntegrationIds {
-	const ids = configuration.get('experimental.cloudIntegrations.github.enabled', undefined, false)
+	const ids = configuration.get('experimental.cloudIntegrations.enabled', undefined, false)
 		? supportedCloudIntegrationIdsExperimental
 		: supportedCloudIntegrationIds;
 	return ids.includes(id as SupportedCloudIntegrationIds);
 }
 
 export function* iterateSupportedCloudIntegrationIds() {
-	const ids = configuration.get('experimental.cloudIntegrations.github.enabled', undefined, false)
+	const ids = configuration.get('experimental.cloudIntegrations.enabled', undefined, false)
 		? supportedCloudIntegrationIdsExperimental
 		: supportedCloudIntegrationIds;
 	for (const id of ids) {


### PR DESCRIPTION
# Description
Checks for a local GitLab authentication and if it exists uses it.
Otherwise, it checks the GKDev for a GitLab integration to use it.
If GKDev is not connected it starts the GK authentication flow.

# Checklist

<!-- Please check off the following -->

- [x] I have followed the guidelines in the Contributing document
- [x] My changes follow the coding style of this project
- [x] My changes build without any errors or warnings
- [x] My changes have been formatted and linted
- [x] My changes include any required corresponding changes to the documentation (including CHANGELOG.md and README.md)
- [x] My changes have been rebased and squashed to the minimal number (typically 1) of relevant commits
- [x] My changes have a descriptive commit message with a short title, including a `Fixes $XXX -` or `Closes #XXX -` prefix to auto-close the issue that your PR addresses
