### PR TITLE
Don't make the second attempt to connect for non-cloud integrations (GLVSC-592)

### DIFF
--- a/src/commands/remoteProviders.ts
+++ b/src/commands/remoteProviders.ts
@@ -110,9 +110,8 @@ export class ConnectRemoteProviderCommand extends Command {
 						},
 					},
 				);
+				connected = await integration.connect();
 			}
-
-			connected = await integration.connect();
 		}
 
 		if (


### PR DESCRIPTION
# Description
Fixes the bug that the connect dialog appears twice for self-hosted integrations.

# Checklist

<!-- Please check off the following -->

- [x] I have followed the guidelines in the Contributing document
- [x] My changes follow the coding style of this project
- [x] My changes build without any errors or warnings
- [x] My changes have been formatted and linted
- [x] My changes include any required corresponding changes to the documentation (including CHANGELOG.md and README.md)
- [x] My changes have been rebased and squashed to the minimal number (typically 1) of relevant commits
- [x] My changes have a descriptive commit message with a short title, including a `Fixes $XXX -` or `Closes #XXX -` prefix to auto-close the issue that your PR addresses
