### PR TITLE
Prevents login flow from being stuck on cancel

### DIFF
--- a/src/plus/gk/account/authenticationProvider.ts
+++ b/src/plus/gk/account/authenticationProvider.ts
@@ -118,7 +118,7 @@ export class AccountAuthenticationProvider implements AuthenticationProvider, Di
 			return session;
 		} catch (ex) {
 			// If login was cancelled, do not notify user.
-			if (ex === 'Cancelled') throw ex;
+			if (ex === 'Cancelled' || ex.message === 'Cancelled') throw ex;
 
 			Logger.error(ex, scope);
 			void window.showErrorMessage(

--- a/src/plus/integrations/integrationService.ts
+++ b/src/plus/integrations/integrationService.ts
@@ -145,7 +145,9 @@ export class IntegrationService implements Disposable {
 
 		const account = (await this.container.subscription.getSubscription()).account;
 		if (account == null) {
-			if (!(await this.container.subscription.loginOrSignUp(true, source))) return;
+			if (!(await this.container.subscription.loginOrSignUp(true, source))) {
+				return;
+			}
 		}
 
 		try {
@@ -246,9 +248,13 @@ export class IntegrationService implements Disposable {
 				await openUrl(this.container.getGkDevExchangeUri(exchangeToken, `connect?${query}`).toString(true));
 			} catch (ex) {
 				Logger.error(ex, scope);
-				if (!(await env.openExternal(this.container.getGkDevUri('connect', query)))) return false;
+				if (!(await env.openExternal(this.container.getGkDevUri('connect', query)))) {
+					return false;
+				}
 			}
-		} else if (!(await env.openExternal(this.container.getGkDevUri('connect', query)))) return false;
+		} else if (!(await env.openExternal(this.container.getGkDevUri('connect', query)))) {
+			return false;
+		}
 
 		const deferredCallback = promisifyDeferred<Uri, string | undefined>(
 			this.container.uri.onDidReceiveCloudIntegrationAuthenticationUri,

--- a/src/plus/integrations/integrationService.ts
+++ b/src/plus/integrations/integrationService.ts
@@ -246,11 +246,9 @@ export class IntegrationService implements Disposable {
 				await openUrl(this.container.getGkDevExchangeUri(exchangeToken, `connect?${query}`).toString(true));
 			} catch (ex) {
 				Logger.error(ex, scope);
-				await env.openExternal(this.container.getGkDevUri('connect', query));
+				if (!(await env.openExternal(this.container.getGkDevUri('connect', query)))) return false;
 			}
-		} else {
-			await env.openExternal(this.container.getGkDevUri('connect', query));
-		}
+		} else if (!(await env.openExternal(this.container.getGkDevUri('connect', query)))) return false;
 
 		const deferredCallback = promisifyDeferred<Uri, string | undefined>(
 			this.container.uri.onDidReceiveCloudIntegrationAuthenticationUri,


### PR DESCRIPTION
Fixes #3395

Two issues addressed here:
1. When initiating a login/register flow, if you hit cancel before opening gkdev, the completion input box still appears. It should not appear if you cancelled at this stage.
2. If the token input box appears, and then you hit `Escape` to cancel it, this should cancel the login flow. Right now, it does not cancel, and instead leaves it stuck, including processes that are waiting on it to complete.

To repro the second issue, log out of your account (both in GitLens and on gkdev), then click on the link under Autolink settings to "connect to Jira". Once you open the url, close out of it and then hide the code input with `Escape`. GitLens is now stuck waiting for that promise, so the next time you click the link it won't work, and if you try to reopen settings it will be blank.