### PR TITLE
Adds support for link to account login

### DIFF
--- a/src/plus/gk/account/authenticationProvider.ts
+++ b/src/plus/gk/account/authenticationProvider.ts
@@ -30,8 +30,7 @@ const authenticationLabel = 'GitKraken: GitLens';
 
 export interface AuthenticationProviderOptions {
 	signUp?: boolean;
-	code?: string;
-	state?: string;
+	signIn?: { code: string; state?: string };
 }
 
 export class AccountAuthenticationProvider implements AuthenticationProvider, Disposable {
@@ -98,8 +97,8 @@ export class AccountAuthenticationProvider implements AuthenticationProvider, Di
 
 		try {
 			const token =
-				options?.code != null
-					? await this._authConnection.getTokenFromCodeAndState(options?.code, options?.state)
+				options?.signIn != null
+					? await this._authConnection.getTokenFromCodeAndState(options.signIn.code, options.signIn.state)
 					: await this._authConnection.login(scopes, scopesKey, options?.signUp);
 			const session = await this.createSessionForToken(token, scopes);
 

--- a/src/plus/gk/account/subscriptionService.ts
+++ b/src/plus/gk/account/subscriptionService.ts
@@ -1381,12 +1381,23 @@ export class SubscriptionService implements Disposable {
 	}
 
 	onLoginUri(uri: Uri) {
+		const scope = getLogScope();
 		const queryParams: URLSearchParams = new URLSearchParams(uri.query);
 		const code = queryParams.get('code');
 		const state = queryParams.get('state');
+		const context = queryParams.get('context');
+		let contextMessage = 'sign in to GitKraken';
+
+		switch (context) {
+			case 'start_trial':
+				contextMessage = 'start a Pro trial';
+				break;
+		}
+
 		if (code == null) {
+			Logger.error(`No code provided. Link: ${uri.toString(true)}`, scope);
 			void window.showErrorMessage(
-				'Unable to sign in to GitKraken with that link. Please try clicking that link again. If this issue persists, please contact support.',
+				`Unable to ${contextMessage} with that link. Please try clicking that link again. If this issue persists, please contact support.`,
 			);
 			return;
 		}

--- a/src/plus/gk/account/subscriptionService.ts
+++ b/src/plus/gk/account/subscriptionService.ts
@@ -1388,7 +1388,7 @@ export class SubscriptionService implements Disposable {
 		const code = queryParams.get('code');
 		const state = queryParams.get('state');
 		if (code == null) {
-			void window.showErrorMessage('Unable to login to GitKraken: invalid error link.');
+			void window.showErrorMessage('Unable to login to GitKraken: invalid link.');
 			return;
 		}
 

--- a/src/plus/gk/account/subscriptionService.ts
+++ b/src/plus/gk/account/subscriptionService.ts
@@ -983,26 +983,19 @@ export class SubscriptionService implements Disposable {
 		const scope = getLogScope();
 
 		let session: AuthenticationSession | null | undefined;
-		let scopes = authenticationProviderScopes;
-		if (options?.signUp) {
-			scopes = [...scopes, 'signUp'];
-		}
-
-		if (options?.code != null) {
-			scopes = [...scopes, `useCode:${options.code}`];
-		}
-
-		if (options?.state != null) {
-			scopes = [...scopes, `useState:${options.state}`];
-		}
-
 		try {
-			session = await authentication.getSession(authenticationProviderId, scopes, {
+			if (options != null && createIfNeeded) {
+				this.container.accountAuthentication.setOptionsForScopes(authenticationProviderScopes, options);
+			}
+			session = await authentication.getSession(authenticationProviderId, authenticationProviderScopes, {
 				createIfNone: createIfNeeded,
 				silent: !createIfNeeded,
 			});
 		} catch (ex) {
 			session = null;
+			if (options != null && createIfNeeded) {
+				this.container.accountAuthentication.clearOptionsForScopes(authenticationProviderScopes);
+			}
 
 			if (ex instanceof Error && ex.message.includes('User did not consent')) {
 				setLogScopeExit(scope, ' \u2022 User declined authentication');

--- a/src/plus/gk/account/subscriptionService.ts
+++ b/src/plus/gk/account/subscriptionService.ts
@@ -1397,7 +1397,7 @@ export class SubscriptionService implements Disposable {
 		if (code == null) {
 			Logger.error(`No code provided. Link: ${uri.toString(true)}`, scope);
 			void window.showErrorMessage(
-				`Unable to ${contextMessage} with that link. Please try clicking that link again. If this issue persists, please contact support.`,
+				`Unable to ${contextMessage} with that link. Please try clicking the link again. If this issue persists, please contact support.`,
 			);
 			return;
 		}

--- a/src/uris/uriService.ts
+++ b/src/uris/uriService.ts
@@ -1,7 +1,7 @@
 import type { Disposable, Event, Uri, UriHandler } from 'vscode';
 import { EventEmitter, window } from 'vscode';
 import type { Container } from '../container';
-import { AuthenticationUriPathPrefix } from '../plus/gk/account/authenticationConnection';
+import { AuthenticationUriPathPrefix, LoginUriPathPrefix } from '../plus/gk/account/authenticationConnection';
 import { SubscriptionUpdatedUriPathPrefix } from '../plus/gk/account/subscription';
 import { CloudIntegrationAuthenticationUriPathPrefix } from '../plus/integrations/authentication/models';
 import { log } from '../system/decorators/log';
@@ -13,11 +13,16 @@ export class UriService implements Disposable, UriHandler {
 	private _disposable: Disposable;
 
 	private _onDidReceiveAuthenticationUri: EventEmitter<Uri> = new EventEmitter<Uri>();
+	private _onDidReceiveLoginUri: EventEmitter<Uri> = new EventEmitter<Uri>();
 	private _onDidReceiveCloudIntegrationAuthenticationUri: EventEmitter<Uri> = new EventEmitter<Uri>();
 	private _onDidReceiveSubscriptionUpdatedUri: EventEmitter<Uri> = new EventEmitter<Uri>();
 
 	get onDidReceiveAuthenticationUri(): Event<Uri> {
 		return this._onDidReceiveAuthenticationUri.event;
+	}
+
+	get onDidReceiveLoginUri(): Event<Uri> {
+		return this._onDidReceiveLoginUri.event;
 	}
 
 	get onDidReceiveCloudIntegrationAuthenticationUri(): Event<Uri> {
@@ -52,6 +57,9 @@ export class UriService implements Disposable, UriHandler {
 			return;
 		} else if (type === SubscriptionUpdatedUriPathPrefix) {
 			this._onDidReceiveSubscriptionUpdatedUri.fire(uri);
+			return;
+		} else if (type === LoginUriPathPrefix) {
+			this._onDidReceiveLoginUri.fire(uri);
 			return;
 		}
 


### PR DESCRIPTION
Adds support for links of the format: `vscode://eamodio.gitlens/login?code={code}(&state={state})`

These will login to the GK account using code-token exchange with the provided code/state.