### PR TITLE
Supress auth error notifications for github triggered by Launchpad

### DIFF
--- a/src/plus/focus/focusProvider.ts
+++ b/src/plus/focus/focusProvider.ts
@@ -276,7 +276,7 @@ export class FocusProvider implements Disposable {
 
 		const [prsResult, subscriptionResult] = await Promise.allSettled([
 			withDurationAndSlowEventOnTimeout(
-				this.container.integrations.getMyPullRequests([HostingIntegrationId.GitHub], cancellation),
+				this.container.integrations.getMyPullRequests([HostingIntegrationId.GitHub], cancellation, true),
 				'getMyPullRequests',
 				this.container,
 			),

--- a/src/plus/integrations/integration.ts
+++ b/src/plus/integrations/integration.ts
@@ -1160,15 +1160,18 @@ export abstract class HostingIntegration<
 	async searchMyPullRequests(
 		repo?: T,
 		cancellation?: CancellationToken,
+		silent?: boolean,
 	): Promise<IntegrationResult<SearchedPullRequest[] | undefined>>;
 	async searchMyPullRequests(
 		repos?: T[],
 		cancellation?: CancellationToken,
+		silent?: boolean,
 	): Promise<IntegrationResult<SearchedPullRequest[] | undefined>>;
 	@debug()
 	async searchMyPullRequests(
 		repos?: T | T[],
 		cancellation?: CancellationToken,
+		silent?: boolean,
 	): Promise<IntegrationResult<SearchedPullRequest[] | undefined>> {
 		const scope = getLogScope();
 		const connected = this.maybeConnected ?? (await this.isConnected());
@@ -1180,6 +1183,7 @@ export abstract class HostingIntegration<
 				this._session!,
 				repos != null ? (Array.isArray(repos) ? repos : [repos]) : undefined,
 				cancellation,
+				silent,
 			);
 			return { value: pullRequests, duration: Date.now() - start };
 		} catch (ex) {
@@ -1192,6 +1196,7 @@ export abstract class HostingIntegration<
 		session: ProviderAuthenticationSession,
 		repos?: T[],
 		cancellation?: CancellationToken,
+		silent?: boolean,
 	): Promise<SearchedPullRequest[] | undefined>;
 
 	async searchPullRequests(

--- a/src/plus/integrations/integrationService.ts
+++ b/src/plus/integrations/integrationService.ts
@@ -449,6 +449,7 @@ export class IntegrationService implements Disposable {
 	async getMyPullRequests(
 		integrationIds?: HostingIntegrationId[],
 		cancellation?: CancellationToken,
+		silent?: boolean,
 	): Promise<IntegrationResult<SearchedPullRequest[] | undefined>> {
 		const integrations: Map<HostingIntegration, ResourceDescriptor[] | undefined> = new Map();
 		for (const integrationId of integrationIds?.length ? integrationIds : Object.values(HostingIntegrationId)) {
@@ -459,12 +460,13 @@ export class IntegrationService implements Disposable {
 		}
 		if (integrations.size === 0) return undefined;
 
-		return this.getMyPullRequestsCore(integrations, cancellation);
+		return this.getMyPullRequestsCore(integrations, cancellation, silent);
 	}
 
 	private async getMyPullRequestsCore(
 		integrations: Map<HostingIntegration, ResourceDescriptor[] | undefined>,
 		cancellation?: CancellationToken,
+		silent?: boolean,
 	): Promise<IntegrationResult<SearchedPullRequest[] | undefined>> {
 		const start = Date.now();
 
@@ -472,7 +474,7 @@ export class IntegrationService implements Disposable {
 		for (const [integration, repos] of integrations) {
 			if (integration == null) continue;
 
-			promises.push(integration.searchMyPullRequests(repos, cancellation));
+			promises.push(integration.searchMyPullRequests(repos, cancellation, silent));
 		}
 
 		const results = await Promise.allSettled(promises);

--- a/src/plus/integrations/providers/github.ts
+++ b/src/plus/integrations/providers/github.ts
@@ -171,6 +171,7 @@ abstract class GitHubIntegrationBase<ID extends SupportedIntegrationIds> extends
 		{ accessToken }: AuthenticationSession,
 		repos?: GitHubRepositoryDescriptor[],
 		cancellation?: CancellationToken,
+		silent?: boolean,
 	): Promise<SearchedPullRequest[] | undefined> {
 		return (await this.container.github)?.searchMyPullRequests(
 			this,
@@ -178,6 +179,7 @@ abstract class GitHubIntegrationBase<ID extends SupportedIntegrationIds> extends
 			{
 				repos: repos?.map(r => `${r.owner}/${r.name}`),
 				baseUrl: this.apiBaseUrl,
+				silent: silent,
 			},
 			cancellation,
 		);

--- a/src/plus/integrations/providers/github/github.ts
+++ b/src/plus/integrations/providers/github/github.ts
@@ -2629,11 +2629,16 @@ export class GitHubApi implements Disposable {
 		}
 	}
 
-	private handleException(ex: Error, provider: Provider | undefined, scope: LogScope | undefined): Error {
+	private handleException(
+		ex: Error,
+		provider: Provider | undefined,
+		scope: LogScope | undefined,
+		silent?: boolean,
+	): Error {
 		Logger.error(ex, scope);
 		// debugger;
 
-		if (ex instanceof AuthenticationError) {
+		if (ex instanceof AuthenticationError && !silent) {
 			void this.showAuthenticationErrorMessage(ex, provider);
 		}
 		return ex;
@@ -2706,7 +2711,14 @@ export class GitHubApi implements Disposable {
 	async searchMyPullRequests(
 		provider: Provider,
 		token: string,
-		options?: { search?: string; user?: string; repos?: string[]; baseUrl?: string; avatarSize?: number },
+		options?: {
+			search?: string;
+			user?: string;
+			repos?: string[];
+			baseUrl?: string;
+			avatarSize?: number;
+			silent?: boolean;
+		},
 		cancellation?: CancellationToken,
 	): Promise<SearchedPullRequest[]> {
 		const scope = getLogScope();
@@ -2817,7 +2829,7 @@ export class GitHubApi implements Disposable {
 			);
 			return results;
 		} catch (ex) {
-			throw this.handleException(ex, provider, scope);
+			throw this.handleException(ex, provider, scope, options?.silent);
 		}
 	}
 
@@ -2825,7 +2837,14 @@ export class GitHubApi implements Disposable {
 	private async searchMyInvolvedPullRequests(
 		provider: Provider,
 		token: string,
-		options?: { search?: string; user?: string; repos?: string[]; baseUrl?: string; avatarSize?: number },
+		options?: {
+			search?: string;
+			user?: string;
+			repos?: string[];
+			baseUrl?: string;
+			avatarSize?: number;
+			silent?: boolean;
+		},
 		cancellation?: CancellationToken,
 	): Promise<SearchedPullRequest[]> {
 		const scope = getLogScope();
@@ -2922,7 +2941,7 @@ export class GitHubApi implements Disposable {
 			const results: SearchedPullRequest[] = rsp.search.nodes.map(pr => toQueryResult(pr));
 			return results;
 		} catch (ex) {
-			throw this.handleException(ex, provider, scope);
+			throw this.handleException(ex, provider, scope, options?.silent);
 		}
 	}
 


### PR DESCRIPTION
Silences error notifications from popping up from the Launchpad indicator's automatic "get my pull requests" query.

This is a workaround until we find a better way to present this issue to users when Launchpad runs into it.

Partially addresses #3367
