### PR TITLE
Change GitLab access token scope (GLVSC-601)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,10 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/) and this p
 
 ## [Unreleased]
 
+### Changed
+
+- GitLab & GitLab self-managed access tokens now require `api` scope instead of `read_api` to be able to merge Pull Requests.
+
 ## [15.2.0] - 2024-07-10
 
 ### Added

--- a/src/plus/integrations/authentication/gitlab.ts
+++ b/src/plus/integrations/authentication/gitlab.ts
@@ -59,7 +59,9 @@ export class GitLabAuthenticationProvider extends LocalIntegrationAuthentication
 				input.placeholder = `Requires ${descriptor?.scopes.join(', ') ?? 'all'} scopes`;
 				input.prompt = `Paste your [GitLab Personal Access Token](https://${
 					descriptor?.domain ?? 'gitlab.com'
-				}/-/profile/personal_access_tokens "Get your GitLab Access Token")`;
+				}/-/user_settings/personal_access_tokens?name=GitLens+Access+token&scopes=${
+					descriptor?.scopes.join(',') ?? 'all'
+				} "Get your GitLab Access Token")`;
 				input.buttons = [infoButton];
 
 				input.show();

--- a/src/plus/integrations/providers/models.ts
+++ b/src/plus/integrations/providers/models.ts
@@ -376,7 +376,7 @@ export const providersMetadata: ProvidersMetadata = {
 		],
 		// Use 'username' property on account for issue filters
 		supportedIssueFilters: [IssueFilter.Author, IssueFilter.Assignee],
-		scopes: ['read_api', 'read_user', 'read_repository'],
+		scopes: ['api', 'read_user', 'read_repository'],
 	},
 	[SelfHostedIntegrationId.GitLabSelfHosted]: {
 		domain: '',
@@ -391,7 +391,7 @@ export const providersMetadata: ProvidersMetadata = {
 		],
 		// Use 'username' property on account for issue filters
 		supportedIssueFilters: [IssueFilter.Author, IssueFilter.Assignee],
-		scopes: ['read_api', 'read_user', 'read_repository'],
+		scopes: ['api', 'read_user', 'read_repository'],
 	},
 	[HostingIntegrationId.Bitbucket]: {
 		domain: 'bitbucket.org',


### PR DESCRIPTION
# Description

In order to be able to merge Pull Requests in GitLab, we need to change the access token scope from `read_api` to `api`.
This PR changes the placeholder text when adding a new GitLab token, and also pre-fills the desired scopes through URL params.
Before:
![before](https://github.com/user-attachments/assets/c7c2932b-3139-4364-95a4-9c6059408419)
After:
![after](https://github.com/user-attachments/assets/48026987-5b71-477f-9dfc-96839b849157)
Pre-fill access token scopes via URL:

https://github.com/user-attachments/assets/757ea241-d8d7-415c-b120-e72ea7b4a4e8





# Checklist

<!-- Please check off the following -->

- [x] I have followed the guidelines in the Contributing document
- [x] My changes follow the coding style of this project
- [x] My changes build without any errors or warnings
- [x] My changes have been formatted and linted
- [x] My changes include any required corresponding changes to the documentation (including CHANGELOG.md and README.md)
- [x] My changes have been rebased and squashed to the minimal number (typically 1) of relevant commits
- [x] My changes have a descriptive commit message with a short title, including a `Fixes $XXX -` or `Closes #XXX -` prefix to auto-close the issue that your PR addresses
