### PR TITLE
Launchpad: show GitLab PRs (and both GitLab+GitHub) [GLVSC-579]

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,10 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/) and this p
 
 ## [Unreleased]
 
+### Added
+
+- Shows GitLab merge requests in the _Launchpad_ when GitLab integration is connected
+
 ### Fixed
 
 - Fixes cloud patch creation error on azure repos

--- a/package.json
+++ b/package.json
@@ -17572,7 +17572,7 @@
 	},
 	"dependencies": {
 		"@gitkraken/gitkraken-components": "10.5.1",
-		"@gitkraken/provider-apis": "0.22.9",
+		"@gitkraken/provider-apis": "0.24.2",
 		"@gitkraken/shared-web-components": "0.1.1-rc.15",
 		"@lit/react": "1.0.5",
 		"@microsoft/fast-element": "1.13.0",

--- a/src/avatars.ts
+++ b/src/avatars.ts
@@ -3,6 +3,7 @@ import { md5 } from '@env/crypto';
 import type { GravatarDefaultStyle } from './config';
 import type { StoredAvatar } from './constants';
 import { Container } from './container';
+import type { CommitAuthor } from './git/models/author';
 import { getGitHubNoReplyAddressParts } from './git/remotes/github';
 import { configuration } from './system/configuration';
 import { getContext } from './system/context';
@@ -220,7 +221,7 @@ async function getAvatarUriFromRemoteProvider(
 	ensureAvatarCache(avatarCache);
 
 	try {
-		let account;
+		let account: CommitAuthor | undefined;
 		// if (typeof repoPathOrCommit === 'string') {
 		// 	const remote = await Container.instance.git.getRichRemoteProvider(repoPathOrCommit);
 		// 	account = await remote?.provider.getAccountForEmail(email, { avatarSize: size });

--- a/src/commands/quickCommand.buttons.ts
+++ b/src/commands/quickCommand.buttons.ts
@@ -1,7 +1,6 @@
 import type { QuickInput, QuickInputButton } from 'vscode';
 import { ThemeIcon, Uri } from 'vscode';
 import { Container } from '../container';
-import { HostingIntegrationId, SelfHostedIntegrationId } from '../plus/integrations/providers/models';
 
 export class ToggleQuickInputButton implements QuickInputButton {
 	constructor(
@@ -132,37 +131,6 @@ export const OpenOnGitLabQuickInputButton: QuickInputButton = {
 	iconPath: new ThemeIcon('globe'),
 	tooltip: 'Open on GitLab',
 };
-
-function getOpenOnGitproviderQuickInputButton(integrationId: string): QuickInputButton | undefined {
-	switch (integrationId) {
-		case HostingIntegrationId.GitLab:
-		case SelfHostedIntegrationId.GitLabSelfHosted:
-			return OpenOnGitLabQuickInputButton;
-		case HostingIntegrationId.GitHub:
-		case SelfHostedIntegrationId.GitHubEnterprise:
-			return OpenOnGitHubQuickInputButton;
-		default:
-			return undefined;
-	}
-}
-
-export function getOpenOnGitproviderQuickInputButtons(integrationId: string): QuickInputButton[] {
-	const button = getOpenOnGitproviderQuickInputButton(integrationId);
-	return button != null ? [button] : [];
-}
-
-export function getIntegrationTitle(integrationId: string): string {
-	switch (integrationId) {
-		case HostingIntegrationId.GitLab:
-		case SelfHostedIntegrationId.GitLabSelfHosted:
-			return 'GitLab';
-		case HostingIntegrationId.GitHub:
-		case SelfHostedIntegrationId.GitHubEnterprise:
-			return 'GitHub';
-		default:
-			return integrationId;
-	}
-}
 
 export const OpenOnWebQuickInputButton: QuickInputButton = {
 	iconPath: new ThemeIcon('globe'),

--- a/src/commands/quickCommand.buttons.ts
+++ b/src/commands/quickCommand.buttons.ts
@@ -1,6 +1,7 @@
 import type { QuickInput, QuickInputButton } from 'vscode';
 import { ThemeIcon, Uri } from 'vscode';
 import { Container } from '../container';
+import { HostingIntegrationId, SelfHostedIntegrationId } from '../plus/integrations/providers/models';
 
 export class ToggleQuickInputButton implements QuickInputButton {
 	constructor(
@@ -126,6 +127,42 @@ export const OpenOnGitHubQuickInputButton: QuickInputButton = {
 	iconPath: new ThemeIcon('globe'),
 	tooltip: 'Open on GitHub',
 };
+
+export const OpenOnGitLabQuickInputButton: QuickInputButton = {
+	iconPath: new ThemeIcon('globe'),
+	tooltip: 'Open on GitLab',
+};
+
+function getOpenOnGitproviderQuickInputButton(integrationId: string): QuickInputButton | undefined {
+	switch (integrationId) {
+		case HostingIntegrationId.GitLab:
+		case SelfHostedIntegrationId.GitLabSelfHosted:
+			return OpenOnGitLabQuickInputButton;
+		case HostingIntegrationId.GitHub:
+		case SelfHostedIntegrationId.GitHubEnterprise:
+			return OpenOnGitHubQuickInputButton;
+		default:
+			return undefined;
+	}
+}
+
+export function getOpenOnGitproviderQuickInputButtons(integrationId: string): QuickInputButton[] {
+	const button = getOpenOnGitproviderQuickInputButton(integrationId);
+	return button != null ? [button] : [];
+}
+
+export function getIntegrationTitle(integrationId: string): string {
+	switch (integrationId) {
+		case HostingIntegrationId.GitLab:
+		case SelfHostedIntegrationId.GitLabSelfHosted:
+			return 'GitLab';
+		case HostingIntegrationId.GitHub:
+		case SelfHostedIntegrationId.GitHubEnterprise:
+			return 'GitHub';
+		default:
+			return integrationId;
+	}
+}
 
 export const OpenOnWebQuickInputButton: QuickInputButton = {
 	iconPath: new ThemeIcon('globe'),

--- a/src/git/models/author.ts
+++ b/src/git/models/author.ts
@@ -1,10 +1,19 @@
 import type { ProviderReference } from './remoteProvider';
 
-export interface Account {
+export interface CommitAuthor {
 	provider: ProviderReference;
-	id: string;
+	readonly id: string | undefined;
+	readonly username: string | undefined;
 	name: string | undefined;
 	email: string | undefined;
 	avatarUrl: string | undefined;
-	username: string | undefined;
+}
+
+export interface UnidentifiedAuthor extends CommitAuthor {
+	readonly id: undefined;
+	readonly username: undefined;
+}
+
+export interface Account extends CommitAuthor {
+	readonly id: string;
 }

--- a/src/git/models/author.ts
+++ b/src/git/models/author.ts
@@ -2,6 +2,7 @@ import type { ProviderReference } from './remoteProvider';
 
 export interface Account {
 	provider: ProviderReference;
+	id: string;
 	name: string | undefined;
 	email: string | undefined;
 	avatarUrl: string | undefined;

--- a/src/git/models/issue.ts
+++ b/src/git/models/issue.ts
@@ -35,6 +35,7 @@ export interface IssueLabel {
 }
 
 export interface IssueMember {
+	id: string;
 	name: string;
 	avatarUrl?: string;
 	url?: string;
@@ -204,6 +205,7 @@ export function serializeIssue(value: IssueShape): IssueShape {
 		closed: value.closed,
 		state: value.state,
 		author: {
+			id: value.author.id,
 			name: value.author.name,
 			avatarUrl: value.author.avatarUrl,
 			url: value.author.url,
@@ -216,6 +218,7 @@ export function serializeIssue(value: IssueShape): IssueShape {
 						repo: value.repository.repo,
 				  },
 		assignees: value.assignees.map(assignee => ({
+			id: assignee.id,
 			name: assignee.name,
 			avatarUrl: assignee.avatarUrl,
 			url: assignee.url,

--- a/src/git/models/pullRequest.ts
+++ b/src/git/models/pullRequest.ts
@@ -56,6 +56,7 @@ export interface PullRequestRefs {
 }
 
 export interface PullRequestMember {
+	id: string;
 	name: string;
 	avatarUrl?: string;
 	url?: string;
@@ -103,6 +104,7 @@ export function serializePullRequest(value: PullRequest): PullRequestShape {
 		closedDate: value.closedDate,
 		closed: value.closed,
 		author: {
+			id: value.author.id,
 			name: value.author.name,
 			avatarUrl: value.author.avatarUrl,
 			url: value.author.url,
@@ -149,6 +151,7 @@ export class PullRequest implements PullRequestShape {
 	constructor(
 		public readonly provider: ProviderReference,
 		public readonly author: {
+			readonly id: string;
 			readonly name: string;
 			readonly avatarUrl?: string;
 			readonly url?: string;

--- a/src/plus/focus/enrichmentService.ts
+++ b/src/plus/focus/enrichmentService.ts
@@ -209,24 +209,28 @@ export class EnrichmentService implements Disposable {
 	}
 }
 
-const supportedRemoteProvidersToEnrich: Record<string, EnrichedItemResponse['provider']> = {
+const supportedRemoteProvidersToEnrich: Record<RemoteProvider['id'], EnrichedItemResponse['provider'] | undefined> = {
 	'azure-devops': 'azure',
 	bitbucket: 'bitbucket',
 	'bitbucket-server': 'bitbucket',
+	custom: undefined,
+	gerrit: undefined,
+	gitea: undefined,
 	github: 'github',
 	gitlab: 'gitlab',
+	'google-source': undefined,
 };
 
 export function convertRemoteProviderToEnrichProvider(provider: RemoteProvider): EnrichedItemResponse['provider'] {
 	return convertRemoteProviderIdToEnrichProvider(provider.id);
 }
 
-export function convertRemoteProviderIdToEnrichProvider(id: string): EnrichedItemResponse['provider'] {
+export function convertRemoteProviderIdToEnrichProvider(id: RemoteProvider['id']): EnrichedItemResponse['provider'] {
 	const enrichProvider = supportedRemoteProvidersToEnrich[id];
 	if (enrichProvider == null) throw new Error(`Unknown remote provider '${id}'`);
 	return enrichProvider;
 }
 
 export function isEnrichableRemoteProviderId(id: string): id is RemoteProvider['id'] {
-	return supportedRemoteProvidersToEnrich[id] != null;
+	return supportedRemoteProvidersToEnrich[id as RemoteProvider['id']] != null;
 }

--- a/src/plus/focus/enrichmentService.ts
+++ b/src/plus/focus/enrichmentService.ts
@@ -210,7 +210,11 @@ export class EnrichmentService implements Disposable {
 }
 
 export function convertRemoteProviderToEnrichProvider(provider: RemoteProvider): EnrichedItemResponse['provider'] {
-	switch (provider.id) {
+	return convertRemoteProviderIdToEnrichProvider(provider.id);
+}
+
+export function convertRemoteProviderIdToEnrichProvider(id: string): EnrichedItemResponse['provider'] {
+	switch (id) {
 		case 'azure-devops':
 			return 'azure';
 
@@ -225,6 +229,10 @@ export function convertRemoteProviderToEnrichProvider(provider: RemoteProvider):
 			return 'gitlab';
 
 		default:
-			throw new Error(`Unknown remote provider '${provider.id}'`);
+			throw new Error(`Unknown remote provider '${id}'`);
 	}
+}
+
+export function isEnrichableRemoteProviderId(id: string): id is RemoteProvider['id'] {
+	return id === 'azure-devops' || id === 'bitbucket' || id === 'github' || id === 'gitlab';
 }

--- a/src/plus/focus/enrichmentService.ts
+++ b/src/plus/focus/enrichmentService.ts
@@ -209,30 +209,24 @@ export class EnrichmentService implements Disposable {
 	}
 }
 
+const supportedRemoteProvidersToEnrich: Record<string, EnrichedItemResponse['provider']> = {
+	'azure-devops': 'azure',
+	bitbucket: 'bitbucket',
+	'bitbucket-server': 'bitbucket',
+	github: 'github',
+	gitlab: 'gitlab',
+};
+
 export function convertRemoteProviderToEnrichProvider(provider: RemoteProvider): EnrichedItemResponse['provider'] {
 	return convertRemoteProviderIdToEnrichProvider(provider.id);
 }
 
 export function convertRemoteProviderIdToEnrichProvider(id: string): EnrichedItemResponse['provider'] {
-	switch (id) {
-		case 'azure-devops':
-			return 'azure';
-
-		case 'bitbucket':
-		case 'bitbucket-server':
-			return 'bitbucket';
-
-		case 'github':
-			return 'github';
-
-		case 'gitlab':
-			return 'gitlab';
-
-		default:
-			throw new Error(`Unknown remote provider '${id}'`);
-	}
+	const enrichProvider = supportedRemoteProvidersToEnrich[id];
+	if (enrichProvider == null) throw new Error(`Unknown remote provider '${id}'`);
+	return enrichProvider;
 }
 
 export function isEnrichableRemoteProviderId(id: string): id is RemoteProvider['id'] {
-	return id === 'azure-devops' || id === 'bitbucket' || id === 'github' || id === 'gitlab';
+	return supportedRemoteProvidersToEnrich[id] != null;
 }

--- a/src/plus/focus/focus.ts
+++ b/src/plus/focus/focus.ts
@@ -259,7 +259,7 @@ export class FocusCommand extends QuickCommand<State> {
 				opened = true;
 
 				const result = yield* this.pickFocusItemStep(state, context, {
-					picked: state.item?.id,
+					picked: state.item?.graphQLId,
 					selectTopItem: state.selectTopItem,
 				});
 				if (result === StepResultBreak) continue;
@@ -421,7 +421,7 @@ export class FocusCommand extends QuickCommand<State> {
 								buttons: buttons,
 								iconPath: i.author?.avatarUrl != null ? Uri.parse(i.author.avatarUrl) : undefined,
 								item: i,
-								picked: i.id === picked || i.id === topItem?.id,
+								picked: i.graphQLId === picked || i.graphQLId === topItem?.graphQLId,
 								group: ui,
 							};
 						}),

--- a/src/plus/focus/focus.ts
+++ b/src/plus/focus/focus.ts
@@ -1,4 +1,4 @@
-import type { QuickPick } from 'vscode';
+import type { QuickInputButton, QuickPick } from 'vscode';
 import { commands, Uri } from 'vscode';
 import { getAvatarUri } from '../../avatars';
 import type {
@@ -17,8 +17,6 @@ import {
 } from '../../commands/quickCommand';
 import {
 	FeedbackQuickInputButton,
-	getIntegrationTitle,
-	getOpenOnGitproviderQuickInputButtons,
 	LaunchpadSettingsQuickInputButton,
 	MergeQuickInputButton,
 	OpenOnGitHubQuickInputButton,
@@ -48,6 +46,7 @@ import {
 	HostingIntegrationId,
 	ProviderBuildStatusState,
 	ProviderPullRequestReviewState,
+	SelfHostedIntegrationId,
 } from '../integrations/providers/models';
 import type {
 	FocusAction,
@@ -403,7 +402,7 @@ export class FocusCommand extends QuickCommand<State> {
 								buttons.push(OpenWorktreeInNewWindowQuickInputButton);
 							}
 
-							buttons.push(...getOpenOnGitproviderQuickInputButtons(i.provider.id));
+							buttons.push(...getOpenOnGitProviderQuickInputButtons(i.provider.id));
 
 							return {
 								label: i.title.length > 60 ? `${i.title.substring(0, 60)}...` : i.title,
@@ -558,7 +557,7 @@ export class FocusCommand extends QuickCommand<State> {
 		state: FocusStepState,
 		context: Context,
 	): StepResultGenerator<FocusAction | FocusTargetAction> {
-		const gitProviderWebButtons = getOpenOnGitproviderQuickInputButtons(state.item.provider.id);
+		const gitProviderWebButtons = getOpenOnGitProviderQuickInputButtons(state.item.provider.id);
 		const confirmations: (
 			| QuickPickItemOfT<FocusAction>
 			| QuickPickItemOfT<FocusTargetAction>
@@ -850,12 +849,12 @@ export class FocusCommand extends QuickCommand<State> {
 			status = `$(pass) No conflicts`;
 		}
 
-		const gitProviderWebButtons = getOpenOnGitproviderQuickInputButtons(item.provider.id);
+		const gitProviderWebButtons = getOpenOnGitProviderQuickInputButtons(item.provider.id);
 		return createQuickPickItemOfT({ label: status, buttons: [...gitProviderWebButtons] }, 'soft-open');
 	}
 
 	private getFocusItemReviewInformation(item: FocusItem): QuickPickItemOfT<FocusAction>[] {
-		const gitProviderWebButtons = getOpenOnGitproviderQuickInputButtons(item.provider.id);
+		const gitProviderWebButtons = getOpenOnGitProviderQuickInputButtons(item.provider.id);
 		if (item.reviews == null || item.reviews.length === 0) {
 			return [
 				createQuickPickItemOfT(
@@ -1048,6 +1047,37 @@ export class FocusCommand extends QuickCommand<State> {
 			{ ...context.telemetryContext!, action: action },
 			this.source,
 		);
+	}
+}
+
+function getOpenOnGitProviderQuickInputButton(integrationId: string): QuickInputButton | undefined {
+	switch (integrationId) {
+		case HostingIntegrationId.GitLab:
+		case SelfHostedIntegrationId.GitLabSelfHosted:
+			return OpenOnGitLabQuickInputButton;
+		case HostingIntegrationId.GitHub:
+		case SelfHostedIntegrationId.GitHubEnterprise:
+			return OpenOnGitHubQuickInputButton;
+		default:
+			return undefined;
+	}
+}
+
+function getOpenOnGitProviderQuickInputButtons(integrationId: string): QuickInputButton[] {
+	const button = getOpenOnGitProviderQuickInputButton(integrationId);
+	return button != null ? [button] : [];
+}
+
+function getIntegrationTitle(integrationId: string): string {
+	switch (integrationId) {
+		case HostingIntegrationId.GitLab:
+		case SelfHostedIntegrationId.GitLabSelfHosted:
+			return 'GitLab';
+		case HostingIntegrationId.GitHub:
+		case SelfHostedIntegrationId.GitHubEnterprise:
+			return 'GitHub';
+		default:
+			return integrationId;
 	}
 }
 

--- a/src/plus/focus/focusProvider.ts
+++ b/src/plus/focus/focusProvider.ts
@@ -354,9 +354,14 @@ export class FocusProvider implements Disposable {
 			!this._codeSuggestions.has(item.uuid) ||
 			this._codeSuggestions.get(item.uuid)!.expiresAt < Date.now()
 		) {
+			const providerId = item.provider.id;
+			if (!isSupportedCloudIntegrationId(providerId)) {
+				return undefined;
+			}
+
 			this._codeSuggestions.set(item.uuid, {
 				promise: withDurationAndSlowEventOnTimeout(
-					this.container.drafts.getCodeSuggestions(item, HostingIntegrationId.GitHub, {
+					this.container.drafts.getCodeSuggestions(item, providerId, {
 						includeArchived: false,
 					}),
 					'getCodeSuggestions',

--- a/src/plus/focus/focusProvider.ts
+++ b/src/plus/focus/focusProvider.ts
@@ -32,7 +32,6 @@ import type { UriTypes } from '../../uris/deepLinks/deepLink';
 import { DeepLinkActionType, DeepLinkType } from '../../uris/deepLinks/deepLink';
 import { showInspectView } from '../../webviews/commitDetails/actions';
 import type { ShowWipArgs } from '../../webviews/commitDetails/protocol';
-import { isSupportedCloudIntegrationId } from '../integrations/authentication/models';
 import type { IntegrationResult } from '../integrations/integration';
 import type { EnrichablePullRequest, ProviderActionablePullRequest } from '../integrations/providers/models';
 import {
@@ -212,6 +211,10 @@ type PullRequestsWithSuggestionCounts = {
 export type FocusRefreshEvent = FocusCategorizedResult;
 
 export const supportedFocusIntegrations = [HostingIntegrationId.GitHub, HostingIntegrationId.GitLab];
+type SupportedFocusIntegrationIds = (typeof supportedFocusIntegrations)[number];
+function isSupportedFocusIntegrationId(id: string): id is SupportedFocusIntegrationIds {
+	return supportedFocusIntegrations.includes(id as SupportedFocusIntegrationIds);
+}
 
 export type FocusCategorizedResult =
 	| {
@@ -355,7 +358,7 @@ export class FocusProvider implements Disposable {
 			this._codeSuggestions.get(item.uuid)!.expiresAt < Date.now()
 		) {
 			const providerId = item.provider.id;
-			if (!isSupportedCloudIntegrationId(providerId)) {
+			if (!isSupportedFocusIntegrationId(providerId)) {
 				return undefined;
 			}
 
@@ -706,7 +709,7 @@ export class FocusProvider implements Disposable {
 
 				const providerId = pr.pullRequest.provider.id;
 
-				if (!isSupportedCloudIntegrationId(providerId) || !isEnrichableRemoteProviderId(providerId)) {
+				if (!isSupportedFocusIntegrationId(providerId) || !isEnrichableRemoteProviderId(providerId)) {
 					Logger.warn(`Unsupported provider ${providerId}`);
 					return undefined;
 				}

--- a/src/plus/focus/focusProvider.ts
+++ b/src/plus/focus/focusProvider.ts
@@ -840,7 +840,12 @@ export class FocusProvider implements Disposable {
 				continue;
 			}
 
-			const actionablePrs = getActionablePullRequests(prs, { id: currentUser.username! }, options);
+			// Now it looks like a hack. Before the GitLab changes (GLVSC-579) the currentUser.username was used. That worked for GitHub.
+			// But user.id in GitLab's pull requests correspond to the `name` rather than `username`, therefore I'm changing it for now.
+			// As a follow up I'm going to do the following:
+			// - investigate why GitLab PR uses name as id field
+			// - add "id" field to all user conversions, so it could be same for every type of provider.
+			const actionablePrs = getActionablePullRequests(prs, { id: currentUser.name! }, options);
 			actionablePullRequests.push(...actionablePrs);
 		}
 

--- a/src/plus/focus/focusProvider.ts
+++ b/src/plus/focus/focusProvider.ts
@@ -842,12 +842,7 @@ export class FocusProvider implements Disposable {
 				continue;
 			}
 
-			// Now it looks like a hack. Before the GitLab changes (GLVSC-579) the currentUser.username was used. That worked for GitHub.
-			// But user.id in GitLab's pull requests correspond to the `name` rather than `username`, therefore I'm changing it for now.
-			// As a follow up I'm going to do the following:
-			// - investigate why GitLab PR uses name as id field
-			// - add "id" field to all user conversions, so it could be same for every type of provider.
-			const actionablePrs = getActionablePullRequests(prs, { id: currentUser.name! }, options);
+			const actionablePrs = getActionablePullRequests(prs, { id: currentUser.id }, options);
 			actionablePullRequests.push(...actionablePrs);
 		}
 

--- a/src/plus/focus/focusProvider.ts
+++ b/src/plus/focus/focusProvider.ts
@@ -811,16 +811,8 @@ export class FocusProvider implements Disposable {
 		}
 	}
 
-	// Note: We need to send an account to `getActionablePullRequests` that is a part of `providers-api`, and it accepts one account.
-	// But now we start having PRs from the different integrations, so, we have many current users (per. integration).
-	//
-	// In future, we probably want to change `providers-api` make it accept many accounts (from every integration that we use to collect PRs)
-	// However, for doing that we’d need consensus with the library owner and the other surfaces, that woudl slow down the development.
-	//
-	// So, now I separate the PRs of different ingegrations and call `getActionablePullRequests` for each integration.
-	// And I wrap these operations in this function so the focusProvider.getCategorizedItems thinks that it just passes current users to the library.
-	//
-	// When the library starts supporting many accounts, we can remove this function.
+	// TODO: Switch to using getActionablePullRequests from the shared provider library
+	// once it supports passing in multiple current users, one for each provider
 	private getActionablePullRequests(
 		pullRequests: (PullRequestWithUniqueID & { provider: { id: string } })[],
 		currentUsers: Map<string, Account>,

--- a/src/plus/focus/focusProvider.ts
+++ b/src/plus/focus/focusProvider.ts
@@ -444,9 +444,9 @@ export class FocusProvider implements Disposable {
 			}? This cannot be undone.`,
 		});
 		if (confirm !== 'Merge') return;
-		const integrations = await this.container.integrations.get(integrationId);
-		const pr: PullRequest = fromProviderPullRequest(item, integrations);
-		await integrations.mergePullRequest(pr);
+		const integration = await this.container.integrations.get(integrationId);
+		const pr: PullRequest = fromProviderPullRequest(item, integration);
+		await integration.mergePullRequest(pr);
 		this.refresh();
 	}
 

--- a/src/plus/focus/focusProvider.ts
+++ b/src/plus/focus/focusProvider.ts
@@ -1,5 +1,4 @@
 import type {
-	ActionablePullRequest,
 	CodeSuggestionsCountByPrUuid,
 	EnrichedItemsByUniqueId,
 	PullRequestWithUniqueID,
@@ -820,13 +819,13 @@ export class FocusProvider implements Disposable {
 			enrichedItemsByUniqueId?: EnrichedItemsByUniqueId;
 			codeSuggestionsCountByPrUuid?: CodeSuggestionsCountByPrUuid;
 		},
-	): ActionablePullRequest[] {
+	): ProviderActionablePullRequest[] {
 		const pullRequestsByIntegration = groupByMap<string, PullRequestWithUniqueID & { provider: { id: string } }>(
 			pullRequests,
 			pr => pr.provider.id,
 		);
 
-		const actionablePullRequests: ActionablePullRequest[] = [];
+		const actionablePullRequests: ProviderActionablePullRequest[] = [];
 		for (const [integrationId, prs] of pullRequestsByIntegration.entries()) {
 			const currentUser = currentUsers.get(integrationId);
 			if (currentUser == null) {

--- a/src/plus/integrations/integration.ts
+++ b/src/plus/integrations/integration.ts
@@ -413,7 +413,7 @@ export abstract class IntegrationBase<
 
 		const { expiryOverride, ...opts } = options ?? {};
 
-		const currentAccount = this.container.cache.getCurrentAccount(
+		const currentAccount = await this.container.cache.getCurrentAccount(
 			this,
 			() => ({
 				value: (async () => {

--- a/src/plus/integrations/integration.ts
+++ b/src/plus/integrations/integration.ts
@@ -693,7 +693,7 @@ export abstract class HostingIntegration<
 	): Promise<RepositoryMetadata | undefined>;
 
 	async mergePullRequest(
-		pr: PullRequest | { id: string; headRefSha: string },
+		pr: PullRequest,
 		options?: {
 			mergeMethod?: PullRequestMergeMethod;
 		},
@@ -714,7 +714,7 @@ export abstract class HostingIntegration<
 
 	protected abstract mergeProviderPullRequest(
 		session: ProviderAuthenticationSession,
-		pr: PullRequest | { id: string; headRefSha: string },
+		pr: PullRequest,
 		options?: {
 			mergeMethod?: PullRequestMergeMethod;
 		},

--- a/src/plus/integrations/integration.ts
+++ b/src/plus/integrations/integration.ts
@@ -5,7 +5,7 @@ import type { AutolinkReference } from '../../config';
 import type { Container } from '../../container';
 import { AuthenticationError, CancellationError, ProviderRequestClientError } from '../../errors';
 import type { PagedResult } from '../../git/gitProvider';
-import type { Account } from '../../git/models/author';
+import type { Account, UnidentifiedAuthor } from '../../git/models/author';
 import type { DefaultBranch } from '../../git/models/defaultBranch';
 import type { IssueOrPullRequest, SearchedIssue } from '../../git/models/issue';
 import type {
@@ -603,7 +603,7 @@ export abstract class HostingIntegration<
 		options?: {
 			avatarSize?: number;
 		},
-	): Promise<Account | undefined> {
+	): Promise<Account | UnidentifiedAuthor | undefined> {
 		const scope = getLogScope();
 
 		const connected = this.maybeConnected ?? (await this.isConnected());
@@ -625,7 +625,7 @@ export abstract class HostingIntegration<
 		options?: {
 			avatarSize?: number;
 		},
-	): Promise<Account | undefined>;
+	): Promise<Account | UnidentifiedAuthor | undefined>;
 
 	@debug()
 	async getDefaultBranch(repo: T): Promise<DefaultBranch | undefined> {

--- a/src/plus/integrations/providers/azureDevOps.ts
+++ b/src/plus/integrations/providers/azureDevOps.ts
@@ -61,7 +61,7 @@ export class AzureDevOpsIntegration extends HostingIntegration<
 
 	protected override async mergeProviderPullRequest(
 		_session: AuthenticationSession,
-		_pr: PullRequest | { id: string; headRefSha: string },
+		_pr: PullRequest,
 		_options?: {
 			mergeMethod?: PullRequestMergeMethod;
 		},

--- a/src/plus/integrations/providers/bitbucket.ts
+++ b/src/plus/integrations/providers/bitbucket.ts
@@ -40,7 +40,7 @@ export class BitbucketIntegration extends HostingIntegration<
 
 	protected override async mergeProviderPullRequest(
 		_session: AuthenticationSession,
-		_pr: PullRequest | { id: string; headRefSha: string },
+		_pr: PullRequest,
 		_options?: {
 			mergeMethod?: PullRequestMergeMethod;
 		},

--- a/src/plus/integrations/providers/github.ts
+++ b/src/plus/integrations/providers/github.ts
@@ -1,7 +1,7 @@
 import type { AuthenticationSession, CancellationToken } from 'vscode';
 import { authentication } from 'vscode';
 import type { Container } from '../../../container';
-import type { Account } from '../../../git/models/author';
+import type { Account, UnidentifiedAuthor } from '../../../git/models/author';
 import type { DefaultBranch } from '../../../git/models/defaultBranch';
 import type { IssueOrPullRequest, SearchedIssue } from '../../../git/models/issue';
 import type {
@@ -53,7 +53,7 @@ abstract class GitHubIntegrationBase<ID extends SupportedIntegrationIds> extends
 		options?: {
 			avatarSize?: number;
 		},
-	): Promise<Account | undefined> {
+	): Promise<Account | UnidentifiedAuthor | undefined> {
 		return (await this.container.github)?.getAccountForCommit(this, accessToken, repo.owner, repo.name, ref, {
 			...options,
 			baseUrl: this.apiBaseUrl,

--- a/src/plus/integrations/providers/github.ts
+++ b/src/plus/integrations/providers/github.ts
@@ -4,8 +4,12 @@ import type { Container } from '../../../container';
 import type { Account } from '../../../git/models/author';
 import type { DefaultBranch } from '../../../git/models/defaultBranch';
 import type { IssueOrPullRequest, SearchedIssue } from '../../../git/models/issue';
-import type { PullRequestMergeMethod, PullRequestState, SearchedPullRequest } from '../../../git/models/pullRequest';
-import { PullRequest } from '../../../git/models/pullRequest';
+import type {
+	PullRequest,
+	PullRequestMergeMethod,
+	PullRequestState,
+	SearchedPullRequest,
+} from '../../../git/models/pullRequest';
 import type { RepositoryMetadata } from '../../../git/models/repositoryMetadata';
 import { log } from '../../../system/decorators/log';
 import { ensurePaidPlan } from '../../utils';
@@ -221,13 +225,13 @@ abstract class GitHubIntegrationBase<ID extends SupportedIntegrationIds> extends
 
 	protected override async mergeProviderPullRequest(
 		{ accessToken }: AuthenticationSession,
-		pr: PullRequest | { id: string; headRefSha: string },
+		pr: PullRequest,
 		options?: {
 			mergeMethod?: PullRequestMergeMethod;
 		},
 	): Promise<boolean> {
-		const id = pr instanceof PullRequest ? pr.nodeId : pr.id;
-		const headRefSha = pr instanceof PullRequest ? pr.refs?.head?.sha : pr.headRefSha;
+		const id = pr.nodeId;
+		const headRefSha = pr.refs?.head?.sha;
 		if (id == null || headRefSha == null) return false;
 		return (
 			(await this.container.github)?.mergePullRequest(this, accessToken, id, headRefSha, {

--- a/src/plus/integrations/providers/github/github.ts
+++ b/src/plus/integrations/providers/github/github.ts
@@ -261,10 +261,11 @@ export class GitHubApi implements Disposable {
 }`;
 
 			const rsp = await this.graphql<QueryResult>(provider, token, query, { ...options }, scope);
-			if (rsp?.viewer == null) return undefined;
+			if (rsp?.viewer?.login == null) return undefined;
 
 			return {
 				provider: provider,
+				id: rsp.viewer.login,
 				name: rsp.viewer.name ?? undefined,
 				email: rsp.viewer.email ?? undefined,
 				// If we are GitHub Enterprise, we may need to convert the avatar URL since it might require authentication
@@ -365,6 +366,7 @@ export class GitHubApi implements Disposable {
 
 			return {
 				provider: provider,
+				id: author?.user?.login ?? '',
 				name: author.name ?? undefined,
 				email: author.email ?? undefined,
 				// If we are GitHub Enterprise, we may need to convert the avatar URL since it might require authentication
@@ -455,6 +457,7 @@ export class GitHubApi implements Disposable {
 
 			return {
 				provider: provider,
+				id: author.login ?? '',
 				name: author.name ?? undefined,
 				email: author.email ?? undefined,
 				// If we are GitHub Enterprise, we may need to convert the avatar URL since it might require authentication

--- a/src/plus/integrations/providers/github/github.ts
+++ b/src/plus/integrations/providers/github/github.ts
@@ -460,11 +460,11 @@ export class GitHubApi implements Disposable {
 			);
 
 			const author = rsp?.search?.nodes?.[0];
-			if (author == null) return undefined;
+			if (author?.login == null) return undefined;
 
 			return {
 				provider: provider,
-				id: author.login ?? '',
+				id: author.login,
 				name: author.name ?? undefined,
 				email: author.email ?? undefined,
 				// If we are GitHub Enterprise, we may need to convert the avatar URL since it might require authentication

--- a/src/plus/integrations/providers/github/github.ts
+++ b/src/plus/integrations/providers/github/github.ts
@@ -17,7 +17,7 @@ import {
 	ProviderRequestRateLimitError,
 } from '../../../../errors';
 import type { PagedResult, RepositoryVisibility } from '../../../../git/gitProvider';
-import type { Account } from '../../../../git/models/author';
+import type { Account, UnidentifiedAuthor } from '../../../../git/models/author';
 import type { DefaultBranch } from '../../../../git/models/defaultBranch';
 import type { IssueOrPullRequest, SearchedIssue } from '../../../../git/models/issue';
 import type { PullRequest, SearchedPullRequest } from '../../../../git/models/pullRequest';
@@ -301,7 +301,7 @@ export class GitHubApi implements Disposable {
 			baseUrl?: string;
 			avatarSize?: number;
 		},
-	): Promise<Account | undefined> {
+	): Promise<Account | UnidentifiedAuthor | undefined> {
 		const scope = getLogScope();
 
 		interface QueryResult {
@@ -366,7 +366,15 @@ export class GitHubApi implements Disposable {
 
 			return {
 				provider: provider,
-				id: author?.user?.login ?? '',
+				...(author?.user?.login != null
+					? {
+							id: author.user.login,
+							username: author.user.login,
+					  }
+					: {
+							id: undefined,
+							username: undefined,
+					  }),
 				name: author.name ?? undefined,
 				email: author.email ?? undefined,
 				// If we are GitHub Enterprise, we may need to convert the avatar URL since it might require authentication
@@ -382,7 +390,6 @@ export class GitHubApi implements Disposable {
 									options.avatarSize,
 						    )
 						  : undefined,
-				username: author.user?.login ?? undefined,
 			};
 		} catch (ex) {
 			if (ex instanceof ProviderRequestNotFoundError) return undefined;

--- a/src/plus/integrations/providers/github/models.ts
+++ b/src/plus/integrations/providers/github/models.ts
@@ -174,6 +174,7 @@ export function fromGitHubPullRequestLite(pr: GitHubPullRequestLite, provider: P
 	return new PullRequest(
 		provider,
 		{
+			id: pr.author.login,
 			name: pr.author.login,
 			avatarUrl: pr.author.avatarUrl,
 			url: pr.author.url,
@@ -312,6 +313,7 @@ export function fromGitHubPullRequest(pr: GitHubPullRequest, provider: Provider)
 	return new PullRequest(
 		provider,
 		{
+			id: pr.author.login,
 			name: pr.author.login,
 			avatarUrl: pr.author.avatarUrl,
 			url: pr.author.url,
@@ -363,6 +365,7 @@ export function fromGitHubPullRequest(pr: GitHubPullRequest, provider: Provider)
 					? {
 							isCodeOwner: r.asCodeOwner,
 							reviewer: {
+								id: r.requestedReviewer.login,
 								name: r.requestedReviewer.login,
 								avatarUrl: r.requestedReviewer.avatarUrl,
 								url: r.requestedReviewer.url,
@@ -374,6 +377,7 @@ export function fromGitHubPullRequest(pr: GitHubPullRequest, provider: Provider)
 			.filter(<T>(r?: T): r is T => Boolean(r)),
 		pr.latestReviews.nodes.map(r => ({
 			reviewer: {
+				id: r.author.login,
 				name: r.author.login,
 				avatarUrl: r.author.avatarUrl,
 				url: r.author.url,
@@ -381,6 +385,7 @@ export function fromGitHubPullRequest(pr: GitHubPullRequest, provider: Provider)
 			state: fromGitHubPullRequestReviewState(r.state),
 		})),
 		pr.assignees.nodes.map(r => ({
+			id: r.login,
 			name: r.login,
 			avatarUrl: r.avatarUrl,
 			url: r.url,
@@ -406,6 +411,7 @@ export function fromGitHubIssue(value: GitHubIssue, provider: Provider): Issue {
 		value.closed,
 		fromGitHubIssueOrPullRequestState(value.state),
 		{
+			id: value.author.login,
 			name: value.author.login,
 			avatarUrl: value.author.avatarUrl,
 			url: value.author.url,
@@ -416,6 +422,7 @@ export function fromGitHubIssue(value: GitHubIssue, provider: Provider): Issue {
 			accessLevel: fromGitHubViewerPermissionToAccessLevel(value.repository.viewerPermission),
 		},
 		value.assignees.nodes.map(assignee => ({
+			id: assignee.login,
 			name: assignee.login,
 			avatarUrl: assignee.avatarUrl,
 			url: assignee.url,

--- a/src/plus/integrations/providers/gitlab.ts
+++ b/src/plus/integrations/providers/gitlab.ts
@@ -1,5 +1,3 @@
-import type { GitPullRequest } from '@gitkraken/provider-apis';
-import { GitPullRequestReviewState } from '@gitkraken/provider-apis';
 import type { AuthenticationSession, CancellationToken } from 'vscode';
 import { window } from 'vscode';
 import type { Container } from '../../../container';
@@ -22,7 +20,13 @@ import type {
 } from '../authentication/integrationAuthentication';
 import { HostingIntegration } from '../integration';
 import { fromGitLabMergeRequestProvidersApi } from './gitlab/models';
-import { HostingIntegrationId, providersMetadata, SelfHostedIntegrationId } from './models';
+import type { ProviderPullRequest } from './models';
+import {
+	HostingIntegrationId,
+	ProviderPullRequestReviewState,
+	providersMetadata,
+	SelfHostedIntegrationId,
+} from './models';
 import type { ProvidersApi } from './providersApi';
 
 const metadata = providersMetadata[HostingIntegrationId.GitLab];
@@ -188,7 +192,7 @@ abstract class GitLabIntegrationBase<
 			prs = apiResult.values;
 		}
 
-		const toQueryResult = (pr: GitPullRequest, reason?: string): SearchedPullRequest => {
+		const toQueryResult = (pr: ProviderPullRequest, reason?: string): SearchedPullRequest => {
 			return {
 				pullRequest: fromGitLabMergeRequestProvidersApi(pr, this),
 				reasons: reason ? [reason] : [],
@@ -218,7 +222,7 @@ abstract class GitLabIntegrationBase<
 						pr.reviews?.some(
 							review =>
 								review.reviewer?.username === username ||
-								review.state === GitPullRequestReviewState.ReviewRequested,
+								review.state === ProviderPullRequestReviewState.ReviewRequested,
 						)
 					) {
 						result.push(toQueryResult(pr, 'review-requested'));

--- a/src/plus/integrations/providers/gitlab.ts
+++ b/src/plus/integrations/providers/gitlab.ts
@@ -187,6 +187,13 @@ abstract class GitLabIntegrationBase<
 		}
 
 		const toQueryResult = (pr: GitPullRequest, reason?: string): SearchedPullRequest => {
+			// This a dirty hack that's needed to enable PRs because providers-api always returns null here: https://github.com/gitkraken/provider-apis-package-js/blob/6ee521eb6b46bbb759d9c68646979c3b25681d90/src/providers/gitlab/gitlab.ts#L597
+			if (!pr.permissions) {
+				pr.permissions = {
+					canMerge: true,
+					canMergeAndBypassProtections: false,
+				};
+			}
 			return {
 				pullRequest: fromProviderPullRequest(pr, this),
 				reasons: reason ? [reason] : [],

--- a/src/plus/integrations/providers/gitlab.ts
+++ b/src/plus/integrations/providers/gitlab.ts
@@ -279,6 +279,7 @@ abstract class GitLabIntegrationBase<
 				domain: this.domain,
 				icon: this.icon,
 			},
+			id: currentUser.id,
 			name: currentUser.name || undefined,
 			email: currentUser.email || undefined,
 			avatarUrl: currentUser.avatarUrl || undefined,

--- a/src/plus/integrations/providers/gitlab.ts
+++ b/src/plus/integrations/providers/gitlab.ts
@@ -176,6 +176,27 @@ abstract class GitLabIntegrationBase<ID extends SupportedIntegrationIds> extends
 	): Promise<boolean> {
 		return Promise.resolve(false);
 	}
+
+	protected override async getProviderCurrentAccount({
+		accessToken,
+	}: AuthenticationSession): Promise<Account | undefined> {
+		const api = await this.getProvidersApi();
+		const currentUser = await api.getCurrentUser(this.id, { accessToken: accessToken });
+		if (currentUser == null) return undefined;
+
+		return {
+			provider: {
+				id: this.id,
+				name: this.name,
+				domain: this.domain,
+				icon: this.icon,
+			},
+			name: currentUser.name || undefined,
+			email: currentUser.email || undefined,
+			avatarUrl: currentUser.avatarUrl || undefined,
+			username: currentUser.username || undefined,
+		};
+	}
 }
 
 export class GitLabIntegration extends GitLabIntegrationBase<HostingIntegrationId.GitLab> {

--- a/src/plus/integrations/providers/gitlab.ts
+++ b/src/plus/integrations/providers/gitlab.ts
@@ -16,7 +16,6 @@ import type {
 	IntegrationAuthenticationProviderDescriptor,
 	IntegrationAuthenticationService,
 } from '../authentication/integrationAuthentication';
-import type { SupportedIntegrationIds } from '../integration';
 import { HostingIntegration } from '../integration';
 import { HostingIntegrationId, providersMetadata, SelfHostedIntegrationId } from './models';
 import type { ProvidersApi } from './providersApi';
@@ -39,10 +38,9 @@ export type GitLabRepositoryDescriptor = {
 	name: string;
 };
 
-abstract class GitLabIntegrationBase<ID extends SupportedIntegrationIds> extends HostingIntegration<
-	ID,
-	GitLabRepositoryDescriptor
-> {
+abstract class GitLabIntegrationBase<
+	ID extends HostingIntegrationId.GitLab | SelfHostedIntegrationId.GitLabSelfHosted,
+> extends HostingIntegration<ID, GitLabRepositoryDescriptor> {
 	protected abstract get apiBaseUrl(): string;
 
 	protected override async getProviderAccountForCommit(

--- a/src/plus/integrations/providers/gitlab.ts
+++ b/src/plus/integrations/providers/gitlab.ts
@@ -208,9 +208,10 @@ abstract class GitLabIntegrationBase<
 
 		const results: SearchedPullRequest[] = uniqueWithReasons(
 			[
-				...prs.map(pr => {
+				...prs.flatMap(pr => {
+					const result: SearchedPullRequest[] = [];
 					if (pr.assignees?.some(a => a.username === username)) {
-						return toQueryResult(pr, 'assigned');
+						result.push(toQueryResult(pr, 'assigned'));
 					}
 
 					if (
@@ -220,11 +221,11 @@ abstract class GitLabIntegrationBase<
 								review.state === GitPullRequestReviewState.ReviewRequested,
 						)
 					) {
-						return toQueryResult(pr, 'review-requested');
+						result.push(toQueryResult(pr, 'review-requested'));
 					}
 
 					if (pr.author?.username === username) {
-						return toQueryResult(pr, 'authored');
+						result.push(toQueryResult(pr, 'authored'));
 					}
 
 					// It seems like GitLab doesn't give us mentioned PRs.
@@ -232,8 +233,7 @@ abstract class GitLabIntegrationBase<
 					// 	return toQueryResult(pr, 'mentioned');
 					// }
 
-					// I assume nothing can come here, but just in case let set it to review-requested
-					return toQueryResult(pr, 'review-requested');
+					return result;
 				}),
 			],
 			r => r.pullRequest.url,

--- a/src/plus/integrations/providers/gitlab.ts
+++ b/src/plus/integrations/providers/gitlab.ts
@@ -251,7 +251,7 @@ abstract class GitLabIntegrationBase<
 
 	protected override async mergeProviderPullRequest(
 		_session: AuthenticationSession,
-		pr: PullRequest | { id: string; headRefSha: string },
+		pr: PullRequest,
 		options?: {
 			mergeMethod?: PullRequestMergeMethod;
 		},

--- a/src/plus/integrations/providers/gitlab/gitlab.ts
+++ b/src/plus/integrations/providers/gitlab/gitlab.ts
@@ -42,6 +42,12 @@ import type {
 } from './models';
 import { fromGitLabMergeRequestREST, fromGitLabMergeRequestState } from './models';
 
+// drop it as soon as we switch to @gitkraken/providers-api
+const gitlabUserIdPrefix = 'gid://gitlab/User/';
+function buildGitLabUserId(id: string | undefined): string | undefined {
+	return id?.startsWith(gitlabUserIdPrefix) ? id.substring(gitlabUserIdPrefix.length) : id;
+}
+
 export class GitLabApi implements Disposable {
 	private readonly _disposable: Disposable;
 	private _projectIds = new Map<string, Promise<string | undefined>>();
@@ -136,6 +142,7 @@ export class GitLabApi implements Disposable {
 
 			return {
 				provider: provider,
+				id: String(user.id),
 				name: user.name || undefined,
 				email: commit.author_email || undefined,
 				avatarUrl: user.avatarUrl || undefined,
@@ -168,6 +175,7 @@ export class GitLabApi implements Disposable {
 
 			return {
 				provider: provider,
+				id: String(user.id),
 				name: user.name || undefined,
 				email: user.publicEmail || undefined,
 				avatarUrl: user.avatarUrl || undefined,
@@ -271,6 +279,7 @@ export class GitLabApi implements Disposable {
 	project(fullPath: $fullPath) {
 		mergeRequest(iid: $iid) {
 			author {
+				id
 				name
 				avatarUrl
 				webUrl
@@ -286,6 +295,7 @@ export class GitLabApi implements Disposable {
 		}
 		issue(iid: $iid) {
 			author {
+				id
 				name
 				avatarUrl
 				webUrl
@@ -398,6 +408,7 @@ export class GitLabApi implements Disposable {
 			nodes {
 				iid
 				author {
+					id
 					name
 					avatarUrl
 					webUrl
@@ -487,6 +498,7 @@ export class GitLabApi implements Disposable {
 			return new PullRequest(
 				provider,
 				{
+					id: buildGitLabUserId(pr.author?.id) ?? '',
 					name: pr.author?.name ?? 'Unknown',
 					avatarUrl: pr.author?.avatarUrl ?? '',
 					url: pr.author?.webUrl ?? '',

--- a/src/plus/integrations/providers/gitlab/models.ts
+++ b/src/plus/integrations/providers/gitlab/models.ts
@@ -51,6 +51,7 @@ export interface GitLabIssue {
 export interface GitLabMergeRequest {
 	iid: string;
 	author: {
+		id: string;
 		name: string;
 		avatarUrl: string | null;
 		webUrl: string;
@@ -78,6 +79,7 @@ export interface GitLabMergeRequestREST {
 	id: number;
 	iid: number;
 	author: {
+		id: string;
 		name: string;
 		avatar_url?: string;
 		web_url: string;
@@ -100,6 +102,7 @@ export function fromGitLabMergeRequestREST(
 	return new PullRequest(
 		provider,
 		{
+			id: pr.author?.id ?? '',
 			name: pr.author?.name ?? 'Unknown',
 			avatarUrl: pr.author?.avatar_url ?? '',
 			url: pr.author?.web_url ?? '',

--- a/src/plus/integrations/providers/models.ts
+++ b/src/plus/integrations/providers/models.ts
@@ -792,6 +792,8 @@ export function fromProviderPullRequest(pr: ProviderPullRequest, integration: In
 		{
 			owner: pr.repository.owner.login,
 			repo: pr.repository.name,
+			// This a dirty hack that's needed to enable PRs original pr does not have this information
+			accessLevel: RepositoryAccessLevel.Write,
 		},
 		fromProviderPullRequestState(pr.state),
 		pr.createdDate,

--- a/src/plus/integrations/providers/models.ts
+++ b/src/plus/integrations/providers/models.ts
@@ -289,10 +289,7 @@ export type GetAzureProjectsForResourceFn = (
 	input: { namespace: string; cursor?: string },
 	options?: EnterpriseOptions,
 ) => Promise<{ data: AzureProject[]; pageInfo?: PageInfo }>;
-export type GetIssuesForProjectFn = (
-	input: GetIssuesForProjectInput,
-	options?: EnterpriseOptions,
-) => Promise<{ data: ProviderIssue[] }>;
+export type GetIssuesForProjectFn = Jira['getIssuesForProject'];
 export type GetIssuesForResourceForCurrentUserFn = (
 	input: { resourceId: string },
 	options?: EnterpriseOptions,

--- a/src/plus/integrations/providers/models.ts
+++ b/src/plus/integrations/providers/models.ts
@@ -26,6 +26,7 @@ import {
 	GitPullRequestReviewState,
 	GitPullRequestState,
 } from '@gitkraken/provider-apis';
+import type { GitProvider } from '@gitkraken/provider-apis/dist/providers/gitProvider';
 import type { Account as UserAccount } from '../../../git/models/author';
 import type { IssueMember, SearchedIssue } from '../../../git/models/issue';
 import { RepositoryAccessLevel } from '../../../git/models/issue';
@@ -235,6 +236,8 @@ export type GetPullRequestsForAzureProjectsFn = (
 	options?: EnterpriseOptions,
 ) => Promise<{ data: ProviderPullRequest[] }>;
 
+export type MergePullRequestFn = GitProvider['mergePullRequest'];
+
 export type GetIssueFn = (
 	input: { resourceId: string; number: string },
 	options?: EnterpriseOptions,
@@ -315,6 +318,7 @@ export interface ProviderInfo extends ProviderMetadata {
 	getIssuesForProjectFn?: GetIssuesForProjectFn;
 	getReposForAzureProjectFn?: GetReposForAzureProjectFn;
 	getIssuesForResourceForCurrentUserFn?: GetIssuesForResourceForCurrentUserFn;
+	mergePullRequestFn?: MergePullRequestFn;
 }
 
 export interface ProviderMetadata {

--- a/src/plus/integrations/providers/models.ts
+++ b/src/plus/integrations/providers/models.ts
@@ -515,12 +515,14 @@ export function toSearchedIssue(
 			closed: issue.closedDate != null,
 			state: issue.closedDate != null ? 'closed' : 'opened',
 			author: {
+				id: issue.author.id ?? '',
 				name: issue.author.name ?? '',
 				avatarUrl: issue.author.avatarUrl ?? undefined,
 				url: issue.author.url ?? undefined,
 			},
 			assignees:
 				issue.assignees?.map(assignee => ({
+					id: assignee.id ?? '',
 					name: assignee.name ?? '',
 					avatarUrl: assignee.avatarUrl ?? undefined,
 					url: assignee.url ?? undefined,
@@ -553,6 +555,7 @@ export function issueFilterToReason(filter: IssueFilter): 'authored' | 'assigned
 export function toAccount(account: ProviderAccount, provider: ProviderReference): UserAccount {
 	return {
 		provider: provider,
+		id: account.id,
 		name: account.name ?? undefined,
 		email: account.email ?? undefined,
 		avatarUrl: account.avatarUrl ?? undefined,
@@ -796,7 +799,7 @@ export function fromProviderPullRequest(pr: ProviderPullRequest, integration: In
 		{
 			owner: pr.repository.owner.login,
 			repo: pr.repository.name,
-			// This a dirty hack that's needed to enable PRs original pr does not have this information
+			// This has to be here until we can take this information from ProviderPullRequest:
 			accessLevel: RepositoryAccessLevel.Write,
 		},
 		fromProviderPullRequestState(pr.state),
@@ -853,18 +856,19 @@ export function toProviderPullRequestWithUniqueId(pr: PullRequest): PullRequestW
 
 export function toProviderAccount(account: PullRequestMember | IssueMember): ProviderAccount {
 	return {
+		id: account.id ?? null,
 		avatarUrl: account.avatarUrl ?? null,
 		name: account.name ?? null,
 		url: account.url ?? null,
 		// TODO: Implement these in our own model
 		email: '',
 		username: account.name ?? null,
-		id: account.name ?? null,
 	};
 }
 
 export function fromProviderAccount(account: ProviderAccount | null): PullRequestMember | IssueMember {
 	return {
+		id: account?.id ?? '',
 		name: account?.name ?? 'unknown',
 		avatarUrl: account?.avatarUrl ?? undefined,
 		url: account?.url ?? '',

--- a/src/plus/integrations/providers/providersApi.ts
+++ b/src/plus/integrations/providers/providersApi.ts
@@ -744,7 +744,7 @@ export class ProvidersApi {
 
 		try {
 			const result = await provider.getIssuesForProjectFn?.(
-				{ project: project, resourceId: resourceId, ...options },
+				{ projectKey: project, resourceId: resourceId, ...options },
 				{ token: token },
 			);
 

--- a/src/plus/integrations/providers/utils.ts
+++ b/src/plus/integrations/providers/utils.ts
@@ -20,9 +20,9 @@ export function getEntityIdentifierInput(entity: IssueOrPullRequest | FocusItem)
 		entityType = EntityType.PullRequest;
 	}
 
-	let provider = EntityIdentifierProviderType.Github;
+	let provider = fromStringToEntityIdentifierProviderType(entity.provider.id);
 	let domain = undefined;
-	if (!isGitHubDotCom(entity.provider.domain)) {
+	if (provider === EntityIdentifierProviderType.Github && !isGitHubDotCom(entity.provider.domain)) {
 		provider = EntityIdentifierProviderType.GithubEnterprise;
 		domain = entity.provider.domain;
 	}
@@ -44,5 +44,16 @@ export function getProviderIdFromEntityIdentifier(entityIdentifier: EntityIdenti
 			return SelfHostedIntegrationId.GitHubEnterprise;
 		default:
 			return undefined;
+	}
+}
+
+function fromStringToEntityIdentifierProviderType(str: string): EntityIdentifierProviderType {
+	switch (str) {
+		case 'github':
+			return EntityIdentifierProviderType.Github;
+		case 'gitlab':
+			return EntityIdentifierProviderType.Gitlab;
+		default:
+			throw new Error(`Unknown provider type '${str}'`);
 	}
 }

--- a/src/plus/integrations/providers/utils.ts
+++ b/src/plus/integrations/providers/utils.ts
@@ -10,6 +10,10 @@ function isGitHubDotCom(domain: string): boolean {
 	return equalsIgnoreCase(domain, 'github.com');
 }
 
+function isGitLabDotCom(domain: string): boolean {
+	return equalsIgnoreCase(domain, 'gitlab.com');
+}
+
 function isFocusItem(item: IssueOrPullRequest | FocusItem): item is FocusItem {
 	return (item as FocusItem).uuid !== undefined;
 }
@@ -24,6 +28,10 @@ export function getEntityIdentifierInput(entity: IssueOrPullRequest | FocusItem)
 	let domain = undefined;
 	if (provider === EntityIdentifierProviderType.Github && !isGitHubDotCom(entity.provider.domain)) {
 		provider = EntityIdentifierProviderType.GithubEnterprise;
+		domain = entity.provider.domain;
+	}
+	if (provider === EntityIdentifierProviderType.Gitlab && !isGitLabDotCom(entity.provider.domain)) {
+		provider = EntityIdentifierProviderType.GitlabSelfHosted;
 		domain = entity.provider.domain;
 	}
 

--- a/src/webviews/settings/settingsWebview.ts
+++ b/src/webviews/settings/settingsWebview.ts
@@ -219,6 +219,7 @@ export class SettingsWebviewProvider implements WebviewProvider<State, State, Se
 							pr = new PullRequest(
 								{ id: 'github', name: 'GitHub', domain: 'github.com', icon: 'github' },
 								{
+									id: 'eamodio',
 									name: 'Eric Amodio',
 									avatarUrl: 'https://avatars1.githubusercontent.com/u/641685?s=32&v=4',
 									url: 'https://github.com/eamodio',

--- a/yarn.lock
+++ b/yarn.lock
@@ -376,10 +376,10 @@
     react-dragula "1.1.17"
     react-onclickoutside "6.13.0"
 
-"@gitkraken/provider-apis@0.22.9":
-  version "0.22.9"
-  resolved "https://registry.yarnpkg.com/@gitkraken/provider-apis/-/provider-apis-0.22.9.tgz#165235f07ec4d56e9dafaee2e36d0eb5b3f24c9c"
-  integrity sha512-942DLjaC6aDyUEEkAVjxX/QfdB8GjpXQineoRT67VzCIT+WWAbWCCOqYiwL3waRHSscRfpDimiLdC0j8/GWRPA==
+"@gitkraken/provider-apis@0.24.2":
+  version "0.24.2"
+  resolved "https://registry.yarnpkg.com/@gitkraken/provider-apis/-/provider-apis-0.24.2.tgz#217ebf881aacc88f1cc487b3f2ed15d46f2f4212"
+  integrity sha512-Il0QqYbw0mzjda+EhApny2re0cMY7LOYygmGh5ASQ33juT9rinMsZo1Wu3wh93jwSbAMEzS0royOHFfw37vz2w==
   dependencies:
     js-base64 "3.7.5"
     node-fetch "2.7.0"


### PR DESCRIPTION
# Description

Shows Merge Requests on the Launchpad if GitLab rich integration is configured.
If both GitLab and GitHub are configured then shows PRs and MRs on the same list.

# Checklist

<!-- Please check off the following -->

- [x] I have followed the guidelines in the Contributing document
- [x] My changes follow the coding style of this project
- [x] My changes build without any errors or warnings
- [x] My changes have been formatted and linted
- [x] My changes include any required corresponding changes to the documentation (including CHANGELOG.md and README.md)
- [x] My changes have been rebased and squashed to the minimal number (typically 1) of relevant commits
- [x] My changes have a descriptive commit message with a short title, including a `Fixes $XXX -` or `Closes #XXX -` prefix to auto-close the issue that your PR addresses
