### PR TITLE
Stores and continues deep link flow when switch opens new window

### DIFF
--- a/src/commands/git/switch.ts
+++ b/src/commands/git/switch.ts
@@ -34,6 +34,7 @@ interface Context {
 
 interface State {
 	repos: string | string[] | Repository | Repository[];
+	onWorkspaceChanging?: (() => Promise<void>) | (() => void);
 	reference: GitReference;
 	createBranch?: string;
 	fastForwardTo?: GitReference;
@@ -239,6 +240,7 @@ export class SwitchGitCommand extends QuickCommand<State> {
 												})} is linked to a worktree`,
 										  },
 								},
+								onWorkspaceChanging: state.onWorkspaceChanging,
 								repo: state.repos[0],
 								skipWorktreeConfirmations: state.skipWorktreeConfirmations,
 							},
@@ -321,6 +323,7 @@ export class SwitchGitCommand extends QuickCommand<State> {
 									createBranch:
 										result === 'switchToNewBranchViaWorktree' ? state.createBranch : undefined,
 									repo: state.repos[0],
+									onWorkspaceChanging: state.onWorkspaceChanging,
 									skipWorktreeConfirmations: state.skipWorktreeConfirmations,
 								},
 							},

--- a/src/commands/git/worktree.ts
+++ b/src/commands/git/worktree.ts
@@ -97,6 +97,7 @@ interface CreateState {
 		title?: string;
 	};
 
+	onWorkspaceChanging?: (() => Promise<void>) | (() => void);
 	skipWorktreeConfirmations?: boolean;
 }
 
@@ -132,6 +133,7 @@ interface OpenState {
 		};
 	};
 
+	onWorkspaceChanging?: (() => Promise<void>) | (() => void);
 	skipWorktreeConfirmations?: boolean;
 }
 
@@ -614,6 +616,7 @@ export class WorktreeGitCommand extends QuickCommand<State> {
 						openOnly: true,
 						overrides: { disallowBack: true },
 						skipWorktreeConfirmations: state.skipWorktreeConfirmations,
+						onWorkspaceChanging: state.onWorkspaceChanging,
 					} satisfies OpenStepState,
 					context,
 				);
@@ -993,6 +996,11 @@ export class WorktreeGitCommand extends QuickCommand<State> {
 					name = `${repo.name}: ${state.worktree.name}`;
 				} else {
 					name = state.worktree.name;
+				}
+
+				const location = convertOpenFlagsToLocation(state.flags);
+				if (location === 'currentWindow' || location === 'newWindow') {
+					await state.onWorkspaceChanging?.();
 				}
 
 				openWorkspace(state.worktree.uri, { location: convertOpenFlagsToLocation(state.flags), name: name });

--- a/src/constants.ts
+++ b/src/constants.ts
@@ -12,6 +12,7 @@ import type { Integration } from './plus/integrations/integration';
 import type { IntegrationId } from './plus/integrations/providers/models';
 import type { TelemetryEventData } from './telemetry/telemetry';
 import type { TrackedUsage, TrackedUsageKeys } from './telemetry/usageTracker';
+import type { DeepLinkServiceState } from './uris/deepLinks/deepLink';
 
 export const extensionPrefix = 'gitlens';
 export const quickPickTitleMaxChars = 80;
@@ -1123,6 +1124,7 @@ export interface StoredDeepLinkContext {
 	targetSha?: string | undefined;
 	secondaryTargetSha?: string | undefined;
 	useProgress?: boolean | undefined;
+	state?: DeepLinkServiceState | undefined;
 }
 
 export interface StoredGraphColumn {

--- a/src/uris/deepLinks/deepLink.ts
+++ b/src/uris/deepLinks/deepLink.ts
@@ -204,6 +204,7 @@ export const enum DeepLinkServiceState {
 	OpenDraft,
 	OpenWorkspace,
 	OpenFile,
+	OpenInspect,
 	SwitchToRef,
 }
 
@@ -234,6 +235,7 @@ export const enum DeepLinkServiceAction {
 	OpenGraph,
 	OpenComparison,
 	OpenFile,
+	OpenInspect,
 	OpenSwitch,
 }
 
@@ -259,6 +261,7 @@ export interface DeepLinkServiceContext {
 	repoOpenLocation?: OpenWorkspaceLocation | undefined;
 	repoOpenUri?: Uri | undefined;
 	params?: URLSearchParams | undefined;
+	currentBranch?: string | undefined;
 }
 
 export const deepLinkStateTransitionTable: Record<string, Record<string, DeepLinkServiceState>> = {
@@ -285,6 +288,7 @@ export const deepLinkStateTransitionTable: Record<string, Record<string, DeepLin
 	},
 	[DeepLinkServiceState.RepoMatch]: {
 		[DeepLinkServiceAction.DeepLinkErrored]: DeepLinkServiceState.Idle,
+		[DeepLinkServiceAction.DeepLinkCancelled]: DeepLinkServiceState.Idle,
 		[DeepLinkServiceAction.RepoMatched]: DeepLinkServiceState.RemoteMatch,
 		[DeepLinkServiceAction.RepoMatchedInLocalMapping]: DeepLinkServiceState.CloneOrAddRepo,
 		[DeepLinkServiceAction.RepoMatchFailed]: DeepLinkServiceState.CloneOrAddRepo,
@@ -297,6 +301,7 @@ export const deepLinkStateTransitionTable: Record<string, Record<string, DeepLin
 	[DeepLinkServiceState.AddedRepoMatch]: {
 		[DeepLinkServiceAction.RepoMatched]: DeepLinkServiceState.RemoteMatch,
 		[DeepLinkServiceAction.DeepLinkErrored]: DeepLinkServiceState.Idle,
+		[DeepLinkServiceAction.DeepLinkCancelled]: DeepLinkServiceState.Idle,
 	},
 	[DeepLinkServiceState.RemoteMatch]: {
 		[DeepLinkServiceAction.DeepLinkErrored]: DeepLinkServiceState.Idle,
@@ -312,6 +317,7 @@ export const deepLinkStateTransitionTable: Record<string, Record<string, DeepLin
 	},
 	[DeepLinkServiceState.TargetMatch]: {
 		[DeepLinkServiceAction.DeepLinkErrored]: DeepLinkServiceState.Idle,
+		[DeepLinkServiceAction.DeepLinkCancelled]: DeepLinkServiceState.Idle,
 		[DeepLinkServiceAction.TargetMatched]: DeepLinkServiceState.MaybeOpenRepo,
 		[DeepLinkServiceAction.TargetMatchFailed]: DeepLinkServiceState.Fetch,
 	},
@@ -353,26 +359,38 @@ export const deepLinkStateTransitionTable: Record<string, Record<string, DeepLin
 	[DeepLinkServiceState.OpenGraph]: {
 		[DeepLinkServiceAction.DeepLinkResolved]: DeepLinkServiceState.Idle,
 		[DeepLinkServiceAction.DeepLinkErrored]: DeepLinkServiceState.Idle,
+		[DeepLinkServiceAction.DeepLinkCancelled]: DeepLinkServiceState.Idle,
 	},
 	[DeepLinkServiceState.OpenComparison]: {
 		[DeepLinkServiceAction.DeepLinkResolved]: DeepLinkServiceState.Idle,
 		[DeepLinkServiceAction.DeepLinkErrored]: DeepLinkServiceState.Idle,
+		[DeepLinkServiceAction.DeepLinkCancelled]: DeepLinkServiceState.Idle,
 	},
 	[DeepLinkServiceState.OpenDraft]: {
 		[DeepLinkServiceAction.DeepLinkResolved]: DeepLinkServiceState.Idle,
 		[DeepLinkServiceAction.DeepLinkErrored]: DeepLinkServiceState.Idle,
+		[DeepLinkServiceAction.DeepLinkCancelled]: DeepLinkServiceState.Idle,
 	},
 	[DeepLinkServiceState.OpenWorkspace]: {
 		[DeepLinkServiceAction.DeepLinkResolved]: DeepLinkServiceState.Idle,
 		[DeepLinkServiceAction.DeepLinkErrored]: DeepLinkServiceState.Idle,
+		[DeepLinkServiceAction.DeepLinkCancelled]: DeepLinkServiceState.Idle,
 	},
 	[DeepLinkServiceState.OpenFile]: {
 		[DeepLinkServiceAction.DeepLinkResolved]: DeepLinkServiceState.Idle,
 		[DeepLinkServiceAction.DeepLinkErrored]: DeepLinkServiceState.Idle,
+		[DeepLinkServiceAction.DeepLinkCancelled]: DeepLinkServiceState.Idle,
 	},
-	[DeepLinkServiceState.SwitchToRef]: {
+	[DeepLinkServiceState.OpenInspect]: {
 		[DeepLinkServiceAction.DeepLinkResolved]: DeepLinkServiceState.Idle,
 		[DeepLinkServiceAction.DeepLinkErrored]: DeepLinkServiceState.Idle,
+		[DeepLinkServiceAction.DeepLinkCancelled]: DeepLinkServiceState.Idle,
+	},
+	[DeepLinkServiceState.SwitchToRef]: {
+		[DeepLinkServiceAction.OpenInspect]: DeepLinkServiceState.OpenInspect,
+		[DeepLinkServiceAction.DeepLinkResolved]: DeepLinkServiceState.Idle,
+		[DeepLinkServiceAction.DeepLinkErrored]: DeepLinkServiceState.Idle,
+		[DeepLinkServiceAction.DeepLinkCancelled]: DeepLinkServiceState.Idle,
 	},
 };
 
@@ -402,5 +420,6 @@ export const deepLinkStateToProgress: Record<string, DeepLinkProgress> = {
 	[DeepLinkServiceState.OpenDraft]: { message: 'Opening cloud patch...', increment: 90 },
 	[DeepLinkServiceState.OpenWorkspace]: { message: 'Opening workspace...', increment: 90 },
 	[DeepLinkServiceState.OpenFile]: { message: 'Opening file...', increment: 90 },
+	[DeepLinkServiceState.OpenInspect]: { message: 'Opening inspect...', increment: 90 },
 	[DeepLinkServiceState.SwitchToRef]: { message: 'Switching to ref...', increment: 90 },
 };

--- a/src/uris/deepLinks/deepLinkService.ts
+++ b/src/uris/deepLinks/deepLinkService.ts
@@ -10,7 +10,6 @@ import { getBranchNameWithoutRemote } from '../../git/models/branch';
 import type { GitCommit } from '../../git/models/commit';
 import type { GitReference } from '../../git/models/reference';
 import { createReference, isSha } from '../../git/models/reference';
-import { Repository } from '../../git/models/repository';
 import type { GitTag } from '../../git/models/tag';
 import { parseGitRemoteUrl } from '../../git/parsers/remoteParser';
 import type { RepositoryIdentity } from '../../gk/models/repositoryIdentities';
@@ -1312,21 +1311,25 @@ export class DeepLinkService implements Disposable {
 							break;
 						}
 
-						// Storing link info in case the switch causes a new window to open
-						await this.container.storage.store('deepLinks:pending', {
+						const pendingDeepLink = {
 							url: this._context.url,
 							repoPath: repo.path,
 							targetSha: this._context.targetSha,
 							secondaryTargetSha: this._context.secondaryTargetSha,
 							useProgress: useProgress,
 							state: this._context.state,
-						});
+						};
+
+						// Storing link info in case the switch causes a new window to open
+						const onWorkspaceChanging = async () =>
+							this.container.storage.store('deepLinks:pending', pendingDeepLink);
 
 						await executeGitCommand({
 							command: 'switch',
 							state: {
 								repos: repo,
 								reference: ref,
+								onWorkspaceChanging: onWorkspaceChanging,
 								skipWorktreeConfirmations:
 									this._context.action === DeepLinkActionType.SwitchToPullRequestWorktree,
 							},


### PR DESCRIPTION
Completes:  GLVSC-595

When we use "switch to" or "open worktree in new window" on a Launchpad item, and that action opens a new window (as a result of the "switch" operation), currently the last remaining part (open the inspect view, in review mode if appropriate) doesn't happen because the new window loses the deep link context.

This is tricky to fix, because the deep link service is not aware of the user's decision while it is awaiting the completion of the 'switch' command.

This solution addresses the issue as follows:
1. Expands the "stored deep link" to include a state representing where the link left off. Optional and if not provided, default is "repo opening".
2. Whenever the deep link needs to use the switch command, it first stores a pending deep link *just in case* a new window will be opened as a result of the switch, and includes the current state ("switch to ref") in the stored link.
3. It then performs the switch. It detects if a new window was opened by checking the "current branch" name from before the switch command run to after. If the current branch wasn't changed, either the switch was canceled or the switch continued in a new window, so it resolves itself.
4. The "process pending deep link" logic was expanded to account for this state. Its repo matching was also expanded because we can't rely on repo path to find the right repo if we opened a worktree, which is now in a different folder.
5. At the new "open inspect" step we always clear the stored deep link because if the link got here, either we already processed the stored link or we did not use it (the user successfully completed the switch in the current context).

I also snuck in some extra cases where cancelling the deep link wasn't being handled in the state transition table.

Unfortunately, this one can't be tested in a debug window. To test "new window" flows, I generate a VSIX using `yarn package', install it and test with it.