### PR TITLE
Fixes multiple patch creation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,7 +9,7 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/) and this p
 ### Fixed
 
 - Fixes cloud patch creation error on azure repos
-- Fixes multiple patch creation
+- Fixes [#3414](https://github.com/gitkraken/vscode-gitlens/issues/3414) - Patch creation may be done multiple times
 
 ## [15.2.1] - 2024-07-24
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/) and this p
 ### Fixed
 
 - Fixes cloud patch creation error on azure repos
+- Fixes multiple patch creation
 
 ## [15.2.1] - 2024-07-24
 

--- a/src/plus/webviews/patchDetails/patchDetailsWebview.ts
+++ b/src/plus/webviews/patchDetails/patchDetailsWebview.ts
@@ -718,7 +718,7 @@ export class PatchDetailsWebviewProvider
 			this.closeView();
 		} catch (ex) {
 			debugger;
-
+			void this.notifyDidChangeCreateDraftState();
 			void window.showErrorMessage(`Unable to create draft: ${ex.message}`);
 		}
 	}

--- a/src/webviews/apps/plus/patchDetails/components/gl-patch-create.ts
+++ b/src/webviews/apps/plus/patchDetails/components/gl-patch-create.ts
@@ -76,6 +76,9 @@ export class GlPatchCreate extends GlTreeBase {
 	@state()
 	generateBusy = false;
 
+	@state()
+	creationBusy = false;
+
 	// @state()
 	// patchTitle = this.create.title ?? '';
 
@@ -143,6 +146,9 @@ export class GlPatchCreate extends GlTreeBase {
 	}
 
 	override updated(changedProperties: Map<string, any>) {
+		if (changedProperties.has('state')) {
+			this.creationBusy = false;
+		}
 		if (changedProperties.has('generate')) {
 			this.generateBusy = false;
 			this.generateAiButton.scrollIntoView();
@@ -333,7 +339,7 @@ export class GlPatchCreate extends GlTreeBase {
 				</div>
 				<p class="button-container">
 					<span class="button-group button-group--single">
-						<gl-button full @click=${(e: Event) => this.onDebouncedCreateAll(e)}
+						<gl-button ?disabled=${this.creationBusy} full @click=${(e: Event) => this.onCreateAll(e)}
 							>Create ${draftName}</gl-button
 						>
 					</span>
@@ -628,9 +634,11 @@ export class GlPatchCreate extends GlTreeBase {
 		// }
 		// this.createPatch([change]);
 		this.createPatch();
+		if (!this.state?.create) {
+			return;
+		}
+		this.creationBusy = true;
 	}
-
-	private onDebouncedCreateAll = debounce(this.onCreateAll, 250);
 
 	private onSelectCreateOption(_e: CustomEvent<{ target: MenuItem }>) {
 		// const target = e.detail?.target;


### PR DESCRIPTION
# Description

Disables `create {draftName}` button after first click

Then, enable if creation has been failed

https://github.com/user-attachments/assets/52a213d9-f221-4803-aa5f-a684b1684677

No need to reactivate the button if the creation is success

https://github.com/user-attachments/assets/9cbe32f4-c236-416a-b29b-fc7a1d5af5cf



# Checklist

<!-- Please check off the following -->

- [x] I have followed the guidelines in the Contributing document
- [x] My changes follow the coding style of this project
- [x] My changes build without any errors or warnings
- [x] My changes have been formatted and linted
- [x] My changes include any required corresponding changes to the documentation (including CHANGELOG.md and README.md)
- [x] My changes have been rebased and squashed to the minimal number (typically 1) of relevant commits
- [x] My changes have a descriptive commit message with a short title, including a `Fixes $XXX -` or `Closes #XXX -` prefix to auto-close the issue that your PR addresses
