### PR TITLE
Adds option to display first name only on inline blame

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/) and this p
 ### Added
 
 - Adds a `gitlens.views.showCurrentBranchOnTop` setting to specify whether the current branch is shown at the top of the views &mdash; closes [#3520](https://github.com/gitkraken/vscode-gitlens/issues/3520)
+- Adds option to display first name only on inline blame
 
 ### Fixed
 

--- a/package.json
+++ b/package.json
@@ -78,6 +78,13 @@
 						"scope": "window",
 						"order": 10
 					},
+					"gitlens.currentLine.fullUserName.enabled": {
+						"type": "boolean",
+						"default": true,
+						"markdownDescription": "Specifies whether to provide a full name of user to inline blame annotation for the current line.",
+						"scope": "window",
+						"order": 15
+					},
 					"gitlens.currentLine.pullRequests.enabled": {
 						"type": "boolean",
 						"default": true,

--- a/src/annotations/lineAnnotationController.ts
+++ b/src/annotations/lineAnnotationController.ts
@@ -323,6 +323,7 @@ export class LineAnnotationController implements Disposable {
 						getBranchAndTagTips: getBranchAndTagTips,
 						pullRequest: pr?.value,
 						pullRequestPendingMessage: `PR ${GlyphChars.Ellipsis}`,
+						authorShortStyle: !cfg.fullUserName.enabled,
 					},
 					fontOptions,
 					cfg.scrollable,

--- a/src/config.ts
+++ b/src/config.ts
@@ -29,6 +29,7 @@ export interface Config {
 		readonly fontStyle: string;
 		readonly fontWeight: string;
 		readonly format: string;
+		readonly fullName: string;
 		readonly heatmap: {
 			readonly enabled: boolean;
 			readonly location: 'left' | 'right';
@@ -63,6 +64,9 @@ export interface Config {
 		readonly fontStyle: string;
 		readonly fontWeight: string;
 		readonly format: string;
+		readonly fullUserName: {
+			readonly enabled: boolean;
+		};
 		readonly pullRequests: {
 			readonly enabled: boolean;
 		};

--- a/src/git/formatters/commitFormatter.ts
+++ b/src/git/formatters/commitFormatter.ts
@@ -47,6 +47,7 @@ export interface CommitFormatOptions extends FormatOptions {
 	dateStyle?: DateStyle;
 	editor?: { line: number; uri: Uri };
 	footnotes?: Map<number, string>;
+	authorShortStyle?: boolean;
 	getBranchAndTagTips?: (sha: string, options?: { compact?: boolean; icons?: boolean }) => string | undefined;
 	htmlFormat?: {
 		classes?: {
@@ -201,6 +202,9 @@ export class CommitFormatter extends Formatter<GitCommit, CommitFormatOptions> {
 
 	get author(): string {
 		let { name, email } = this._item.author;
+		if (this._options.authorShortStyle) {
+			name = name.split(' ')[0];
+		}
 		const author = this._padOrTruncate(name, this._options.tokenOptions.author);
 
 		switch (this._options.outputFormat) {


### PR DESCRIPTION
# Description


https://github.com/user-attachments/assets/9ab28094-c491-426a-9fb9-88dbe7591542


# Checklist

<!-- Please check off the following -->

- [x] I have followed the guidelines in the Contributing document
- [x] My changes follow the coding style of this project
- [x] My changes build without any errors or warnings
- [x] My changes have been formatted and linted
- [x] My changes include any required corresponding changes to the documentation (including CHANGELOG.md and README.md)
- [x] My changes have been rebased and squashed to the minimal number (typically 1) of relevant commits
- [x] My changes have a descriptive commit message with a short title, including a `Fixes $XXX -` or `Closes #XXX -` prefix to auto-close the issue that your PR addresses
