### PR TITLE
Check subscription even if users cannot check in (GLVSC-593)

### DIFF
--- a/src/plus/gk/account/subscriptionService.ts
+++ b/src/plus/gk/account/subscriptionService.ts
@@ -874,6 +874,9 @@ export class SubscriptionService implements Disposable {
 
 			Logger.error(ex, scope);
 			debugger;
+
+			// If we cannot check in, validate stored subscription
+			this.changeSubscription(this._subscription);
 			if (ex instanceof AccountValidationError) throw ex;
 
 			throw new AccountValidationError('Unable to validate account', ex);


### PR DESCRIPTION
# Description

With this little change, we will validate the current subscription even if check-in fails or user is offline.
I tested this forcing a free account that expired yesterday into an offline client. In this case, GitLens checks if the stored license is valid even if it cannot check-in online to retrieve the latest information about the user's license.

# Checklist

<!-- Please check off the following -->

- [x] I have followed the guidelines in the Contributing document
- [x] My changes follow the coding style of this project
- [x] My changes build without any errors or warnings
- [x] My changes have been formatted and linted
- [x] My changes have been rebased and squashed to the minimal number (typically 1) of relevant commits
- [x] My changes have a descriptive commit message with a short title, including a `Fixes $XXX -` or `Closes #XXX -` prefix to auto-close the issue that your PR addresses
