### PR TITLE
Consolidates similar code to integration.connect GLVSC-591

### DIFF
--- a/src/constants.ts
+++ b/src/constants.ts
@@ -883,10 +883,13 @@ export type SupportedAIModels =
 	| 'vscode';
 
 export type SecretKeys =
-	| `gitlens.integration.auth:${IntegrationId}|${string}`
-	| `gitlens.integration.auth.cloud:${IntegrationId}|${string}`
+	| IntegrationAuthenticationKeys
 	| `gitlens.${AIProviders}.key`
 	| `gitlens.plus.auth:${Environment}`;
+
+export type IntegrationAuthenticationKeys =
+	| `gitlens.integration.auth:${IntegrationId}|${string}`
+	| `gitlens.integration.auth.cloud:${IntegrationId}|${string}`;
 
 export const enum SyncedStorageKeys {
 	Version = 'gitlens:synced:version',

--- a/src/plus/focus/focus.ts
+++ b/src/plus/focus/focus.ts
@@ -41,7 +41,6 @@ import { getScopedCounter } from '../../system/counter';
 import { fromNow } from '../../system/date';
 import { interpolate, pluralize } from '../../system/string';
 import { openUrl } from '../../system/utils';
-import { isSupportedCloudIntegrationId } from '../integrations/authentication/models';
 import type { IntegrationId } from '../integrations/providers/models';
 import {
 	HostingIntegrationId,
@@ -179,19 +178,7 @@ export class FocusCommand extends QuickCommand<State> {
 		const integration = await this.container.integrations.get(id);
 		let connected = integration.maybeConnected ?? (await integration.isConnected());
 		if (!connected) {
-			if (isSupportedCloudIntegrationId(integration.id)) {
-				await this.container.integrations.manageCloudIntegrations(
-					{ integrationId: integration.id },
-					{
-						source: 'launchpad',
-						detail: {
-							action: 'connect',
-							integration: integration.id,
-						},
-					},
-				);
-			}
-			connected = await integration.connect();
+			connected = await integration.connect('launchpad');
 		}
 
 		return connected;

--- a/src/plus/focus/focusIndicator.ts
+++ b/src/plus/focus/focusIndicator.ts
@@ -567,18 +567,7 @@ export class FocusIndicator implements Disposable {
 						const github = await this.container.integrations?.get(HostingIntegrationId.GitHub);
 						if (github == null) break;
 						if (!(github.maybeConnected ?? (await github.isConnected()))) {
-							// TODO: Add back in once we switch GitHub to use the cloud
-							/* await this.container.integrations.manageCloudIntegrations(
-								{ integrationId: HostingIntegrationId.GitHub },
-								{
-									source: 'launchpad-indicator',
-									detail: {
-										action: 'connect',
-										integration: HostingIntegrationId.GitHub,
-									},
-								},
-							); */
-							void github.connect();
+							void github.connect('launchpad-indicator');
 						}
 						break;
 					}

--- a/src/plus/integrations/authentication/integrationAuthentication.ts
+++ b/src/plus/integrations/authentication/integrationAuthentication.ts
@@ -145,11 +145,11 @@ abstract class IntegrationAuthenticationProviderBase<ID extends IntegrationId = 
 export abstract class LocalIntegrationAuthenticationProvider<
 	ID extends IntegrationId = IntegrationId,
 > extends IntegrationAuthenticationProviderBase<ID> {
-	protected async deleteAllSecrets(sessionId: string) {
+	protected override async deleteAllSecrets(sessionId: string) {
 		await this.deleteSecret(this.getLocalSecretKey(sessionId));
 	}
 
-	protected async storeSession(sessionId: string, session: AuthenticationSession) {
+	protected override async storeSession(sessionId: string, session: AuthenticationSession) {
 		await this.writeSecret(this.getLocalSecretKey(sessionId), session);
 	}
 
@@ -183,7 +183,7 @@ export abstract class CloudIntegrationAuthenticationProvider<
 		await this.deleteSecret(key);
 	}
 
-	protected async deleteAllSecrets(sessionId: string) {
+	protected override async deleteAllSecrets(sessionId: string) {
 		await Promise.allSettled([
 			this.deleteSecret(this.getLocalSecretKey(sessionId)),
 			this.deleteSecret(this.getCloudSecretKey(sessionId)),

--- a/src/plus/integrations/authentication/integrationAuthentication.ts
+++ b/src/plus/integrations/authentication/integrationAuthentication.ts
@@ -1,7 +1,7 @@
 import type { AuthenticationSession, CancellationToken, Disposable, Uri } from 'vscode';
 import { authentication, CancellationTokenSource, window } from 'vscode';
 import { wrapForForcedInsecureSSL } from '@env/fetch';
-import type { SecretKeys } from '../../../constants';
+import type { IntegrationAuthenticationKeys } from '../../../constants';
 import type { Container } from '../../../container';
 import { debug, log } from '../../../system/decorators/log';
 import type { DeferredEventExecutor } from '../../../system/event';
@@ -68,15 +68,18 @@ abstract class IntegrationAuthenticationProviderBase<ID extends IntegrationId = 
 		ignoreErrors: boolean;
 	}): Promise<StoredSession | undefined>;
 
-	protected async deleteSecret(key: SecretKeys) {
+	protected async deleteSecret(key: IntegrationAuthenticationKeys) {
 		await this.container.storage.deleteSecret(key);
 	}
 
-	protected async writeSecret(key: SecretKeys, session: AuthenticationSession | StoredSession) {
+	protected async writeSecret(key: IntegrationAuthenticationKeys, session: AuthenticationSession | StoredSession) {
 		await this.container.storage.storeSecret(key, JSON.stringify(session));
 	}
 
-	protected async readSecret(key: SecretKeys, ignoreErrors: boolean): Promise<StoredSession | undefined> {
+	protected async readSecret(
+		key: IntegrationAuthenticationKeys,
+		ignoreErrors: boolean,
+	): Promise<StoredSession | undefined> {
 		let storedSession: StoredSession | undefined;
 		try {
 			const sessionJSON = await this.container.storage.getSecret(key);

--- a/src/plus/integrations/authentication/integrationAuthentication.ts
+++ b/src/plus/integrations/authentication/integrationAuthentication.ts
@@ -181,7 +181,7 @@ export abstract class CloudIntegrationAuthenticationProvider<
 	}
 
 	protected async deleteAllSecrets(sessionId: string) {
-		await Promise.all([
+		await Promise.allSettled([
 			this.deleteSecret(this.getLocalSecretKey(sessionId)),
 			this.deleteSecret(this.getCloudSecretKey(sessionId)),
 		]);
@@ -215,7 +215,7 @@ export abstract class CloudIntegrationAuthenticationProvider<
 			// store with the "cloud" type key, and then use that one
 			//
 			if (session.expiresAt != null) {
-				await Promise.all([
+				await Promise.allSettled([
 					this.deleteSecret(this.getLocalSecretKey(sessionId)),
 					this.writeSecret(this.getCloudSecretKey(sessionId), session),
 				]);

--- a/src/plus/integrations/integration.ts
+++ b/src/plus/integrations/integration.ts
@@ -2,6 +2,7 @@ import type { CancellationToken, Event, MessageItem } from 'vscode';
 import { EventEmitter, window } from 'vscode';
 import type { DynamicAutolinkReference } from '../../annotations/autolinks';
 import type { AutolinkReference } from '../../config';
+import type { Sources } from '../../constants';
 import type { Container } from '../../container';
 import { AuthenticationError, CancellationError, ProviderRequestClientError } from '../../errors';
 import type { PagedResult } from '../../git/gitProvider';
@@ -29,6 +30,7 @@ import type {
 } from './authentication/integrationAuthentication';
 import { CloudIntegrationAuthenticationProvider } from './authentication/integrationAuthentication';
 import type { ProviderAuthenticationSession } from './authentication/models';
+import { isSupportedCloudIntegrationId } from './authentication/models';
 import type {
 	GetIssuesOptions,
 	GetPullRequestsOptions,
@@ -136,10 +138,28 @@ export abstract class IntegrationBase<
 	}
 
 	@log()
-	async connect(): Promise<boolean> {
+	async connect(source?: Sources): Promise<boolean> {
 		try {
-			const session = await this.ensureSession(true);
-			return Boolean(session);
+			// Some integrations does not require managmement of Cloud Integrations (e.g. GitHub that can take a built-in VS Code session),
+			// therefore we try to connect them right away.
+			// Only if our attempt fails, we fall to manageCloudIntegrations flow.
+			let connected = Boolean(await this.ensureSession(true));
+			if (!connected) {
+				if (isSupportedCloudIntegrationId(this.id)) {
+					await this.container.integrations.manageCloudIntegrations(
+						{ integrationId: this.id, skipIfConnected: true },
+						{
+							source: source || 'integrations',
+							detail: {
+								action: 'connect',
+								integration: this.id,
+							},
+						},
+					);
+					connected = Boolean(await this.ensureSession(true));
+				}
+			}
+			return connected;
 		} catch (ex) {
 			return false;
 		}


### PR DESCRIPTION
# Description

This is the solution of this issue: #3379 (GLVSC-591)

- Consolidates similar code to integration.connect call to hide that complexity
- Restricts the key params to be a subset of SecretKeys to avoid something else getting in there https://github.com/gitkraken/vscode-gitlens/blob/305d406cc7fe4247ad3cfae86cb860b87b4659ef/src/plus/integrations/authentication/integrationAuthentication.ts#L71-L96
- Replaces `Promise.all` and uses `Promose.allSettled` when we want to wait for everything

# Checklist

<!-- Please check off the following -->

- [x] I have followed the guidelines in the Contributing document
- [x] My changes follow the coding style of this project
- [x] My changes build without any errors or warnings
- [x] My changes have been formatted and linted
- [x] My changes include any required corresponding changes to the documentation (including CHANGELOG.md and README.md)
- [x] My changes have been rebased and squashed to the minimal number (typically 1) of relevant commits
- [x] My changes have a descriptive commit message with a short title, including a `Fixes $XXX -` or `Closes #XXX -` prefix to auto-close the issue that your PR addresses
