### PR TITLE
Enable GitHub authentication in gk.dev and hide it behind a config [GLVSC-618]

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/) and this p
 
 - Shows GitLab merge requests in the _Launchpad_ when GitLab integration is connected
 - Adds a new "Connect" button to the _Launchpad_ that allows the user to connect additional integrations.
+- Adds `gitlens.experimental.cloudIntegrations.github.enabled` setting to connect GitHub integration using cloud integration of GitKraken account.
 
 ## [15.2.3] - 2024-07-26
 

--- a/package.json
+++ b/package.json
@@ -3367,6 +3367,13 @@
 						"scope": "window",
 						"order": 20
 					},
+					"gitlens.experimental.cloudIntegrations.github.enabled": {
+						"type": "boolean",
+						"default": false,
+						"markdownDescription": "Specifies whether to use the GitKraken cloud integration when authenticating with GitHub",
+						"scope": "window",
+						"order": 30
+					},
 					"gitlens.remotes": {
 						"type": [
 							"array",

--- a/src/config.ts
+++ b/src/config.ts
@@ -82,6 +82,11 @@ export interface Config {
 		readonly generateCommitMessagePrompt: string;
 		readonly generateCloudPatchMessagePrompt: string;
 		readonly generateCodeSuggestionMessagePrompt: string;
+		readonly cloudIntegrations: {
+			readonly github: {
+				readonly enabled: boolean;
+			};
+		};
 	};
 	readonly fileAnnotations: {
 		readonly preserveWhileEditing: boolean;

--- a/src/plus/integrations/authentication/integrationAuthentication.ts
+++ b/src/plus/integrations/authentication/integrationAuthentication.ts
@@ -239,12 +239,12 @@ export abstract class CloudIntegrationAuthenticationProvider<
 		descriptor?: IntegrationAuthenticationSessionDescriptor,
 		options?: { createIfNeeded?: boolean; forceNewSession?: boolean },
 	): Promise<ProviderAuthenticationSession | undefined> {
-		const session = await super.getSession(descriptor, options);
-		if (session != null) return session;
-
 		// by default getBuiltInExistingSession returns undefined
 		// but specific providers can override it to return a session (e.g. GitHub)
-		return this.getBuiltInExistingSession(descriptor);
+		const existingSession = await this.getBuiltInExistingSession(descriptor);
+		if (existingSession != null) return existingSession;
+
+		return super.getSession(descriptor, options);
 	}
 
 	protected override async createSession(

--- a/src/plus/integrations/authentication/integrationAuthentication.ts
+++ b/src/plus/integrations/authentication/integrationAuthentication.ts
@@ -15,6 +15,7 @@ import {
 	supportedIntegrationIds,
 } from '../providers/models';
 import type { ProviderAuthenticationSession } from './models';
+import { isSupportedCloudIntegrationId } from './models';
 
 interface StoredSession {
 	id: string;
@@ -438,6 +439,14 @@ export class IntegrationAuthenticationService implements Disposable {
 					provider = new (
 						await import(/* webpackChunkName: "integrations" */ './bitbucket')
 					).BitbucketAuthenticationProvider(this.container);
+					break;
+				case HostingIntegrationId.GitHub:
+					provider = isSupportedCloudIntegrationId(HostingIntegrationId.GitHub)
+						? new (
+								await import(/* webpackChunkName: "integrations" */ './github')
+						  ).GitHubAuthenticationProvider(this.container)
+						: new BuiltInAuthenticationProvider(this.container, providerId);
+
 					break;
 				case SelfHostedIntegrationId.GitHubEnterprise:
 					provider = new (

--- a/src/plus/integrations/authentication/models.ts
+++ b/src/plus/integrations/authentication/models.ts
@@ -1,4 +1,5 @@
 import type { AuthenticationSession } from 'vscode';
+import { configuration } from '../../../system/configuration';
 import type { IntegrationId } from '../providers/models';
 import { HostingIntegrationId, IssueIntegrationId, SelfHostedIntegrationId } from '../providers/models';
 
@@ -30,11 +31,25 @@ export type CloudIntegrationAuthType = 'oauth' | 'pat';
 
 export const CloudIntegrationAuthenticationUriPathPrefix = 'did-authenticate-cloud-integration';
 
-export const supportedCloudIntegrationIds = [IssueIntegrationId.Jira];
-export type SupportedCloudIntegrationIds = (typeof supportedCloudIntegrationIds)[number];
+const supportedCloudIntegrationIds = [IssueIntegrationId.Jira];
+const supportedCloudIntegrationIdsExperimental = [IssueIntegrationId.Jira, HostingIntegrationId.GitHub];
+
+export type SupportedCloudIntegrationIds = (typeof supportedCloudIntegrationIdsExperimental)[number];
 
 export function isSupportedCloudIntegrationId(id: string): id is SupportedCloudIntegrationIds {
-	return supportedCloudIntegrationIds.includes(id as SupportedCloudIntegrationIds);
+	const ids = configuration.get('experimental.cloudIntegrations.github.enabled', undefined, false)
+		? supportedCloudIntegrationIdsExperimental
+		: supportedCloudIntegrationIds;
+	return ids.includes(id as SupportedCloudIntegrationIds);
+}
+
+export function* iterateSupportedCloudIntegrationIds() {
+	const ids = configuration.get('experimental.cloudIntegrations.github.enabled', undefined, false)
+		? supportedCloudIntegrationIdsExperimental
+		: supportedCloudIntegrationIds;
+	for (const id of ids) {
+		yield id;
+	}
 }
 
 export const toIntegrationId: { [key in CloudIntegrationType]: IntegrationId } = {

--- a/src/plus/integrations/integrationService.ts
+++ b/src/plus/integrations/integrationService.ts
@@ -18,7 +18,11 @@ import { openUrl } from '../../system/utils';
 import type { SubscriptionChangeEvent } from '../gk/account/subscriptionService';
 import type { IntegrationAuthenticationService } from './authentication/integrationAuthentication';
 import type { SupportedCloudIntegrationIds } from './authentication/models';
-import { isSupportedCloudIntegrationId, supportedCloudIntegrationIds, toIntegrationId } from './authentication/models';
+import {
+	isSupportedCloudIntegrationId,
+	iterateSupportedCloudIntegrationIds,
+	toIntegrationId,
+} from './authentication/models';
 import type {
 	HostingIntegration,
 	Integration,
@@ -87,7 +91,7 @@ export class IntegrationService implements Disposable {
 			connectedProviders = new Set(connections.map(p => toIntegrationId[p.provider]));
 		}
 
-		for (const cloudIntegrationId of supportedCloudIntegrationIds) {
+		for (const cloudIntegrationId of iterateSupportedCloudIntegrationIds()) {
 			const integration = await this.get(cloudIntegrationId);
 			const isConnected = integration.maybeConnected ?? (await integration.isConnected());
 			if (connectedProviders.has(cloudIntegrationId)) {


### PR DESCRIPTION
# Description

1. Get GitHub connection to GKDev active again
2. Hide it behind a config
3. Access local token before checking the remote

# Checklist

<!-- Please check off the following -->

- [x] I have followed the guidelines in the Contributing document
- [x] My changes follow the coding style of this project
- [x] My changes build without any errors or warnings
- [x] My changes have been formatted and linted
- [x] My changes include any required corresponding changes to the documentation (including CHANGELOG.md and README.md)
- [x] My changes have been rebased and squashed to the minimal number (typically 1) of relevant commits
- [x] My changes have a descriptive commit message with a short title, including a `Fixes $XXX -` or `Closes #XXX -` prefix to auto-close the issue that your PR addresses
