### PR TITLE
bugfix: Column resizing gets stuck when your mouse leaves the graph (GLVSC-610)

### DIFF
--- a/src/webviews/apps/plus/graph/GraphWrapper.tsx
+++ b/src/webviews/apps/plus/graph/GraphWrapper.tsx
@@ -477,6 +477,14 @@ export function GraphWrapper({
 
 	const handleOnGraphMouseLeave = (_event: React.MouseEvent<any>) => {
 		minimap.current?.unselect(undefined, true);
+
+		document.dispatchEvent(
+			new MouseEvent('mouseup', {
+				view: window,
+				bubbles: true,
+				cancelable: false,
+			}),
+		);
 	};
 
 	const handleOnGraphRowHovered = (

--- a/src/webviews/apps/plus/graph/GraphWrapper.tsx
+++ b/src/webviews/apps/plus/graph/GraphWrapper.tsx
@@ -475,16 +475,23 @@ export function GraphWrapper({
 		}
 	};
 
-	const handleOnGraphMouseLeave = (_event: React.MouseEvent<any>) => {
-		minimap.current?.unselect(undefined, true);
+	const stopColumnResize = () => {
+		const activeResizeElement = document.querySelector('.graph-header .resizable.resizing');
+		if (!activeResizeElement) return;
 
+		// Trigger a mouseup event to reset the column resize state
 		document.dispatchEvent(
 			new MouseEvent('mouseup', {
 				view: window,
 				bubbles: true,
-				cancelable: false,
+				cancelable: true,
 			}),
 		);
+	};
+
+	const handleOnGraphMouseLeave = (_event: React.MouseEvent<any>) => {
+		minimap.current?.unselect(undefined, true);
+		stopColumnResize();
 	};
 
 	const handleOnGraphRowHovered = (

--- a/src/webviews/apps/plus/graph/graph.scss
+++ b/src/webviews/apps/plus/graph/graph.scss
@@ -1031,6 +1031,14 @@ gl-feature-gate gl-feature-badge {
 	}
 }
 
+.graph-app:not(:hover) {
+	.gk-graph .graph-header {
+		& .resizable-handle.horizontal:before {
+			display: none;
+		}
+	}
+}
+
 .graph-container {
 	& .resizable-handle.horizontal {
 		display: none;


### PR DESCRIPTION
# Description

The drag event would get stuck if you kept dragging the resize handle outside the graph.
Creating a `mouseup` event when leaving the graph zone will release the resize event.
This behavior simulates what GKD does.

Before the fix:

https://github.com/user-attachments/assets/8716f315-5670-412d-9eed-f20280c7b049

After the fix:

https://github.com/user-attachments/assets/2aa228b5-8de3-4d64-ad03-0b7dc8f4c983

GKD's behavior:

https://github.com/user-attachments/assets/5a69d258-dfd5-4ff0-9505-a40096d48ee1


# Checklist

<!-- Please check off the following -->

- [x] I have followed the guidelines in the Contributing document
- [x] My changes follow the coding style of this project
- [x] My changes build without any errors or warnings
- [x] My changes have been formatted and linted
- [x] My changes have been rebased and squashed to the minimal number (typically 1) of relevant commits
- [x] My changes have a descriptive commit message with a short title, including a `Fixes $XXX -` or `Closes #XXX -` prefix to auto-close the issue that your PR addresses
