### PR TITLE
Adds Launchpad view (wip)

### DIFF
--- a/package.json
+++ b/package.json
@@ -14551,23 +14551,23 @@
 				},
 				{
 					"command": "gitlens.views.openPullRequestChanges",
-					"when": "viewItem =~ /gitlens:pullrequest\\b(?=.*?\\b\\+refs\\b)/ && config.multiDiffEditor.experimental.enabled",
+					"when": "viewItem =~ /gitlens:(pullrequest\\b(?=.*?\\b\\+refs\\b)|launchpad:item\\b(?=.*?\\b\\+pr\\b))/ && config.multiDiffEditor.experimental.enabled",
 					"group": "inline@2"
 				},
 				{
 					"command": "gitlens.views.openPullRequestComparison",
-					"when": "viewItem =~ /gitlens:pullrequest\\b(?=.*?\\b\\+refs\\b)/",
+					"when": "viewItem =~ /gitlens:(pullrequest\\b(?=.*?\\b\\+refs\\b)|launchpad:item\\b(?=.*?\\b\\+pr\\b))/",
 					"group": "inline@3"
 				},
 				{
 					"command": "gitlens.openPullRequestOnRemote",
-					"when": "viewItem =~ /gitlens:pullrequest\\b/",
+					"when": "viewItem =~ /gitlens:(pullrequest\\b|launchpad:item\\b(?=.*?\\b\\+pr\\b))/",
 					"group": "inline@99",
 					"alt": "gitlens.copyRemotePullRequestUrl"
 				},
 				{
 					"command": "gitlens.views.openPullRequestChanges",
-					"when": "!listMultiSelection && viewItem =~ /gitlens:pullrequest\\b(?=.*?\\b\\+refs\\b)/ && config.multiDiffEditor.experimental.enabled",
+					"when": "!listMultiSelection && viewItem =~ /gitlens:(pullrequest\\b(?=.*?\\b\\+refs\\b)|launchpad:item\\b(?=.*?\\b\\+pr\\b))/ && config.multiDiffEditor.experimental.enabled",
 					"group": "1_gitlens_actions@1"
 				},
 				{
@@ -14577,7 +14577,7 @@
 				},
 				{
 					"command": "gitlens.openPullRequestOnRemote",
-					"when": "!listMultiSelection && viewItem =~ /gitlens:pullrequest\\b/",
+					"when": "!listMultiSelection && viewItem =~ /gitlens:(pullrequest\\b|launchpad:item\\b(?=.*?\\b\\+pr\\b))/",
 					"group": "1_gitlens_actions@99"
 				},
 				{
@@ -14587,13 +14587,8 @@
 				},
 				{
 					"command": "gitlens.views.openPullRequestComparison",
-					"when": "!listMultiSelection && viewItem =~ /gitlens:pullrequest\\b(?=.*?\\b\\+refs\\b)/",
+					"when": "!listMultiSelection && viewItem =~ /gitlens:(pullrequest\\b(?=.*?\\b\\+refs\\b)|launchpad:item\\b(?=.*?\\b\\+pr\\b))/",
 					"group": "4_gitlens_compare@1"
-				},
-				{
-					"command": "gitlens.copyRemotePullRequestUrl",
-					"when": "!listMultiSelection && viewItem =~ /gitlens:pullrequest\\b/",
-					"group": "7_gitlens_cutcopypaste@1"
 				},
 				{
 					"command": "gitlens.views.addRemote",

--- a/package.json
+++ b/package.json
@@ -1344,7 +1344,7 @@
 					"gitlens.launchpad.experimental.queryLimit": {
 						"type": "number",
 						"default": 100,
-						"markdownDescription": "Specifies an experimental limit on the number of pull requests to be queried in the _Launchpad_",
+						"markdownDescription": "(Experimental) Specifies a limit on the number of pull requests to be queried in the _Launchpad_",
 						"scope": "window",
 						"order": 1100
 					}
@@ -1506,6 +1506,73 @@
 					"gitlens.views.statusFileDescriptionFormat": {
 						"deprecationMessage": "Deprecated. Use `gitlens.views.formats.files.description` instead",
 						"markdownDeprecationMessage": "Deprecated. Use `#gitlens.views.formats.files.description#` instead"
+					}
+				}
+			},
+			{
+				"id": "launchpad-view",
+				"title": "Launchpad View",
+				"order": 101,
+				"properties": {
+					"gitlens.views.launchpad.enabled": {
+						"type": "boolean",
+						"default": false,
+						"markdownDescription": "(Experimental) Specifies whether to enable an experimental _Launchpad_ view",
+						"scope": "window",
+						"order": 10
+					},
+					"gitlens.views.launchpad.files.layout": {
+						"type": "string",
+						"default": "auto",
+						"enum": [
+							"auto",
+							"list",
+							"tree"
+						],
+						"enumDescriptions": [
+							"Automatically switches between displaying files as a `tree` or `list` based on the `#gitlens.views.launchpad.files.threshold#` value and the number of files at each nesting level",
+							"Displays files as a list",
+							"Displays files as a tree"
+						],
+						"markdownDescription": "Specifies how the _Launchpad_ view will display files",
+						"scope": "window",
+						"order": 30
+					},
+					"gitlens.views.launchpad.files.threshold": {
+						"type": "number",
+						"default": 5,
+						"markdownDescription": "Specifies when to switch between displaying files as a `tree` or `list` based on the number of files in a nesting level in the _Launchpad_ view. Only applies when `#gitlens.views.launchpad.files.layout#` is set to `auto`",
+						"scope": "window",
+						"order": 31
+					},
+					"gitlens.views.launchpad.files.compact": {
+						"type": "boolean",
+						"default": true,
+						"markdownDescription": "Specifies whether to compact (flatten) unnecessary file nesting in the _Launchpad_ view. Only applies when `#gitlens.views.launchpad.files.layout#` is set to `tree` or `auto`",
+						"scope": "window",
+						"order": 32
+					},
+					"gitlens.views.launchpad.files.icon": {
+						"type": "string",
+						"default": "type",
+						"enum": [
+							"status",
+							"type"
+						],
+						"enumDescriptions": [
+							"Shows the file's status as the icon",
+							"Shows the file's type (theme icon) as the icon"
+						],
+						"markdownDescription": "Specifies how the _Launchpad_ view will display file icons",
+						"scope": "window",
+						"order": 33
+					},
+					"gitlens.views.launchpad.avatars": {
+						"type": "boolean",
+						"default": true,
+						"markdownDescription": "Specifies whether to show avatar images instead of commit (or status) icons in the _Launchpad_ view",
+						"scope": "window",
+						"order": 40
 					}
 				}
 			},
@@ -7960,6 +8027,51 @@
 				"icon": "$(refresh)"
 			},
 			{
+				"command": "gitlens.views.launchpad.copy",
+				"title": "Copy",
+				"category": "GitLens"
+			},
+			{
+				"command": "gitlens.views.launchpad.info",
+				"title": "Learn about Launchpad...",
+				"category": "GitLens",
+				"icon": "$(info)"
+			},
+			{
+				"command": "gitlens.views.launchpad.refresh",
+				"title": "Refresh",
+				"category": "GitLens",
+				"icon": "$(refresh)"
+			},
+			{
+				"command": "gitlens.views.launchpad.setFilesLayoutToAuto",
+				"title": "View Files as Auto",
+				"category": "GitLens",
+				"icon": "$(list-tree)"
+			},
+			{
+				"command": "gitlens.views.launchpad.setFilesLayoutToList",
+				"title": "View Files as List",
+				"category": "GitLens",
+				"icon": "$(gitlens-list-auto)"
+			},
+			{
+				"command": "gitlens.views.launchpad.setFilesLayoutToTree",
+				"title": "View Files as Tree",
+				"category": "GitLens",
+				"icon": "$(list-flat)"
+			},
+			{
+				"command": "gitlens.views.launchpad.setShowAvatarsOn",
+				"title": "Show Avatars",
+				"category": "GitLens"
+			},
+			{
+				"command": "gitlens.views.launchpad.setShowAvatarsOff",
+				"title": "Hide Avatars",
+				"category": "GitLens"
+			},
+			{
 				"command": "gitlens.views.lineHistory.changeBase",
 				"title": "Change Base...",
 				"category": "GitLens",
@@ -11281,6 +11393,38 @@
 					"when": "false"
 				},
 				{
+					"command": "gitlens.views.launchpad.copy",
+					"when": "false"
+				},
+				{
+					"command": "gitlens.views.launchpad.info",
+					"when": "false"
+				},
+				{
+					"command": "gitlens.views.launchpad.refresh",
+					"when": "false"
+				},
+				{
+					"command": "gitlens.views.launchpad.setFilesLayoutToAuto",
+					"when": "false"
+				},
+				{
+					"command": "gitlens.views.launchpad.setFilesLayoutToList",
+					"when": "false"
+				},
+				{
+					"command": "gitlens.views.launchpad.setFilesLayoutToTree",
+					"when": "false"
+				},
+				{
+					"command": "gitlens.views.launchpad.setShowAvatarsOn",
+					"when": "false"
+				},
+				{
+					"command": "gitlens.views.launchpad.setShowAvatarsOff",
+					"when": "false"
+				},
+				{
 					"command": "gitlens.views.lineHistory.changeBase",
 					"when": "false"
 				},
@@ -13092,6 +13236,41 @@
 					"command": "gitlens.views.account.refresh",
 					"when": "view =~ /^gitlens\\.views\\.account/",
 					"group": "navigation@99"
+				},
+				{
+					"command": "gitlens.views.launchpad.refresh",
+					"when": "view =~ /^gitlens\\.views\\.launchpad/",
+					"group": "navigation@99"
+				},
+				{
+					"command": "gitlens.views.launchpad.setFilesLayoutToAuto",
+					"when": "view =~ /^gitlens\\.views\\.launchpad/ && config.gitlens.views.launchpad.files.layout == tree",
+					"group": "navigation@50"
+				},
+				{
+					"command": "gitlens.views.launchpad.setFilesLayoutToList",
+					"when": "view =~ /^gitlens\\.views\\.launchpad/ && config.gitlens.views.launchpad.files.layout == auto",
+					"group": "navigation@50"
+				},
+				{
+					"command": "gitlens.views.launchpad.setFilesLayoutToTree",
+					"when": "view =~ /^gitlens\\.views\\.launchpad/ && config.gitlens.views.launchpad.files.layout == list",
+					"group": "navigation@50"
+				},
+				{
+					"command": "gitlens.views.launchpad.setShowAvatarsOn",
+					"when": "view =~ /^gitlens\\.views\\.launchpad/ && !config.gitlens.views.launchpad.avatars",
+					"group": "5_gitlens@0"
+				},
+				{
+					"command": "gitlens.views.launchpad.setShowAvatarsOff",
+					"when": "view =~ /^gitlens\\.views\\.launchpad/ && config.gitlens.views.launchpad.avatars",
+					"group": "5_gitlens@0"
+				},
+				{
+					"command": "gitlens.views.launchpad.info",
+					"when": "view =~ /^gitlens\\.views\\.launchpad/",
+					"group": "8_info@1"
 				},
 				{
 					"command": "gitlens.showLineHistoryView",
@@ -15242,7 +15421,7 @@
 				},
 				{
 					"command": "gitlens.views.copy",
-					"when": "viewItem =~ /gitlens:(?=(autolinked:item\\b|branch|commit|contributor|file(?!.*?\\b\\+(staged|unstaged))\\b|folder|history:line|pullrequest|remote|repository|repo-folder|search:results|stash|tag|workspace|worktree)\\b)/",
+					"when": "viewItem =~ /gitlens:(?=(autolinked:item\\b|branch|commit|contributor|file(?!.*?\\b\\+(staged|unstaged))\\b|folder|history:line|launchpad:item|pullrequest|remote|repository|repo-folder|search:results|stash|tag|workspace|worktree)\\b)/",
 					"group": "7_gitlens_cutcopypaste@1"
 				},
 				{
@@ -15614,7 +15793,7 @@
 				},
 				{
 					"command": "gitlens.graph.copy",
-					"when": "webviewItem =~ /gitlens:(branch|commit|contributor|pullrequest|stash|tag)\\b/",
+					"when": "webviewItem =~ /gitlens:(branch|commit|contributor|launchpad:item|pullrequest|stash|tag)\\b/",
 					"group": "7_gitlens_cutcopypaste@1"
 				},
 				{
@@ -17277,6 +17456,15 @@
 					"contextualTitle": "GitLens",
 					"icon": "$(gitlens-gitlens)",
 					"initialSize": 6,
+					"visibility": "visible"
+				},
+				{
+					"id": "gitlens.views.launchpad",
+					"name": "Launchpad",
+					"when": "config.gitlens.views.launchpad.enabled",
+					"contextualTitle": "GitLens",
+					"icon": "$(rocket)",
+					"initialSize": 2,
 					"visibility": "visible"
 				},
 				{

--- a/package.json
+++ b/package.json
@@ -17386,6 +17386,15 @@
 				"contents": "Preview feature ☁️ — requires an account and may require a paid plan in the future."
 			},
 			{
+				"view": "gitlens.views.launchpad",
+				"contents": "[Launchpad](command:gitlens.views.launchpad.info \"Learn about Launchpad\") — organizes your pull requests into actionable groups to help you focus and keep your team unblocked."
+			},
+			{
+				"view": "gitlens.views.launchpad",
+				"contents": "[Connect Integrations...](command:gitlens.showLaunchpad)\n\nConnect to your Git provider to see pull requests in Launchpad.",
+				"when": "gitlens:launchpad:connect"
+			},
+			{
 				"view": "gitlens.views.workspaces",
 				"contents": "Workspaces ᴘʀᴇᴠɪᴇᴡ — group and manage multiple repositories together, accessible from anywhere, streamlining your workflow.\n\nCreate workspaces just for yourself or share (coming soon in GitLens) them with your team for faster onboarding and better collaboration."
 			},

--- a/src/commands/openPullRequestOnRemote.ts
+++ b/src/commands/openPullRequestOnRemote.ts
@@ -4,7 +4,6 @@ import type { Container } from '../container';
 import { shortenRevision } from '../git/models/reference';
 import { command } from '../system/command';
 import { openUrl } from '../system/utils';
-import { PullRequestNode } from '../views/nodes/pullRequestNode';
 import type { CommandContext } from './base';
 import { Command } from './base';
 
@@ -22,10 +21,10 @@ export class OpenPullRequestOnRemoteCommand extends Command {
 	}
 
 	protected override preExecute(context: CommandContext, args?: OpenPullRequestOnRemoteCommandArgs) {
-		if (context.type === 'viewItem' && context.node instanceof PullRequestNode) {
+		if (context.type === 'viewItem' && (context.node.is('pullrequest') || context.node.is('launchpad-item'))) {
 			args = {
 				...args,
-				pr: { url: context.node.pullRequest.url },
+				pr: context.node.pullRequest != null ? { url: context.node.pullRequest.url } : undefined,
 				clipboard: context.command === Commands.CopyRemotePullRequestUrl,
 			};
 		}

--- a/src/config.ts
+++ b/src/config.ts
@@ -632,6 +632,7 @@ interface ViewsConfigs {
 	readonly contributors: ContributorsViewConfig;
 	readonly drafts: DraftsViewConfig;
 	readonly fileHistory: FileHistoryViewConfig;
+	readonly launchpad: LaunchpadViewConfig;
 	readonly lineHistory: LineHistoryViewConfig;
 	readonly patchDetails: PatchDetailsViewConfig;
 	readonly pullRequest: PullRequestViewConfig;
@@ -732,6 +733,17 @@ export interface DraftsViewConfig {
 }
 
 export interface FileHistoryViewConfig {
+	readonly avatars: boolean;
+	readonly files: ViewsFilesConfig;
+	readonly pullRequests: {
+		readonly enabled: boolean;
+		readonly showForCommits: boolean;
+	};
+}
+
+export interface LaunchpadViewConfig {
+	readonly enabled: boolean;
+
 	readonly avatars: boolean;
 	readonly files: ViewsFilesConfig;
 	readonly pullRequests: {

--- a/src/constants.ts
+++ b/src/constants.ts
@@ -437,6 +437,12 @@ export type TreeViewCommands = `gitlens.views.${
 			| `setShowAllBranches${'On' | 'Off'}`
 			| `setShowMergeCommits${'On' | 'Off'}`
 			| `setShowAvatars${'On' | 'Off'}`}`
+	| `launchpad.${
+			| 'copy'
+			| 'info'
+			| 'refresh'
+			| `setFilesLayoutTo${'Auto' | 'List' | 'Tree'}`
+			| `setShowAvatars${'On' | 'Off'}`}`
 	| `lineHistory.${
 			| 'copy'
 			| 'refresh'
@@ -444,9 +450,9 @@ export type TreeViewCommands = `gitlens.views.${
 			| `setEditorFollowing${'On' | 'Off'}`
 			| `setShowAvatars${'On' | 'Off'}`}`
 	| `pullRequest.${
+			| 'close'
 			| 'copy'
 			| 'refresh'
-			| 'close'
 			| `setFilesLayoutTo${'Auto' | 'List' | 'Tree'}`
 			| `setShowAvatars${'On' | 'Off'}`}`
 	| `remotes.${
@@ -540,6 +546,7 @@ export type TreeViewTypes =
 	| 'contributors'
 	| 'drafts'
 	| 'fileHistory'
+	| 'launchpad'
 	| 'lineHistory'
 	| 'pullRequest'
 	| 'remotes'
@@ -645,6 +652,8 @@ export type TreeViewNodeTypes =
 	| 'drafts'
 	| 'drafts-code-suggestions'
 	| 'grouping'
+	| 'launchpad'
+	| 'launchpad-item'
 	| 'merge-status'
 	| 'message'
 	| 'pager'
@@ -861,6 +870,7 @@ export type Sources =
 	| 'integrations'
 	| 'launchpad'
 	| 'launchpad-indicator'
+	| 'launchpad-view'
 	| 'notification'
 	| 'patchDetails'
 	| 'prompt'

--- a/src/constants.ts
+++ b/src/constants.ts
@@ -16,6 +16,7 @@ import type { TrackedUsage, TrackedUsageKeys } from './telemetry/usageTracker';
 export const extensionPrefix = 'gitlens';
 export const quickPickTitleMaxChars = 80;
 
+export const experimentalBadge = 'ᴇxᴘᴇʀɪᴍᴇɴᴛᴀʟ';
 export const previewBadge = 'ᴘʀᴇᴠɪᴇᴡ';
 export const proBadge = 'ᴘʀᴏ';
 export const proBadgeSuperscript = 'ᴾᴿᴼ';
@@ -687,6 +688,7 @@ export type ContextKeys = {
 	'gitlens:gk:organization:drafts:byob': boolean;
 	'gitlens:gk:organization:drafts:enabled': boolean;
 	'gitlens:hasVirtualFolders': boolean;
+	'gitlens:launchpad:connect': boolean;
 	'gitlens:plus': SubscriptionPlanId;
 	'gitlens:plus:disallowedRepos': string[];
 	'gitlens:plus:enabled': boolean;

--- a/src/container.ts
+++ b/src/container.ts
@@ -73,6 +73,7 @@ import { CommitsView } from './views/commitsView';
 import { ContributorsView } from './views/contributorsView';
 import { DraftsView } from './views/draftsView';
 import { FileHistoryView } from './views/fileHistoryView';
+import { LaunchpadView } from './views/launchpadView';
 import { LineHistoryView } from './views/lineHistoryView';
 import { PullRequestView } from './views/pullRequestView';
 import { RemotesView } from './views/remotesView';
@@ -277,6 +278,7 @@ export class Container {
 		this._disposables.push((this._commitsView = new CommitsView(this)));
 		this._disposables.push((this._pullRequestView = new PullRequestView(this)));
 		this._disposables.push((this._fileHistoryView = new FileHistoryView(this)));
+		this._disposables.push((this._launchpadView = new LaunchpadView(this)));
 		this._disposables.push((this._lineHistoryView = new LineHistoryView(this)));
 		this._disposables.push((this._branchesView = new BranchesView(this)));
 		this._disposables.push((this._remotesView = new RemotesView(this)));
@@ -648,6 +650,11 @@ export class Container {
 	private readonly _keyboard: Keyboard;
 	get keyboard() {
 		return this._keyboard;
+	}
+
+	private _launchpadView: LaunchpadView;
+	get launchpadView() {
+		return this._launchpadView;
 	}
 
 	private readonly _lineAnnotationController: LineAnnotationController;

--- a/src/git/models/pullRequest.ts
+++ b/src/git/models/pullRequest.ts
@@ -304,3 +304,14 @@ export async function getOrOpenPullRequestRepository(
 
 	return repo;
 }
+
+export async function getOpenedPullRequestRepoPath(
+	container: Container,
+	pr: PullRequest,
+	repoPath?: string,
+): Promise<string | undefined> {
+	if (repoPath) return repoPath;
+
+	const repo = await getOrOpenPullRequestRepository(container, pr);
+	return repo?.path;
+}

--- a/src/plus/focus/focus.ts
+++ b/src/plus/focus/focus.ts
@@ -533,6 +533,7 @@ export class FocusCommand extends QuickCommand<State> {
 					case ConnectIntegrationButton:
 						this.sendTitleActionTelemetry('connect', context);
 						return this.next([connectMoreIntegrationsItem]);
+
 					case LaunchpadSettingsQuickInputButton:
 						this.sendTitleActionTelemetry('settings', context);
 						void commands.executeCommand('workbench.action.openSettings', 'gitlens.launchpad');
@@ -547,6 +548,7 @@ export class FocusCommand extends QuickCommand<State> {
 						this.sendTitleActionTelemetry('open-on-gkdev', context);
 						void openUrl(this.container.focus.generateWebUrl());
 						break;
+
 					case RefreshQuickInputButton:
 						this.sendTitleActionTelemetry('refresh', context);
 						await updateItems(quickpick);

--- a/src/plus/focus/focus.ts
+++ b/src/plus/focus/focus.ts
@@ -165,7 +165,10 @@ export class FocusCommand extends QuickCommand<State> {
 			this.container.telemetry.sendEvent('launchpad/open', { ...this.telemetryContext }, this.source);
 		}
 
-		const counter = 0;
+		let counter = 0;
+		if (args?.state?.item != null) {
+			counter++;
+		}
 
 		this.initialState = {
 			counter: counter,
@@ -219,7 +222,7 @@ export class FocusCommand extends QuickCommand<State> {
 
 			let newlyConnected = false;
 			const hasConnectedIntegrations = [...context.connectedIntegrations.values()].some(c => c);
-			if (state.counter < 1 && !hasConnectedIntegrations) {
+			if (!hasConnectedIntegrations) {
 				if (this.container.telemetry.enabled) {
 					this.container.telemetry.sendEvent(
 						opened ? 'launchpad/steps/connect' : 'launchpad/opened',
@@ -251,7 +254,7 @@ export class FocusCommand extends QuickCommand<State> {
 
 			await updateContextItems(this.container, context, { force: newlyConnected });
 
-			if (state.counter < 2 || state.item == null) {
+			if (state.counter < 1 || state.item == null) {
 				if (this.container.telemetry.enabled) {
 					this.container.telemetry.sendEvent(
 						opened ? 'launchpad/steps/main' : 'launchpad/opened',

--- a/src/plus/integrations/providers/models.ts
+++ b/src/plus/integrations/providers/models.ts
@@ -33,6 +33,7 @@ import { RepositoryAccessLevel } from '../../../git/models/issue';
 import type {
 	PullRequestMember,
 	PullRequestRefs,
+	PullRequestRepositoryIdentityDescriptor,
 	PullRequestReviewer,
 	PullRequestState,
 } from '../../../git/models/pullRequest';
@@ -44,7 +45,6 @@ import {
 	PullRequestStatusCheckRollupState,
 } from '../../../git/models/pullRequest';
 import type { ProviderReference } from '../../../git/models/remoteProvider';
-import type { RepositoryIdentityDescriptor } from '../../../gk/models/repositoryIdentities';
 import type { EnrichableItem } from '../../focus/enrichmentService';
 import type { Integration } from '../integration';
 import { getEntityIdentifierInput } from './utils';
@@ -879,12 +879,9 @@ export type EnrichablePullRequest = ProviderPullRequest & {
 	type: 'pullrequest';
 	provider: ProviderReference;
 	enrichable: EnrichableItem;
-	repoIdentity: RequireSomeWithProps<
-		RequireSome<RepositoryIdentityDescriptor<string>, 'remote' | 'provider'>,
-		'provider',
-		'id' | 'domain' | 'repoDomain' | 'repoName'
-	>;
+	repoIdentity: PullRequestRepositoryIdentityDescriptor;
 	refs?: PullRequestRefs;
+	underlyingPullRequest: PullRequest;
 };
 
 export const getActionablePullRequests = GitProviderUtils.getActionablePullRequests;

--- a/src/plus/repos/repositoryIdentityService.ts
+++ b/src/plus/repos/repositoryIdentityService.ts
@@ -4,7 +4,7 @@ import type { Container } from '../../container';
 import { RemoteResourceType } from '../../git/models/remoteResource';
 import type { Repository } from '../../git/models/repository';
 import { parseGitRemoteUrl } from '../../git/parsers/remoteParser';
-import type { RepositoryIdentityDescriptor } from '../../gk/models/repositoryIdentities';
+import type { GkProviderId, RepositoryIdentityDescriptor } from '../../gk/models/repositoryIdentities';
 import { missingRepositoryId } from '../../gk/models/repositoryIdentities';
 import { log } from '../../system/decorators/log';
 import type { ServerConnection } from '../gk/serverConnection';
@@ -18,16 +18,16 @@ export class RepositoryIdentityService implements Disposable {
 	dispose(): void {}
 
 	@log()
-	getRepository(
-		identity: RepositoryIdentityDescriptor,
+	getRepository<T extends string | GkProviderId>(
+		identity: RepositoryIdentityDescriptor<T>,
 		options?: { openIfNeeded?: boolean; keepOpen?: boolean; prompt?: boolean; skipRefValidation?: boolean },
 	): Promise<Repository | undefined> {
 		return this.locateRepository(identity, options);
 	}
 
 	@log()
-	private async locateRepository(
-		identity: RepositoryIdentityDescriptor,
+	private async locateRepository<T extends string | GkProviderId>(
+		identity: RepositoryIdentityDescriptor<T>,
 		options?: { openIfNeeded?: boolean; keepOpen?: boolean; prompt?: boolean; skipRefValidation?: boolean },
 	): Promise<Repository | undefined> {
 		const hasInitialCommitSha =
@@ -139,7 +139,10 @@ export class RepositoryIdentityService implements Disposable {
 		return foundRepo;
 	}
 
-	private async addFoundRepositoryToMap(repo: Repository, identity?: RepositoryIdentityDescriptor) {
+	private async addFoundRepositoryToMap<T extends string | GkProviderId>(
+		repo: Repository,
+		identity?: RepositoryIdentityDescriptor<T>,
+	) {
 		const repoPath = repo.uri.fsPath;
 
 		const remotes = await repo.getRemotes();

--- a/src/system/iterable.ts
+++ b/src/system/iterable.ts
@@ -60,12 +60,14 @@ export function every<T>(source: Iterable<T> | IterableIterator<T>, predicate: (
 	return true;
 }
 
-export function filter<T>(source: Iterable<T | undefined | null> | IterableIterator<T | undefined | null>): Iterable<T>;
-export function filter<T>(source: Iterable<T> | IterableIterator<T>, predicate: (item: T) => boolean): Iterable<T>;
+export function filter<T>(
+	source: Iterable<T | undefined | null> | IterableIterator<T | undefined | null>,
+): Iterable<NonNullable<T>>;
 export function filter<T, U extends T>(
 	source: Iterable<T> | IterableIterator<T>,
 	predicate: (item: T) => item is U,
 ): Iterable<U>;
+export function filter<T>(source: Iterable<T> | IterableIterator<T>, predicate: (item: T) => boolean): Iterable<T>;
 export function* filter<T, U extends T = T>(
 	source: Iterable<T> | IterableIterator<T>,
 	predicate?: ((item: T) => item is U) | ((item: T) => boolean),

--- a/src/views/launchpadView.ts
+++ b/src/views/launchpadView.ts
@@ -20,11 +20,13 @@ import { ViewBase } from './viewBase';
 import { registerViewCommand } from './viewCommands';
 
 export class LaunchpadItemNode extends CacheableChildrenViewNode<'launchpad-item', LaunchpadView> {
+	readonly repoPath: string | undefined;
+
 	constructor(
 		view: LaunchpadView,
 		protected override readonly parent: ViewNode,
 		private readonly group: FocusGroup,
-		private readonly item: FocusItem,
+		public readonly item: FocusItem,
 	) {
 		const repoPath = item.openRepository?.repo?.path;
 
@@ -32,6 +34,7 @@ export class LaunchpadItemNode extends CacheableChildrenViewNode<'launchpad-item
 
 		this.updateContext({ launchpadGroup: group, launchpadItem: item });
 		this._uniqueId = getViewNodeId(this.type, this.context);
+		this.repoPath = repoPath;
 	}
 
 	override get id(): string {
@@ -52,13 +55,17 @@ export class LaunchpadItemNode extends CacheableChildrenViewNode<'launchpad-item
 		return this.item.url ?? this.item.underlyingPullRequest.url;
 	}
 
+	get pullRequest() {
+		return this.item.type === 'pullrequest' ? this.item.underlyingPullRequest : undefined;
+	}
+
 	async getChildren(): Promise<ViewNode[]> {
 		if (this.children == null) {
 			const children = await getPullRequestChildren(
 				this.view,
 				this,
 				this.item.underlyingPullRequest,
-				this.item.openRepository?.repo,
+				this.item.openRepository?.repo ?? this.repoPath,
 			);
 			this.children = children;
 		}

--- a/src/views/launchpadView.ts
+++ b/src/views/launchpadView.ts
@@ -1,0 +1,250 @@
+import type { ConfigurationChangeEvent, TreeViewVisibilityChangeEvent } from 'vscode';
+import { Disposable, ThemeIcon, TreeItem, TreeItemCollapsibleState, Uri } from 'vscode';
+import type { OpenWalkthroughCommandArgs } from '../commands/walkthroughs';
+import type { LaunchpadViewConfig, ViewFilesLayout } from '../config';
+import { Commands, previewBadge } from '../constants';
+import type { Container } from '../container';
+import { AuthenticationRequiredError } from '../errors';
+import { GitUri, unknownGitUri } from '../git/gitUri';
+import type { FocusCommandArgs } from '../plus/focus/focus';
+import type { FocusGroup, FocusItem } from '../plus/focus/focusProvider';
+import { focusGroupIconMap, focusGroupLabelMap, groupAndSortFocusItems } from '../plus/focus/focusProvider';
+import { createCommand, executeCommand } from '../system/command';
+import { configuration } from '../system/configuration';
+import { CacheableChildrenViewNode } from './nodes/abstract/cacheableChildrenViewNode';
+import type { ClipboardType, ViewNode } from './nodes/abstract/viewNode';
+import { ContextValues, getViewNodeId } from './nodes/abstract/viewNode';
+import { GroupingNode } from './nodes/groupingNode';
+import { getPullRequestChildren, getPullRequestTooltip } from './nodes/pullRequestNode';
+import { ViewBase } from './viewBase';
+import { registerViewCommand } from './viewCommands';
+
+export class LaunchpadItemNode extends CacheableChildrenViewNode<'launchpad-item', LaunchpadView> {
+	constructor(
+		view: LaunchpadView,
+		protected override readonly parent: ViewNode,
+		private readonly group: FocusGroup,
+		private readonly item: FocusItem,
+	) {
+		const repoPath = item.openRepository?.repo?.path;
+
+		super('launchpad-item', repoPath != null ? GitUri.fromRepoPath(repoPath) : unknownGitUri, view, parent);
+
+		this.updateContext({ launchpadGroup: group, launchpadItem: item });
+		this._uniqueId = getViewNodeId(this.type, this.context);
+	}
+
+	override get id(): string {
+		return this._uniqueId;
+	}
+
+	override toClipboard(type?: ClipboardType): string {
+		const url = this.getUrl();
+		switch (type) {
+			case 'markdown':
+				return `[${this.item.underlyingPullRequest.id}](${url}) ${this.item.underlyingPullRequest.title}`;
+			default:
+				return url;
+		}
+	}
+
+	override getUrl(): string {
+		return this.item.url ?? this.item.underlyingPullRequest.url;
+	}
+
+	async getChildren(): Promise<ViewNode[]> {
+		if (this.children == null) {
+			const children = await getPullRequestChildren(
+				this.view,
+				this,
+				this.item.underlyingPullRequest,
+				this.item.openRepository?.repo,
+			);
+			this.children = children;
+		}
+
+		return this.children;
+	}
+
+	getTreeItem(): TreeItem {
+		const lpi = this.item;
+
+		const item = new TreeItem(
+			lpi.title.length > 60 ? `${lpi.title.substring(0, 60)}...` : lpi.title,
+			TreeItemCollapsibleState.Collapsed,
+		);
+		item.contextValue = ContextValues.LaunchpadItem;
+		item.description = `\u00a0 ${lpi.repository.owner.login}/${lpi.repository.name}#${lpi.id} \u00a0 ${
+			lpi.codeSuggestionsCount > 0 ? ` $(gitlens-code-suggestion) ${lpi.codeSuggestionsCount}` : ''
+		}`;
+		item.iconPath = lpi.author?.avatarUrl != null ? Uri.parse(lpi.author.avatarUrl) : undefined;
+		item.command = createCommand<[Omit<FocusCommandArgs, 'command'>]>(Commands.ShowLaunchpad, 'Open in Launchpad', {
+			source: 'launchpad-view',
+			state: {
+				item: { ...this.item, group: this.group },
+			},
+		} satisfies Omit<FocusCommandArgs, 'command'>);
+
+		if (lpi.type === 'pullrequest') {
+			item.contextValue += '+pr';
+			item.tooltip = getPullRequestTooltip(lpi.underlyingPullRequest);
+		}
+
+		return item;
+	}
+}
+
+export class LaunchpadViewNode extends CacheableChildrenViewNode<
+	'launchpad',
+	LaunchpadView,
+	GroupingNode | LaunchpadItemNode
+> {
+	constructor(view: LaunchpadView) {
+		super('launchpad', unknownGitUri, view);
+	}
+
+	async getChildren(): Promise<(GroupingNode | LaunchpadItemNode)[]> {
+		if (this.children == null) {
+			const children: (GroupingNode | LaunchpadItemNode)[] = [];
+
+			try {
+				const result = await this.view.container.focus.getCategorizedItems();
+				if (result.items == null) return [];
+
+				const uiGroups = groupAndSortFocusItems(result.items);
+				for (const [ui, groupItems] of uiGroups) {
+					if (!groupItems.length) continue;
+
+					const icon = focusGroupIconMap.get(ui)!;
+
+					children.push(
+						new GroupingNode(
+							this.view,
+							focusGroupLabelMap.get(ui)!,
+							groupItems.map(i => new LaunchpadItemNode(this.view, this, ui, i)),
+							TreeItemCollapsibleState.Collapsed,
+							undefined,
+							undefined,
+							new ThemeIcon(icon.substring(2, icon.length - 1)),
+						),
+					);
+				}
+			} catch (ex) {
+				if (!(ex instanceof AuthenticationRequiredError)) throw ex;
+			}
+
+			this.children = children;
+		}
+
+		return this.children;
+	}
+
+	getTreeItem(): TreeItem {
+		const item = new TreeItem('Launchpad', TreeItemCollapsibleState.Expanded);
+		return item;
+	}
+}
+
+export class LaunchpadView extends ViewBase<'launchpad', LaunchpadViewNode, LaunchpadViewConfig> {
+	protected readonly configKey = 'launchpad';
+	private _disposable: Disposable | undefined;
+
+	constructor(container: Container) {
+		super(container, 'launchpad', 'Launchpad', 'launchpadView');
+
+		this.description = previewBadge;
+	}
+
+	override dispose() {
+		this._disposable?.dispose();
+		super.dispose();
+	}
+
+	protected getRoot() {
+		return new LaunchpadViewNode(this);
+	}
+
+	protected override onVisibilityChanged(e: TreeViewVisibilityChangeEvent): void {
+		if (this._disposable == null) {
+			this._disposable = Disposable.from(this.container.subscription.onDidChange(() => this.refresh(true), this));
+		}
+
+		super.onVisibilityChanged(e);
+	}
+
+	// override async show(options?: { preserveFocus?: boolean | undefined }): Promise<void> {
+	// 	if (!(await ensurePlusFeaturesEnabled())) return;
+
+	// 	return super.show(options);
+	// }
+
+	override get canReveal(): boolean {
+		return false;
+	}
+
+	protected registerCommands(): Disposable[] {
+		void this.container.viewCommands;
+
+		return [
+			registerViewCommand(
+				this.getQualifiedCommand('info'),
+				() =>
+					executeCommand<OpenWalkthroughCommandArgs>(Commands.OpenWalkthrough, {
+						step: 'launchpad',
+						source: 'launchpad-view',
+						detail: 'info',
+					}),
+				this,
+			),
+			registerViewCommand(
+				this.getQualifiedCommand('copy'),
+				() => executeCommand(Commands.ViewsCopy, this.activeSelection, this.selection),
+				this,
+			),
+			registerViewCommand(this.getQualifiedCommand('refresh'), () => this.refresh(true), this),
+			registerViewCommand(
+				this.getQualifiedCommand('setFilesLayoutToAuto'),
+				() => this.setFilesLayout('auto'),
+				this,
+			),
+			registerViewCommand(
+				this.getQualifiedCommand('setFilesLayoutToList'),
+				() => this.setFilesLayout('list'),
+				this,
+			),
+			registerViewCommand(
+				this.getQualifiedCommand('setFilesLayoutToTree'),
+				() => this.setFilesLayout('tree'),
+				this,
+			),
+			registerViewCommand(this.getQualifiedCommand('setShowAvatarsOn'), () => this.setShowAvatars(true), this),
+			registerViewCommand(this.getQualifiedCommand('setShowAvatarsOff'), () => this.setShowAvatars(false), this),
+		];
+	}
+
+	protected override filterConfigurationChanged(e: ConfigurationChangeEvent) {
+		const changed = super.filterConfigurationChanged(e);
+		if (
+			!changed &&
+			!configuration.changed(e, 'defaultDateFormat') &&
+			!configuration.changed(e, 'defaultDateLocale') &&
+			!configuration.changed(e, 'defaultDateShortFormat') &&
+			!configuration.changed(e, 'defaultDateSource') &&
+			!configuration.changed(e, 'defaultDateStyle') &&
+			!configuration.changed(e, 'defaultGravatarsStyle') &&
+			!configuration.changed(e, 'defaultTimeFormat')
+		) {
+			return false;
+		}
+
+		return true;
+	}
+
+	private setFilesLayout(layout: ViewFilesLayout) {
+		return configuration.updateEffective(`views.${this.configKey}.files.layout` as const, layout);
+	}
+
+	private setShowAvatars(enabled: boolean) {
+		return configuration.updateEffective(`views.${this.configKey}.avatars` as const, enabled);
+	}
+}

--- a/src/views/nodes/abstract/viewNode.ts
+++ b/src/views/nodes/abstract/viewNode.ts
@@ -24,6 +24,7 @@ import { gate } from '../../../system/decorators/gate';
 import { debug, logName } from '../../../system/decorators/log';
 import { is as isA } from '../../../system/function';
 import { getLoggableName } from '../../../system/logger';
+import type { LaunchpadItemNode } from '../../launchpadView';
 import type { View } from '../../viewBase';
 import type { BranchNode } from '../branchNode';
 import type { BranchTrackingStatusFilesNode } from '../branchTrackingStatusFilesNode';
@@ -37,6 +38,7 @@ import type { FileRevisionAsCommitNode } from '../fileRevisionAsCommitNode';
 import type { FolderNode } from '../folderNode';
 import type { LineHistoryTrackerNode } from '../lineHistoryTrackerNode';
 import type { MergeConflictFileNode } from '../mergeConflictFileNode';
+import type { PullRequestNode } from '../pullRequestNode';
 import type { RepositoryNode } from '../repositoryNode';
 import type { ResultsCommitsNode } from '../resultsCommitsNode';
 import type { ResultsFileNode } from '../resultsFileNode';
@@ -421,8 +423,12 @@ type TreeViewNodesByType = {
 		? FileRevisionAsCommitNode
 		: T extends 'folder'
 		? FolderNode
+		: T extends 'launchpad-item'
+		? LaunchpadItemNode
 		: T extends 'line-history-tracker'
 		? LineHistoryTrackerNode
+		: T extends 'pullrequest'
+		? PullRequestNode
 		: T extends 'repository'
 		? RepositoryNode
 		: T extends 'repo-folder'

--- a/src/views/nodes/abstract/viewNode.ts
+++ b/src/views/nodes/abstract/viewNode.ts
@@ -12,6 +12,8 @@ import type { Repository } from '../../../git/models/repository';
 import type { GitTag } from '../../../git/models/tag';
 import type { GitWorktree } from '../../../git/models/worktree';
 import type { Draft } from '../../../gk/models/drafts';
+import type { FocusGroup, FocusItem } from '../../../plus/focus/focusProvider';
+import { focusCategoryToGroupMap, sharedCategoryToFocusActionCategoryMap } from '../../../plus/focus/focusProvider';
 import type {
 	CloudWorkspace,
 	CloudWorkspaceRepositoryDescriptor,
@@ -76,6 +78,7 @@ export const enum ContextValues {
 	FileHistory = 'gitlens:history:file',
 	Folder = 'gitlens:folder',
 	Grouping = 'gitlens:grouping',
+	LaunchpadItem = 'gitlens:launchpad:item',
 	LineHistory = 'gitlens:history:line',
 	Merge = 'gitlens:merge',
 	MergeConflictCurrentChanges = 'gitlens:merge-conflict:current',
@@ -127,6 +130,8 @@ export interface AmbientContext {
 	readonly contributor?: GitContributor;
 	readonly draft?: Draft;
 	readonly file?: GitFile;
+	readonly launchpadGroup?: FocusGroup;
+	readonly launchpadItem?: FocusItem;
 	readonly pullRequest?: PullRequest;
 	readonly reflog?: GitReflogRecord;
 	readonly remote?: GitRemote;
@@ -174,6 +179,16 @@ export function getViewNodeId(type: string, context: AmbientContext): string {
 	}
 	if (context.branchStatusUpstreamType != null) {
 		uniqueness += `/branch-status-direction/${context.branchStatusUpstreamType}`;
+	}
+	if (context.launchpadGroup != null) {
+		uniqueness += `/lp/${context.launchpadGroup}`;
+		if (context.launchpadItem != null) {
+			uniqueness += `/${context.launchpadItem.type}/${context.launchpadItem.uuid}`;
+		}
+	} else if (context.launchpadItem != null) {
+		uniqueness += `/lp/${focusCategoryToGroupMap.get(
+			sharedCategoryToFocusActionCategoryMap.get(context.launchpadItem.suggestedActionCategory)!,
+		)}/${context.launchpadItem.type}/${context.launchpadItem.uuid}`;
 	}
 	if (context.pullRequest != null) {
 		uniqueness += `/pr/${context.pullRequest.id}`;

--- a/src/views/nodes/pullRequestNode.ts
+++ b/src/views/nodes/pullRequestNode.ts
@@ -15,6 +15,7 @@ import { CacheableChildrenViewNode } from './abstract/cacheableChildrenViewNode'
 import type { ClipboardType, ViewNode } from './abstract/viewNode';
 import { ContextValues, getViewNodeId } from './abstract/viewNode';
 import { CodeSuggestionsNode } from './codeSuggestionsNode';
+import { MessageNode } from './common';
 import { ResultsCommitsNode } from './resultsCommitsNode';
 import { ResultsFilesNode } from './resultsFilesNode';
 
@@ -156,6 +157,10 @@ export async function getPullRequestChildren(
 		repoPath,
 		createRevisionRange(comparison.ref1, comparison.ref2, '...'),
 	);
+
+	if (!counts?.right) {
+		return [new MessageNode(view, parent, 'No commits could be found.')];
+	}
 
 	const children = [
 		new ResultsCommitsNode(

--- a/src/views/pullRequestView.ts
+++ b/src/views/pullRequestView.ts
@@ -131,8 +131,7 @@ export class PullRequestView extends ViewBase<'pullRequest', PullRequestViewNode
 			!configuration.changed(e, 'defaultDateSource') &&
 			!configuration.changed(e, 'defaultDateStyle') &&
 			!configuration.changed(e, 'defaultGravatarsStyle') &&
-			!configuration.changed(e, 'defaultTimeFormat') &&
-			!configuration.changed(e, 'plusFeatures.enabled')
+			!configuration.changed(e, 'defaultTimeFormat')
 		) {
 			return false;
 		}

--- a/src/views/viewBase.ts
+++ b/src/views/viewBase.ts
@@ -18,6 +18,7 @@ import type {
 	ContributorsViewConfig,
 	DraftsViewConfig,
 	FileHistoryViewConfig,
+	LaunchpadViewConfig,
 	LineHistoryViewConfig,
 	PullRequestViewConfig,
 	RemotesViewConfig,
@@ -46,6 +47,7 @@ import type { CommitsView } from './commitsView';
 import type { ContributorsView } from './contributorsView';
 import type { DraftsView } from './draftsView';
 import type { FileHistoryView } from './fileHistoryView';
+import type { LaunchpadView } from './launchpadView';
 import type { LineHistoryView } from './lineHistoryView';
 import type { PageableViewNode, ViewNode } from './nodes/abstract/viewNode';
 import { isPageableViewNode } from './nodes/abstract/viewNode';
@@ -64,6 +66,7 @@ export type View =
 	| ContributorsView
 	| DraftsView
 	| FileHistoryView
+	| LaunchpadView
 	| LineHistoryView
 	| PullRequestView
 	| RemotesView
@@ -85,7 +88,7 @@ export type ViewsWithRepositories = RepositoriesView | WorkspacesView;
 export type ViewsWithRepositoriesNode = RepositoriesView | WorkspacesView;
 export type ViewsWithRepositoryFolders = Exclude<
 	View,
-	DraftsView | FileHistoryView | LineHistoryView | PullRequestView | RepositoriesView | WorkspacesView
+	DraftsView | FileHistoryView | LaunchpadView | LineHistoryView | PullRequestView | RepositoriesView | WorkspacesView
 >;
 export type ViewsWithStashes = StashesView | ViewsWithCommits;
 export type ViewsWithStashesNode = RepositoriesView | StashesView | WorkspacesView;
@@ -108,6 +111,7 @@ export abstract class ViewBase<
 			| ContributorsViewConfig
 			| DraftsViewConfig
 			| FileHistoryViewConfig
+			| LaunchpadViewConfig
 			| LineHistoryViewConfig
 			| PullRequestViewConfig
 			| RemotesViewConfig


### PR DESCRIPTION
Adds an experimental Launchpad view, behind a `gitlens.views.launchpad.enabled` setting. It has very basic PR functionality -- no specific launchpad actions, other than clicking on the row opens Launchpad

![image](https://github.com/user-attachments/assets/3af169aa-343b-42b6-9783-ef05d76e59bb)

It also adds local repo matching and virtual repository fallback to show PR commits/files.

