### PR TITLE
Adds onboarding feature on the home page GLVSC-613

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -223,6 +223,7 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/) and this p
 - Adds a _Connect Remote Integration_ command to the _Autolinked Issues and Pull Requests_ section in the _Search & Compare_ view
 - Adds `gitlens.currentLine.fontFamily`, `gitlens.currentLine.fontSize`, `gitlens.currentLine.fontStyle`, `gitlens.currentLine.fontWeight` settings to specify the font (family, size, style, and weight respectively) of the _Inline Blame_ annotation &mdash; closes [#3306](https://github.com/gitkraken/vscode-gitlens/issues/3306)
 - Adds `gitlens.blame.fontStyle` settings to specify the font style of the _File Blame_ annotations
+- Adds new onboarding widget to the home page
 
 ### Changed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/) and this p
 ### Added
 
 - Adds a `gitlens.views.showCurrentBranchOnTop` setting to specify whether the current branch is shown at the top of the views &mdash; closes [#3520](https://github.com/gitkraken/vscode-gitlens/issues/3520)
+- Adds new onboarding widget to the home page
 
 ### Fixed
 
@@ -223,7 +224,6 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/) and this p
 - Adds a _Connect Remote Integration_ command to the _Autolinked Issues and Pull Requests_ section in the _Search & Compare_ view
 - Adds `gitlens.currentLine.fontFamily`, `gitlens.currentLine.fontSize`, `gitlens.currentLine.fontStyle`, `gitlens.currentLine.fontWeight` settings to specify the font (family, size, style, and weight respectively) of the _Inline Blame_ annotation &mdash; closes [#3306](https://github.com/gitkraken/vscode-gitlens/issues/3306)
 - Adds `gitlens.blame.fontStyle` settings to specify the font style of the _File Blame_ annotations
-- Adds new onboarding widget to the home page
 
 ### Changed
 

--- a/package.json
+++ b/package.json
@@ -17903,7 +17903,11 @@
 						"media": {
 							"altText": "Illustrations of Launchpad",
 							"svg": "walkthroughs/welcome/launchpad-quick.svg"
-						}
+						},
+						"//": "there can be used vscode context that we could sync with the onboarding state",
+						"completionEvents": [
+							"onCommand:gitlens.showLaunchpad"
+						]
 					},
 					{
 						"id": "code-collab",

--- a/src/codelens/codeLensController.ts
+++ b/src/codelens/codeLensController.ts
@@ -60,6 +60,7 @@ export class GitCodeLensController implements Disposable {
 		using scope = startLogScope(`${getLoggableName(this)}.onBlameStateChanged`, false);
 
 		Logger.log(scope, 'resetting CodeLens provider');
+		void this.container.usage.track('codeLens:activated');
 		this._provider.reset();
 	}
 

--- a/src/codelens/codeLensProvider.ts
+++ b/src/codelens/codeLensProvider.ts
@@ -169,6 +169,7 @@ export class GitCodeLensProvider implements CodeLensProvider {
 
 		if (symbols !== undefined) {
 			Logger.log(scope, `${symbols.length} symbol(s) found`);
+			this._onDidChangeCodeLenses.fire();
 			for (const sym of symbols) {
 				this.provideCodeLens(
 					lenses,

--- a/src/git/gitProviderService.ts
+++ b/src/git/gitProviderService.ts
@@ -1055,6 +1055,16 @@ export class GitProviderService implements Disposable {
 
 	private _sendProviderContextTelemetryDebounced: Deferrable<() => void> | undefined;
 
+	private trackRepoHostUsage(hasReposWithHostingIntegrationsConnected: boolean) {
+		const previouslySavedValue = Boolean(this.container.usage.get('integration:repoHost'));
+		if (previouslySavedValue && !hasReposWithHostingIntegrationsConnected) {
+			void this.container.usage.reset('integration:repoHost');
+		}
+		if (!previouslySavedValue && hasReposWithHostingIntegrationsConnected) {
+			void this.container.usage.track('integration:repoHost');
+		}
+	}
+
 	private updateContext() {
 		if (this.container.deactivating) return;
 
@@ -1141,6 +1151,8 @@ export class GitProviderService implements Disposable {
 				}
 				this._sendProviderContextTelemetryDebounced();
 			}
+
+			this.trackRepoHostUsage(Boolean(reposWithHostingIntegrationsConnected.size));
 
 			await Promise.allSettled([
 				setContext('gitlens:repos:withRemotes', reposWithRemotes.size ? [...reposWithRemotes] : undefined),

--- a/src/system/command.ts
+++ b/src/system/command.ts
@@ -33,6 +33,7 @@ export function registerCommand(command: string, callback: CommandCallback, this
 				}
 			}
 			Container.instance.telemetry.sendEvent('command', { command: command, context: context });
+			void Container.instance.usage.track(`command:${command as Commands}:executed`);
 			callback.call(this, ...args);
 		},
 		thisArg,

--- a/src/telemetry/usageTracker.ts
+++ b/src/telemetry/usageTracker.ts
@@ -64,7 +64,7 @@ export class UsageTracker implements Disposable {
 		if (usages == null) {
 			usages = Object.create(null) as NonNullable<typeof usages>;
 		}
-
+		// debugger;
 		const usedAt = Date.now();
 
 		let usage = usages[key];

--- a/src/telemetry/usageTracker.ts
+++ b/src/telemetry/usageTracker.ts
@@ -1,5 +1,6 @@
 import type { Disposable, Event } from 'vscode';
 import { EventEmitter } from 'vscode';
+import type { Commands } from '../constants.commands';
 import type { CustomEditorTypes, TreeViewTypes, WebviewTypes, WebviewViewTypes } from '../constants.views';
 import type { Container } from '../container';
 import { updateRecordValue } from '../system/object';
@@ -11,11 +12,19 @@ export interface TrackedUsage {
 	lastUsedAt: number;
 }
 
+export type EditorTrackedFeatures = 'lineBlame:hovered' | 'codeLens:activated';
+export type IntegrationTrackedFeatures = 'integration:repoHost';
+export type CommandExecutionTrackedFeatures = `command:${Commands}:executed`;
+
 export type TrackedUsageFeatures =
 	| `${WebviewTypes}Webview`
 	| `${TreeViewTypes | WebviewViewTypes}View`
 	| `${CustomEditorTypes}Editor`;
-export type TrackedUsageKeys = `${TrackedUsageFeatures}:shown`;
+export type TrackedUsageKeys =
+	| `${TrackedUsageFeatures}:shown`
+	| EditorTrackedFeatures
+	| CommandExecutionTrackedFeatures
+	| IntegrationTrackedFeatures;
 
 export type UsageChangeEvent = {
 	/**
@@ -64,7 +73,7 @@ export class UsageTracker implements Disposable {
 		if (usages == null) {
 			usages = Object.create(null) as NonNullable<typeof usages>;
 		}
-		// debugger;
+
 		const usedAt = Date.now();
 
 		let usage = usages[key];

--- a/src/webviews/apps/home/home.html
+++ b/src/webviews/apps/home/home.html
@@ -140,7 +140,26 @@
 			<p data-requires="norepo">
 				<code-icon icon="question"></code-icon> Features which need a repository are currently unavailable
 			</p>
-			<div id="section-walkthrough" data-section-expand="walkthrough" class="alert">
+			<div class="promo-banner" id="promo-hs2023" hidden>
+				<a
+					class="promo-banner__link"
+					href="https://gitkraken.com/hs23?utm_source=holiday_special&utm_medium=gitlens_banner&utm_campaign=holiday_special_2023"
+					aria-label="Holiday Special: 1st seat of Pro (plus the entire GitKraken DevEx platform) is now 50%+ off. Includes all Pro versions: GitLens, GitKraken Client, CLI, Browser Extension & more! See your special price."
+				>
+					<img
+						class="promo-banner__media is-dark"
+						src="#{webroot}/media/holiday-2023-small-dark.webp"
+						alt=""
+					/>
+					<img
+						class="promo-banner__media is-light"
+						src="#{webroot}/media/holiday-2023-small-light.webp"
+						alt=""
+					/><br />
+					1st seat of Pro (plus the entire GitKraken DevEx platform) is now 50%+ off. See your special price.
+				</a>
+			</div>
+			<!-- <div id="section-walkthrough" data-section-expand="walkthrough" class="alert">
 				<h1 class="alert__title">Get Started with GitLens</h1>
 				<div class="alert__description">
 					<p>Explore all of the powerful features in GitLens</p>
@@ -177,7 +196,12 @@
 						<span slot="content">Expand</span>
 					</gl-tooltip>
 				</a>
-			</div>
+			</div> -->
+			<nav class="nav-list">
+				<gl-onboarding>
+					<span slot="title">Get Started with GitLens</span>
+				</gl-onboarding>
+			</nav>
 			<nav class="nav-list">
 				<h2 class="nav-list__title t-eyebrow sticky">Setup</h2>
 				<div class="nav-list__item">

--- a/src/webviews/apps/home/home.html
+++ b/src/webviews/apps/home/home.html
@@ -159,44 +159,6 @@
 					1st seat of Pro (plus the entire GitKraken DevEx platform) is now 50%+ off. See your special price.
 				</a>
 			</div>
-			<!-- <div id="section-walkthrough" data-section-expand="walkthrough" class="alert">
-				<h1 class="alert__title">Get Started with GitLens</h1>
-				<div class="alert__description">
-					<p>Explore all of the powerful features in GitLens</p>
-					<p class="button-container button-container--trio">
-						<gl-button
-							appearance="secondary"
-							full
-							href="command:gitlens.showWelcomePage"
-							aria-label="Open Welcome"
-							>Start Here (Welcome)</gl-button
-						>
-						<span class="button-group button-group--single">
-							<gl-button appearance="secondary" full href="command:gitlens.getStarted?%22home%22"
-								>Walkthrough</gl-button
-							>
-							<gl-button
-								appearance="secondary"
-								full
-								href="https://youtu.be/oJdlGtsbc3U?utm_source=inapp&utm_medium=home_banner&utm_id=GitLens+tutorial"
-								aria-label="Watch the GitLens Tutorial video"
-								tooltip="Watch the GitLens Tutorial video"
-								><code-icon icon="vm-running" slot="prefix"></code-icon>Tutorial</gl-button
-							>
-						</span>
-					</p>
-				</div>
-				<a href="#" class="alert__close" data-section-toggle="walkthrough">
-					<gl-tooltip hoist>
-						<code-icon icon="chevron-down" aria-label="Collapse walkthrough section"></code-icon>
-						<span slot="content">Collapse</span>
-					</gl-tooltip>
-					<gl-tooltip hoist>
-						<code-icon icon="chevron-right" aria-label="Expand walkthrough section"></code-icon>
-						<span slot="content">Expand</span>
-					</gl-tooltip>
-				</a>
-			</div> -->
 			<nav class="nav-list">
 				<gl-onboarding>
 					<span slot="title">Get Started with GitLens</span>

--- a/src/webviews/apps/home/home.html
+++ b/src/webviews/apps/home/home.html
@@ -396,7 +396,7 @@
 					<a
 						class="nav-list__link"
 						href="command:workbench.view.scm"
-						aria-label="Show GitLens Side Bar"
+						aria-label="Show Source Control Side Bar"
 						data-requires="repo"
 						><code-icon class="nav-list__icon" icon="source-control"></code-icon
 						><gl-tooltip hoist class="nav-list__label" content="Show Source Control Side Bar"

--- a/src/webviews/apps/home/home.scss
+++ b/src/webviews/apps/home/home.scss
@@ -23,10 +23,6 @@
 	--promo-banner-dark-display: inline-block;
 }
 
-gl-onboarding {
-	// padding: 0 20px;
-}
-
 .vscode-high-contrast-light,
 .vscode-light {
 	--progress-bar-color: var(--color-background--darken-15);

--- a/src/webviews/apps/home/home.scss
+++ b/src/webviews/apps/home/home.scss
@@ -23,6 +23,10 @@
 	--promo-banner-dark-display: inline-block;
 }
 
+gl-onboarding {
+	// padding: 0 20px;
+}
+
 .vscode-high-contrast-light,
 .vscode-light {
 	--progress-bar-color: var(--color-background--darken-15);

--- a/src/webviews/apps/home/home.ts
+++ b/src/webviews/apps/home/home.ts
@@ -2,14 +2,15 @@
 import './home.scss';
 import type { Disposable } from 'vscode';
 import { getApplicablePromo } from '../../../plus/gk/account/promos';
-import type { OnboardingState, State } from '../../home/protocol';
+import type { OnboardingItem, OnboardingState, State } from '../../home/protocol';
 import {
 	DidChangeIntegrationsConnections,
-	DidChangeOnboardingConfiguration,
+	DidChangeOnboardingEditor,
+	DidChangeOnboardingIntegration,
+	DidChangeOnboardingState,
 	DidChangeOrgSettings,
 	DidChangeRepositories,
 	DidChangeSubscription,
-	DidChangeOnboardingState,
 } from '../../home/protocol';
 import type { IpcMessage } from '../../protocol';
 import { ExecuteCommand } from '../../protocol';
@@ -24,7 +25,6 @@ import '../shared/components/feature-badge';
 import '../shared/components/overlays/tooltip';
 import '../shared/components/promo';
 import '../shared/components/onboarding/onboarding';
-import type { OnboardingItem } from './model/gitlens-onboarding';
 import { getOnboardingConfiguration } from './model/gitlens-onboarding';
 
 type GlOnboarding = _GlOnboarding<OnboardingState, OnboardingItem>;
@@ -43,7 +43,10 @@ export class HomeApp extends App<State> {
 
 	attachState() {
 		this.component.state = this.state.onboardingState;
-		this.component.onboardingConfiguration = getOnboardingConfiguration(this.state.onboardingExtras);
+		this.component.onboardingConfiguration = getOnboardingConfiguration(
+			this.state.editorPreviewEnabled,
+			this.state.repoHostConnected,
+		);
 	}
 
 	private get blockRepoFeatures() {
@@ -79,8 +82,16 @@ export class HomeApp extends App<State> {
 				this.attachState();
 				break;
 
-			case DidChangeOnboardingConfiguration.is(msg):
-				this.state.onboardingExtras = msg.params;
+			case DidChangeOnboardingEditor.is(msg):
+				this.state.editorPreviewEnabled = msg.params.editorPreviewEnabled;
+				this.state.timestamp = Date.now();
+				this.setState(this.state);
+				this.attachState();
+				break;
+
+			case DidChangeOnboardingIntegration.is(msg):
+				this.state.onboardingState = msg.params.onboardingState;
+				this.state.repoHostConnected = msg.params.repoHostConnected;
 				this.state.timestamp = Date.now();
 				this.setState(this.state);
 				this.attachState();

--- a/src/webviews/apps/home/home.ts
+++ b/src/webviews/apps/home/home.ts
@@ -9,6 +9,7 @@ import {
 	DidChangeLineBlameState,
 	DidChangeOnboardingEditor,
 	DidChangeOnboardingIntegration,
+	DidChangeOnboardingIsInitialized,
 	DidChangeOnboardingState,
 	DidChangeOrgSettings,
 	DidChangeRepositories,
@@ -44,6 +45,7 @@ export class HomeApp extends App<State> {
 	}
 
 	attachState() {
+		this.component.isInitialized = this.state.isOnboardingInitialized;
 		this.component.state = this.state.onboardingState;
 		this.component.disabled = this.blockRepoFeatures;
 		this.component.onboardingConfiguration = getOnboardingConfiguration(
@@ -111,6 +113,13 @@ export class HomeApp extends App<State> {
 			case DidChangeOnboardingIntegration.is(msg):
 				this.state.onboardingState = msg.params.onboardingState;
 				this.state.repoHostConnected = msg.params.repoHostConnected;
+				this.state.timestamp = Date.now();
+				this.setState(this.state);
+				this.attachState();
+				break;
+
+			case DidChangeOnboardingIsInitialized.is(msg):
+				this.state.isOnboardingInitialized = msg.params.isInitialized;
 				this.state.timestamp = Date.now();
 				this.setState(this.state);
 				this.attachState();

--- a/src/webviews/apps/home/home.ts
+++ b/src/webviews/apps/home/home.ts
@@ -9,7 +9,7 @@ import {
 	DidChangeOrgSettings,
 	DidChangeRepositories,
 	DidChangeSubscription,
-	DidChangeUsage,
+	DidChangeOnboardingState,
 } from '../../home/protocol';
 import type { IpcMessage } from '../../protocol';
 import { ExecuteCommand } from '../../protocol';
@@ -72,7 +72,7 @@ export class HomeApp extends App<State> {
 
 	protected override onMessageReceived(msg: IpcMessage) {
 		switch (true) {
-			case DidChangeUsage.is(msg):
+			case DidChangeOnboardingState.is(msg):
 				this.state.onboardingState = msg.params;
 				this.state.timestamp = Date.now();
 				this.setState(this.state);

--- a/src/webviews/apps/home/home.ts
+++ b/src/webviews/apps/home/home.ts
@@ -12,10 +12,9 @@ import {
 	DidChangeOrgSettings,
 	DidChangeRepositories,
 	DidChangeSubscription,
-	DidResume,
 } from '../../home/protocol';
 import type { IpcMessage } from '../../protocol';
-import { DidChangeHostWindowFocusNotification, DidChangeWebviewFocusNotfication, ExecuteCommand } from '../../protocol';
+import { ExecuteCommand } from '../../protocol';
 import { App } from '../shared/appBase';
 import type { GlFeatureBadge } from '../shared/components/feature-badge';
 import type { GlOnboarding as _GlOnboarding } from '../shared/components/onboarding/onboarding';
@@ -45,6 +44,7 @@ export class HomeApp extends App<State> {
 
 	attachState() {
 		this.component.state = this.state.onboardingState;
+		this.component.disabled = this.blockRepoFeatures;
 		this.component.onboardingConfiguration = getOnboardingConfiguration(
 			this.state.editorPreviewEnabled,
 			this.state.repoHostConnected,
@@ -78,11 +78,6 @@ export class HomeApp extends App<State> {
 
 	protected override onMessageReceived(msg: IpcMessage) {
 		switch (true) {
-			case DidResume.is(msg):
-				console.log('home test focus', msg.params);
-				this.attachState();
-				break;
-
 			case DidChangeOnboardingState.is(msg):
 				this.state.onboardingState = msg.params;
 				this.state.timestamp = Date.now();

--- a/src/webviews/apps/home/home.ts
+++ b/src/webviews/apps/home/home.ts
@@ -4,6 +4,7 @@ import type { Disposable } from 'vscode';
 import { getApplicablePromo } from '../../../plus/gk/account/promos';
 import type { OnboardingItem, OnboardingState, State } from '../../home/protocol';
 import {
+	DidChangeCodeLensState,
 	DidChangeIntegrationsConnections,
 	DidChangeOnboardingEditor,
 	DidChangeOnboardingIntegration,
@@ -11,9 +12,10 @@ import {
 	DidChangeOrgSettings,
 	DidChangeRepositories,
 	DidChangeSubscription,
+	DidResume,
 } from '../../home/protocol';
 import type { IpcMessage } from '../../protocol';
-import { ExecuteCommand } from '../../protocol';
+import { DidChangeHostWindowFocusNotification, DidChangeWebviewFocusNotfication, ExecuteCommand } from '../../protocol';
 import { App } from '../shared/appBase';
 import type { GlFeatureBadge } from '../shared/components/feature-badge';
 import type { GlOnboarding as _GlOnboarding } from '../shared/components/onboarding/onboarding';
@@ -46,6 +48,7 @@ export class HomeApp extends App<State> {
 		this.component.onboardingConfiguration = getOnboardingConfiguration(
 			this.state.editorPreviewEnabled,
 			this.state.repoHostConnected,
+			this.state.canEnableCodeLens,
 		);
 	}
 
@@ -75,6 +78,11 @@ export class HomeApp extends App<State> {
 
 	protected override onMessageReceived(msg: IpcMessage) {
 		switch (true) {
+			case DidResume.is(msg):
+				console.log('home test focus', msg.params);
+				this.attachState();
+				break;
+
 			case DidChangeOnboardingState.is(msg):
 				this.state.onboardingState = msg.params;
 				this.state.timestamp = Date.now();
@@ -84,6 +92,13 @@ export class HomeApp extends App<State> {
 
 			case DidChangeOnboardingEditor.is(msg):
 				this.state.editorPreviewEnabled = msg.params.editorPreviewEnabled;
+				this.state.timestamp = Date.now();
+				this.setState(this.state);
+				this.attachState();
+				break;
+
+			case DidChangeCodeLensState.is(msg):
+				this.state.canEnableCodeLens = msg.params.canBeEnabled;
 				this.state.timestamp = Date.now();
 				this.setState(this.state);
 				this.attachState();

--- a/src/webviews/apps/home/home.ts
+++ b/src/webviews/apps/home/home.ts
@@ -2,6 +2,7 @@
 import './home.scss';
 import type { Disposable } from 'vscode';
 import { getApplicablePromo } from '../../../plus/gk/account/promos';
+import { SubscriptionState } from '../../../plus/gk/account/subscription';
 import type { OnboardingItem, OnboardingState, State } from '../../home/protocol';
 import {
 	DidChangeCodeLensState,
@@ -14,6 +15,7 @@ import {
 	DidChangeOrgSettings,
 	DidChangeRepositories,
 	DidChangeSubscription,
+	DidTogglePlusFeatures,
 } from '../../home/protocol';
 import type { IpcMessage } from '../../protocol';
 import { ExecuteCommand } from '../../protocol';
@@ -53,6 +55,10 @@ export class HomeApp extends App<State> {
 			this.state.repoHostConnected,
 			this.state.canEnableCodeLens,
 			this.state.canEnableLineBlame,
+			this.state.proFeaturesEnabled,
+			this.state.subscription.state === SubscriptionState.Free,
+			this.state.subscription.state === SubscriptionState.FreePlusTrialReactivationEligible,
+			this.state.subscription.state !== SubscriptionState.Paid,
 		);
 	}
 
@@ -84,6 +90,13 @@ export class HomeApp extends App<State> {
 		switch (true) {
 			case DidChangeOnboardingState.is(msg):
 				this.state.onboardingState = msg.params;
+				this.state.timestamp = Date.now();
+				this.setState(this.state);
+				this.attachState();
+				break;
+
+			case DidTogglePlusFeatures.is(msg):
+				this.state.proFeaturesEnabled = msg.params;
 				this.state.timestamp = Date.now();
 				this.setState(this.state);
 				this.attachState();

--- a/src/webviews/apps/home/home.ts
+++ b/src/webviews/apps/home/home.ts
@@ -4,8 +4,8 @@ import type { Disposable } from 'vscode';
 import { getApplicablePromo } from '../../../plus/gk/account/promos';
 import type { OnboardingState, State } from '../../home/protocol';
 import {
-	CollapseSectionCommand,
 	DidChangeIntegrationsConnections,
+	DidChangeOnboardingConfiguration,
 	DidChangeOrgSettings,
 	DidChangeRepositories,
 	DidChangeSubscription,
@@ -15,8 +15,8 @@ import type { IpcMessage } from '../../protocol';
 import { ExecuteCommand } from '../../protocol';
 import { App } from '../shared/appBase';
 import type { GlFeatureBadge } from '../shared/components/feature-badge';
-import type { GlPromo } from '../shared/components/promo';
 import type { GlOnboarding as _GlOnboarding } from '../shared/components/onboarding/onboarding';
+import type { GlPromo } from '../shared/components/promo';
 import { DOM } from '../shared/dom';
 import '../shared/components/button';
 import '../shared/components/code-icon';
@@ -25,7 +25,7 @@ import '../shared/components/overlays/tooltip';
 import '../shared/components/promo';
 import '../shared/components/onboarding/onboarding';
 import type { OnboardingItem } from './model/gitlens-onboarding';
-import { onboardingConfiguration } from './model/gitlens-onboarding';
+import { getOnboardingConfiguration } from './model/gitlens-onboarding';
 
 type GlOnboarding = _GlOnboarding<OnboardingState, OnboardingItem>;
 export class HomeApp extends App<State> {
@@ -43,7 +43,7 @@ export class HomeApp extends App<State> {
 
 	attachState() {
 		this.component.state = this.state.onboardingState;
-		this.component.onboardingConfiguration = onboardingConfiguration;
+		this.component.onboardingConfiguration = getOnboardingConfiguration(this.state.onboardingExtras);
 	}
 
 	private get blockRepoFeatures() {
@@ -65,12 +65,6 @@ export class HomeApp extends App<State> {
 		disposables.push(
 			DOM.on('[data-action]', 'click', (e, target: HTMLElement) => this.onDataActionClicked(e, target)),
 			DOM.on('[data-requires="repo"]', 'click', (e, target: HTMLElement) => this.onRepoFeatureClicked(e, target)),
-			DOM.on('[data-section-toggle]', 'click', (e, target: HTMLElement) =>
-				this.onSectionToggleClicked(e, target),
-			),
-			DOM.on('[data-section-expand]', 'click', (e, target: HTMLElement) =>
-				this.onSectionExpandClicked(e, target),
-			),
 		);
 
 		return disposables;
@@ -84,6 +78,14 @@ export class HomeApp extends App<State> {
 				this.setState(this.state);
 				this.attachState();
 				break;
+
+			case DidChangeOnboardingConfiguration.is(msg):
+				this.state.onboardingExtras = msg.params;
+				this.state.timestamp = Date.now();
+				this.setState(this.state);
+				this.attachState();
+				break;
+
 			case DidChangeRepositories.is(msg):
 				this.state.repositories = msg.params;
 				this.state.timestamp = Date.now();
@@ -138,24 +140,6 @@ export class HomeApp extends App<State> {
 		}
 	}
 
-	private onSectionToggleClicked(e: MouseEvent, target: HTMLElement) {
-		e.stopImmediatePropagation();
-		const section = target.dataset.sectionToggle;
-		if (section !== 'walkthrough') {
-			return;
-		}
-
-		this.updateCollapsedSections(!this.state.walkthroughCollapsed);
-	}
-
-	private onSectionExpandClicked(e: MouseEvent, target: HTMLElement) {
-		const section = target.dataset.sectionExpand;
-		if (section !== 'walkthrough') {
-			return;
-		}
-		this.updateCollapsedSections(false);
-	}
-
 	private updateNoRepo() {
 		const {
 			repositories: { openCount, hasUnsafe, trusted },
@@ -203,16 +187,6 @@ export class HomeApp extends App<State> {
 			el.source = { source: 'home', detail: 'badge' };
 			el.subscription = subscription;
 		}
-	}
-
-	private updateCollapsedSections(toggle = this.state.walkthroughCollapsed) {
-		this.state.walkthroughCollapsed = toggle;
-		this.setState({ walkthroughCollapsed: toggle });
-		document.getElementById('section-walkthrough')!.classList.toggle('is-collapsed', toggle);
-		this.sendCommand(CollapseSectionCommand, {
-			section: 'walkthrough',
-			collapsed: toggle,
-		});
 	}
 
 	private updateIntegrations() {

--- a/src/webviews/apps/home/home.ts
+++ b/src/webviews/apps/home/home.ts
@@ -6,6 +6,7 @@ import type { OnboardingItem, OnboardingState, State } from '../../home/protocol
 import {
 	DidChangeCodeLensState,
 	DidChangeIntegrationsConnections,
+	DidChangeLineBlameState,
 	DidChangeOnboardingEditor,
 	DidChangeOnboardingIntegration,
 	DidChangeOnboardingState,
@@ -49,6 +50,7 @@ export class HomeApp extends App<State> {
 			this.state.editorPreviewEnabled,
 			this.state.repoHostConnected,
 			this.state.canEnableCodeLens,
+			this.state.canEnableLineBlame,
 		);
 	}
 
@@ -94,6 +96,13 @@ export class HomeApp extends App<State> {
 
 			case DidChangeCodeLensState.is(msg):
 				this.state.canEnableCodeLens = msg.params.canBeEnabled;
+				this.state.timestamp = Date.now();
+				this.setState(this.state);
+				this.attachState();
+				break;
+
+			case DidChangeLineBlameState.is(msg):
+				this.state.canEnableLineBlame = msg.params.canBeEnabled;
 				this.state.timestamp = Date.now();
 				this.setState(this.state);
 				this.attachState();

--- a/src/webviews/apps/home/model/gitlens-onboarding.ts
+++ b/src/webviews/apps/home/model/gitlens-onboarding.ts
@@ -1,0 +1,58 @@
+import { Commands } from '../../../../constants';
+import type { OnboardingItemConfiguration } from '../../shared/components/onboarding/onboarding-types';
+
+export enum OnboardingItem {
+	configuration = 'configuration',
+	commitGraph = 'commitGraph',
+	gitLens = 'gitLens',
+	inspect = 'inspect',
+	stashes = 'stashes',
+	commits = 'commits',
+	branches = 'branches',
+	tags = 'tags',
+	workTrees = 'workTrees',
+	workSpaces = 'workSpaces',
+	contributors = 'contributors',
+	cloudPatches = 'cloudPatches',
+	searchAndCompare = 'searchAndCompare',
+	fileHistory = 'fileHistory',
+	lineHistory = 'lineHistory',
+	visualFileHistory = 'visualFileHistory',
+	launchpad = 'launchpad',
+	revisionHistory = 'revisionHistory',
+	allViews = 'allViews',
+}
+
+const createCommandLink = (command: Commands) => `command:${command}`;
+
+export const onboardingConfiguration: OnboardingItemConfiguration<OnboardingItem>[] = [
+	{
+		itemId: OnboardingItem.configuration,
+		title: 'Configure GitLens',
+		infoHref: '#',
+		playHref: createCommandLink(Commands.ShowSettingsPage),
+	},
+	{
+		itemId: OnboardingItem.commitGraph,
+		title: 'Visit Commit Graph',
+		playHref: createCommandLink(Commands.ShowGraph),
+	},
+	{
+		itemId: OnboardingItem.allViews,
+		title: 'Visit All the GitLens pages',
+		infoTooltip: 'Be familiar with all views that you can see in the GitLens',
+		playHref: '#',
+		children: [
+			{
+				itemId: OnboardingItem.stashes,
+				title: 'Stashes View',
+				playHref: createCommandLink(Commands.ShowStashesView),
+			},
+			{
+				itemId: OnboardingItem.branches,
+				title: 'Branches View',
+				playHref: createCommandLink(Commands.ShowBranchesView),
+			},
+		],
+	},
+];

--- a/src/webviews/apps/home/model/gitlens-onboarding.ts
+++ b/src/webviews/apps/home/model/gitlens-onboarding.ts
@@ -17,7 +17,8 @@ export function getOnboardingConfiguration(
 				{
 					itemId: OnboardingItem.gitLens,
 					title: 'GitLens',
-					playHref: createCommandLink(Commands.ShowHomeView),
+					playHref: createCommandLink('workbench.view.extension.gitlens'),
+					playTooltip: 'Show the GitLens Sidebar',
 					infoHref: 'https://youtu.be/oJdlGtsbc3U?t=65',
 					infoTooltip:
 						'The GitLens tab includes short links to the main features, cloud patches, workspaces, and GitKraken account management sections',
@@ -25,7 +26,8 @@ export function getOnboardingConfiguration(
 				{
 					itemId: OnboardingItem.inspect,
 					title: 'GitLens Inspect',
-					playHref: createCommandLink(Commands.ShowCommitDetailsView),
+					playHref: createCommandLink('workbench.view.extension.gitlensInspect'),
+					playTooltip: 'Show the GitLens Inspect Sidebar',
 					infoTooltip: 'The GitLens Inspect tab includes compare tools',
 					infoHref: 'https://youtu.be/oJdlGtsbc3U?t=213',
 				},
@@ -33,6 +35,7 @@ export function getOnboardingConfiguration(
 					itemId: OnboardingItem.sourceControl,
 					title: 'Source Control',
 					playHref: createCommandLink('workbench.view.scm'),
+					playTooltip: 'Show the Source Control Sidebar',
 					infoHref: 'https://youtu.be/oJdlGtsbc3U?t=185',
 					infoTooltip:
 						'The Source Control is a default VSCode view, but it contains such GitLens sections as Commits, Branches, Remotes, Stashes, Tags, WorkTrees and Contributors',
@@ -44,17 +47,22 @@ export function getOnboardingConfiguration(
 			title: 'Editor / file features',
 			infoTooltip: 'Check the features of GitLens with active file editor',
 			playHref: passIfTrue(!editorPreviewEnabled, createCommandLink('workbench.action.quickOpen')),
+			playTooltip: 'Open a file to try editor features',
 			children: [
 				{
 					itemId: OnboardingItem.blame,
 					title: 'Hover over inline blame ',
 					infoHref: 'https://youtu.be/oJdlGtsbc3U?t=129',
 					infoTooltip: 'Put the cursor on any line in your file and hover over inline blame',
+					playHref: passIfTrue(editorPreviewEnabled, createCommandLink(Commands.ToggleLineBlame)),
+					playTooltip: 'Toggle inline blame',
 				},
 				{
 					itemId: OnboardingItem.codeLens,
 					title: 'Use Codelens',
 					infoHref: 'https://youtu.be/oJdlGtsbc3U?t=145',
+					playHref: passIfTrue(editorPreviewEnabled, createCommandLink(Commands.ToggleCodeLens)),
+					playTooltip: 'Toggle Git CodeLens',
 				},
 				{
 					itemId: OnboardingItem.fileAnnotations,
@@ -62,6 +70,7 @@ export function getOnboardingConfiguration(
 					infoHref: 'https://youtu.be/oJdlGtsbc3U?t=153',
 					infoTooltip: 'Check file history. Open any file to test it',
 					playHref: passIfTrue(editorPreviewEnabled, createCommandLink(Commands.ToggleFileBlame)),
+					playTooltip: 'Toggle File Blame',
 				},
 				{
 					itemId: OnboardingItem.revisionHistory,
@@ -69,6 +78,7 @@ export function getOnboardingConfiguration(
 					infoHref: 'https://youtu.be/oJdlGtsbc3U?t=178',
 					infoTooltip: 'Check file history. Open any file to test it',
 					playHref: passIfTrue(editorPreviewEnabled, createCommandLink(Commands.DiffWithPrevious)),
+					playTooltip: 'Open changes with the previous revision',
 				},
 			],
 		},
@@ -77,12 +87,14 @@ export function getOnboardingConfiguration(
 			title: 'View the Commit Graph',
 			infoHref: 'https://youtu.be/oJdlGtsbc3U?t=275',
 			playHref: createCommandLink(Commands.ShowGraph),
+			playTooltip: 'Show the Commit Graph',
 		},
 		{
 			itemId: OnboardingItem.launchpad,
 			title: 'Open Launchpad',
-			playHref: createCommandLink('gitlens.launchpad.split'),
+			playHref: createCommandLink(Commands.ShowLaunchpad),
 			infoHref: 'https://youtu.be/oJdlGtsbc3U?t=443',
+			playTooltip: 'Open Launchpad',
 		},
 		{
 			itemId: OnboardingItem.repoHost,
@@ -90,13 +102,14 @@ export function getOnboardingConfiguration(
 			playHref: passIfTrue(!repoHostConnected, createCommandLink(Commands.ConnectRemoteProvider)),
 			infoTooltip:
 				'Connect remote integration to have such additional features as enriched autolinks, extensive PR support on commits/branches, extensive repo and commit metadata, Launchpad support',
+			playTooltip: 'Connect remote integration',
 		},
 		{
 			itemId: OnboardingItem.visualFileHistory,
 			title: 'Visual File History',
 			infoHref: 'https://youtu.be/oJdlGtsbc3U?t=233',
-			// ??? should we show play button if no active editor ???
-			playHref: createCommandLink(editorPreviewEnabled ? Commands.ShowInTimeline : 'workbench.action.quickOpen'),
+			playHref: createCommandLink(Commands.ShowTimelineView),
+			playTooltip: 'Show Visual File History',
 		},
 	];
 }

--- a/src/webviews/apps/home/model/gitlens-onboarding.ts
+++ b/src/webviews/apps/home/model/gitlens-onboarding.ts
@@ -1,13 +1,21 @@
+import type { WalkthroughSteps } from '../../../../constants';
 import { Commands } from '../../../../constants.commands';
 import { OnboardingItem } from '../../../home/protocol';
 import { createCommandLink } from '../../shared/commands';
 import type { OnboardingItemConfiguration } from '../../shared/components/onboarding/onboarding-types';
+
+const createWalkthroughLink = (step: WalkthroughSteps) =>
+	createCommandLink(Commands.OpenWalkthrough, { args: { source: 'welcome', step: step } });
 
 export function getOnboardingConfiguration(
 	editorPreviewEnabled: boolean,
 	repoHostConnected: boolean,
 	canEnableCodeLens: boolean,
 	canEnableLineBlame: boolean,
+	proFeaturesEnabled: boolean,
+	canActivateTrial: boolean,
+	canReActivateTrial: boolean,
+	canUpgradeToPro: boolean,
 ): OnboardingItemConfiguration<OnboardingItem>[] {
 	const passIfTrue = <T>(condition: boolean, value: T): T | undefined => (condition ? value : undefined);
 	return [
@@ -48,6 +56,7 @@ export function getOnboardingConfiguration(
 			itemId: OnboardingItem.editorFeatures,
 			title: 'Editor / file features',
 			infoTooltip: 'Check the features of GitLens with active file editor',
+			infoHref: createWalkthroughLink('core-features'),
 			playHref: passIfTrue(!editorPreviewEnabled, createCommandLink('workbench.action.quickOpen')),
 			playTooltip: 'Open a file to try editor features',
 			children: [
@@ -88,33 +97,59 @@ export function getOnboardingConfiguration(
 			],
 		},
 		{
-			itemId: OnboardingItem.commitGraph,
-			title: 'View the Commit Graph',
-			infoHref: 'https://youtu.be/oJdlGtsbc3U?t=275',
-			playHref: createCommandLink(Commands.ShowGraph),
-			playTooltip: 'Show the Commit Graph',
-		},
-		{
 			itemId: OnboardingItem.launchpad,
 			title: 'Open Launchpad',
 			playHref: createCommandLink(Commands.ShowLaunchpad),
-			infoHref: 'https://youtu.be/oJdlGtsbc3U?t=443',
+			infoHref: createWalkthroughLink('launchpad'),
 			playTooltip: 'Open Launchpad',
 		},
 		{
 			itemId: OnboardingItem.repoHost,
 			title: 'Connect with Repo Host',
 			playHref: passIfTrue(!repoHostConnected, createCommandLink(Commands.ConnectRemoteProvider)),
+			infoHref: createWalkthroughLink('integrations'),
 			infoTooltip:
 				'Connect remote integration to have such additional features as enriched autolinks, extensive PR support on commits/branches, extensive repo and commit metadata, Launchpad support',
 			playTooltip: 'Connect remote integration',
 		},
 		{
-			itemId: OnboardingItem.visualFileHistory,
-			title: 'Visual File History',
-			infoHref: 'https://youtu.be/oJdlGtsbc3U?t=233',
-			playHref: createCommandLink(Commands.ShowTimelineView),
-			playTooltip: 'Show Visual File History',
+			itemId: OnboardingItem.proFeatures,
+			title: 'Pro features',
+			infoHref: createWalkthroughLink('pro-upgrade'),
+			playTooltip: 'Restore plus features',
+			playHref: passIfTrue(!proFeaturesEnabled, createCommandLink(Commands.PlusRestore)),
+			children: [
+				{
+					itemId: OnboardingItem.tryTrial,
+					title: canReActivateTrial ? 'Reactivate trial' : 'Activate trial',
+					infoTooltip: 'Try pro features',
+					playHref:
+						passIfTrue(canActivateTrial, createCommandLink(Commands.PlusStartPreviewTrial)) ??
+						passIfTrue(canReActivateTrial, createCommandLink(Commands.PlusReactivateProTrial)),
+				},
+				{
+					itemId: OnboardingItem.upgradeToPro,
+					playHref: passIfTrue(!canUpgradeToPro, createCommandLink(Commands.PlusUpgrade)),
+					title: 'Upgrade to pro',
+					playTooltip: 'Upgrade to pro to get more features',
+				},
+				{
+					itemId: OnboardingItem.commitGraph,
+					title: 'View the Commit Graph',
+					infoHref: createWalkthroughLink('visualize'),
+					playHref: createCommandLink(Commands.ShowGraph),
+					playTooltip: 'Show the Commit Graph',
+					disabled: !proFeaturesEnabled,
+				},
+				{
+					itemId: OnboardingItem.visualFileHistory,
+					title: 'Visual File History',
+					infoHref: 'https://youtu.be/oJdlGtsbc3U?t=233',
+					playHref: createCommandLink(Commands.ShowTimelineView),
+					playTooltip: 'Show Visual File History',
+					disabled: !proFeaturesEnabled,
+				},
+			],
 		},
 	];
 }

--- a/src/webviews/apps/home/model/gitlens-onboarding.ts
+++ b/src/webviews/apps/home/model/gitlens-onboarding.ts
@@ -7,6 +7,7 @@ export function getOnboardingConfiguration(
 	editorPreviewEnabled: boolean,
 	repoHostConnected: boolean,
 	canEnableCodeLens: boolean,
+	canEnableLineBlame: boolean,
 ): OnboardingItemConfiguration<OnboardingItem>[] {
 	const passIfTrue = <T>(condition: boolean, value: T): T | undefined => (condition ? value : undefined);
 	return [
@@ -55,8 +56,8 @@ export function getOnboardingConfiguration(
 					title: 'Hover over inline blame ',
 					infoHref: 'https://youtu.be/oJdlGtsbc3U?t=129',
 					infoTooltip: 'Put the cursor on any line in your file and hover over inline blame',
-					playHref: passIfTrue(editorPreviewEnabled, createCommandLink(Commands.ToggleLineBlame)),
-					playTooltip: 'Toggle inline blame',
+					playHref: passIfTrue(canEnableLineBlame, createCommandLink(Commands.ToggleLineBlame)),
+					playTooltip: 'Enable inline blame',
 				},
 				{
 					itemId: OnboardingItem.codeLens,
@@ -66,7 +67,7 @@ export function getOnboardingConfiguration(
 						editorPreviewEnabled && canEnableCodeLens,
 						createCommandLink(Commands.ToggleCodeLens),
 					),
-					playTooltip: 'Toggle Git CodeLens',
+					playTooltip: 'Enable Git CodeLens',
 				},
 				{
 					itemId: OnboardingItem.fileAnnotations,

--- a/src/webviews/apps/home/model/gitlens-onboarding.ts
+++ b/src/webviews/apps/home/model/gitlens-onboarding.ts
@@ -1,29 +1,12 @@
 import { Commands } from '../../../../constants.commands';
-import type { OnboardingConfigurationExtras } from '../../../home/protocol';
+import { OnboardingItem } from '../../../home/protocol';
+import { createCommandLink } from '../../shared/commands';
 import type { OnboardingItemConfiguration } from '../../shared/components/onboarding/onboarding-types';
 
-export enum OnboardingItem {
-	repoHost = 'repoHost',
-	commitGraph = 'commitGraph',
-	sourceControl = 'sourceControl',
-	gitLens = 'gitLens',
-	inspect = 'inspect',
-	visualFileHistory = 'visualFileHistory',
-	launchpad = 'launchpad',
-	revisionHistory = 'revisionHistory',
-	allSidebarViews = 'allSidebarViews',
-	editorFeatures = 'editorFeatures',
-	blame = 'blame',
-	codeLens = 'codeLens',
-	fileAnnotations = 'fileAnnotations',
-}
-
-const createCommandLink = (command: Commands | string) => `command:${command}`;
-
-export function getOnboardingConfiguration({
-	editorPreviewEnabled,
-	repoHostConnected,
-}: OnboardingConfigurationExtras): OnboardingItemConfiguration<OnboardingItem>[] {
+export function getOnboardingConfiguration(
+	editorPreviewEnabled: boolean,
+	repoHostConnected: boolean,
+): OnboardingItemConfiguration<OnboardingItem>[] {
 	const passIfTrue = <T>(condition: boolean, value: T): T | undefined => (condition ? value : undefined);
 	return [
 		{

--- a/src/webviews/apps/home/model/gitlens-onboarding.ts
+++ b/src/webviews/apps/home/model/gitlens-onboarding.ts
@@ -1,58 +1,119 @@
-import { Commands } from '../../../../constants';
+import { Commands } from '../../../../constants.commands';
+import type { OnboardingConfigurationExtras } from '../../../home/protocol';
 import type { OnboardingItemConfiguration } from '../../shared/components/onboarding/onboarding-types';
 
 export enum OnboardingItem {
-	configuration = 'configuration',
+	repoHost = 'repoHost',
 	commitGraph = 'commitGraph',
+	sourceControl = 'sourceControl',
 	gitLens = 'gitLens',
 	inspect = 'inspect',
-	stashes = 'stashes',
-	commits = 'commits',
-	branches = 'branches',
-	tags = 'tags',
-	workTrees = 'workTrees',
-	workSpaces = 'workSpaces',
-	contributors = 'contributors',
-	cloudPatches = 'cloudPatches',
-	searchAndCompare = 'searchAndCompare',
-	fileHistory = 'fileHistory',
-	lineHistory = 'lineHistory',
 	visualFileHistory = 'visualFileHistory',
 	launchpad = 'launchpad',
 	revisionHistory = 'revisionHistory',
-	allViews = 'allViews',
+	allSidebarViews = 'allSidebarViews',
+	editorFeatures = 'editorFeatures',
+	blame = 'blame',
+	codeLens = 'codeLens',
+	fileAnnotations = 'fileAnnotations',
 }
 
-const createCommandLink = (command: Commands) => `command:${command}`;
+const createCommandLink = (command: Commands | string) => `command:${command}`;
 
-export const onboardingConfiguration: OnboardingItemConfiguration<OnboardingItem>[] = [
-	{
-		itemId: OnboardingItem.configuration,
-		title: 'Configure GitLens',
-		infoHref: '#',
-		playHref: createCommandLink(Commands.ShowSettingsPage),
-	},
-	{
-		itemId: OnboardingItem.commitGraph,
-		title: 'Visit Commit Graph',
-		playHref: createCommandLink(Commands.ShowGraph),
-	},
-	{
-		itemId: OnboardingItem.allViews,
-		title: 'Visit All the GitLens pages',
-		infoTooltip: 'Be familiar with all views that you can see in the GitLens',
-		playHref: '#',
-		children: [
-			{
-				itemId: OnboardingItem.stashes,
-				title: 'Stashes View',
-				playHref: createCommandLink(Commands.ShowStashesView),
-			},
-			{
-				itemId: OnboardingItem.branches,
-				title: 'Branches View',
-				playHref: createCommandLink(Commands.ShowBranchesView),
-			},
-		],
-	},
-];
+export function getOnboardingConfiguration({
+	editorPreviewEnabled,
+	repoHostConnected,
+}: OnboardingConfigurationExtras): OnboardingItemConfiguration<OnboardingItem>[] {
+	const passIfTrue = <T>(condition: boolean, value: T): T | undefined => (condition ? value : undefined);
+	return [
+		{
+			itemId: OnboardingItem.allSidebarViews,
+			title: 'Visit sidebars with GitLens views',
+			infoHref: 'https://marketplace.visualstudio.com/items?itemName=eamodio.gitlens#side-bar-views',
+			children: [
+				{
+					itemId: OnboardingItem.gitLens,
+					title: 'GitLens',
+					playHref: createCommandLink(Commands.ShowHomeView),
+					infoHref: 'https://youtu.be/oJdlGtsbc3U?t=65',
+					infoTooltip:
+						'The GitLens tab includes short links to the main features, cloud patches, workspaces, and GitKraken account management sections',
+				},
+				{
+					itemId: OnboardingItem.inspect,
+					title: 'GitLens Inspect',
+					playHref: createCommandLink(Commands.ShowCommitDetailsView),
+					infoTooltip: 'The GitLens Inspect tab includes compare tools',
+					infoHref: 'https://youtu.be/oJdlGtsbc3U?t=213',
+				},
+				{
+					itemId: OnboardingItem.sourceControl,
+					title: 'Source Control',
+					playHref: createCommandLink('workbench.view.scm'),
+					infoHref: 'https://youtu.be/oJdlGtsbc3U?t=185',
+					infoTooltip:
+						'The Source Control is a default VSCode view, but it contains such GitLens sections as Commits, Branches, Remotes, Stashes, Tags, WorkTrees and Contributors',
+				},
+			],
+		},
+		{
+			itemId: OnboardingItem.editorFeatures,
+			title: 'Editor / file features',
+			infoTooltip: 'Check the features of GitLens with active file editor',
+			playHref: passIfTrue(!editorPreviewEnabled, createCommandLink('workbench.action.quickOpen')),
+			children: [
+				{
+					itemId: OnboardingItem.blame,
+					title: 'Hover over inline blame ',
+					infoHref: 'https://youtu.be/oJdlGtsbc3U?t=129',
+					infoTooltip: 'Put the cursor on any line in your file and hover over inline blame',
+				},
+				{
+					itemId: OnboardingItem.codeLens,
+					title: 'Use Codelens',
+					infoHref: 'https://youtu.be/oJdlGtsbc3U?t=145',
+				},
+				{
+					itemId: OnboardingItem.fileAnnotations,
+					title: 'Try File Annotations',
+					infoHref: 'https://youtu.be/oJdlGtsbc3U?t=153',
+					infoTooltip: 'Check file history. Open any file to test it',
+					playHref: passIfTrue(editorPreviewEnabled, createCommandLink(Commands.ToggleFileBlame)),
+				},
+				{
+					itemId: OnboardingItem.revisionHistory,
+					title: 'Navigate with Revision History',
+					infoHref: 'https://youtu.be/oJdlGtsbc3U?t=178',
+					infoTooltip: 'Check file history. Open any file to test it',
+					playHref: passIfTrue(editorPreviewEnabled, createCommandLink(Commands.DiffWithPrevious)),
+				},
+			],
+		},
+		{
+			itemId: OnboardingItem.commitGraph,
+			title: 'View the Commit Graph',
+			infoHref: 'https://youtu.be/oJdlGtsbc3U?t=275',
+			playHref: createCommandLink(Commands.ShowGraph),
+		},
+		{
+			itemId: OnboardingItem.launchpad,
+			title: 'Open Launchpad',
+			playHref: createCommandLink('gitlens.launchpad.split'),
+			infoHref: 'https://youtu.be/oJdlGtsbc3U?t=443',
+		},
+		{
+			itemId: OnboardingItem.repoHost,
+			title: 'Connect with Repo Host',
+			playHref: passIfTrue(!repoHostConnected, createCommandLink(Commands.ConnectRemoteProvider)),
+			infoTooltip:
+				'Connect remote integration to have such additional features as enriched autolinks, extensive PR support on commits/branches, extensive repo and commit metadata, Launchpad support',
+		},
+		{
+			itemId: OnboardingItem.visualFileHistory,
+			title: 'Visual File History',
+			infoHref: 'https://youtu.be/oJdlGtsbc3U?t=233',
+			// ??? should we show play button if no active editor ???
+			playHref: createCommandLink(editorPreviewEnabled ? Commands.ShowInTimeline : 'workbench.action.quickOpen'),
+		},
+	];
+}

--- a/src/webviews/apps/home/model/gitlens-onboarding.ts
+++ b/src/webviews/apps/home/model/gitlens-onboarding.ts
@@ -6,6 +6,7 @@ import type { OnboardingItemConfiguration } from '../../shared/components/onboar
 export function getOnboardingConfiguration(
 	editorPreviewEnabled: boolean,
 	repoHostConnected: boolean,
+	canEnableCodeLens: boolean,
 ): OnboardingItemConfiguration<OnboardingItem>[] {
 	const passIfTrue = <T>(condition: boolean, value: T): T | undefined => (condition ? value : undefined);
 	return [
@@ -61,7 +62,10 @@ export function getOnboardingConfiguration(
 					itemId: OnboardingItem.codeLens,
 					title: 'Use Codelens',
 					infoHref: 'https://youtu.be/oJdlGtsbc3U?t=145',
-					playHref: passIfTrue(editorPreviewEnabled, createCommandLink(Commands.ToggleCodeLens)),
+					playHref: passIfTrue(
+						editorPreviewEnabled && canEnableCodeLens,
+						createCommandLink(Commands.ToggleCodeLens),
+					),
 					playTooltip: 'Toggle Git CodeLens',
 				},
 				{

--- a/src/webviews/apps/shared/components/accordion/accordion.css.ts
+++ b/src/webviews/apps/shared/components/accordion/accordion.css.ts
@@ -1,0 +1,54 @@
+import { css } from 'lit';
+
+export const accordionBaseStyles = css`
+	.accordion-button {
+		appearance: none;
+		border: var(--gk-accordion-button-border, 1px solid #111a22);
+		border-radius: var(--gk-accordion-button-border-radius, 0.25rem);
+		background-color: var(--gk-accordion-button-background-color, transparent);
+		color: var(--gk-accordion-button-color, #111a22);
+		cursor: pointer;
+		display: flex;
+		align-items: center;
+		padding: var(--gk-accordion-button-padding, 0.5rem);
+		width: var(--gk-accordion-button-width);
+	}
+	/* override hover only if provided; */
+	@container style(--gk-accordion-button-background-color-hovered) {
+		.accordion-button:hover,
+		.accordion-button:focus-within {
+			background-color: var(--gk-accordion-button-background-color-hovered, transparent);
+		}
+	}
+
+	.accordion-button svg {
+		width: var(--gk-accordion-button-chevron-size, 16px);
+		height: var(--gk-accordion-button-chevron-size, 16px);
+	}
+
+	.accordion-button:not(.accordion-button--expanded) code-icon {
+		transform: rotate(-90deg);
+	}
+
+	/* override outline only if provided; */
+	@container style(--gk-accordion-button-focus-outline) {
+		.accordion-button:focus-within,
+		.accordion-button:focus-visible {
+			outline: var(--gk-accordion-button-focus-outline);
+		}
+	}
+
+	.chevron-down-icon {
+		margin-left: auto;
+		transition: all 0.25s;
+		-moz-transition: all 0.25s;
+		-webkit-transition: all 0.25s;
+	}
+
+	.accordion-details {
+		background-color: var(--gk-accordion-details-background-color, transparent);
+		border: var(--gk-accordion-details-border, none);
+		color: var(--gk-accordion-details-color, #111a22);
+		padding: var(--gk-accordion-details-padding, 0.5rem);
+	}
+`;

--- a/src/webviews/apps/shared/components/accordion/accordion.css.ts
+++ b/src/webviews/apps/shared/components/accordion/accordion.css.ts
@@ -2,6 +2,7 @@ import { css } from 'lit';
 
 export const accordionBaseStyles = css`
 	.accordion-button {
+		position: relative;
 		appearance: none;
 		border: var(--gk-accordion-button-border, 1px solid var(--color-foreground));
 		border-radius: var(--gk-accordion-button-border-radius, 0.25rem);

--- a/src/webviews/apps/shared/components/accordion/accordion.css.ts
+++ b/src/webviews/apps/shared/components/accordion/accordion.css.ts
@@ -3,15 +3,15 @@ import { css } from 'lit';
 export const accordionBaseStyles = css`
 	.accordion-button {
 		appearance: none;
-		border: var(--gk-accordion-button-border, 1px solid #111a22);
+		border: var(--gk-accordion-button-border, 1px solid var(--color-foreground));
 		border-radius: var(--gk-accordion-button-border-radius, 0.25rem);
 		background-color: var(--gk-accordion-button-background-color, transparent);
-		color: var(--gk-accordion-button-color, #111a22);
+		color: var(--gk-accordion-button-color, var(--color-foreground));
 		cursor: pointer;
 		display: flex;
 		align-items: center;
 		padding: var(--gk-accordion-button-padding, 0.5rem);
-		width: var(--gk-accordion-button-width);
+		width: var(--gk-accordion-button-width, 100%);
 	}
 	/* override hover only if provided; */
 	@container style(--gk-accordion-button-background-color-hovered) {
@@ -48,7 +48,7 @@ export const accordionBaseStyles = css`
 	.accordion-details {
 		background-color: var(--gk-accordion-details-background-color, transparent);
 		border: var(--gk-accordion-details-border, none);
-		color: var(--gk-accordion-details-color, #111a22);
+		color: var(--gk-accordion-details-color, var(--color-foreground));
 		padding: var(--gk-accordion-details-padding, 0.5rem);
 	}
 `;

--- a/src/webviews/apps/shared/components/accordion/accordion.ts
+++ b/src/webviews/apps/shared/components/accordion/accordion.ts
@@ -1,6 +1,7 @@
 import { html, LitElement } from 'lit';
-import { customElement, property, state } from 'lit/decorators.js';
+import { customElement, property } from 'lit/decorators.js';
 import { classMap } from 'lit/directives/class-map.js';
+import { ifDefined } from 'lit/directives/if-defined.js';
 import { GlElement } from '../element';
 import { accordionBaseStyles } from './accordion.css';
 
@@ -42,7 +43,6 @@ export class Accordion extends GlElement {
 	@property()
 	override id!: string;
 
-	@property({ attribute: 'default-is-expanded', type: Boolean }) defaultIsExpanded: boolean = false;
 	@property({ attribute: 'show-chevron', type: Boolean }) showChevron: boolean = false;
 
 	get buttonId() {
@@ -52,18 +52,13 @@ export class Accordion extends GlElement {
 		return `accordion-${this.id}__details`;
 	}
 
-	@state() isExpanded = false;
-
-	override connectedCallback() {
-		super.connectedCallback();
-		this.isExpanded = this.defaultIsExpanded;
-	}
+	@property({ type: Boolean, attribute: 'is-expanded' })
+	isExpanded?: boolean = false;
 
 	_handleClick(e: MouseEvent) {
 		e.stopPropagation();
-		this.isExpanded = !this.isExpanded;
 		const buttonEl = this as any;
-		buttonEl.dispatchEvent(new Event('click'));
+		buttonEl.dispatchEvent(new Event('toggle'));
 	}
 
 	get chevronIcon() {
@@ -74,11 +69,11 @@ export class Accordion extends GlElement {
 		return html`
 			<div class="accordion" part="wrapper">
 				<button
-					?aria-expanded=${this.isExpanded}
+					aria-expanded=${ifDefined(this.isExpanded)}
 					aria-controls="${this.detailsId}"
 					class=${classMap({
 						'accordion-button': true,
-						'accordion-button--expanded': this.isExpanded,
+						'accordion-button--expanded': Boolean(this.isExpanded),
 					})}
 					id="${this.buttonId}"
 					@click="${this._handleClick}"
@@ -92,7 +87,7 @@ export class Accordion extends GlElement {
 					aria-labelledby="${this.buttonId}"
 					class=${classMap({
 						'accordion-details': true,
-						'accordion-details--expanded': this.isExpanded,
+						'accordion-details--expanded': Boolean(this.isExpanded),
 					})}
 					?hidden=${!this.isExpanded}
 					id="${this.detailsId}"

--- a/src/webviews/apps/shared/components/accordion/accordion.ts
+++ b/src/webviews/apps/shared/components/accordion/accordion.ts
@@ -1,0 +1,107 @@
+import { html, LitElement } from 'lit';
+import { customElement, property, state } from 'lit/decorators.js';
+import { classMap } from 'lit/directives/class-map.js';
+import { GlElement } from '../element';
+import { accordionBaseStyles } from './accordion.css';
+
+/**
+ * An uncontrolled accordion component
+ *
+ * @element gk-accordion
+ *
+ * @slot button-content - items in this slot show up in the accordion button element.
+ * @slot details content - items in this slot show up in the accordion details. They are hidden/shown when the accordion is toggled
+ *
+ * @cssprop --gk-accordion-button-border - Defines the border of the accordion button.
+ * @cssprop --gk-accordion-button-border-radius - Defines the border radius of the accordion button.
+ * @cssprop --gk-accordion-button-background-color - Defines the background color of the accordion button.
+ * @cssprop --gk-accordion-button-color - Defines the button color of the accordion button.
+ * @cssprop --gk-accordion-button-padding - Defines the accordion button padding.
+ * @cssprop --gk-accordion-button-background-color-hovered - Defines the background color of the accordion button on :hover or :focus-within
+ * @cssprop --gk-accordion-button-width - Defines the width of the accordion button
+ * @cssprop --gk-accordion-button-focus-outline - Defines the outline of the accordion button on :focus-within
+ * @cssprop --gk-accordion-button-chevron-size - Defines the size of the chevron in the right of the accordion button
+ *
+ * @cssprop --gk-accordion-details-border - Defines the border of the accordion details section.
+ * @cssprop --gk-accordion-details-background-color - Defines the background color of the accordion details section.
+ * @cssprop --gk-accordion-details-color - Defines the button color of the accordion details section.
+ * @cssprop --gk-accordion-details-padding - Defines the accordion details section padding.
+
+ * @csspart wrapper - the wrapping div around the accordion elements
+ * @csspart button - the accordion button
+ * @csspart details - the accordion details section
+ */
+@customElement('gl-accordion')
+export class Accordion extends GlElement {
+	static override readonly styles = accordionBaseStyles;
+	static override readonly shadowRootOptions: ShadowRootInit = {
+		...LitElement.shadowRootOptions,
+		delegatesFocus: true,
+	};
+
+	@property()
+	override id!: string;
+
+	@property({ attribute: 'default-is-expanded', type: Boolean }) defaultIsExpanded: boolean = false;
+	@property({ attribute: 'show-chevron', type: Boolean }) showChevron: boolean = false;
+
+	get buttonId() {
+		return `accordion-${this.id}__trigger`;
+	}
+	get detailsId() {
+		return `accordion-${this.id}__details`;
+	}
+
+	@state() isExpanded = false;
+
+	override connectedCallback() {
+		super.connectedCallback();
+		this.isExpanded = this.defaultIsExpanded;
+	}
+
+	_handleClick(e: MouseEvent) {
+		e.stopPropagation();
+		this.isExpanded = !this.isExpanded;
+		const buttonEl = this as any;
+		buttonEl.dispatchEvent(new Event('click'));
+	}
+
+	get chevronIcon() {
+		return html` <code-icon icon="chevron-down"></code-icon>`;
+	}
+
+	override render() {
+		return html`
+			<div class="accordion" part="wrapper">
+				<button
+					?aria-expanded=${this.isExpanded}
+					aria-controls="${this.detailsId}"
+					class=${classMap({
+						'accordion-button': true,
+						'accordion-button--expanded': this.isExpanded,
+					})}
+					id="${this.buttonId}"
+					@click="${this._handleClick}"
+					type="button"
+					part="button"
+				>
+					<slot name="button-content"></slot>
+					${this.showChevron ? html`${this.chevronIcon}` : null}
+				</button>
+				<div
+					aria-labelledby="${this.buttonId}"
+					class=${classMap({
+						'accordion-details': true,
+						'accordion-details--expanded': this.isExpanded,
+					})}
+					?hidden=${!this.isExpanded}
+					id="${this.detailsId}"
+					role="region"
+					part="details"
+				>
+					<slot name="details-content"></slot>
+				</div>
+			</div>
+		`;
+	}
+}

--- a/src/webviews/apps/shared/components/accordion/index.ts
+++ b/src/webviews/apps/shared/components/accordion/index.ts
@@ -1,0 +1,1 @@
+export * from './accordion';

--- a/src/webviews/apps/shared/components/onboarding/onboarding-item-group.ts
+++ b/src/webviews/apps/shared/components/onboarding/onboarding-item-group.ts
@@ -1,0 +1,31 @@
+import { css, html, LitElement } from 'lit';
+import { customElement } from 'lit/decorators.js';
+
+@customElement('gl-onboarding-item-group')
+export class GlOnboardingItemGroup extends LitElement {
+	static override readonly styles = css`
+		:host {
+			--gl-onboarding-group-indent: 10px;
+		}
+		:host,
+		.wrapper {
+			display: flex;
+			flex-direction: column;
+			gap: 4px;
+		}
+		.wrapper {
+			--indent: var(--gl-onboarding-group-indent);
+			margin-left: var(--indent);
+			width: calc(100% - var(--indent));
+		}
+	`;
+
+	protected override render() {
+		return html`
+			<slot name="top"></slot>
+			<div class="wrapper">
+				<slot></slot>
+			</div>
+		`;
+	}
+}

--- a/src/webviews/apps/shared/components/onboarding/onboarding-item.ts
+++ b/src/webviews/apps/shared/components/onboarding/onboarding-item.ts
@@ -3,13 +3,18 @@ import { customElement, property } from 'lit/decorators.js';
 import { classMap } from 'lit/directives/class-map.js';
 import { ifDefined } from 'lit/directives/if-defined.js';
 import { when } from 'lit/directives/when.js';
+import { GlElement, observe } from '../element';
 
 @customElement('gl-onboarding-item')
-export class GlOnboardingItem extends LitElement {
+export class GlOnboardingItem extends GlElement {
 	static override readonly shadowRootOptions: ShadowRootInit = {
 		...LitElement.shadowRootOptions,
 		delegatesFocus: true,
 	};
+
+	override attachShadow(init: ShadowRootInit): ShadowRoot {
+		return super.attachShadow({ ...init, delegatesFocus: !this.disabled });
+	}
 
 	static override readonly styles = [
 		css`

--- a/src/webviews/apps/shared/components/onboarding/onboarding-item.ts
+++ b/src/webviews/apps/shared/components/onboarding/onboarding-item.ts
@@ -1,0 +1,160 @@
+import { css, html, LitElement } from 'lit';
+import { customElement, property } from 'lit/decorators.js';
+import { classMap } from 'lit/directives/class-map.js';
+import { ifDefined } from 'lit/directives/if-defined.js';
+import { when } from 'lit/directives/when.js';
+
+@customElement('gl-onboarding-item')
+export class GlOnboardingItem extends LitElement {
+	static override readonly shadowRootOptions: ShadowRootInit = {
+		...LitElement.shadowRootOptions,
+		delegatesFocus: true,
+	};
+
+	private static cssInputVariables = css`
+		:host {
+			--gl-action-button-color: gray;
+			--gl-disabled-text-color: gray;
+			--gl-unchecked-icon-color: inherit;
+			--gl-checked-icon-color: green;
+		}
+	`;
+
+	private static actionButtonsStyles = css`
+		.actions {
+			display: flex;
+			align-items: center;
+			margin: -4px 0;
+		}
+		.actions gl-button {
+			--button-padding: 2px 0 0 0;
+		}
+		.actions gl-button.tooltip-only:focus-within {
+			outline: none;
+		}
+		.actions gl-button.tooltip-only {
+			cursor: default !important;
+			background: unset;
+		}
+		.actions gl-button.tooltip-only * {
+			cursor: default !important;
+		}
+		.actions gl-button code-icon {
+			font-size: 20px;
+			color: var(--gl-action-button-color);
+		}
+	`;
+
+	private static checkIconStyles = css`
+		code-icon.check {
+			color: var(--gl-unchecked-icon-color);
+			overflow: visible;
+			display: inline-block;
+			width: 14px;
+			flex-shrink: 0;
+			margin-right: 8px;
+		}
+		code-icon.check.checked {
+			color: var(--gl-checked-icon-color);
+		}
+	`;
+
+	private static descriptionStyles = css`
+		.description {
+			display: inline-flex;
+			flex: 1;
+			align-items: center;
+		}
+		.description span {
+			flex: 1;
+		}
+		.description.disabled span {
+			color: var(--gl-disabled-text-color);
+		}
+	`;
+
+	static override readonly styles = [
+		GlOnboardingItem.cssInputVariables,
+		GlOnboardingItem.actionButtonsStyles,
+		GlOnboardingItem.checkIconStyles,
+		GlOnboardingItem.descriptionStyles,
+		css`
+			:host {
+				display: flex;
+				align-items: center;
+				font-size: 14px;
+			}
+		`,
+	];
+
+	@property({ type: Boolean })
+	checked = false;
+
+	@property({ type: String, attribute: 'play-href' })
+	playHref = '';
+
+	@property({ type: String, attribute: 'info-title' })
+	infoTitle?: string;
+
+	@property({ type: String, attribute: 'info-href' })
+	infoHref?: string;
+
+	private get infoPresented() {
+		return Boolean(this.infoHref) || Boolean(this.infoTitle);
+	}
+
+	private renderPlay() {
+		return html`<gl-button href=${this.playHref} appearance="toolbar"
+			><code-icon icon="play-circle"></code-icon
+		></gl-button>`;
+	}
+
+	private renderInfo() {
+		return html`<gl-button
+			href=${ifDefined(this.infoHref)}
+			class=${classMap({
+				'tooltip-only': !this.infoHref,
+			})}
+			appearance="toolbar"
+		>
+			${when(this.infoTitle, () => html`<span slot="tooltip">${this.infoTitle}</span>`)}
+			<code-icon icon="info"></code-icon
+		></gl-button>`;
+	}
+
+	private renderCheckIcon() {
+		return html` <code-icon
+			class=${classMap({
+				check: true,
+				checked: this.checked,
+			})}
+			icon=${when(
+				this.checked,
+				() => 'pass',
+				() => 'circle-large-outline',
+			)}
+		></code-icon>`;
+	}
+
+	private renderActions() {
+		return html` <div class="actions">
+			${when(Boolean(this.playHref), this.renderPlay.bind(this))}
+			${when(this.infoPresented, this.renderInfo.bind(this))}
+		</div>`;
+	}
+
+	protected override render() {
+		return html`
+			${this.renderCheckIcon()}
+			<div
+				class=${classMap({
+					description: true,
+					disabled: this.checked,
+				})}
+			>
+				<span><slot></slot></span>
+				${this.renderActions()}
+			</div>
+		`;
+	}
+}

--- a/src/webviews/apps/shared/components/onboarding/onboarding-item.ts
+++ b/src/webviews/apps/shared/components/onboarding/onboarding-item.ts
@@ -68,10 +68,10 @@ export class GlOnboardingItem extends LitElement {
 				flex: 1;
 				align-items: center;
 			}
-			.description span {
+			.description-label {
 				flex: 1;
 			}
-			.description.disabled span {
+			.description.disabled .description-label {
 				color: var(--gl-disabled-text-color);
 			}
 		`,
@@ -146,7 +146,7 @@ export class GlOnboardingItem extends LitElement {
 					disabled: this.checked,
 				})}
 			>
-				<span><slot></slot></span>
+				<span class="description-label"><slot></slot></span>
 				${this.renderActions()}
 			</div>
 		`;

--- a/src/webviews/apps/shared/components/onboarding/onboarding-item.ts
+++ b/src/webviews/apps/shared/components/onboarding/onboarding-item.ts
@@ -58,7 +58,13 @@ export class GlOnboardingItem extends LitElement {
 				flex-shrink: 0;
 				margin-right: 8px;
 			}
-			code-icon.check.checked {
+			code-icon.check.disabled {
+				color: var(--gl-disabled-text-color);
+			}
+			code-icon.check:not(.disabled) {
+				color: var(--gl-unchecked-icon-color);
+			}
+			code-icon.check.checked:not(.disabled) {
 				color: var(--gl-checked-icon-color);
 			}
 
@@ -92,6 +98,9 @@ export class GlOnboardingItem extends LitElement {
 	@property({ type: String, attribute: 'info-href' })
 	infoHref?: string;
 
+	@property({ type: Boolean })
+	disabled?: boolean;
+
 	private get infoPresented() {
 		return Boolean(this.infoHref) || Boolean(this.infoTitle);
 	}
@@ -99,7 +108,11 @@ export class GlOnboardingItem extends LitElement {
 	private renderPlay() {
 		if (!this.playHref) return nothing;
 
-		return html`<gl-button href=${this.playHref} tooltip=${ifDefined(this.playTitle)} appearance="toolbar"
+		return html`<gl-button
+			?disabled=${this.disabled}
+			href=${this.playHref}
+			tooltip=${ifDefined(this.playTitle)}
+			appearance="toolbar"
 			><code-icon icon="play-circle"></code-icon
 		></gl-button>`;
 	}
@@ -108,6 +121,7 @@ export class GlOnboardingItem extends LitElement {
 		if (!this.infoPresented) return nothing;
 
 		return html`<gl-button
+			?disabled=${this.disabled}
 			href=${ifDefined(this.infoHref)}
 			class=${classMap({
 				'tooltip-only': !this.infoHref,
@@ -124,6 +138,7 @@ export class GlOnboardingItem extends LitElement {
 			class=${classMap({
 				check: true,
 				checked: this.checked,
+				disabled: Boolean(this.disabled),
 			})}
 			icon=${when(
 				this.checked,
@@ -143,7 +158,7 @@ export class GlOnboardingItem extends LitElement {
 			<div
 				class=${classMap({
 					description: true,
-					disabled: this.checked,
+					disabled: this.checked || Boolean(this.disabled),
 				})}
 			>
 				<span class="description-label"><slot></slot></span>

--- a/src/webviews/apps/shared/components/onboarding/onboarding-item.ts
+++ b/src/webviews/apps/shared/components/onboarding/onboarding-item.ts
@@ -1,4 +1,4 @@
-import { css, html, LitElement } from 'lit';
+import { css, html, LitElement, nothing } from 'lit';
 import { customElement, property } from 'lit/decorators.js';
 import { classMap } from 'lit/directives/class-map.js';
 import { ifDefined } from 'lit/directives/if-defined.js';
@@ -11,78 +11,68 @@ export class GlOnboardingItem extends LitElement {
 		delegatesFocus: true,
 	};
 
-	private static cssInputVariables = css`
-		:host {
-			--gl-action-button-color: gray;
-			--gl-disabled-text-color: gray;
-			--gl-unchecked-icon-color: inherit;
-			--gl-checked-icon-color: green;
-		}
-	`;
-
-	private static actionButtonsStyles = css`
-		.actions {
-			display: flex;
-			align-items: center;
-			margin: -4px 0;
-		}
-		.actions gl-button {
-			--button-padding: 2px 0 0 0;
-		}
-		.actions gl-button.tooltip-only:focus-within {
-			outline: none;
-		}
-		.actions gl-button.tooltip-only {
-			cursor: default !important;
-			background: unset;
-		}
-		.actions gl-button.tooltip-only * {
-			cursor: default !important;
-		}
-		.actions gl-button code-icon {
-			font-size: 20px;
-			color: var(--gl-action-button-color);
-		}
-	`;
-
-	private static checkIconStyles = css`
-		code-icon.check {
-			color: var(--gl-unchecked-icon-color);
-			overflow: visible;
-			display: inline-block;
-			width: 14px;
-			flex-shrink: 0;
-			margin-right: 8px;
-		}
-		code-icon.check.checked {
-			color: var(--gl-checked-icon-color);
-		}
-	`;
-
-	private static descriptionStyles = css`
-		.description {
-			display: inline-flex;
-			flex: 1;
-			align-items: center;
-		}
-		.description span {
-			flex: 1;
-		}
-		.description.disabled span {
-			color: var(--gl-disabled-text-color);
-		}
-	`;
-
 	static override readonly styles = [
-		GlOnboardingItem.cssInputVariables,
-		GlOnboardingItem.actionButtonsStyles,
-		GlOnboardingItem.checkIconStyles,
-		GlOnboardingItem.descriptionStyles,
 		css`
 			:host {
+				--gl-action-button-color: var(--sl-color-neutral-700, gray);
+				--gl-disabled-text-color: var(--vscode-disabledForeground);
+				--gl-unchecked-icon-color: inherit;
+				--gl-checked-icon-color: var(--sl-color-success-500, green);
+
 				display: flex;
 				align-items: center;
 				font-size: 14px;
+			}
+
+			/* action buttons */
+			.actions {
+				display: flex;
+				align-items: center;
+				margin: -4px 0;
+			}
+			.actions gl-button {
+				--button-padding: 0;
+			}
+			.actions gl-button.tooltip-only:focus-within {
+				outline: none;
+			}
+			.actions gl-button.tooltip-only {
+				cursor: default !important;
+				background: unset;
+			}
+			.actions gl-button.tooltip-only * {
+				cursor: default !important;
+			}
+			.actions gl-button code-icon {
+				--code-icon-size: 20px;
+				--code-icon-v-align: middle;
+				color: var(--gl-action-button-color);
+			}
+
+			/* check icon */
+			code-icon.check {
+				color: var(--gl-unchecked-icon-color);
+				overflow: visible;
+				display: inline-block;
+				width: 14px;
+				flex-shrink: 0;
+				margin-right: 8px;
+			}
+			code-icon.check.checked {
+				color: var(--gl-checked-icon-color);
+			}
+
+			/* description */
+			.description {
+				display: inline-flex;
+				flex: 1;
+				align-items: center;
+			}
+			.description span {
+				flex: 1;
+			}
+			.description.disabled span {
+				color: var(--gl-disabled-text-color);
 			}
 		`,
 	];
@@ -90,8 +80,11 @@ export class GlOnboardingItem extends LitElement {
 	@property({ type: Boolean })
 	checked = false;
 
+	@property({ type: String, attribute: 'play-title' })
+	playTitle?: string;
+
 	@property({ type: String, attribute: 'play-href' })
-	playHref = '';
+	playHref?: string;
 
 	@property({ type: String, attribute: 'info-title' })
 	infoTitle?: string;
@@ -104,12 +97,16 @@ export class GlOnboardingItem extends LitElement {
 	}
 
 	private renderPlay() {
-		return html`<gl-button href=${this.playHref} appearance="toolbar"
+		if (!this.playHref) return nothing;
+
+		return html`<gl-button href=${this.playHref} tooltip=${ifDefined(this.playTitle)} appearance="toolbar"
 			><code-icon icon="play-circle"></code-icon
 		></gl-button>`;
 	}
 
 	private renderInfo() {
+		if (!this.infoPresented) return nothing;
+
 		return html`<gl-button
 			href=${ifDefined(this.infoHref)}
 			class=${classMap({
@@ -137,10 +134,7 @@ export class GlOnboardingItem extends LitElement {
 	}
 
 	private renderActions() {
-		return html` <div class="actions">
-			${when(Boolean(this.playHref), this.renderPlay.bind(this))}
-			${when(this.infoPresented, this.renderInfo.bind(this))}
-		</div>`;
+		return html` <div class="actions">${this.renderPlay()}${this.renderInfo()}</div>`;
 	}
 
 	protected override render() {

--- a/src/webviews/apps/shared/components/onboarding/onboarding-types.ts
+++ b/src/webviews/apps/shared/components/onboarding/onboarding-types.ts
@@ -1,6 +1,4 @@
-export interface OnboardingStateTemplate {
-	[key: `${string}Checked`]: boolean;
-}
+export type OnboardingStateTemplate = Partial<Record<`${string}Checked`, boolean>>;
 
 export interface OnboardingItemConfiguration<T extends string> {
 	itemId: T;

--- a/src/webviews/apps/shared/components/onboarding/onboarding-types.ts
+++ b/src/webviews/apps/shared/components/onboarding/onboarding-types.ts
@@ -1,0 +1,12 @@
+export interface OnboardingStateTemplate {
+	[key: `${string}Checked`]: boolean;
+}
+
+export interface OnboardingItemConfiguration<T extends string> {
+	itemId: T;
+	playHref?: string;
+	infoHref?: string;
+	infoTooltip?: string;
+	title: string;
+	children?: OnboardingItemConfiguration<T>[];
+}

--- a/src/webviews/apps/shared/components/onboarding/onboarding-types.ts
+++ b/src/webviews/apps/shared/components/onboarding/onboarding-types.ts
@@ -3,6 +3,7 @@ export type OnboardingStateTemplate = Partial<Record<`${string}Checked`, boolean
 export interface OnboardingItemConfiguration<T extends string> {
 	itemId: T;
 	playHref?: string;
+	playTooltip?: string;
 	infoHref?: string;
 	infoTooltip?: string;
 	title: string;

--- a/src/webviews/apps/shared/components/onboarding/onboarding-types.ts
+++ b/src/webviews/apps/shared/components/onboarding/onboarding-types.ts
@@ -7,5 +7,6 @@ export interface OnboardingItemConfiguration<T extends string> {
 	infoHref?: string;
 	infoTooltip?: string;
 	title: string;
+	disabled?: boolean;
 	children?: OnboardingItemConfiguration<T>[];
 }

--- a/src/webviews/apps/shared/components/onboarding/onboarding.ts
+++ b/src/webviews/apps/shared/components/onboarding/onboarding.ts
@@ -1,5 +1,6 @@
+import type { PropertyValues } from 'lit';
 import { css, html, LitElement } from 'lit';
-import { customElement, property, state } from 'lit/decorators.js';
+import { customElement, property } from 'lit/decorators.js';
 import { ifDefined } from 'lit/directives/if-defined.js';
 import { repeat } from 'lit/directives/repeat.js';
 import { when } from 'lit/directives/when.js';
@@ -70,12 +71,25 @@ export class GlOnboarding<
 	@property({ type: Array })
 	onboardingConfiguration?: OnboardingItemConfiguration<OnboardingItem>[];
 
-	@state()
-	isExpanded: boolean = true;
+	@property({ type: Boolean, attribute: 'is-expanded' })
+	isExpanded: boolean = false;
 
 	override connectedCallback(): void {
 		super.connectedCallback();
-		this.isExpanded = !this.finished;
+	}
+
+	@property({ type: Boolean, attribute: 'is-initialized' })
+	isInitialized = false;
+
+	protected override updated(
+		_changedProperties: PropertyValues<GlOnboarding<OnboardingState, OnboardingItem>>,
+	): void {
+		// expand not finished onboarding accordion, but only on component initialize
+		if (this.isInitialized) {
+			if (_changedProperties.has('isInitialized') && !this.finished) {
+				this.isExpanded = true;
+			}
+		}
 	}
 
 	private get progress() {
@@ -147,7 +161,11 @@ export class GlOnboarding<
 			return html``;
 		}
 		return html`
-			<gl-accordion show-chevron ?default-is-expanded=${!this.finished}>
+			<gl-accordion
+				show-chevron
+				?is-expanded=${this.isExpanded}
+				@toggle=${() => (this.isExpanded = !this.isExpanded)}
+			>
 				<h3 class="title" slot="button-content">
 					<slot name="title"></slot>
 					<span class="progress">${this.progress}/${this.stepCount}</span>

--- a/src/webviews/apps/shared/components/onboarding/onboarding.ts
+++ b/src/webviews/apps/shared/components/onboarding/onboarding.ts
@@ -1,0 +1,168 @@
+import { css, html, LitElement } from 'lit';
+import { customElement, property, state } from 'lit/decorators.js';
+import { ifDefined } from 'lit/directives/if-defined.js';
+import { repeat } from 'lit/directives/repeat.js';
+import { when } from 'lit/directives/when.js';
+import type { OnboardingItemConfiguration, OnboardingStateTemplate } from './onboarding-types';
+
+import './onboarding-item';
+import './onboarding-item-group';
+import './progress-tracker';
+import '../accordion/accordion';
+
+@customElement('gl-onboarding')
+export class GlOnboarding<
+	OnboardingState extends OnboardingStateTemplate,
+	OnboardingItem extends string,
+> extends LitElement {
+	static override readonly styles = css`
+		gl-accordion {
+			--gk-accordion-details-color: currentColor;
+			--gk-accordion-button-color: currentColor;
+			--gk-accordion-button-padding: 12px 20px;
+			--gk-accordion-details-padding: 6px 20px 12px 20px;
+			--gk-accordion-button-width: 100%;
+			--gk-accordion-button-border: none;
+			--gk-accordion-button-chevron-size: 13px;
+			--gk-accordion-button-focus-outline: none;
+			--gk-accordion-button-background-color-hovered: var(--vscode-list-hoverBackground);
+			--gk-accordion-button-border-radius: 0;
+		}
+		h3.title {
+			text-transform: uppercase;
+			font-weight: 700;
+			font-size: 11px;
+			text-align: left;
+			margin: 0;
+			color: currentColor;
+			width: 100%;
+		}
+		h3.title span.progress {
+			color: var(--vscode-progressBar-background);
+		}
+		gl-progress-tracker {
+			--gl-progress-foreground-color: var(--vscode-progressBar-background);
+			--gl-progress-background-color: var(--progress-bar-color);
+		}
+
+		gl-onboarding-item {
+			margin: 2px 0;
+			--gl-disabled-text-color: var(--vscode-disabledForeground);
+			--gl-checked-icon-color: var(--sl-color-success-500, green);
+			--gl-action-button-color: var(--sl-color-neutral-700, gray);
+		}
+
+		gl-onboarding-item-group {
+			--gl-onboarding-group-indent: 20px;
+		}
+		gl-onboarding-item-group.top-onboarding-group {
+			--gl-onboarding-group-indent: 0px;
+			margin-top: 12px;
+		}
+	`;
+
+	static override readonly shadowRootOptions: ShadowRootInit = {
+		...LitElement.shadowRootOptions,
+		delegatesFocus: true,
+	};
+
+	@property({ type: Object })
+	state?: OnboardingState;
+
+	@property({ type: Array })
+	onboardingConfiguration?: OnboardingItemConfiguration<OnboardingItem>[];
+
+	@state()
+	isExpanded: boolean = true;
+
+	override connectedCallback(): void {
+		super.connectedCallback();
+		this.isExpanded = !this.finished;
+	}
+
+	private get progress() {
+		const onboardingState = this.state;
+		const onboardingConfiguration = this.onboardingConfiguration;
+		if (!onboardingState || !onboardingConfiguration) return 0;
+		return Number(
+			onboardingConfiguration.reduce(
+				(a, b) =>
+					a + Number(b.children ? this.calcStateFromChildren(b) : onboardingState[`${b.itemId}Checked`]),
+				0,
+			),
+		);
+	}
+
+	private get stepCount() {
+		return this.onboardingConfiguration?.length ?? 0;
+	}
+
+	private renderOnboardingItem(onboardingItem: OnboardingItemConfiguration<OnboardingItem>) {
+		return html`
+			<gl-onboarding-item
+				.checked=${Boolean(this.state?.[`${onboardingItem.itemId}Checked`])}
+				play-href=${ifDefined(onboardingItem.playHref)}
+				info-href=${ifDefined(onboardingItem.infoHref)}
+				info-title=${ifDefined(onboardingItem.infoTooltip)}
+				>${onboardingItem.title}
+			</gl-onboarding-item>
+		`;
+	}
+
+	private calcStateFromChildren(onboardingItem: OnboardingItemConfiguration<OnboardingItem>) {
+		return (
+			onboardingItem.children?.reduce((a, b) => a && Boolean(this.state?.[`${b.itemId}Checked`]), true) ?? false
+		);
+	}
+
+	private renderOnboardingGroup(onboardingItem: OnboardingItemConfiguration<OnboardingItem>) {
+		return html`
+			<gl-onboarding-item-group>
+				<gl-onboarding-item
+					.checked=${this.calcStateFromChildren(onboardingItem)}
+					slot=${'top'}
+					play-href=${ifDefined(onboardingItem.playHref)}
+					info-href=${ifDefined(onboardingItem.infoHref)}
+					info-title=${ifDefined(onboardingItem.infoTooltip)}
+					>${onboardingItem.title}
+				</gl-onboarding-item>
+				${repeat(onboardingItem.children ?? [], item => item.itemId, this.renderOnboardingItem.bind(this))}
+			</gl-onboarding-item-group>
+		`;
+	}
+
+	private get finished() {
+		return this.progress === this.stepCount;
+	}
+
+	protected override render() {
+		if (!this.state) {
+			return html``;
+		}
+		return html`
+			<gl-accordion show-chevron ?default-is-expanded=${!this.finished}>
+				<h3 class="title" slot="button-content">
+					<slot name="title"></slot>
+					<span class="progress">${this.progress}/${this.stepCount}</span>
+				</h3>
+
+				<div slot="details-content">
+					<gl-progress-tracker progress=${this.progress} stepCount=${this.stepCount}></gl-progress-tracker>
+					<gl-onboarding-item-group class="top-onboarding-group">
+						${repeat(
+							this.onboardingConfiguration ?? [],
+							item => item.itemId,
+							item => html`
+								${when(
+									Boolean(item.children?.length),
+									this.renderOnboardingGroup.bind(this, item),
+									this.renderOnboardingItem.bind(this, item),
+								)}
+							`,
+						)}
+					</gl-onboarding-item-group>
+				</div></gl-accordion
+			>
+		`;
+	}
+}

--- a/src/webviews/apps/shared/components/onboarding/onboarding.ts
+++ b/src/webviews/apps/shared/components/onboarding/onboarding.ts
@@ -61,6 +61,9 @@ export class GlOnboarding<
 		delegatesFocus: true,
 	};
 
+	@property({ type: Boolean })
+	disabled?: boolean;
+
 	@property({ type: Object })
 	state?: OnboardingState;
 
@@ -97,6 +100,7 @@ export class GlOnboarding<
 	private renderOnboardingItem(onboardingItem: OnboardingItemConfiguration<OnboardingItem>) {
 		return html`
 			<gl-onboarding-item
+				?disabled=${this.disabled}
 				.checked=${Boolean(this.state?.[`${onboardingItem.itemId}Checked`])}
 				play-href=${ifDefined(onboardingItem.playHref)}
 				play-title=${ifDefined(onboardingItem.playTooltip)}
@@ -120,6 +124,7 @@ export class GlOnboarding<
 		return html`
 			<gl-onboarding-item-group>
 				<gl-onboarding-item
+					?disabled=${this.disabled}
 					.checked=${this.calcStateFromChildren(onboardingItem)}
 					slot=${'top'}
 					play-href=${ifDefined(onboardingItem.playHref)}

--- a/src/webviews/apps/shared/components/onboarding/onboarding.ts
+++ b/src/webviews/apps/shared/components/onboarding/onboarding.ts
@@ -85,11 +85,13 @@ export class GlOnboarding<
 		const onboardingConfiguration = this.onboardingConfiguration;
 		if (!onboardingState || !onboardingConfiguration) return 0;
 		return Number(
-			onboardingConfiguration.reduce(
-				(a, b) =>
-					a + Number(b.children ? this.calcStateFromChildren(b) : onboardingState[`${b.itemId}Checked`]),
-				0,
-			),
+			onboardingConfiguration.reduce((acc, onboardingItem) => {
+				const ownState = Boolean(onboardingState[`${onboardingItem.itemId}Checked`]);
+				if (!onboardingItem.children) {
+					return acc + Number(ownState);
+				}
+				return acc + Number(this.calcStateFromChildren(onboardingItem));
+			}, 0),
 		);
 	}
 
@@ -111,7 +113,10 @@ export class GlOnboarding<
 
 	private calcStateFromChildren(onboardingItem: OnboardingItemConfiguration<OnboardingItem>) {
 		return (
-			onboardingItem.children?.reduce((a, b) => a && Boolean(this.state?.[`${b.itemId}Checked`]), true) ?? false
+			onboardingItem.children?.reduce(
+				(acc, onboardingItemChild) => acc && Boolean(this.state?.[`${onboardingItemChild.itemId}Checked`]),
+				true,
+			) ?? false
 		);
 	}
 

--- a/src/webviews/apps/shared/components/onboarding/onboarding.ts
+++ b/src/webviews/apps/shared/components/onboarding/onboarding.ts
@@ -169,7 +169,11 @@ export class GlOnboarding<
 					info-title=${ifDefined(onboardingItem.infoTooltip)}
 					>${onboardingItem.title}
 				</gl-onboarding-item>
-				${repeat(onboardingItem.children ?? [], item => item.itemId, this.renderOnboardingItem.bind(this))}
+				${repeat(
+					onboardingItem.children ?? [],
+					item => item.itemId + String(item.disabled),
+					this.renderOnboardingItem.bind(this),
+				)}
 			</gl-onboarding-item-group>
 		`;
 	}

--- a/src/webviews/apps/shared/components/onboarding/onboarding.ts
+++ b/src/webviews/apps/shared/components/onboarding/onboarding.ts
@@ -136,7 +136,7 @@ export class GlOnboarding<
 	private renderOnboardingItem(onboardingItem: OnboardingItemConfiguration<OnboardingItem>) {
 		return html`
 			<gl-onboarding-item
-				?disabled=${this.disabled}
+				?disabled=${this.disabled || onboardingItem.disabled}
 				.checked=${Boolean(this.state?.[`${onboardingItem.itemId}Checked`])}
 				play-href=${ifDefined(onboardingItem.playHref)}
 				play-title=${ifDefined(onboardingItem.playTooltip)}
@@ -160,7 +160,7 @@ export class GlOnboarding<
 		return html`
 			<gl-onboarding-item-group>
 				<gl-onboarding-item
-					?disabled=${this.disabled}
+					?disabled=${this.disabled || onboardingItem.disabled}
 					.checked=${this.calcStateFromChildren(onboardingItem)}
 					slot=${'top'}
 					play-href=${ifDefined(onboardingItem.playHref)}

--- a/src/webviews/apps/shared/components/onboarding/onboarding.ts
+++ b/src/webviews/apps/shared/components/onboarding/onboarding.ts
@@ -1,6 +1,7 @@
 import type { PropertyValues } from 'lit';
 import { css, html, LitElement } from 'lit';
 import { customElement, property } from 'lit/decorators.js';
+import { classMap } from 'lit/directives/class-map.js';
 import { ifDefined } from 'lit/directives/if-defined.js';
 import { repeat } from 'lit/directives/repeat.js';
 import { when } from 'lit/directives/when.js';
@@ -54,6 +55,27 @@ export class GlOnboarding<
 		gl-onboarding-item-group.top-onboarding-group {
 			--gl-onboarding-group-indent: 0px;
 			margin-top: 12px;
+		}
+
+		progress#mini-progress::-webkit-progress-bar {
+			background-color: unset;
+		}
+		progress#mini-progress.finished::-webkit-progress-value {
+			background: unset;
+		}
+		progress#mini-progress::-webkit-progress-value {
+			background: var(--vscode-progressBar-background, blue);
+			transition: 0.1s ease-in;
+		}
+		progress#mini-progress {
+			pointer-events: none;
+			width: 100%;
+			position: absolute;
+			bottom: 0;
+			left: 0;
+			background: unset;
+			height: 2px;
+			flex: 1;
 		}
 	`;
 
@@ -156,6 +178,19 @@ export class GlOnboarding<
 		return this.progress === this.stepCount;
 	}
 
+	private renderMiniProgress() {
+		return html`
+			<progress
+				class=${classMap({
+					finished: this.finished,
+				})}
+				id="mini-progress"
+				value=${this.progress}
+				max=${this.stepCount}
+			></progress>
+		`;
+	}
+
 	protected override render() {
 		if (!this.state) {
 			return html``;
@@ -169,6 +204,7 @@ export class GlOnboarding<
 				<h3 class="title" slot="button-content">
 					<slot name="title"></slot>
 					<span class="progress">${this.progress}/${this.stepCount}</span>
+					${when(!this.isExpanded, this.renderMiniProgress.bind(this))}
 				</h3>
 
 				<div slot="details-content">

--- a/src/webviews/apps/shared/components/onboarding/onboarding.ts
+++ b/src/webviews/apps/shared/components/onboarding/onboarding.ts
@@ -28,28 +28,23 @@ export class GlOnboarding<
 			--gk-accordion-button-background-color-hovered: var(--vscode-list-hoverBackground);
 			--gk-accordion-button-border-radius: 0;
 		}
-		h3.title {
+
+		.title {
 			text-transform: uppercase;
 			font-weight: 700;
 			font-size: 11px;
 			text-align: left;
-			margin: 0;
+			margin-block: 0;
 			color: currentColor;
 			width: 100%;
 		}
-		h3.title span.progress {
+
+		.progress {
 			color: var(--vscode-progressBar-background);
-		}
-		gl-progress-tracker {
-			--gl-progress-foreground-color: var(--vscode-progressBar-background);
-			--gl-progress-background-color: var(--progress-bar-color);
 		}
 
 		gl-onboarding-item {
-			margin: 2px 0;
-			--gl-disabled-text-color: var(--vscode-disabledForeground);
-			--gl-checked-icon-color: var(--sl-color-success-500, green);
-			--gl-action-button-color: var(--sl-color-neutral-700, gray);
+			margin-block: 2px;
 		}
 
 		gl-onboarding-item-group {
@@ -104,6 +99,7 @@ export class GlOnboarding<
 			<gl-onboarding-item
 				.checked=${Boolean(this.state?.[`${onboardingItem.itemId}Checked`])}
 				play-href=${ifDefined(onboardingItem.playHref)}
+				play-title=${ifDefined(onboardingItem.playTooltip)}
 				info-href=${ifDefined(onboardingItem.infoHref)}
 				info-title=${ifDefined(onboardingItem.infoTooltip)}
 				>${onboardingItem.title}

--- a/src/webviews/apps/shared/components/onboarding/onboarding.ts
+++ b/src/webviews/apps/shared/components/onboarding/onboarding.ts
@@ -123,6 +123,7 @@ export class GlOnboarding<
 					.checked=${this.calcStateFromChildren(onboardingItem)}
 					slot=${'top'}
 					play-href=${ifDefined(onboardingItem.playHref)}
+					play-title=${ifDefined(onboardingItem.playTooltip)}
 					info-href=${ifDefined(onboardingItem.infoHref)}
 					info-title=${ifDefined(onboardingItem.infoTooltip)}
 					>${onboardingItem.title}

--- a/src/webviews/apps/shared/components/onboarding/progress-tracker.ts
+++ b/src/webviews/apps/shared/components/onboarding/progress-tracker.ts
@@ -1,0 +1,48 @@
+import { css, html, LitElement } from 'lit';
+import { customElement, property } from 'lit/decorators.js';
+
+@customElement('gl-progress-tracker')
+export class ProgressTracker extends LitElement {
+	@property({ type: Number })
+	stepCount = 0;
+
+	@property({ type: Number })
+	progress = 0;
+
+	static override readonly styles = css`
+		:host {
+			padding: initial;
+			display: flex;
+			align-items: center;
+			gap: 12px;
+			--gl-progress-background-color: gray;
+			--gl-progress-foreground-color: var(--vscode-progressBar-background, blue);
+		}
+		span {
+			flex-shrink: 0;
+			font-weight: 700;
+			font-size: 13px;
+		}
+		progress::-webkit-progress-bar {
+			background-color: var(--gl-progress-background-color);
+			border-radius: 4px;
+		}
+		progress::-webkit-progress-value {
+			background: var(--gl-progress-foreground-color);
+			transition: 0.1s ease-in;
+			border-radius: 4px;
+		}
+		progress {
+			background: unset;
+			height: 7px;
+			flex: 1;
+		}
+	`;
+
+	protected override render() {
+		return html`
+			<label for="progress-bar">${this.progress}/${this.stepCount}</label>
+			<progress id="progress-bar" value=${this.progress} max=${this.stepCount}></progress>
+		`;
+	}
+}

--- a/src/webviews/apps/shared/components/onboarding/progress-tracker.ts
+++ b/src/webviews/apps/shared/components/onboarding/progress-tracker.ts
@@ -11,12 +11,13 @@ export class ProgressTracker extends LitElement {
 
 	static override readonly styles = css`
 		:host {
+			--gl-progress-background-color: var(--progress-bar-color, gray);
+			--gl-progress-foreground-color: var(--vscode-progressBar-background, blue);
+
 			padding: initial;
 			display: flex;
 			align-items: center;
 			gap: 12px;
-			--gl-progress-background-color: gray;
-			--gl-progress-foreground-color: var(--vscode-progressBar-background, blue);
 		}
 		span {
 			flex-shrink: 0;

--- a/src/webviews/home/homeWebview.ts
+++ b/src/webviews/home/homeWebview.ts
@@ -14,7 +14,7 @@ import type { WebviewHost, WebviewProvider } from '../webviewProvider';
 import type { DidChangeOnboardingStateParams, DidChangeRepositoriesParams, OnboardingItem, State } from './protocol';
 import {
 	DidChangeCodeLensState,
-	DidChangeIntegrationsConnections,
+	DidChangeLineBlameState,
 	DidChangeOnboardingEditor,
 	DidChangeOnboardingIntegration,
 	DidChangeOnboardingState,
@@ -53,6 +53,7 @@ export class HomeWebviewProvider implements WebviewProvider<State> {
 				if (isSupportedIntegration(e.key)) this.onChangeConnectionState();
 			}, this),
 			this.container.codeLens.onCodeLensToggle(this.onToggleCodeLens, this),
+			this.container.lineAnnotations.onToggle(this.onToggleLineAnnotations, this),
 		);
 	}
 
@@ -79,6 +80,10 @@ export class HomeWebviewProvider implements WebviewProvider<State> {
 		this.notifyDidToggleCodeLens();
 	}
 
+	private onToggleLineAnnotations() {
+		this.notifyDidToggleLineBlame();
+	}
+
 	private onUsagesChanged(e: UsageChangeEvent | undefined) {
 		if (!e || e?.key === 'integration:repoHost') {
 			this.notifyDidChangeOnboardingIntegration();
@@ -102,6 +107,8 @@ export class HomeWebviewProvider implements WebviewProvider<State> {
 		this.notifyDidChangeRepositories();
 		this.notifyDidChangeEditor();
 		this.notifyDidChangeOnboardingState();
+		this.notifyDidToggleCodeLens();
+		this.notifyDidToggleLineBlame();
 		this.notifyDidChangeOnboardingIntegration();
 	}
 
@@ -129,6 +136,7 @@ export class HomeWebviewProvider implements WebviewProvider<State> {
 			onboardingState: this.getOnboardingState(),
 			editorPreviewEnabled: this.isEditorPreviewEnabled(),
 			canEnableCodeLens: this.canCodeLensBeEnabled(),
+			canEnableLineBlame: this.canLineBlameBeEnabled(),
 			repoHostConnected: this.isHostedIntegrationConnected(),
 			webroot: this.host.getWebRoot(),
 			subscription: subscription,
@@ -173,6 +181,10 @@ export class HomeWebviewProvider implements WebviewProvider<State> {
 
 	private canCodeLensBeEnabled() {
 		return this.container.codeLens.canToggle && !this.container.codeLens.isEnabled;
+	}
+
+	private canLineBlameBeEnabled() {
+		return !this.container.lineAnnotations.enabled;
 	}
 
 	private isHostedIntegrationConnected(force = false) {
@@ -261,6 +273,12 @@ export class HomeWebviewProvider implements WebviewProvider<State> {
 	private notifyDidToggleCodeLens() {
 		void this.host.notify(DidChangeCodeLensState, {
 			canBeEnabled: this.canCodeLensBeEnabled(),
+		});
+	}
+
+	private notifyDidToggleLineBlame() {
+		void this.host.notify(DidChangeLineBlameState, {
+			canBeEnabled: this.canLineBlameBeEnabled(),
 		});
 	}
 

--- a/src/webviews/home/homeWebview.ts
+++ b/src/webviews/home/homeWebview.ts
@@ -11,6 +11,7 @@ import type { TrackedUsageKeys, UsageChangeEvent } from '../../telemetry/usageTr
 import type { WebviewHost, WebviewProvider } from '../webviewProvider';
 import type { DidChangeOnboardingStateParams, DidChangeRepositoriesParams, OnboardingItem, State } from './protocol';
 import {
+	DidChangeCodeLensState,
 	DidChangeIntegrationsConnections,
 	DidChangeOnboardingEditor,
 	DidChangeOnboardingIntegration,
@@ -18,6 +19,7 @@ import {
 	DidChangeOrgSettings,
 	DidChangeRepositories,
 	DidChangeSubscription,
+	DidResume,
 } from './protocol';
 
 const emptyDisposable = Object.freeze({
@@ -28,15 +30,13 @@ const emptyDisposable = Object.freeze({
 
 export class HomeWebviewProvider implements WebviewProvider<State> {
 	private readonly _disposable: Disposable;
-	private activeTextEditor: TextEditor | undefined;
+	private activeTrackedTextEditor: TextEditor | undefined;
 	private hostedIntegrationConnected: boolean | undefined;
 
 	constructor(
 		private readonly container: Container,
 		private readonly host: WebviewHost,
 	) {
-		this.activeTextEditor = window.activeTextEditor;
-
 		this._disposable = Disposable.from(
 			this.container.git.onDidChangeRepositories(this.onRepositoriesChanged, this),
 			!workspace.isTrusted
@@ -50,11 +50,14 @@ export class HomeWebviewProvider implements WebviewProvider<State> {
 			this.container.integrations.onDidChangeConnectionState(e => {
 				if (isSupportedIntegration(e.key)) this.onChangeConnectionState();
 			}, this),
+			this.container.codeLens.onCodeLensToggle(this.onToggleCodeLens, this),
+			// window.on.focus.onDidChange(e => {
+			// 	console.log('home test focus', e);
+			// }, this),
 		);
 	}
 
 	dispose() {
-		this.notifyDidChangeOnboardingState();
 		this._disposable.dispose();
 	}
 
@@ -62,9 +65,23 @@ export class HomeWebviewProvider implements WebviewProvider<State> {
 		this.notifyDidChangeOnboardingIntegration();
 	}
 
-	private onChangeActiveTextEditor(e: TextEditor | undefined) {
-		this.activeTextEditor = e;
+	onVisibilityChanged(visible: boolean): void {
+		if (visible) this.notifyDidResume();
+	}
+
+	private async onChangeActiveTextEditor(e: TextEditor | undefined) {
+		if (!e) {
+			this.activeTrackedTextEditor = undefined;
+		} else if (await this.container.git.isTracked(e.document.uri)) {
+			this.activeTrackedTextEditor = e;
+		} else {
+			this.activeTrackedTextEditor = undefined;
+		}
 		this.notifyDidChangeEditor();
+	}
+
+	private onToggleCodeLens() {
+		this.notifyDidToggleCodeLens();
 	}
 
 	private onUsagesChanged(e: UsageChangeEvent | undefined) {
@@ -113,6 +130,7 @@ export class HomeWebviewProvider implements WebviewProvider<State> {
 			repositories: this.getRepositoriesState(),
 			onboardingState: this.getOnboardingState(),
 			editorPreviewEnabled: this.isEditorPreviewEnabled(),
+			canEnableCodeLens: this.canCodeLensBeEnabled(),
 			repoHostConnected: this.isHostedIntegrationConnected(),
 			webroot: this.host.getWebRoot(),
 			subscription: subscription,
@@ -152,7 +170,11 @@ export class HomeWebviewProvider implements WebviewProvider<State> {
 	}
 
 	private isEditorPreviewEnabled() {
-		return Boolean(this.activeTextEditor);
+		return Boolean(this.activeTrackedTextEditor);
+	}
+
+	private canCodeLensBeEnabled() {
+		return this.container.codeLens.canToggle && !this.container.codeLens.isEnabled;
 	}
 
 	private isHostedIntegrationConnected(force = false) {
@@ -232,9 +254,28 @@ export class HomeWebviewProvider implements WebviewProvider<State> {
 	}
 
 	private notifyDidChangeEditor() {
+		console.log('home test changed editor', this.isEditorPreviewEnabled());
 		void this.host.notify(DidChangeOnboardingEditor, {
 			editorPreviewEnabled: this.isEditorPreviewEnabled(),
 		});
+	}
+
+	private notifyDidToggleCodeLens() {
+		void this.host.notify(DidChangeCodeLensState, {
+			canBeEnabled: this.canCodeLensBeEnabled(),
+		});
+	}
+
+	// the webview is not updated when it's invisible, but the provider is alive.
+	// need to refresh all states on open already loaded view
+	// TODO: this part doesn't work
+	private notifyDidResume() {
+		console.log('home test notify');
+		setTimeout(() => {
+			void this.host.notify(DidResume, {
+				canBeEnabled: this.canCodeLensBeEnabled(),
+			});
+		}, 2000);
 	}
 
 	private async notifyDidChangeSubscription(subscription?: Subscription) {

--- a/src/webviews/home/homeWebview.ts
+++ b/src/webviews/home/homeWebview.ts
@@ -5,15 +5,17 @@ import type { Subscription } from '../../plus/gk/account/subscription';
 import type { SubscriptionChangeEvent } from '../../plus/gk/account/subscriptionService';
 import { registerCommand } from '../../system/command';
 import { getContext, onDidChangeContext } from '../../system/context';
+import { Logger } from '../../system/logger';
 import type { IpcMessage } from '../protocol';
 import type { WebviewHost, WebviewProvider } from '../webviewProvider';
-import type { CollapseSectionParams, DidChangeRepositoriesParams, State } from './protocol';
+import type { CollapseSectionParams, DidChangeRepositoriesParams, DidChangeUsagesParams, State } from './protocol';
 import {
 	CollapseSectionCommand,
 	DidChangeIntegrationsConnections,
 	DidChangeOrgSettings,
 	DidChangeRepositories,
 	DidChangeSubscription,
+	DidChangeUsage,
 } from './protocol';
 
 const emptyDisposable = Object.freeze({
@@ -29,6 +31,8 @@ export class HomeWebviewProvider implements WebviewProvider<State> {
 		private readonly container: Container,
 		private readonly host: WebviewHost,
 	) {
+		Logger.log('test usage', this.container.usage.get('graphView:shown'));
+
 		this._disposable = Disposable.from(
 			this.container.git.onDidChangeRepositories(this.onRepositoriesChanged, this),
 			!workspace.isTrusted
@@ -37,6 +41,7 @@ export class HomeWebviewProvider implements WebviewProvider<State> {
 			this.container.subscription.onDidChange(this.onSubscriptionChanged, this),
 			onDidChangeContext(this.onContextChanged, this),
 			this.container.integrations.onDidChangeConnectionState(this.onChangeConnectionState, this),
+			this.container.usage.onDidChange(this.onUsagesChanged, this),
 		);
 	}
 
@@ -46,6 +51,15 @@ export class HomeWebviewProvider implements WebviewProvider<State> {
 
 	private onChangeConnectionState() {
 		this.notifyDidChangeOnboardingIntegration();
+	}
+
+	private onUsagesChanged() {
+		Logger.log(
+			'usage changed',
+			this.container.usage.get('graphView:shown'),
+			this.container.usage.get('graphWebview:shown'),
+		);
+		this.notifyDidChangeUsages();
 	}
 
 	private onRepositoriesChanged() {
@@ -113,6 +127,8 @@ export class HomeWebviewProvider implements WebviewProvider<State> {
 	}
 
 	private onSubscriptionChanged(e: SubscriptionChangeEvent) {
+		Logger.log('test usage', this.container.usage);
+
 		void this.notifyDidChangeSubscription(e.current);
 	}
 
@@ -121,6 +137,7 @@ export class HomeWebviewProvider implements WebviewProvider<State> {
 		return {
 			...this.host.baseWebviewState,
 			repositories: this.getRepositoriesState(),
+			onboardingState: this.getOnboardingState(),
 			webroot: this.host.getWebRoot(),
 			subscription: subscription,
 			orgSettings: this.getOrgSettings(),
@@ -150,6 +167,31 @@ export class HomeWebviewProvider implements WebviewProvider<State> {
 		return this._hostedIntegrationConnected;
 	}
 
+	private getOnboardingState(): DidChangeUsagesParams {
+		return {
+			configurationChecked: Boolean(this.container.usage.get('settingsWebview:shown')?.firstUsedAt),
+			revisionHistoryChecked: false,
+			commitGraphChecked:
+				Boolean(this.container.usage.get('graphView:shown')?.firstUsedAt) ||
+				Boolean(this.container.usage.get('graphWebview:shown')?.firstUsedAt),
+			branchesChecked: Boolean(this.container.usage.get('branchesView:shown')?.firstUsedAt),
+			cloudPatchesChecked: false,
+			commitsChecked: Boolean(this.container.usage.get('commitsView:shown')?.firstUsedAt),
+			contributorsChecked: Boolean(this.container.usage.get('contributorsView:shown')?.firstUsedAt),
+			fileHistoryChecked: Boolean(this.container.usage.get('fileHistoryView:shown')?.firstUsedAt),
+			inspectChecked: false,
+			gitLensChecked: false,
+			launchpadChecked: false,
+			lineHistoryChecked: Boolean(this.container.usage.get('lineHistoryView:shown')?.firstUsedAt),
+			searchAndCompareChecked: Boolean(this.container.usage.get('searchAndCompareView:shown')?.firstUsedAt),
+			stashesChecked: Boolean(this.container.usage.get('stashesView:shown')?.firstUsedAt),
+			tagsChecked: Boolean(this.container.usage.get('tagsView:shown')?.firstUsedAt),
+			visualFileHistoryChecked: false,
+			workTreesChecked: Boolean(this.container.usage.get('worktreesView:shown')?.firstUsedAt),
+			workSpacesChecked: Boolean(this.container.usage.get('workspacesView:shown')?.firstUsedAt),
+		};
+	}
+
 	private notifyDidChangeRepositories() {
 		void this.host.notify(DidChangeRepositories, this.getRepositoriesState());
 	}
@@ -160,6 +202,9 @@ export class HomeWebviewProvider implements WebviewProvider<State> {
 		void this.host.notify(DidChangeIntegrationsConnections, {
 			hasAnyIntegrationConnected: isConnected,
 		});
+	}
+	private notifyDidChangeUsages() {
+		void this.host.notify(DidChangeUsage, this.getOnboardingState());
 	}
 
 	private async notifyDidChangeSubscription(subscription?: Subscription) {

--- a/src/webviews/home/homeWebview.ts
+++ b/src/webviews/home/homeWebview.ts
@@ -21,7 +21,6 @@ import {
 	DidChangeOrgSettings,
 	DidChangeRepositories,
 	DidChangeSubscription,
-	DidResume,
 } from './protocol';
 
 const emptyDisposable = Object.freeze({
@@ -54,9 +53,6 @@ export class HomeWebviewProvider implements WebviewProvider<State> {
 				if (isSupportedIntegration(e.key)) this.onChangeConnectionState();
 			}, this),
 			this.container.codeLens.onCodeLensToggle(this.onToggleCodeLens, this),
-			// window.on.focus.onDidChange(e => {
-			// 	console.log('home test focus', e);
-			// }, this),
 		);
 	}
 
@@ -108,6 +104,9 @@ export class HomeWebviewProvider implements WebviewProvider<State> {
 
 	onReloaded() {
 		this.notifyDidChangeRepositories();
+		this.notifyDidChangeEditor();
+		this.notifyDidChangeOnboardingState();
+		this.notifyDidChangeOnboardingIntegration();
 	}
 
 	private getOrgSettings(): State['orgSettings'] {
@@ -267,18 +266,6 @@ export class HomeWebviewProvider implements WebviewProvider<State> {
 		void this.host.notify(DidChangeCodeLensState, {
 			canBeEnabled: this.canCodeLensBeEnabled(),
 		});
-	}
-
-	// the webview is not updated when it's invisible, but the provider is alive.
-	// need to refresh all states on open already loaded view
-	// TODO: this part doesn't work
-	private notifyDidResume() {
-		console.log('home test notify');
-		setTimeout(() => {
-			void this.host.notify(DidResume, {
-				canBeEnabled: this.canCodeLensBeEnabled(),
-			});
-		}, 2000);
 	}
 
 	private async notifyDidChangeSubscription(subscription?: Subscription) {

--- a/src/webviews/home/homeWebview.ts
+++ b/src/webviews/home/homeWebview.ts
@@ -64,10 +64,6 @@ export class HomeWebviewProvider implements WebviewProvider<State> {
 		this.notifyDidChangeOnboardingIntegration();
 	}
 
-	onVisibilityChanged(visible: boolean): void {
-		if (visible) this.notifyDidResume();
-	}
-
 	private async onChangeActiveTextEditor(e: TextEditor | undefined) {
 		if (!e || !isTextEditor(e)) {
 			this.activeTrackedTextEditor = undefined;

--- a/src/webviews/home/protocol.ts
+++ b/src/webviews/home/protocol.ts
@@ -1,8 +1,11 @@
 import type { Subscription } from '../../plus/gk/account/subscription';
+import type { OnboardingItem } from '../apps/home/model/gitlens-onboarding';
 import type { IpcScope, WebviewState } from '../protocol';
 import { IpcCommand, IpcNotification } from '../protocol';
 
 export const scope: IpcScope = 'home';
+
+export type OnboardingState = Partial<Record<`${OnboardingItem}Checked`, boolean>>;
 
 export interface State extends WebviewState {
 	repositories: DidChangeRepositoriesParams;
@@ -11,6 +14,7 @@ export interface State extends WebviewState {
 	orgSettings: {
 		drafts: boolean;
 	};
+	onboardingState: OnboardingState;
 	walkthroughCollapsed: boolean;
 	hasAnyIntegrationConnected: boolean;
 }
@@ -40,6 +44,8 @@ export const DidChangeIntegrationsConnections = new IpcNotification<DidChangeInt
 	scope,
 	'integrations/didChange',
 );
+export type DidChangeUsagesParams = OnboardingState;
+export const DidChangeUsage = new IpcNotification<DidChangeUsagesParams>(scope, 'onboarding/usage/didChange');
 
 export interface DidChangeSubscriptionParams {
 	subscription: Subscription;

--- a/src/webviews/home/protocol.ts
+++ b/src/webviews/home/protocol.ts
@@ -1,9 +1,24 @@
 import type { Subscription } from '../../plus/gk/account/subscription';
-import type { OnboardingItem } from '../apps/home/model/gitlens-onboarding';
 import type { IpcScope, WebviewState } from '../protocol';
 import { IpcNotification } from '../protocol';
 
 export const scope: IpcScope = 'home';
+
+export enum OnboardingItem {
+	repoHost = 'repoHost',
+	commitGraph = 'commitGraph',
+	sourceControl = 'sourceControl',
+	gitLens = 'gitLens',
+	inspect = 'inspect',
+	visualFileHistory = 'visualFileHistory',
+	launchpad = 'launchpad',
+	revisionHistory = 'revisionHistory',
+	allSidebarViews = 'allSidebarViews',
+	editorFeatures = 'editorFeatures',
+	blame = 'blame',
+	codeLens = 'codeLens',
+	fileAnnotations = 'fileAnnotations',
+}
 
 export type OnboardingState = Partial<Record<`${OnboardingItem}Checked`, boolean>>;
 
@@ -21,7 +36,8 @@ export interface State extends WebviewState {
 	};
 	onboardingState: OnboardingState;
 	hasAnyIntegrationConnected: boolean;
-	onboardingExtras: OnboardingConfigurationExtras;
+	repoHostConnected: boolean;
+	editorPreviewEnabled: boolean;
 }
 
 // NOTIFICATIONS
@@ -48,10 +64,21 @@ export const DidChangeOnboardingState = new IpcNotification<DidChangeOnboardingS
 	'onboarding/usage/didChange',
 );
 
-export type DidChangeOnboardingConfigurationParams = OnboardingConfigurationExtras;
-export const DidChangeOnboardingConfiguration = new IpcNotification<DidChangeOnboardingConfigurationParams>(
+export interface DidChangeOnboardingEditorParams {
+	editorPreviewEnabled: boolean;
+}
+export const DidChangeOnboardingEditor = new IpcNotification<DidChangeOnboardingEditorParams>(
 	scope,
-	'onboarding/configuration/didChange',
+	'onboarding/editor/didChange',
+);
+
+export interface DidChangeOnboardingIntegrationParams {
+	onboardingState: OnboardingState;
+	repoHostConnected: boolean;
+}
+export const DidChangeOnboardingIntegration = new IpcNotification<DidChangeOnboardingIntegrationParams>(
+	scope,
+	'onboarding/integration/didChange',
 );
 
 export interface DidChangeSubscriptionParams {

--- a/src/webviews/home/protocol.ts
+++ b/src/webviews/home/protocol.ts
@@ -39,6 +39,7 @@ export interface State extends WebviewState {
 	repoHostConnected: boolean;
 	editorPreviewEnabled: boolean;
 	canEnableCodeLens: boolean;
+	canEnableLineBlame: boolean;
 }
 
 // NOTIFICATIONS
@@ -79,6 +80,15 @@ export interface DidChangeCodeLensStateParams {
 export const DidChangeCodeLensState = new IpcNotification<DidChangeCodeLensStateParams>(
 	scope,
 	'onboarding/codelens/didToggle',
+);
+
+export interface DidChangeLineBlameStateParams {
+	canBeEnabled: boolean;
+}
+
+export const DidChangeLineBlameState = new IpcNotification<DidChangeLineBlameStateParams>(
+	scope,
+	'onboarding/lineblame/didToggle',
 );
 
 export interface DidChangeOnboardingIntegrationParams {

--- a/src/webviews/home/protocol.ts
+++ b/src/webviews/home/protocol.ts
@@ -38,6 +38,7 @@ export interface State extends WebviewState {
 	hasAnyIntegrationConnected: boolean;
 	repoHostConnected: boolean;
 	editorPreviewEnabled: boolean;
+	canEnableCodeLens: boolean;
 }
 
 // NOTIFICATIONS
@@ -71,6 +72,16 @@ export const DidChangeOnboardingEditor = new IpcNotification<DidChangeOnboarding
 	scope,
 	'onboarding/editor/didChange',
 );
+
+export interface DidChangeCodeLensStateParams {
+	canBeEnabled: boolean;
+}
+export const DidChangeCodeLensState = new IpcNotification<DidChangeCodeLensStateParams>(
+	scope,
+	'onboarding/codelens/didToggle',
+);
+
+export const DidResume = new IpcNotification<DidChangeCodeLensStateParams>(scope, 'onboarding/home/didResume');
 
 export interface DidChangeOnboardingIntegrationParams {
 	onboardingState: OnboardingState;

--- a/src/webviews/home/protocol.ts
+++ b/src/webviews/home/protocol.ts
@@ -18,6 +18,9 @@ export enum OnboardingItem {
 	blame = 'blame',
 	codeLens = 'codeLens',
 	fileAnnotations = 'fileAnnotations',
+	proFeatures = 'proFeatures',
+	tryTrial = 'tryTrial',
+	upgradeToPro = 'upgradeToPro',
 }
 
 export type OnboardingState = Partial<Record<`${OnboardingItem}Checked`, boolean>>;
@@ -36,6 +39,7 @@ export interface State extends WebviewState {
 	canEnableCodeLens: boolean;
 	canEnableLineBlame: boolean;
 	isOnboardingInitialized: boolean;
+	proFeaturesEnabled: boolean;
 }
 
 // NOTIFICATIONS
@@ -69,6 +73,8 @@ export const DidChangeOnboardingEditor = new IpcNotification<DidChangeOnboarding
 	scope,
 	'onboarding/editor/didChange',
 );
+
+export const DidTogglePlusFeatures = new IpcNotification<boolean>(scope, 'onboarding/plus/toggle');
 
 export interface DidChangeCodeLensStateParams {
 	canBeEnabled: boolean;

--- a/src/webviews/home/protocol.ts
+++ b/src/webviews/home/protocol.ts
@@ -1,11 +1,16 @@
 import type { Subscription } from '../../plus/gk/account/subscription';
 import type { OnboardingItem } from '../apps/home/model/gitlens-onboarding';
 import type { IpcScope, WebviewState } from '../protocol';
-import { IpcCommand, IpcNotification } from '../protocol';
+import { IpcNotification } from '../protocol';
 
 export const scope: IpcScope = 'home';
 
 export type OnboardingState = Partial<Record<`${OnboardingItem}Checked`, boolean>>;
+
+export interface OnboardingConfigurationExtras {
+	editorPreviewEnabled: boolean;
+	repoHostConnected: boolean;
+}
 
 export interface State extends WebviewState {
 	repositories: DidChangeRepositoriesParams;
@@ -15,17 +20,9 @@ export interface State extends WebviewState {
 		drafts: boolean;
 	};
 	onboardingState: OnboardingState;
-	walkthroughCollapsed: boolean;
 	hasAnyIntegrationConnected: boolean;
+	onboardingExtras: OnboardingConfigurationExtras;
 }
-
-// COMMANDS
-
-export interface CollapseSectionParams {
-	section: string;
-	collapsed: boolean;
-}
-export const CollapseSectionCommand = new IpcCommand<CollapseSectionParams>(scope, 'section/collapse');
 
 // NOTIFICATIONS
 
@@ -46,6 +43,12 @@ export const DidChangeIntegrationsConnections = new IpcNotification<DidChangeInt
 );
 export type DidChangeUsagesParams = OnboardingState;
 export const DidChangeUsage = new IpcNotification<DidChangeUsagesParams>(scope, 'onboarding/usage/didChange');
+
+export type DidChangeOnboardingConfigurationParams = OnboardingConfigurationExtras;
+export const DidChangeOnboardingConfiguration = new IpcNotification<DidChangeOnboardingConfigurationParams>(
+	scope,
+	'onboarding/configuration/didChange',
+);
 
 export interface DidChangeSubscriptionParams {
 	subscription: Subscription;

--- a/src/webviews/home/protocol.ts
+++ b/src/webviews/home/protocol.ts
@@ -41,8 +41,12 @@ export const DidChangeIntegrationsConnections = new IpcNotification<DidChangeInt
 	scope,
 	'integrations/didChange',
 );
-export type DidChangeUsagesParams = OnboardingState;
-export const DidChangeUsage = new IpcNotification<DidChangeUsagesParams>(scope, 'onboarding/usage/didChange');
+
+export type DidChangeOnboardingStateParams = OnboardingState;
+export const DidChangeOnboardingState = new IpcNotification<DidChangeOnboardingStateParams>(
+	scope,
+	'onboarding/usage/didChange',
+);
 
 export type DidChangeOnboardingConfigurationParams = OnboardingConfigurationExtras;
 export const DidChangeOnboardingConfiguration = new IpcNotification<DidChangeOnboardingConfigurationParams>(

--- a/src/webviews/home/protocol.ts
+++ b/src/webviews/home/protocol.ts
@@ -81,8 +81,6 @@ export const DidChangeCodeLensState = new IpcNotification<DidChangeCodeLensState
 	'onboarding/codelens/didToggle',
 );
 
-export const DidResume = new IpcNotification<DidChangeCodeLensStateParams>(scope, 'onboarding/home/didResume');
-
 export interface DidChangeOnboardingIntegrationParams {
 	onboardingState: OnboardingState;
 	repoHostConnected: boolean;

--- a/src/webviews/home/protocol.ts
+++ b/src/webviews/home/protocol.ts
@@ -22,11 +22,6 @@ export enum OnboardingItem {
 
 export type OnboardingState = Partial<Record<`${OnboardingItem}Checked`, boolean>>;
 
-export interface OnboardingConfigurationExtras {
-	editorPreviewEnabled: boolean;
-	repoHostConnected: boolean;
-}
-
 export interface State extends WebviewState {
 	repositories: DidChangeRepositoriesParams;
 	webroot?: string;
@@ -34,12 +29,13 @@ export interface State extends WebviewState {
 	orgSettings: {
 		drafts: boolean;
 	};
-	onboardingState: OnboardingState;
 	hasAnyIntegrationConnected: boolean;
+	onboardingState: undefined | OnboardingState;
 	repoHostConnected: boolean;
 	editorPreviewEnabled: boolean;
 	canEnableCodeLens: boolean;
 	canEnableLineBlame: boolean;
+	isOnboardingInitialized: boolean;
 }
 
 // NOTIFICATIONS
@@ -80,6 +76,15 @@ export interface DidChangeCodeLensStateParams {
 export const DidChangeCodeLensState = new IpcNotification<DidChangeCodeLensStateParams>(
 	scope,
 	'onboarding/codelens/didToggle',
+);
+
+export interface DidChangeOnboardingIsInitializedParams {
+	isInitialized: boolean;
+}
+
+export const DidChangeOnboardingIsInitialized = new IpcNotification<DidChangeOnboardingIsInitializedParams>(
+	scope,
+	'onboarding/isInitialized/didChange',
 );
 
 export interface DidChangeLineBlameStateParams {

--- a/src/webviews/webviewController.ts
+++ b/src/webviews/webviewController.ts
@@ -403,6 +403,12 @@ export class WebviewController<
 
 	@debug()
 	private onParentVisibilityChanged(visible: boolean, active?: boolean) {
+		// if (
+		// 	!this.descriptor.trackingFeature ||
+		// 	['graphView', 'graphWebview'].includes(this.descriptor.trackingFeature)
+		// ) {
+		// 	debugger;
+		// }
 		if (this.descriptor.webviewHostOptions?.retainContextWhenHidden !== true) {
 			if (visible) {
 				if (this._ready) {

--- a/src/webviews/webviewsController.ts
+++ b/src/webviews/webviewsController.ts
@@ -270,7 +270,6 @@ export class WebviewsController implements Disposable {
 			options?: WebviewPanelsShowOptions,
 			...args: WebviewShowingArgs<ShowingArgs, SerializedState>
 		): Promise<void> {
-			// debugger;
 			const { descriptor } = registration;
 			if (descriptor.plusFeature) {
 				if (!(await ensurePlusFeaturesEnabled())) return;

--- a/src/webviews/webviewsController.ts
+++ b/src/webviews/webviewsController.ts
@@ -270,6 +270,7 @@ export class WebviewsController implements Disposable {
 			options?: WebviewPanelsShowOptions,
 			...args: WebviewShowingArgs<ShowingArgs, SerializedState>
 		): Promise<void> {
+			// debugger;
 			const { descriptor } = registration;
 			if (descriptor.plusFeature) {
 				if (!(await ensurePlusFeaturesEnabled())) return;


### PR DESCRIPTION
# Description

Shows progress tracker and onboarding items according to UsageTracker data

![Screenshot 2024-08-05 at 18 34 15](https://github.com/user-attachments/assets/222332b8-f818-4e51-9fc9-162f3710ddbb)

Both action buttons as optional

Play icon is always a button that expects the href to be passed. Can run commands or open tabs

Info icon can have href property and title property. These properties are independent.
If the button has a href, then it can work as the play button. If the button has a title, it renders the tooltip on hover

![Screenshot 2024-07-30 at 16 35 14](https://github.com/user-attachments/assets/3073c4b1-3bb7-4d31-9dc1-efe8733784f5)

Onboarding items state is based on UsageTracker. Some items check if Views or webViews are shown, other checks if commands are executed, and there are 2 specific states:
- connect with repo host is based on current connection state
- codelens has its' own track key and it's tracked on the first codelens os shown

Info icons lead to corresponding youtube video part from the previous onboarding. Play buttons inspect corresponding app views.


https://github.com/user-attachments/assets/fb4887f0-92b7-43ad-9ddd-0214a3004175


# Checklist

<!-- Please check off the following -->

- [x] I have followed the guidelines in the Contributing document
- [x] My changes follow the coding style of this project
- [ ] My changes build without any errors or warnings
- [x] My changes have been formatted and linted
- [x] My changes include any required corresponding changes to the documentation (including CHANGELOG.md and README.md)
- [x] My changes have been rebased and squashed to the minimal number (typically 1) of relevant commits
- [x] My changes have a descriptive commit message with a short title, including a `Fixes $XXX -` or `Closes #XXX -` prefix to auto-close the issue that your PR addresses
