### PR TITLE
Adds menu for stashes on the commit graph

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,10 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/) and this p
 
 ## [Unreleased]
 
+### Added
+
+- Adds `...` inline action for stashes on the _GitLens Inspect_ view
+
 ## [15.3.0] - 2024-08-15
 
 ### Added

--- a/src/git/actions/commit.ts
+++ b/src/git/actions/commit.ts
@@ -799,6 +799,7 @@ export async function showDetailsQuickPick(commit: GitCommit, fileOrUri?: string
 
 	void (await executeCommand<[Uri, ShowQuickCommitFileCommandArgs]>(Commands.ShowQuickCommitFile, uri, {
 		sha: commit.sha,
+		commit: commit,
 	}));
 }
 

--- a/src/webviews/apps/commitDetails/components/gl-commit-details.ts
+++ b/src/webviews/apps/commitDetails/components/gl-commit-details.ts
@@ -522,20 +522,17 @@ export class GlCommitDetails extends GlDetailsBase {
 		});
 
 		if (!this.isStash) {
-			actions.push(
-				{
-					icon: 'globe',
-					label: 'Open on remote',
-					action: 'file-open-on-remote',
-				},
-				{
-					icon: 'ellipsis',
-					label: 'Show more actions',
-					action: 'file-more-actions',
-				},
-			);
+			actions.push({
+				icon: 'globe',
+				label: 'Open on remote',
+				action: 'file-open-on-remote',
+			});
 		}
-
+		actions.push({
+			icon: 'ellipsis',
+			label: 'Show more actions',
+			action: 'file-more-actions',
+		});
 		return actions;
 	}
 }


### PR DESCRIPTION
# Description

- Adds menu for stashes on the commit graph from commits
- Makes localGitProvider.getCommitForFile return GitStashCommit | GitCommit | undefined

https://github.com/user-attachments/assets/41251127-1c76-487f-91be-1baf23952849



# Checklist

<!-- Please check off the following -->

- [x] I have followed the guidelines in the Contributing document
- [x] My changes follow the coding style of this project
- [x] My changes build without any errors or warnings
- [x] My changes have been formatted and linted
- [x] My changes include any required corresponding changes to the documentation (including CHANGELOG.md and README.md)
- [ ] My changes have been rebased and squashed to the minimal number (typically 1) of relevant commits
- [x] My changes have a descriptive commit message with a short title, including a `Fixes $XXX -` or `Closes #XXX -` prefix to auto-close the issue that your PR addresses
