### PR TITLE
Adds new cloud integration connection flow and applies to Launchpad

### DIFF
--- a/src/commands/gitCommands.ts
+++ b/src/commands/gitCommands.ts
@@ -1030,6 +1030,8 @@ export class GitCommandsCommand extends Command {
 						debugger;
 					}
 				}
+
+				step.onDidActivate?.(quickpick);
 			});
 		} finally {
 			quickpick.dispose();

--- a/src/commands/quickCommand.ts
+++ b/src/commands/quickCommand.ts
@@ -67,6 +67,8 @@ export interface QuickPickStep<T extends QuickPickItem = QuickPickItem> {
 
 	frozen?: boolean;
 
+	onDidActivate?(quickpick: QuickPick<DirectiveQuickPickItem | T>): void;
+
 	onDidAccept?(quickpick: QuickPick<DirectiveQuickPickItem | T>): boolean | Promise<boolean>;
 	onDidChangeValue?(quickpick: QuickPick<DirectiveQuickPickItem | T>): boolean | Promise<boolean>;
 	onDidChangeSelection?(quickpick: QuickPick<DirectiveQuickPickItem | T>, selection: readonly T[]): void;

--- a/src/constants.ts
+++ b/src/constants.ts
@@ -886,10 +886,20 @@ export type Sources =
 	| 'welcome'
 	| 'worktrees';
 
+export type LoginContext = 'start_trial';
+
+export type ConnectIntegrationContext = 'launchpad';
+
+export type Context = LoginContext | ConnectIntegrationContext;
+
 export interface Source {
 	source: Sources;
 	detail?: string | TelemetryEventData;
 }
+
+export const sourceToContext: { [source in Sources]?: Context } = {
+	launchpad: 'launchpad',
+};
 
 export type AIProviders = 'anthropic' | 'gemini' | 'openai' | 'vscode';
 export type AIModels<Provider extends AIProviders = AIProviders> = Provider extends 'openai'

--- a/src/plus/focus/focus.ts
+++ b/src/plus/focus/focus.ts
@@ -2,6 +2,7 @@ import type { QuickInputButton, QuickPick, QuickPickItem } from 'vscode';
 import { commands, Uri } from 'vscode';
 import { getAvatarUri } from '../../avatars';
 import type {
+	AsyncStepResultGenerator,
 	PartialStepState,
 	StepGenerator,
 	StepResultGenerator,
@@ -12,6 +13,7 @@ import {
 	canPickStepContinue,
 	createPickStep,
 	endSteps,
+	freezeStep,
 	QuickCommand,
 	StepResultBreak,
 } from '../../commands/quickCommand';
@@ -37,6 +39,7 @@ import type { QuickPickItemOfT } from '../../quickpicks/items/common';
 import { createQuickPickItemOfT, createQuickPickSeparator } from '../../quickpicks/items/common';
 import type { DirectiveQuickPickItem } from '../../quickpicks/items/directive';
 import { createDirectiveQuickPickItem, Directive, isDirectiveQuickPickItem } from '../../quickpicks/items/directive';
+import { configuration } from '../../system/configuration';
 import { getScopedCounter } from '../../system/counter';
 import { fromNow } from '../../system/date';
 import { interpolate, pluralize } from '../../system/string';
@@ -44,6 +47,7 @@ import { openUrl } from '../../system/utils';
 import type { IntegrationId } from '../integrations/providers/models';
 import {
 	HostingIntegrationId,
+	isIntegrationId,
 	ProviderBuildStatusState,
 	ProviderPullRequestReviewState,
 	SelfHostedIntegrationId,
@@ -236,20 +240,30 @@ export class FocusCommand extends QuickCommand<State> {
 
 				opened = true;
 
-				const result = yield* this.confirmIntegrationConnectStep(state, context);
-				if (result !== StepResultBreak && !(await this.ensureIntegrationConnected(result))) {
-					let integration;
-					switch (result) {
-						case HostingIntegrationId.GitHub:
-							integration = 'GitHub';
-							break;
-						default:
-							integration = `integration (${result})`;
-							break;
-					}
-					throw new Error(`Unable to connect to ${integration}`);
+				const isUsingCloudIntegrations = configuration.get(
+					'experimental.cloudIntegrations.enabled',
+					undefined,
+					false,
+				);
+				const result = isUsingCloudIntegrations
+					? yield* this.confirmCloudIntegrationsConnectStep(state)
+					: yield* this.confirmLocalIntegrationConnectStep(state, context);
+				if (result === StepResultBreak) {
+					return result;
 				}
-				newlyConnected = result !== StepResultBreak;
+
+				result.resume();
+
+				const connected = result.connected;
+				if (!connected) {
+					throw new Error(
+						`Unable to connect to ${
+							isIntegrationId(connected) ? getIntegrationTitle(connected) : 'integrations'
+						}`,
+					);
+				}
+
+				newlyConnected = Boolean(connected);
 			}
 
 			await updateContextItems(this.container, context, { force: newlyConnected });
@@ -275,23 +289,28 @@ export class FocusCommand extends QuickCommand<State> {
 				if (result === StepResultBreak) continue;
 
 				if (isConnectMoreIntegrationsItem(result)) {
-					const connectingResult = yield* this.confirmIntegrationConnectStep(state, context);
-					if (
-						connectingResult !== StepResultBreak &&
-						!(await this.ensureIntegrationConnected(connectingResult))
-					) {
-						let integration;
-						switch (connectingResult) {
-							case HostingIntegrationId.GitHub:
-								integration = 'GitHub';
-								break;
-							default:
-								integration = `integration (${connectingResult})`;
-								break;
-						}
-						throw new Error(`Unable to connect to ${integration}`);
+					const isUsingCloudIntegrations = configuration.get(
+						'experimental.cloudIntegrations.enabled',
+						undefined,
+						false,
+					);
+					const result = isUsingCloudIntegrations
+						? yield* this.confirmCloudIntegrationsConnectStep(state)
+						: yield* this.confirmLocalIntegrationConnectStep(state, context);
+					if (result === StepResultBreak) continue;
+
+					result.resume();
+
+					const connected = result.connected;
+					if (!connected) {
+						throw new Error(
+							`Unable to connect to ${
+								isIntegrationId(connected) ? getIntegrationTitle(connected) : 'integrations'
+							}`,
+						);
 					}
-					newlyConnected = connectingResult !== StepResultBreak;
+
+					newlyConnected = Boolean(connected);
 					await updateContextItems(this.container, context, { force: newlyConnected });
 					continue;
 				}
@@ -803,10 +822,10 @@ export class FocusCommand extends QuickCommand<State> {
 		return canPickStepContinue(step, state, selection) ? selection[0].item : StepResultBreak;
 	}
 
-	private *confirmIntegrationConnectStep(
+	private async *confirmLocalIntegrationConnectStep(
 		state: StepState<State>,
 		context: Context,
-	): StepResultGenerator<IntegrationId> {
+	): AsyncStepResultGenerator<{ connected: boolean | IntegrationId; resume: () => void }> {
 		const confirmations: (QuickPickItemOfT<IntegrationId> | DirectiveQuickPickItem)[] = [];
 
 		for (const integration of supportedFocusIntegrations) {
@@ -848,8 +867,54 @@ export class FocusCommand extends QuickCommand<State> {
 			{ placeholder: 'Launchpad requires a connected integration', ignoreFocusOut: false },
 		);
 
+		let freeze!: () => Disposable;
+		step.onDidActivate = qp => {
+			freeze = () => freezeStep(step, qp);
+		};
+
 		const selection: StepSelection<typeof step> = yield step;
-		return canPickStepContinue(step, state, selection) ? selection[0].item : StepResultBreak;
+		if (canPickStepContinue(step, state, selection)) {
+			const resume = freeze();
+			const chosenIntegrationId = selection[0].item;
+			const connected = await this.ensureIntegrationConnected(chosenIntegrationId);
+			return { connected: connected ? chosenIntegrationId : false, resume: () => resume[Symbol.dispose]() };
+		}
+
+		return StepResultBreak;
+	}
+
+	private async *confirmCloudIntegrationsConnectStep(
+		state: StepState<State>,
+	): AsyncStepResultGenerator<{ connected: boolean | IntegrationId; resume: () => void }> {
+		const step = this.createConfirmStep(
+			`${this.title} \u00a0\u2022\u00a0 Connect an Integration`,
+			[
+				createQuickPickItemOfT(
+					{
+						label: 'Connect a Cloud Integration...',
+						detail: 'Will connect a cloud integration to use with Launchpad',
+					},
+					true,
+				),
+			],
+			createDirectiveQuickPickItem(Directive.Cancel, false, { label: 'Cancel' }),
+			{ placeholder: 'Launchpad requires a connected integration', ignoreFocusOut: true },
+		);
+
+		let freeze!: () => Disposable;
+		step.onDidActivate = qp => {
+			freeze = () => freezeStep(step, qp);
+		};
+
+		const selection: StepSelection<typeof step> = yield step;
+
+		if (canPickStepContinue(step, state, selection)) {
+			const resume = freeze();
+			const connected = await this.container.integrations.connectCloudIntegrations(undefined, this.source);
+			return { connected: connected, resume: () => resume[Symbol.dispose]() };
+		}
+
+		return StepResultBreak;
 	}
 
 	private getFocusItemInformationRows(

--- a/src/plus/focus/focus.ts
+++ b/src/plus/focus/focus.ts
@@ -910,7 +910,9 @@ export class FocusCommand extends QuickCommand<State> {
 
 		if (canPickStepContinue(step, state, selection)) {
 			const resume = freeze();
-			const connected = await this.container.integrations.connectCloudIntegrations(undefined, this.source);
+			const connected = await this.container.integrations.connectCloudIntegrations(undefined, {
+				source: 'launchpad',
+			});
 			return { connected: connected, resume: () => resume[Symbol.dispose]() };
 		}
 

--- a/src/plus/integrations/providers/models.ts
+++ b/src/plus/integrations/providers/models.ts
@@ -107,6 +107,10 @@ export function isSelfHostedIntegrationId(id: IntegrationId): id is SelfHostedIn
 	return selfHostedIntegrationIds.includes(id as SelfHostedIntegrationId);
 }
 
+export function isIntegrationId(id: any): id is IntegrationId {
+	return typeof id === 'string' && supportedIntegrationIds.includes(id as IntegrationId);
+}
+
 export enum PullRequestFilter {
 	Author = 'author',
 	Assignee = 'assignee',

--- a/src/plus/integrations/providers/models.ts
+++ b/src/plus/integrations/providers/models.ts
@@ -107,10 +107,6 @@ export function isSelfHostedIntegrationId(id: IntegrationId): id is SelfHostedIn
 	return selfHostedIntegrationIds.includes(id as SelfHostedIntegrationId);
 }
 
-export function isIntegrationId(id: any): id is IntegrationId {
-	return typeof id === 'string' && supportedIntegrationIds.includes(id as IntegrationId);
-}
-
 export enum PullRequestFilter {
 	Author = 'author',
 	Assignee = 'assignee',


### PR DESCRIPTION
Adds support for using the new `/connect` page to connect cloud integrations.

Applies to the Launchpad "connect integrations" step when cloud integrations setting is enabled.