### PR TITLE
Adds "smart" branches visibility

### DIFF
--- a/package.json
+++ b/package.json
@@ -932,6 +932,23 @@
 				"title": "Commit Graph",
 				"order": 50,
 				"properties": {
+					"gitlens.graph.branchesVisibility": {
+						"type": "string",
+						"enum": [
+							"all",
+							"smart",
+							"current"
+						],
+						"enumDescriptions": [
+							"Shows all branches",
+							"Shows only relevant branches",
+							"Shows only the current branch"
+						],
+						"default": "smart",
+						"markdownDescription": "Specifies the visibility of branches on the _Commit Graph_",
+						"scope": "window",
+						"order": 2
+					},
 					"gitlens.graph.allowMultiple": {
 						"type": "boolean",
 						"default": true,

--- a/src/config.ts
+++ b/src/config.ts
@@ -307,6 +307,7 @@ export type DateSource = 'authored' | 'committed';
 export type DateStyle = 'absolute' | 'relative';
 export type FileAnnotationType = 'blame' | 'changes' | 'heatmap';
 export type GitCommandSorting = 'name' | 'usage';
+export type GraphBranchesVisibility = 'all' | 'smart' | 'current';
 export type GraphScrollMarkersAdditionalTypes =
 	| 'localBranches'
 	| 'remoteBranches'
@@ -385,6 +386,7 @@ export interface AdvancedConfig {
 export interface GraphConfig {
 	readonly allowMultiple: boolean;
 	readonly avatars: boolean;
+	readonly branchesVisibility: GraphBranchesVisibility;
 	readonly commitOrdering: 'date' | 'author-date' | 'topo';
 	readonly dateFormat: DateTimeFormat | string | null;
 	readonly dateStyle: DateStyle | null;

--- a/src/constants.ts
+++ b/src/constants.ts
@@ -3,7 +3,7 @@ import type { GeminiModels } from './ai/geminiProvider';
 import type { OpenAIModels } from './ai/openaiProvider';
 import type { VSCodeAIModels } from './ai/vscodeProvider';
 import type { AnnotationStatus } from './annotations/annotationProvider';
-import type { ViewShowBranchComparison } from './config';
+import type { GraphBranchesVisibility, ViewShowBranchComparison } from './config';
 import type { Environment } from './container';
 import type { StoredSearchQuery } from './git/search';
 import type { Subscription, SubscriptionPlanId, SubscriptionState } from './plus/gk/account/subscription';
@@ -986,8 +986,6 @@ export type DeprecatedWorkspaceStorage = {
 	'confirm:sendToOpenAI': boolean;
 	/** @deprecated */
 	'graph:banners:dismissed': Record<string, boolean>;
-	/** @deprecated use `graph:filtersByRepo.excludeRefs` */
-	'graph:hiddenRefs': Record<string, StoredGraphExcludedRef>;
 	/** @deprecated */
 	'views:searchAndCompare:keepResults': boolean;
 };
@@ -1116,10 +1114,13 @@ export interface StoredGraphColumn {
 	width?: number;
 }
 
+export type StoredGraphExcludeTypes = 'remotes' | 'stashes' | 'tags';
+
 export interface StoredGraphFilters {
+	branchesVisibility?: GraphBranchesVisibility;
 	includeOnlyRefs?: Record<string, StoredGraphIncludeOnlyRef>;
 	excludeRefs?: Record<string, StoredGraphExcludedRef>;
-	excludeTypes?: Record<string, boolean>;
+	excludeTypes?: Record<StoredGraphExcludeTypes, boolean>;
 }
 
 export type StoredGraphRefType = 'head' | 'remote' | 'tag';

--- a/src/constants.ts
+++ b/src/constants.ts
@@ -402,6 +402,10 @@ export const enum Commands {
 	Deprecated_ShowFileHistoryInView = 'gitlens.showFileHistoryInView',
 }
 
+export type GitConfigKeys =
+	| `branch.${string}.${'gk' | 'vscode'}-merge-base`
+	| `branch.${string}.github-pr-owner-number`;
+
 export type TreeViewCommands = `gitlens.views.${
 	| `branches.${
 			| 'copy'

--- a/src/git/gitProvider.ts
+++ b/src/git/gitProvider.ts
@@ -1,6 +1,7 @@
 import type { CancellationToken, Disposable, Event, Range, TextDocument, Uri, WorkspaceFolder } from 'vscode';
 import type { Commit, InputBox } from '../@types/vscode.git';
 import type { ForcePushMode } from '../@types/vscode.git.enums';
+import type { GitConfigKeys } from '../constants';
 import type { Features } from '../features';
 import type { GitUri } from './gitUri';
 import type { GitBlame, GitBlameLine, GitBlameLines } from './models/blame';
@@ -292,8 +293,8 @@ export interface GitProvider extends Disposable {
 			mode?: 'contains' | 'pointsAt' | undefined;
 		},
 	): Promise<string[]>;
-	getConfig?(repoPath: string, key: string): Promise<string | undefined>;
-	setConfig?(repoPath: string, key: string, value: string | undefined): Promise<void>;
+	getConfig?(repoPath: string, key: GitConfigKeys): Promise<string | undefined>;
+	setConfig?(repoPath: string, key: GitConfigKeys, value: string | undefined): Promise<void>;
 	getContributors(
 		repoPath: string,
 		options?: {
@@ -304,6 +305,7 @@ export interface GitProvider extends Disposable {
 		},
 	): Promise<GitContributor[]>;
 	getCurrentUser(repoPath: string): Promise<GitUser | undefined>;
+	getBaseBranchName?(repoPath: string, ref: string): Promise<string | undefined>;
 	getDefaultBranchName(repoPath: string | undefined, remote?: string): Promise<string | undefined>;
 	getDiff?(
 		repoPath: string | Uri,

--- a/src/git/gitProviderService.ts
+++ b/src/git/gitProviderService.ts
@@ -12,6 +12,7 @@ import type {
 import { Disposable, EventEmitter, FileType, ProgressLocation, Uri, window, workspace } from 'vscode';
 import { isWeb } from '@env/platform';
 import { resetAvatarCache } from '../avatars';
+import type { GitConfigKeys } from '../constants';
 import { GlyphChars, Schemes } from '../constants';
 import type { Container } from '../container';
 import { AccessDeniedError, CancellationError, ProviderNotFoundError } from '../errors';
@@ -1756,13 +1757,13 @@ export class GitProviderService implements Disposable {
 	}
 
 	@log()
-	async getConfig(repoPath: string | Uri, key: string): Promise<string | undefined> {
+	async getConfig(repoPath: string | Uri, key: GitConfigKeys): Promise<string | undefined> {
 		const { provider, path } = this.getProvider(repoPath);
 		return provider.getConfig?.(path, key);
 	}
 
 	@log()
-	async setConfig(repoPath: string | Uri, key: string, value: string | undefined): Promise<void> {
+	async setConfig(repoPath: string | Uri, key: GitConfigKeys, value: string | undefined): Promise<void> {
 		const { provider, path } = this.getProvider(repoPath);
 		return provider.setConfig?.(path, key, value);
 	}
@@ -1783,6 +1784,12 @@ export class GitProviderService implements Disposable {
 	getCurrentUser(repoPath: string | Uri): Promise<GitUser | undefined> {
 		const { provider, path } = this.getProvider(repoPath);
 		return provider.getCurrentUser(path);
+	}
+
+	@log()
+	async getBaseBranchName(repoPath: string | Uri, ref: string): Promise<string | undefined> {
+		const { provider, path } = this.getProvider(repoPath);
+		return provider.getBaseBranchName?.(path, ref);
 	}
 
 	@log()

--- a/src/plus/webviews/graph/protocol.ts
+++ b/src/plus/webviews/graph/protocol.ts
@@ -22,7 +22,7 @@ import type {
 	UpstreamMetadata,
 	WorkDirStats,
 } from '@gitkraken/gitkraken-components';
-import type { Config, DateStyle } from '../../../config';
+import type { Config, DateStyle, GraphBranchesVisibility } from '../../../config';
 import type { RepositoryVisibility } from '../../../git/gitProvider';
 import type { GitTrackingState } from '../../../git/models/branch';
 import type { GitGraphRowType } from '../../../git/models/graph';
@@ -92,6 +92,7 @@ export interface State extends WebviewState {
 	repositories?: GraphRepository[];
 	selectedRepository?: string;
 	selectedRepositoryVisibility?: RepositoryVisibility;
+	branchesVisibility?: GraphBranchesVisibility;
 	branchName?: string;
 	branchState?: BranchState;
 	lastFetched?: Date;
@@ -292,6 +293,7 @@ export const UpdateGraphConfigurationCommand = new IpcCommand<UpdateGraphConfigu
 );
 
 export interface UpdateIncludedRefsParams {
+	branchesVisibility?: GraphBranchesVisibility;
 	refs?: GraphIncludeOnlyRef[];
 }
 export const UpdateIncludedRefsCommand = new IpcCommand<UpdateIncludedRefsParams>(scope, 'filters/update/includedRefs');
@@ -405,6 +407,7 @@ export const DidChangeScrollMarkersNotification = new IpcNotification<DidChangeS
 );
 
 export interface DidChangeRefsVisibilityParams {
+	branchesVisibility: GraphBranchesVisibility;
 	excludeRefs?: GraphExcludeRefs;
 	excludeTypes?: GraphExcludeTypes;
 	includeOnlyRefs?: GraphIncludeOnlyRefs;

--- a/src/webviews/apps/plus/graph/GraphWrapper.tsx
+++ b/src/webviews/apps/plus/graph/GraphWrapper.tsx
@@ -1286,11 +1286,7 @@ export function GraphWrapper({
 													Shows only relevant branches
 													<br />
 													<br />
-													<i>
-														Includes the current branch, the current branch's upstream (if
-														any), and either the base branch or if current branch is
-														associated with a PR then the PR's target branch
-													</i>
+													<i>Includes the current branch, its upstream, and its base</i>
 												</span>
 											</GlTooltip>
 										) : (

--- a/src/webviews/apps/plus/graph/graph.scss
+++ b/src/webviews/apps/plus/graph/graph.scss
@@ -395,12 +395,13 @@ button:not([disabled]),
 	> *:not(:first-child) .action-button {
 		padding-left: 0.5rem;
 		padding-right: 0.5rem;
+		height: 100%;
 	}
 
-	> *:not(:last-child),
-	> *:not(:last-child) .action-button {
-		padding-right: 0.5rem;
-	}
+	// > *:not(:last-child),
+	// > *:not(:last-child) .action-button {
+	// 	padding-right: 0.5rem;
+	// }
 
 	&:hover > *:not(:last-child),
 	&:active > *:not(:last-child),
@@ -1219,4 +1220,49 @@ hr {
 	border-radius: 3px;
 	padding: 0px 4px 2px 4px;
 	font-family: var(--vscode-editor-font-family);
+}
+
+sl-option::part(base) {
+	padding: 0.2rem 0.4rem;
+}
+
+sl-option[aria-selected='true']::part(base),
+sl-option:not([aria-selected='true']):hover::part(base),
+sl-option:not([aria-selected='true']):focus::part(base) {
+	background-color: var(--vscode-list-activeSelectionBackground);
+	color: var(--vscode-list-activeSelectionForeground);
+}
+
+sl-option::part(checked-icon) {
+	display: none;
+}
+
+sl-select::part(listbox) {
+	padding-block: 0.2rem 0;
+	width: max-content;
+}
+
+sl-select::part(combobox) {
+	--sl-input-background-color: var(--color-graph-actionbar-background);
+	--sl-input-color: var(--color-foreground);
+	--sl-input-color-hover: var(--color-foreground);
+	padding: 0 0.75rem;
+	color: var(--color-foreground);
+	border-radius: var(--sl-border-radius-small);
+}
+
+sl-select::part(display-input) {
+	field-sizing: content;
+}
+
+sl-select::part(expand-icon) {
+	margin-inline-start: var(--sl-spacing-x-small);
+}
+
+sl-select[open]::part(combobox) {
+	background-color: var(--color-graph-actionbar-background);
+}
+sl-select:hover::part(combobox),
+sl-select:focus::part(combobox) {
+	background-color: var(--color-graph-actionbar-selectedBackground);
 }

--- a/src/webviews/apps/plus/graph/graph.tsx
+++ b/src/webviews/apps/plus/graph/graph.tsx
@@ -1,7 +1,8 @@
 /*global document window*/
-import type { CssVariables, GraphRef, GraphRow } from '@gitkraken/gitkraken-components';
+import type { CssVariables, GraphRef, GraphRefOptData, GraphRow } from '@gitkraken/gitkraken-components';
 import React from 'react';
 import { render, unmountComponentAtNode } from 'react-dom';
+import type { GraphBranchesVisibility } from '../../../../config';
 import type { GitGraphRowType } from '../../../../git/models/graph';
 import type { SearchQuery } from '../../../../git/search';
 import type {
@@ -183,6 +184,7 @@ export class GraphApp extends App<State> {
 				break;
 
 			case DidChangeRefsVisibilityNotification.is(msg):
+				this.state.branchesVisibility = msg.params.branchesVisibility;
 				this.state.excludeRefs = msg.params.excludeRefs;
 				this.state.excludeTypes = msg.params.excludeTypes;
 				this.state.includeOnlyRefs = msg.params.includeOnlyRefs;
@@ -633,8 +635,8 @@ export class GraphApp extends App<State> {
 		this.sendCommand(UpdateExcludeTypesCommand, { key: key, value: value });
 	}
 
-	private onRefIncludesChanged(all?: boolean) {
-		this.sendCommand(UpdateIncludedRefsCommand, all ? {} : { refs: [{ id: 'HEAD', type: 'head', name: 'HEAD' }] });
+	private onRefIncludesChanged(branchesVisibility: GraphBranchesVisibility, refs?: GraphRefOptData[]) {
+		this.sendCommand(UpdateIncludedRefsCommand, { branchesVisibility: branchesVisibility, refs: refs });
 	}
 
 	private onGraphConfigurationChanged(changes: UpdateGraphConfigurationParams['changes']) {

--- a/src/webviews/apps/shared/styles/shoelace/vscode-theme.scss
+++ b/src/webviews/apps/shared/styles/shoelace/vscode-theme.scss
@@ -133,6 +133,8 @@
 	--sl-color-neutral-0: var(--vscode-editor-background);
 	--sl-color-neutral-1000: var(--vscode-foreground);
 
+	--sl-color-primary-600: var(--vscode-list-activeSelectionBackground);
+
 	--sl-border-radius-small: 0.3rem; // 0.1875rem;
 	--sl-border-radius-medium: 0.4rem; // 0.25rem;
 	--sl-border-radius-large: 0.8rem; // 0.5rem;
@@ -197,7 +199,7 @@
 
 	--sl-focus-ring-color: var(--vscode-focusBorder);
 	--sl-focus-ring-style: solid;
-	--sl-focus-ring-width: 3px;
+	--sl-focus-ring-width: 1px;
 	--sl-focus-ring: var(--sl-focus-ring-style) var(--sl-focus-ring-width) var(--sl-focus-ring-color);
 	--sl-focus-ring-offset: 1px;
 
@@ -215,7 +217,7 @@
 	--sl-input-background-color-disabled: var(--sl-color-neutral-100);
 	--sl-input-border-color: var(--sl-color-neutral-300);
 	--sl-input-border-color-hover: var(--sl-color-neutral-400);
-	--sl-input-border-color-focus: var(--sl-color-primary-500);
+	--sl-input-border-color-focus: var(--vscode-focusBorder);
 	--sl-input-border-color-disabled: var(--sl-color-neutral-300);
 	--sl-input-border-width: 1px;
 	--sl-input-required-content: '*';


### PR DESCRIPTION
Replaces the branches filter toggle with a top-line dropdown and adds a new "smart" filter mode.

The "smart" mode which includes the current branch, the current branch's upstream (if any), and either the base branch or if current branch is associated with a PR then the PR's target branch.

Also adds a `gitlens.graph.branchesVisibility` setting to control the default behavior, though once you can it via the dropdown the change is remembered per-repo.

![image](https://github.com/user-attachments/assets/0d73833a-84a5-41f8-b857-10483781c328)

While I think this is in a reasonable state to merge, it can still be improved in future follow-ups:
 - [x] ~Add better caching of the computed refs~
 - [x] ~Improve "base" branch detection when there is no PR involved (dig into the reflog)~