### PR TITLE
Makes "Select for Compare" on a Commit/Stash/etc doesn't cause the Search and Compare view to be forcibly shown

### DIFF
--- a/src/views/searchAndCompareView.ts
+++ b/src/views/searchAndCompareView.ts
@@ -237,8 +237,6 @@ export class SearchAndCompareViewNode extends ViewNode<'search-compare', SearchA
 
 		await this.triggerChange();
 
-		await this.view.reveal(this.comparePicker, { focus: false, select: true });
-
 		if (prompt) {
 			await this.compareWithSelected(repoPath, ref2);
 		}


### PR DESCRIPTION
# Description

# Checklist

<!-- Please check off the following -->

- [ ] I have followed the guidelines in the Contributing document
- [ ] My changes follow the coding style of this project
- [ ] My changes build without any errors or warnings
- [ ] My changes have been formatted and linted
- [ ] My changes include any required corresponding changes to the documentation (including CHANGELOG.md and README.md)
- [ ] My changes have been rebased and squashed to the minimal number (typically 1) of relevant commits
- [ ] My changes have a descriptive commit message with a short title, including a `Fixes $XXX -` or `Closes #XXX -` prefix to auto-close the issue that your PR addresses
