### PR TITLE
Adds worktree id to refs and worktree icons to the graph

### DIFF
--- a/src/env/node/git/localGitProvider.ts
+++ b/src/env/node/git/localGitProvider.ts
@@ -128,7 +128,7 @@ import type { GitTreeEntry } from '../../../git/models/tree';
 import type { GitUser } from '../../../git/models/user';
 import { isUserMatch } from '../../../git/models/user';
 import type { GitWorktree } from '../../../git/models/worktree';
-import { getWorktreesByBranch } from '../../../git/models/worktree';
+import { getWorktreeId, getWorktreesByBranch } from '../../../git/models/worktree';
 import { parseGitBlame } from '../../../git/parsers/blameParser';
 import { parseGitBranches } from '../../../git/parsers/branchParser';
 import {
@@ -2620,6 +2620,7 @@ export class LocalGitProvider implements GitProvider, Disposable {
 							},
 						};
 
+						const worktree = worktreesByBranch?.get(branchId);
 						refHead = {
 							id: branchId,
 							name: tip,
@@ -2632,6 +2633,7 @@ export class LocalGitProvider implements GitProvider, Disposable {
 											id: getBranchId(repoPath, true, branch.upstream.name),
 									  }
 									: undefined,
+							worktreeId: worktree != null ? getWorktreeId(repoPath, worktree.name) : undefined,
 						};
 						refHeads.push(refHead);
 						if (branch?.upstream?.name != null) {

--- a/src/git/models/worktree.ts
+++ b/src/git/models/worktree.ts
@@ -252,6 +252,10 @@ export async function getWorktreeForBranch(
 	return undefined;
 }
 
+export function getWorktreeId(repoPath: string, name: string): string {
+	return `${repoPath}|worktrees/${name}`;
+}
+
 export function isWorktree(worktree: any): worktree is GitWorktree {
 	return worktree instanceof GitWorktree;
 }

--- a/src/webviews/apps/plus/graph/GraphWrapper.tsx
+++ b/src/webviews/apps/plus/graph/GraphWrapper.tsx
@@ -151,6 +151,7 @@ const createIconElements = (): Record<string, ReactElement> => {
 		'message',
 		'changes',
 		'files',
+		'worktree',
 	];
 
 	const miniIconList = ['upstream-ahead', 'upstream-behind'];

--- a/src/webviews/apps/plus/graph/graph.scss
+++ b/src/webviews/apps/plus/graph/graph.scss
@@ -839,6 +839,14 @@ button:not([disabled]),
 			content: '\eb60';
 		}
 	}
+
+	&--worktree {
+		&::before {
+			// glicon-repositories-view
+			font-family: glicons;
+			content: '\f10e';
+		}
+	}
 }
 
 .titlebar {


### PR DESCRIPTION
Note: requires graph-side PR to merge first.

After that, will bump the library version in this PR and remove it from draft.