### PR TITLE
Adds 'open in worktree' context menu command to branches and prs in views, and branches in graph

### DIFF
--- a/package.json
+++ b/package.json
@@ -7415,6 +7415,12 @@
 				"icon": "$(empty-window)"
 			},
 			{
+				"command": "gitlens.graph.openInWorktree",
+				"title": "Open in Worktree",
+				"category": "GitLens",
+				"icon": "$(window)"
+			},
+			{
 				"command": "gitlens.views.openWorktreeInNewWindow.multi",
 				"title": "Open Worktrees in New Window",
 				"category": "GitLens",
@@ -11011,6 +11017,10 @@
 				},
 				{
 					"command": "gitlens.views.openWorktreeInNewWindow.multi",
+					"when": "false"
+				},
+				{
+					"command": "gitlens.graph.openInWorktree",
 					"when": "false"
 				},
 				{
@@ -15567,6 +15577,11 @@
 					"command": "gitlens.graph.openWorktreeInNewWindow",
 					"when": "!gitlens:hasVirtualFolders && webviewItem =~ /gitlens:branch\\b(?=.*?\\b\\+worktree\\b)/",
 					"group": "1_gitlens_action@2"
+				},
+				{
+					"command": "gitlens.graph.openInWorktree",
+					"when": "!gitlens:hasVirtualFolders && webviewItem =~ /gitlens:branch\\b(?!.*?\\b\\+current\\b)/",
+					"group": "1_gitlens_action@3"
 				},
 				{
 					"command": "gitlens.graph.switchToAnotherBranch",

--- a/package.json
+++ b/package.json
@@ -14064,7 +14064,7 @@
 				},
 				{
 					"command": "gitlens.views.openInWorktree",
-					"when": "!listMultiSelection && !gitlens:hasVirtualFolders && viewItem =~ /gitlens:branch\\b(?!.*?\\b\\+current|closed\\b)/",
+					"when": "!listMultiSelection && !gitlens:hasVirtualFolders && viewItem =~ /gitlens:branch\\b(?!.*?\\b\\+current|closed|worktree\\b)/",
 					"group": "1_gitlens_action@3"
 				},
 				{
@@ -15580,7 +15580,7 @@
 				},
 				{
 					"command": "gitlens.graph.openInWorktree",
-					"when": "!gitlens:hasVirtualFolders && webviewItem =~ /gitlens:branch\\b(?!.*?\\b\\+current\\b)/",
+					"when": "!gitlens:hasVirtualFolders && webviewItem =~ /gitlens:branch\\b(?!.*?\\b\\+current|worktree\\b)/",
 					"group": "1_gitlens_action@3"
 				},
 				{

--- a/package.json
+++ b/package.json
@@ -7397,6 +7397,12 @@
 				"enablement": "!operationInProgress"
 			},
 			{
+				"command": "gitlens.views.openInWorktree",
+				"title": "Open in Worktree",
+				"category": "GitLens",
+				"icon": "$(window)"
+			},
+			{
 				"command": "gitlens.views.openWorktree",
 				"title": "Open Worktree",
 				"category": "GitLens",
@@ -10996,6 +11002,10 @@
 					"when": "false"
 				},
 				{
+					"command": "gitlens.views.openInWorktree",
+					"when": "false"
+				},
+				{
 					"command": "gitlens.views.openWorktreeInNewWindow",
 					"when": "false"
 				},
@@ -14041,6 +14051,11 @@
 					"command": "gitlens.views.openWorktreeInNewWindow",
 					"when": "!listMultiSelection && !gitlens:hasVirtualFolders && viewItem =~ /gitlens:branch\\b(?=.*?\\b\\+worktree\\b)(?!.*?\\b\\+closed\\b)/",
 					"group": "1_gitlens_action@2"
+				},
+				{
+					"command": "gitlens.views.openInWorktree",
+					"when": "!listMultiSelection && !gitlens:hasVirtualFolders && viewItem =~ /gitlens:branch\\b(?!.*?\\b\\+current|closed\\b)/",
+					"group": "1_gitlens_action@3"
 				},
 				{
 					"command": "gitlens.views.switchToAnotherBranch",

--- a/package.json
+++ b/package.json
@@ -14688,6 +14688,11 @@
 					"group": "1_gitlens_actions@99"
 				},
 				{
+					"command": "gitlens.views.openInWorktree",
+					"when": "!listMultiSelection && viewItem =~ /gitlens:(pullrequest\\b|launchpad:item\\b(?=.*?\\b\\+pr\\b))/",
+					"group": "1_gitlens_actions@100"
+				},
+				{
 					"command": "gitlens.showInCommitGraph",
 					"when": "!listMultiSelection && viewItem =~ /gitlens:pullrequest\\b(?=.*?\\b\\+refs\\b)/",
 					"group": "3_gitlens_explore@1"

--- a/src/commands/git/switch.ts
+++ b/src/commands/git/switch.ts
@@ -273,7 +273,10 @@ export class SwitchGitCommand extends QuickCommand<State> {
 				}
 			}
 
-			if (this.confirm(context.promptToCreateBranch || context.canSwitchToLocalBranch ? true : state.confirm)) {
+			if (
+				state.skipWorktreeConfirmations ||
+				this.confirm(context.promptToCreateBranch || context.canSwitchToLocalBranch ? true : state.confirm)
+			) {
 				const result = yield* this.confirmStep(state as SwitchStepState, context);
 				if (result === StepResultBreak) continue;
 

--- a/src/views/viewCommands.ts
+++ b/src/views/viewCommands.ts
@@ -11,7 +11,7 @@ import type { ViewShowBranchComparison } from '../config';
 import { GlyphChars } from '../constants';
 import { Commands } from '../constants.commands';
 import type { Container } from '../container';
-import { browseAtRevision } from '../git/actions';
+import { browseAtRevision, executeGitCommand } from '../git/actions';
 import * as BranchActions from '../git/actions/branch';
 import * as CommitActions from '../git/actions/commit';
 import * as ContributorActions from '../git/actions/contributor';
@@ -363,6 +363,7 @@ export class ViewCommands {
 		registerViewCommand('gitlens.views.deleteWorktree', this.deleteWorktree, this);
 		registerViewCommand('gitlens.views.deleteWorktree.multi', this.deleteWorktree, this, true);
 		registerViewCommand('gitlens.views.openWorktree', this.openWorktree, this);
+		registerViewCommand('gitlens.views.openInWorktree', this.openInWorktree, this);
 		registerViewCommand('gitlens.views.revealRepositoryInExplorer', this.revealRepositoryInExplorer, this);
 		registerViewCommand('gitlens.views.revealWorktreeInExplorer', this.revealWorktreeInExplorer, this);
 		registerViewCommand(
@@ -773,6 +774,19 @@ export class ViewCommands {
 		}
 
 		openWorkspace(uri, options);
+	}
+
+	@log()
+	private async openInWorktree(node: BranchNode) {
+		if (!node.is('branch')) return;
+		return executeGitCommand({
+			command: 'switch',
+			state: {
+				repos: node.repo,
+				reference: node.branch,
+				skipWorktreeConfirmations: true,
+			},
+		});
 	}
 
 	@log()

--- a/src/views/viewCommands.ts
+++ b/src/views/viewCommands.ts
@@ -27,10 +27,12 @@ import {
 	ensurePullRequestRefs,
 	getComparisonRefsForPullRequest,
 	getOpenedPullRequestRepo,
+	getRepositoryIdentityForPullRequest,
 } from '../git/models/pullRequest';
 import { createReference, shortenRevision } from '../git/models/reference';
 import { RemoteResourceType } from '../git/models/remoteResource';
 import { showPatchesView } from '../plus/drafts/actions';
+import { getPullRequestBranchDeepLink } from '../plus/focus/focusProvider';
 import { showContributorsPicker } from '../quickpicks/contributorsPicker';
 import { filterMap, mapAsync } from '../system/array';
 import {
@@ -47,6 +49,7 @@ import { log } from '../system/decorators/log';
 import { partial, sequentialize } from '../system/function';
 import type { OpenWorkspaceLocation } from '../system/utils';
 import { openUrl, openWorkspace, revealInFileExplorer } from '../system/utils';
+import { DeepLinkActionType } from '../uris/deepLinks/deepLink';
 import type { LaunchpadItemNode } from './launchpadView';
 import type { RepositoryFolderNode } from './nodes/abstract/repositoryFolderNode';
 import type { ClipboardType } from './nodes/abstract/viewNode';
@@ -777,16 +780,31 @@ export class ViewCommands {
 	}
 
 	@log()
-	private async openInWorktree(node: BranchNode) {
-		if (!node.is('branch')) return;
-		return executeGitCommand({
-			command: 'switch',
-			state: {
-				repos: node.repo,
-				reference: node.branch,
-				skipWorktreeConfirmations: true,
-			},
-		});
+	private async openInWorktree(node: BranchNode | PullRequestNode | LaunchpadItemNode) {
+		if (!node.is('branch') && !node.is('pullrequest') && !node.is('launchpad-item')) return;
+
+		if (node.is('branch')) {
+			return executeGitCommand({
+				command: 'switch',
+				state: {
+					repos: node.repo,
+					reference: node.branch,
+					skipWorktreeConfirmations: true,
+				},
+			});
+		} else if (node.is('pullrequest') || node.is('launchpad-item')) {
+			const pr = node.pullRequest;
+			if (pr?.refs?.head == null) return Promise.resolve();
+			const repoIdentity = getRepositoryIdentityForPullRequest(pr);
+			if (repoIdentity.remote.url == null) return Promise.resolve();
+			const deepLink = getPullRequestBranchDeepLink(
+				this.container,
+				pr.refs.head.branch,
+				repoIdentity.remote.url,
+				DeepLinkActionType.SwitchToPullRequestWorktree,
+			);
+			return this.container.deepLinks.processDeepLinkUri(deepLink, false);
+		}
 	}
 
 	@log()


### PR DESCRIPTION
Adds the 'open in worktree' command to branches in views, prs in views (including launchpad view), and branches in the commit graph.

Note some restrictions:
- Is hidden for the current branch (attempting a switch there gives an error because it's your active worktree)
- Is hidden for branches that already have a worktree (there is already a command 'Open Worktree in New Window' that does the exact same thing)