### PR TITLE
Doesn't reveal compare view on the `select to compare` action

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -27,6 +27,8 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/) and this p
 ### Fixed
 
 - Fixes [#3479](https://github.com/gitkraken/vscode-gitlens/issues/3479) - Tooltip flickering
+- Fixes [#3472](https://github.com/gitkraken/vscode-gitlens/issues/3472) - "Compare working tree with.." often flashes open then closes the menu
+- Fixes [#3448](https://github.com/gitkraken/vscode-gitlens/issues/3448) - "Select for Compare" on a Commit/Stash/etc causes the Search and Compare view to be forcibly shown
 - Fixes _Copy Remote Comparison URL_ command to not open the URL, just copy it
 
 ### Removed

--- a/src/views/searchAndCompareView.ts
+++ b/src/views/searchAndCompareView.ts
@@ -237,8 +237,6 @@ export class SearchAndCompareViewNode extends ViewNode<'search-compare', SearchA
 
 		await this.triggerChange();
 
-		await this.view.reveal(this.comparePicker, { focus: false, select: true });
-
 		if (prompt) {
 			await this.compareWithSelected(repoPath, ref2);
 		}


### PR DESCRIPTION
# Description

Fixes #3472 
Fixes #3448 

# Checklist

<!-- Please check off the following -->

- [x] I have followed the guidelines in the Contributing document
- [x] My changes follow the coding style of this project
- [x] My changes build without any errors or warnings
- [x] My changes have been formatted and linted
- [x] My changes include any required corresponding changes to the documentation (including CHANGELOG.md and README.md)
- [x] My changes have been rebased and squashed to the minimal number (typically 1) of relevant commits
- [x] My changes have a descriptive commit message with a short title, including a `Fixes $XXX -` or `Closes #XXX -` prefix to auto-close the issue that your PR addresses
