### PR TITLE
Fix connecting rich integrations on login to GK Dev (GLVSC-631)

### DIFF
--- a/src/plus/integrations/integration.ts
+++ b/src/plus/integrations/integration.ts
@@ -193,8 +193,9 @@ export abstract class IntegrationBase<
 		this._session = null;
 
 		if (connected) {
-			// Don't store the disconnected flag if this only for this current VS Code session (will be re-connected on next restart)
-			if (!options?.currentSessionOnly) {
+			// Don't store the disconnected flag if silently disconnecting or disconnecting this only for
+			// this current VS Code session (will be re-connected on next restart)
+			if (!options?.currentSessionOnly && !options?.silent) {
 				void this.container.storage.storeWorkspace(this.connectedKey, false);
 			}
 
@@ -261,7 +262,7 @@ export abstract class IntegrationBase<
 				await this.ensureSession({ createIfNeeded: forceSync });
 				break;
 			case 'disconnected':
-				await this.reset();
+				await this.disconnect({ silent: true });
 				break;
 		}
 	}

--- a/src/plus/integrations/integration.ts
+++ b/src/plus/integrations/integration.ts
@@ -261,7 +261,7 @@ export abstract class IntegrationBase<
 				await this.ensureSession({ createIfNeeded: forceSync });
 				break;
 			case 'disconnected':
-				await this.disconnect({ silent: true });
+				await this.reset();
 				break;
 		}
 	}


### PR DESCRIPTION
# Description

When you logout from GK Dev and then login back, all configured cloud integrations should become connected.

# Checklist

<!-- Please check off the following -->

- [x] I have followed the guidelines in the Contributing document
- [x] My changes follow the coding style of this project
- [x] My changes build without any errors or warnings
- [x] My changes have been formatted and linted
- [x] My changes include any required corresponding changes to the documentation (including CHANGELOG.md and README.md)
- [x] My changes have been rebased and squashed to the minimal number (typically 1) of relevant commits
- [ ] My changes have a descriptive commit message with a short title, including a `Fixes $XXX -` or `Closes #XXX -` prefix to auto-close the issue that your PR addresses
