### PR TITLE
Adds a way to force push from the Graph

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/) and this p
 - Adds [Cursor](https://cursor.so) support &mdash; closes [#3222](https://github.com/gitkraken/vscode-gitlens/issues/3222)
 - Adds monospace formatting in commit messages &mdash; closes [#2350](https://github.com/gitkraken/vscode-gitlens/issues/2350)
 - Adds a new `${authorFirst}` and `${authorLast}` commit formatting tokens that can be used in inline blame, commit hovers, etc &mdash; closes [#2980](https://github.com/gitkraken/vscode-gitlens/issues/2980)
+- Adds a way to force push from the Graph
 
 ### Changed
 

--- a/package.json
+++ b/package.json
@@ -8826,10 +8826,10 @@
 				"enablement": "!operationInProgress"
 			},
 			{
-				"command": "gitlens.graph.sync",
-				"title": "Pull",
+				"command": "gitlens.graph.pushWithForce",
+				"title": "Push (force)",
 				"category": "GitLens",
-				"icon": "$(gitlens-repo-sync)",
+				"icon": "$(gitlens-repo-force-push)",
 				"enablement": "!operationInProgress"
 			},
 			{
@@ -12003,7 +12003,7 @@
 					"when": "false"
 				},
 				{
-					"command": "gitlens.graph.sync",
+					"command": "gitlens.graph.pushWithForce",
 					"when": "false"
 				},
 				{
@@ -15589,11 +15589,6 @@
 					"group": "1_gitlens_actions@2"
 				},
 				{
-					"command": "gitlens.graph.sync",
-					"when": "false",
-					"group": "1_gitlens_actions@2"
-				},
-				{
 					"command": "gitlens.graph.fetch",
 					"when": "gitlens:repos:withRemotes && !gitlens:readonly && !gitlens:untrusted && !gitlens:hasVirtualFolders && webviewItem =~ /gitlens:branch\\b(?=.*?\\b\\+(remote|tracking)\\b)(?!.*?\\b\\+closed\\b)/",
 					"group": "1_gitlens_actions@3"
@@ -15846,11 +15841,6 @@
 				{
 					"command": "gitlens.graph.pull",
 					"when": "webviewItem =~ /gitlens:upstreamStatus\\b/",
-					"group": "1_gitlens_actions@2"
-				},
-				{
-					"command": "gitlens.graph.sync",
-					"when": "sync",
 					"group": "1_gitlens_actions@2"
 				},
 				{

--- a/package.json
+++ b/package.json
@@ -8826,6 +8826,13 @@
 				"enablement": "!operationInProgress"
 			},
 			{
+				"command": "gitlens.graph.sync",
+				"title": "Pull",
+				"category": "GitLens",
+				"icon": "$(gitlens-repo-sync)",
+				"enablement": "!operationInProgress"
+			},
+			{
 				"command": "gitlens.graph.fetch",
 				"title": "Fetch",
 				"category": "GitLens",
@@ -11993,6 +12000,10 @@
 				},
 				{
 					"command": "gitlens.graph.pull",
+					"when": "false"
+				},
+				{
+					"command": "gitlens.graph.sync",
 					"when": "false"
 				},
 				{
@@ -15578,6 +15589,11 @@
 					"group": "1_gitlens_actions@2"
 				},
 				{
+					"command": "gitlens.graph.sync",
+					"when": "false",
+					"group": "1_gitlens_actions@2"
+				},
+				{
 					"command": "gitlens.graph.fetch",
 					"when": "gitlens:repos:withRemotes && !gitlens:readonly && !gitlens:untrusted && !gitlens:hasVirtualFolders && webviewItem =~ /gitlens:branch\\b(?=.*?\\b\\+(remote|tracking)\\b)(?!.*?\\b\\+closed\\b)/",
 					"group": "1_gitlens_actions@3"
@@ -15830,6 +15846,11 @@
 				{
 					"command": "gitlens.graph.pull",
 					"when": "webviewItem =~ /gitlens:upstreamStatus\\b/",
+					"group": "1_gitlens_actions@2"
+				},
+				{
+					"command": "gitlens.graph.sync",
+					"when": "sync",
 					"group": "1_gitlens_actions@2"
 				},
 				{

--- a/src/commands/git/pull.ts
+++ b/src/commands/git/pull.ts
@@ -133,8 +133,8 @@ export class PullGitCommand extends QuickCommand<State> {
 				state.flags = result;
 			}
 
+			await this.execute(state as PullStepState);
 			endSteps(state);
-			void this.execute(state as PullStepState);
 		}
 
 		return state.counter < 0 ? StepResultBreak : undefined;

--- a/src/plus/webviews/graph/graphWebview.ts
+++ b/src/plus/webviews/graph/graphWebview.ts
@@ -447,6 +447,7 @@ export class GraphWebviewProvider implements WebviewProvider<State, State, Graph
 			this.host.registerWebviewCommand('gitlens.graph.push', this.push),
 			this.host.registerWebviewCommand('gitlens.graph.pull', this.pull),
 			this.host.registerWebviewCommand('gitlens.graph.fetch', this.fetch),
+			this.host.registerWebviewCommand('gitlens.graph.sync', this.sync),
 			this.host.registerWebviewCommand('gitlens.graph.publishBranch', this.publishBranch),
 			this.host.registerWebviewCommand('gitlens.graph.switchToAnotherBranch', this.switchToAnother),
 
@@ -2853,6 +2854,13 @@ export class GraphWebviewProvider implements WebviewProvider<State, State, Graph
 	private fetch(item?: GraphItemContext) {
 		const ref = item != null ? this.getGraphItemRef(item, 'branch') : undefined;
 		void RepoActions.fetch(this.repository, ref);
+	}
+
+	@log()
+	private async sync(item?: GraphItemContext) {
+		const ref = item != null ? this.getGraphItemRef(item, 'branch') : undefined;
+		await RepoActions.pull(this.repository, ref);
+		void RepoActions.push(this.repository, undefined, ref);
 	}
 
 	@log()

--- a/src/plus/webviews/graph/graphWebview.ts
+++ b/src/plus/webviews/graph/graphWebview.ts
@@ -447,7 +447,7 @@ export class GraphWebviewProvider implements WebviewProvider<State, State, Graph
 			this.host.registerWebviewCommand('gitlens.graph.push', this.push),
 			this.host.registerWebviewCommand('gitlens.graph.pull', this.pull),
 			this.host.registerWebviewCommand('gitlens.graph.fetch', this.fetch),
-			this.host.registerWebviewCommand('gitlens.graph.sync', this.sync),
+			this.host.registerWebviewCommand('gitlens.graph.pushWithForce', this.forcePush),
 			this.host.registerWebviewCommand('gitlens.graph.publishBranch', this.publishBranch),
 			this.host.registerWebviewCommand('gitlens.graph.switchToAnotherBranch', this.switchToAnother),
 
@@ -2856,13 +2856,9 @@ export class GraphWebviewProvider implements WebviewProvider<State, State, Graph
 		void RepoActions.fetch(this.repository, ref);
 	}
 
-	// @unimplemented
 	@log()
-	private sync(item?: GraphItemContext) {
-		throw new Error('unimplemented');
-		// const ref = item != null ? this.getGraphItemRef(item, 'branch') : undefined;
-		// await RepoActions.pull(this.repository, ref);
-		// void RepoActions.push(this.repository, undefined, ref);
+	private forcePush(item?: GraphItemContext) {
+		this.push(item, true);
 	}
 
 	@log()
@@ -2872,9 +2868,9 @@ export class GraphWebviewProvider implements WebviewProvider<State, State, Graph
 	}
 
 	@log()
-	private push(item?: GraphItemContext) {
+	private push(item?: GraphItemContext, force?: boolean) {
 		const ref = item != null ? this.getGraphItemRef(item) : undefined;
-		void RepoActions.push(this.repository, undefined, ref);
+		void RepoActions.push(this.repository, force, ref);
 	}
 
 	@log()

--- a/src/plus/webviews/graph/graphWebview.ts
+++ b/src/plus/webviews/graph/graphWebview.ts
@@ -2856,11 +2856,13 @@ export class GraphWebviewProvider implements WebviewProvider<State, State, Graph
 		void RepoActions.fetch(this.repository, ref);
 	}
 
+	// @unimplemented
 	@log()
-	private async sync(item?: GraphItemContext) {
-		const ref = item != null ? this.getGraphItemRef(item, 'branch') : undefined;
-		await RepoActions.pull(this.repository, ref);
-		void RepoActions.push(this.repository, undefined, ref);
+	private sync(item?: GraphItemContext) {
+		throw new Error('unimplemented');
+		// const ref = item != null ? this.getGraphItemRef(item, 'branch') : undefined;
+		// await RepoActions.pull(this.repository, ref);
+		// void RepoActions.push(this.repository, undefined, ref);
 	}
 
 	@log()

--- a/src/webviews/apps/plus/graph/GraphWrapper.tsx
+++ b/src/webviews/apps/plus/graph/GraphWrapper.tsx
@@ -86,6 +86,7 @@ import { GlSearchBox } from '../../shared/components/search/react';
 import type { SearchNavigationEventDetail } from '../../shared/components/search/search-box';
 import type { DateTimeFormat } from '../../shared/date';
 import { formatDate, fromNow } from '../../shared/date';
+import { GitActionsButtons } from './actions/gitActionsButtons';
 import { GlGraphHover } from './hover/graphHover.react';
 import type { GraphMinimapDaySelectedEventDetail } from './minimap/minimap';
 import { GlGraphMinimapContainer } from './minimap/minimap-container.react';
@@ -991,146 +992,6 @@ export function GraphWrapper({
 		onChangeSelection?.(rows);
 	};
 
-	const renderFetchAction = () => {
-		let action: 'fetch' | 'pull' | 'push' = 'fetch';
-		let icon = 'repo-fetch';
-		let label = 'Fetch';
-		let isBehind = false;
-		let isAhead = false;
-
-		const remote = branchState?.upstream ? (
-			<>
-				<span className="md-code">{branchState?.upstream}</span>
-			</>
-		) : (
-			'remote'
-		);
-
-		let tooltip;
-		if (branchState) {
-			isAhead = branchState.ahead > 0;
-			isBehind = branchState.behind > 0;
-
-			const branchPrefix = (
-				<>
-					<span className="md-code">{branchName}</span> is
-				</>
-			);
-
-			if (isBehind) {
-				action = 'pull';
-				icon = 'repo-pull';
-				label = 'Pull';
-				tooltip = (
-					<>
-						Pull {pluralize('commit', branchState.behind)} from {remote}
-						{branchState.provider?.name ? ` on ${branchState.provider?.name}` : ''}
-					</>
-				);
-				if (isAhead) {
-					tooltip = (
-						<>
-							{tooltip}
-							<hr />
-							{branchPrefix} {pluralize('commit', branchState.behind)} behind and{' '}
-							{pluralize('commit', branchState.ahead)} ahead of {remote}
-							{branchState.provider?.name ? ` on ${branchState.provider?.name}` : ''}
-						</>
-					);
-				} else {
-					tooltip = (
-						<>
-							{tooltip}
-							<hr />
-							{branchPrefix} {pluralize('commit', branchState.behind)} behind {remote}
-							{branchState.provider?.name ? ` on ${branchState.provider?.name}` : ''}
-						</>
-					);
-				}
-			} else if (isAhead) {
-				action = 'push';
-				icon = 'repo-push';
-				label = 'Push';
-				tooltip = (
-					<>
-						Push {pluralize('commit', branchState.ahead)} to {remote}
-						{branchState.provider?.name ? ` on ${branchState.provider?.name}` : ''}
-						<hr />
-						{branchPrefix} {pluralize('commit', branchState.ahead)} ahead of {remote}
-					</>
-				);
-			}
-		}
-
-		const lastFetchedDate = lastFetched && new Date(lastFetched);
-		const fetchedText = lastFetchedDate && lastFetchedDate.getTime() !== 0 ? fromNow(lastFetchedDate) : undefined;
-
-		return (
-			<>
-				{(isBehind || isAhead) && (
-					<GlTooltip placement="bottom">
-						<a
-							href={createWebviewCommandLink(
-								`gitlens.graph.${action}`,
-								state.webviewId,
-								state.webviewInstanceId,
-							)}
-							className={`action-button${isBehind ? ' is-behind' : ''}${isAhead ? ' is-ahead' : ''}`}
-						>
-							<span className={`glicon glicon-${icon} action-button__icon`}></span>
-							{label}
-							{(isAhead || isBehind) && (
-								<span>
-									<span className="pill action-button__pill">
-										{isBehind && (
-											<span>
-												{branchState!.behind}
-												<span className="codicon codicon-arrow-down"></span>
-											</span>
-										)}
-										{isAhead && (
-											<span>
-												{isBehind && <>&nbsp;&nbsp;</>}
-												{branchState!.ahead}
-												<span className="codicon codicon-arrow-up"></span>
-											</span>
-										)}
-									</span>
-								</span>
-							)}
-						</a>
-						<div slot="content" style={{ whiteSpace: 'break-spaces' }}>
-							{tooltip}
-							{fetchedText && (
-								<>
-									<hr /> Last fetched {fetchedText}
-								</>
-							)}
-						</div>
-					</GlTooltip>
-				)}
-				<GlTooltip placement="bottom">
-					<a
-						href={createWebviewCommandLink('gitlens.graph.fetch', state.webviewId, state.webviewInstanceId)}
-						className="action-button"
-					>
-						<span className="glicon glicon-repo-fetch action-button__icon"></span>
-						Fetch {fetchedText && <span className="action-button__small">({fetchedText})</span>}
-					</a>
-					<span slot="content" style={{ whiteSpace: 'break-spaces' }}>
-						Fetch from {remote}
-						{branchState?.provider?.name ? ` on ${branchState.provider?.name}` : ''}
-						{fetchedText && (
-							<>
-								<hr /> Last fetched {fetchedText}
-							</>
-						)}
-					</span>
-				</GlTooltip>
-			</>
-		);
-	};
-
 	return (
 		<>
 			<header className="titlebar graph-app__header">
@@ -1274,7 +1135,12 @@ export function GraphWrapper({
 								<span>
 									<span className="codicon codicon-chevron-right"></span>
 								</span>
-								{renderFetchAction()}
+								<GitActionsButtons
+									branchName={branchName}
+									branchState={branchState}
+									lastFetched={lastFetched}
+									state={state}
+								/>
 							</>
 						)}
 					</div>

--- a/src/webviews/apps/plus/graph/GraphWrapper.tsx
+++ b/src/webviews/apps/plus/graph/GraphWrapper.tsx
@@ -65,7 +65,6 @@ import {
 } from '../../../../plus/webviews/graph/protocol';
 import { createCommandLink } from '../../../../system/commands';
 import { filterMap, first, groupByFilterMap, join } from '../../../../system/iterable';
-import { pluralize } from '../../../../system/string';
 import { createWebviewCommandLink } from '../../../../system/webview';
 import type { IpcNotification } from '../../../protocol';
 import { DidChangeHostWindowFocusNotification } from '../../../protocol';

--- a/src/webviews/apps/plus/graph/actions/fetchButton.tsx
+++ b/src/webviews/apps/plus/graph/actions/fetchButton.tsx
@@ -1,0 +1,38 @@
+import type { ReactNode } from 'react';
+import React from 'react';
+import type { BranchState, State } from '../../../../../plus/webviews/graph/protocol';
+import { createWebviewCommandLink } from '../../../../../system/webview';
+import { GlTooltip } from '../../../shared/components/overlays/tooltip.react';
+
+export const FetchButton = ({
+	state,
+	fetchedText,
+	branchState,
+	remote,
+}: {
+	branchState: BranchState | undefined;
+	state: State;
+	fetchedText: string | undefined;
+	remote: ReactNode;
+}) => {
+	return (
+		<GlTooltip placement="bottom">
+			<a
+				href={createWebviewCommandLink('gitlens.graph.fetch', state.webviewId, state.webviewInstanceId)}
+				className="action-button"
+			>
+				<span className="glicon glicon-repo-fetch action-button__icon"></span>
+				Fetch {fetchedText && <span className="action-button__small">({fetchedText})</span>}
+			</a>
+			<span slot="content" style={{ whiteSpace: 'break-spaces' }}>
+				Fetch from {remote}
+				{branchState?.provider?.name ? ` on ${branchState.provider?.name}` : ''}
+				{fetchedText && (
+					<>
+						<hr /> Last fetched {fetchedText}
+					</>
+				)}
+			</span>
+		</GlTooltip>
+	);
+};

--- a/src/webviews/apps/plus/graph/actions/gitActionsButtons.tsx
+++ b/src/webviews/apps/plus/graph/actions/gitActionsButtons.tsx
@@ -1,0 +1,35 @@
+import React from 'react';
+import type { BranchState, State } from '../../../../../plus/webviews/graph/protocol';
+import { fromNow } from '../../../../../system/date';
+import { FetchButton } from './fetchButton';
+import { SyncButton } from './syncButton';
+
+export const GitActionsButtons = ({
+	branchState,
+	branchName,
+	lastFetched,
+	state,
+}: {
+	branchState: BranchState | undefined;
+	branchName: string | undefined;
+	lastFetched: Date | undefined;
+	state: State;
+}) => {
+	const remote = branchState?.upstream ? <span className="md-code">{branchState?.upstream}</span> : 'remote';
+
+	const lastFetchedDate = lastFetched && new Date(lastFetched);
+	const fetchedText = lastFetchedDate && lastFetchedDate.getTime() !== 0 ? fromNow(lastFetchedDate) : undefined;
+
+	return (
+		<>
+			<SyncButton
+				branchState={branchState}
+				state={state}
+				fetchedText={fetchedText}
+				branchName={branchName}
+				remote={remote}
+			/>
+			<FetchButton branchState={branchState} fetchedText={fetchedText} remote={remote} state={state} />
+		</>
+	);
+};

--- a/src/webviews/apps/plus/graph/actions/gitActionsButtons.tsx
+++ b/src/webviews/apps/plus/graph/actions/gitActionsButtons.tsx
@@ -2,7 +2,7 @@ import React from 'react';
 import type { BranchState, State } from '../../../../../plus/webviews/graph/protocol';
 import { fromNow } from '../../../../../system/date';
 import { FetchButton } from './fetchButton';
-import { SyncButton } from './syncButton';
+import { PushPullButton } from './pushPullButton';
 
 export const GitActionsButtons = ({
 	branchState,
@@ -22,7 +22,7 @@ export const GitActionsButtons = ({
 
 	return (
 		<>
-			<SyncButton
+			<PushPullButton
 				branchState={branchState}
 				state={state}
 				fetchedText={fetchedText}

--- a/src/webviews/apps/plus/graph/actions/pushPullButton.tsx
+++ b/src/webviews/apps/plus/graph/actions/pushPullButton.tsx
@@ -129,11 +129,14 @@ export const PushPullButton = ({
 							state.webviewInstanceId,
 						)}
 						className="action-button"
-						aria-label="Push (force)"
+						aria-label="Force Push"
 					>
 						<span className="codicon codicon-repo-force-push" aria-hidden="true"></span>
 					</a>
-					<span slot="content">Push (force)</span>
+					<span slot="content">
+						Force Push {pluralize('commit', branchState.ahead)} to {remote}
+						{branchState.provider?.name ? ` on ${branchState.provider?.name}` : ''}
+					</span>
 				</GlTooltip>
 			)}
 		</>

--- a/src/webviews/apps/plus/graph/actions/pushPullButton.tsx
+++ b/src/webviews/apps/plus/graph/actions/pushPullButton.tsx
@@ -3,11 +3,9 @@ import React from 'react';
 import type { BranchState, State } from '../../../../../plus/webviews/graph/protocol';
 import { pluralize } from '../../../../../system/string';
 import { createWebviewCommandLink } from '../../../../../system/webview';
-import { MenuItem, MenuLabel } from '../../../shared/components/menu/react';
-import { GlPopover } from '../../../shared/components/overlays/popover.react';
 import { GlTooltip } from '../../../shared/components/overlays/tooltip.react';
 
-export const SyncButton = ({
+export const PushPullButton = ({
 	branchState,
 	state,
 	fetchedText,
@@ -20,17 +18,21 @@ export const SyncButton = ({
 	branchName: string | undefined;
 	remote: ReactNode;
 }) => {
-	const isBehind = Boolean(branchState?.behind);
-	const isAhead = Boolean(branchState?.ahead);
-	const hasChanges = isAhead || isBehind;
-	if (!hasChanges || !branchState) {
+	let isBehind = false;
+	let isAhead = false;
+	if (branchState) {
+		isBehind = branchState.behind > 0;
+		isAhead = branchState.ahead > 0;
+	}
+
+	if (!branchState || (!isAhead && !isBehind)) {
 		return null;
 	}
 
-	let action: 'pull' | 'push' | 'sync' = 'sync';
-	let icon = 'codicon codicon-repo-sync';
-	let label = 'Fetch';
-	let tooltip;
+	let action: 'pull' | 'push';
+	let icon: string;
+	let label: string;
+	let tooltip: ReactNode;
 
 	const branchPrefix = (
 		<>
@@ -68,7 +70,7 @@ export const SyncButton = ({
 				</>
 			);
 		}
-	} else if (isAhead) {
+	} else {
 		action = 'push';
 		icon = 'glicon glicon-repo-push';
 		label = 'Push';
@@ -83,7 +85,7 @@ export const SyncButton = ({
 	}
 
 	return (
-		<span className="button-group">
+		<>
 			<GlTooltip placement="bottom">
 				<a
 					href={createWebviewCommandLink(`gitlens.graph.${action}`, state.webviewId, state.webviewInstanceId)}
@@ -119,30 +121,21 @@ export const SyncButton = ({
 				</div>
 			</GlTooltip>
 			{isAhead && isBehind && (
-				<GlPopover className="popover" placement="bottom-start" trigger="focus" arrow={false} distance={0}>
-					<GlTooltip placement="top" slot="anchor">
-						<button type="button" className="action-button" aria-label="Branch Actions">
-							<span
-								className="codicon codicon-chevron-down action-button__more"
-								aria-hidden="true"
-							></span>
-						</button>
-						<span slot="content">Branch Actions</span>
-					</GlTooltip>
-					<div slot="content">
-						<MenuLabel>Branch actions</MenuLabel>
-						<MenuItem
-							href={createWebviewCommandLink(
-								'gitlens.graph.pushWithForce',
-								state.webviewId,
-								state.webviewInstanceId,
-							)}
-						>
-							Push (force)
-						</MenuItem>
-					</div>
-				</GlPopover>
+				<GlTooltip placement="top" slot="anchor">
+					<a
+						href={createWebviewCommandLink(
+							'gitlens.graph.pushWithForce',
+							state.webviewId,
+							state.webviewInstanceId,
+						)}
+						className="action-button"
+						aria-label="Push (force)"
+					>
+						<span className="codicon codicon-repo-force-push" aria-hidden="true"></span>
+					</a>
+					<span slot="content">Push (force)</span>
+				</GlTooltip>
 			)}
-		</span>
+		</>
 	);
 };

--- a/src/webviews/apps/plus/graph/actions/syncButton.tsx
+++ b/src/webviews/apps/plus/graph/actions/syncButton.tsx
@@ -1,0 +1,178 @@
+import type { ReactNode } from 'react';
+import React from 'react';
+import type { BranchState, State } from '../../../../../plus/webviews/graph/protocol';
+import { pluralize } from '../../../../../system/string';
+import { createWebviewCommandLink } from '../../../../../system/webview';
+import { MenuItem, MenuLabel, MenuList } from '../../../shared/components/menu/react';
+import { PopMenu } from '../../../shared/components/overlays/pop-menu/react';
+import { GlTooltip } from '../../../shared/components/overlays/tooltip.react';
+
+export const SyncButton = ({
+	branchState,
+	state,
+	fetchedText,
+	branchName,
+	remote,
+}: {
+	branchState: BranchState | undefined;
+	state: State;
+	fetchedText: string | undefined;
+	branchName: string | undefined;
+	remote: ReactNode;
+}) => {
+	const isBehind = Boolean(branchState?.behind);
+	const isAhead = Boolean(branchState?.ahead);
+	const hasChanges = isAhead || isBehind;
+	if (!hasChanges || !branchState) {
+		return null;
+	}
+
+	let action: 'pull' | 'push' | 'sync' = 'sync';
+	let icon = 'codicon codicon-repo-sync';
+	let label = 'Fetch';
+	let tooltip;
+
+	const branchPrefix = (
+		<>
+			<span className="md-code">{branchName}</span> is
+		</>
+	);
+
+	if (isBehind) {
+		action = 'pull';
+		icon = 'glicon glicon-repo-pull';
+		label = 'Pull';
+		tooltip = (
+			<>
+				Pull {pluralize('commit', branchState.behind)} from {remote}
+				{branchState.provider?.name ? ` on ${branchState.provider?.name}` : ''}
+			</>
+		);
+		if (isAhead) {
+			action = 'sync';
+			icon = 'codicon codicon-repo-sync';
+			label = 'Sync';
+			tooltip = (
+				<>
+					{tooltip}
+					<hr />
+					{branchPrefix} {pluralize('commit', branchState.behind)} behind and{' '}
+					{pluralize('commit', branchState.ahead)} ahead of {remote}
+					{branchState.provider?.name ? ` on ${branchState.provider?.name}` : ''}
+				</>
+			);
+		} else {
+			tooltip = (
+				<>
+					{tooltip}
+					<hr />
+					{branchPrefix} {pluralize('commit', branchState.behind)} behind {remote}
+					{branchState.provider?.name ? ` on ${branchState.provider?.name}` : ''}
+				</>
+			);
+		}
+	} else if (isAhead) {
+		action = 'push';
+		icon = 'glicon glicon-repo-push';
+		label = 'Push';
+		tooltip = (
+			<>
+				Push {pluralize('commit', branchState.ahead)} to {remote}
+				{branchState.provider?.name ? ` on ${branchState.provider?.name}` : ''}
+				<hr />
+				{branchPrefix} {pluralize('commit', branchState.ahead)} ahead of {remote}
+			</>
+		);
+	}
+
+	return (
+		<span className="button-group">
+			<GlTooltip placement="bottom">
+				<a
+					href={createWebviewCommandLink(`gitlens.graph.${action}`, state.webviewId, state.webviewInstanceId)}
+					className={`action-button${isBehind ? ' is-behind' : ''}${isAhead ? ' is-ahead' : ''}`}
+				>
+					<span className={`${icon} action-button__icon`}></span>
+					{label}
+					<span>
+						<span className="pill action-button__pill">
+							{isBehind && (
+								<span>
+									{branchState.behind}
+									<span className="codicon codicon-arrow-down"></span>
+								</span>
+							)}
+							{isAhead && (
+								<span>
+									{isBehind && <>&nbsp;&nbsp;</>}
+									{branchState.ahead}
+									<span className="codicon codicon-arrow-up"></span>
+								</span>
+							)}
+						</span>
+					</span>
+				</a>
+				<div slot="content" style={{ whiteSpace: 'break-spaces' }}>
+					{tooltip}
+					{fetchedText && (
+						<>
+							<hr /> Last fetched {fetchedText}
+						</>
+					)}
+				</div>
+			</GlTooltip>
+			{isAhead && isBehind && (
+				<GlTooltip placement="top" distance={7}>
+					<PopMenu position="right">
+						<button type="button" className="action-button" slot="trigger" aria-label="Minimap Options">
+							<span
+								className="codicon codicon-chevron-down action-button__more"
+								aria-hidden="true"
+							></span>
+						</button>
+						<MenuList slot="content" style={{ width: 120 }}>
+							<MenuLabel>Git actions</MenuLabel>
+							<GlTooltip>
+								<MenuItem>
+									<a
+										href={createWebviewCommandLink(
+											'gitlens.graph.sync',
+											state.webviewId,
+											state.webviewInstanceId,
+										)}
+									>
+										Sync
+									</a>
+								</MenuItem>
+								<span slot="content">Run pull then push</span>
+							</GlTooltip>
+							<MenuItem>
+								<a
+									href={createWebviewCommandLink(
+										'gitlens.graph.pull',
+										state.webviewId,
+										state.webviewInstanceId,
+									)}
+								>
+									Pull...
+								</a>
+							</MenuItem>
+							<MenuItem>
+								<a
+									href={createWebviewCommandLink(
+										'gitlens.graph.push',
+										state.webviewId,
+										state.webviewInstanceId,
+									)}
+								>
+									Push...
+								</a>
+							</MenuItem>
+						</MenuList>
+					</PopMenu>
+					<span slot="content">Git Sync Options</span>
+				</GlTooltip>
+			)}
+		</span>
+	);
+};

--- a/src/webviews/apps/plus/graph/actions/syncButton.tsx
+++ b/src/webviews/apps/plus/graph/actions/syncButton.tsx
@@ -49,9 +49,6 @@ export const SyncButton = ({
 			</>
 		);
 		if (isAhead) {
-			action = 'sync';
-			icon = 'codicon codicon-repo-sync';
-			label = 'Sync';
 			tooltip = (
 				<>
 					{tooltip}
@@ -132,20 +129,6 @@ export const SyncButton = ({
 						</button>
 						<MenuList slot="content" style={{ width: 120 }}>
 							<MenuLabel>Git actions</MenuLabel>
-							<GlTooltip>
-								<MenuItem>
-									<a
-										href={createWebviewCommandLink(
-											'gitlens.graph.sync',
-											state.webviewId,
-											state.webviewInstanceId,
-										)}
-									>
-										Sync
-									</a>
-								</MenuItem>
-								<span slot="content">Run pull then push</span>
-							</GlTooltip>
 							<MenuItem>
 								<a
 									href={createWebviewCommandLink(

--- a/src/webviews/apps/plus/graph/actions/syncButton.tsx
+++ b/src/webviews/apps/plus/graph/actions/syncButton.tsx
@@ -3,8 +3,8 @@ import React from 'react';
 import type { BranchState, State } from '../../../../../plus/webviews/graph/protocol';
 import { pluralize } from '../../../../../system/string';
 import { createWebviewCommandLink } from '../../../../../system/webview';
-import { MenuItem, MenuLabel, MenuList } from '../../../shared/components/menu/react';
-import { PopMenu } from '../../../shared/components/overlays/pop-menu/react';
+import { MenuItem, MenuLabel } from '../../../shared/components/menu/react';
+import { GlPopover } from '../../../shared/components/overlays/popover.react';
 import { GlTooltip } from '../../../shared/components/overlays/tooltip.react';
 
 export const SyncButton = ({
@@ -119,42 +119,29 @@ export const SyncButton = ({
 				</div>
 			</GlTooltip>
 			{isAhead && isBehind && (
-				<GlTooltip placement="top" distance={7}>
-					<PopMenu position="right">
-						<button type="button" className="action-button" slot="trigger" aria-label="Minimap Options">
+				<GlPopover className="popover" placement="bottom-start" trigger="focus" arrow={false} distance={0}>
+					<GlTooltip placement="top" slot="anchor">
+						<button type="button" className="action-button" aria-label="Branch Actions">
 							<span
 								className="codicon codicon-chevron-down action-button__more"
 								aria-hidden="true"
 							></span>
 						</button>
-						<MenuList slot="content" style={{ width: 120 }}>
-							<MenuLabel>Git actions</MenuLabel>
-							<MenuItem>
-								<a
-									href={createWebviewCommandLink(
-										'gitlens.graph.pull',
-										state.webviewId,
-										state.webviewInstanceId,
-									)}
-								>
-									Pull...
-								</a>
-							</MenuItem>
-							<MenuItem>
-								<a
-									href={createWebviewCommandLink(
-										'gitlens.graph.push',
-										state.webviewId,
-										state.webviewInstanceId,
-									)}
-								>
-									Push...
-								</a>
-							</MenuItem>
-						</MenuList>
-					</PopMenu>
-					<span slot="content">Git Sync Options</span>
-				</GlTooltip>
+						<span slot="content">Branch Actions</span>
+					</GlTooltip>
+					<div slot="content">
+						<MenuLabel>Branch actions</MenuLabel>
+						<MenuItem
+							href={createWebviewCommandLink(
+								'gitlens.graph.pushWithForce',
+								state.webviewId,
+								state.webviewInstanceId,
+							)}
+						>
+							Push (force)
+						</MenuItem>
+					</div>
+				</GlPopover>
 			)}
 		</span>
 	);

--- a/src/webviews/apps/plus/graph/graph.scss
+++ b/src/webviews/apps/plus/graph/graph.scss
@@ -9,6 +9,15 @@
 	outline-offset: -1px;
 }
 
+menu-list {
+	menu-item > a[href] {
+		text-decoration: none;
+		color: var(--vscode-foreground);
+		width: 100%;
+		display: inline-block;
+	}
+}
+
 .vscode-high-contrast,
 .vscode-dark {
 	--popover-bg: var(--color-background--lighten-15);

--- a/src/webviews/apps/shared/components/menu/menu-item.ts
+++ b/src/webviews/apps/shared/components/menu/menu-item.ts
@@ -37,11 +37,25 @@ export class MenuItem extends LitElement {
 				color: var(--vscode-menu-selectionForeground);
 				background-color: var(--vscode-menu-background);
 			}
+
+			:host([href]) {
+				padding-inline: 0;
+			}
+
+			a {
+				display: block;
+				color: inherit;
+				text-decoration: none;
+				padding: 0 0.6rem;
+			}
 		`,
 	];
 
 	@property({ type: Boolean, reflect: true })
 	disabled = false;
+
+	@property({ reflect: true })
+	href?: string;
 
 	@property({ reflect: true })
 	override role = 'option';
@@ -57,6 +71,9 @@ export class MenuItem extends LitElement {
 	}
 
 	override render() {
+		if (this.href) {
+			return html`<a href=${this.href}><slot></slot></a>`;
+		}
 		return html`<slot></slot>`;
 	}
 }

--- a/src/webviews/apps/shared/components/overlays/popover.ts
+++ b/src/webviews/apps/shared/components/overlays/popover.ts
@@ -49,6 +49,23 @@ declare global {
 	}
 }
 
+/**
+ * @tag gl-popover
+ *
+ * @slot anchor - The element that triggers the popover
+ * @slot content - The content of the popover
+ *
+ * @csspart base - Styles the sl-popup element itself
+ * @csspart arrow - Styles the arrow's container
+ * @csspart popup - Styles the popup's container
+ * @csspart body - Styles the element that wraps the content slot
+ *
+ * @fires gl-popover-show - Fired when the popover is shown
+ * @fires gl-popover-after-show - Fired after the popover is shown
+ * @fires gl-popover-hide - Fired when the popover is hidden
+ * @fires gl-popover-after-hide - Fired after the popover is hidden
+ */
+
 @customElement('gl-popover')
 export class GlPopover extends GlElement {
 	static override shadowRootOptions: ShadowRootInit = {


### PR DESCRIPTION
# Description

- add split button dropdown in case of both ahead and behind changes appeared

![Screenshot 2024-09-04 at 14 58 43](https://github.com/user-attachments/assets/c925baba-a342-42d3-a21f-0f8a22a01000)

![Screenshot 2024-09-04 at 14 58 50](https://github.com/user-attachments/assets/569778ec-09c8-421d-9d21-b997d06180c0)


# Checklist

<!-- Please check off the following -->

- [x] I have followed the guidelines in the Contributing document
- [x] My changes follow the coding style of this project
- [x] My changes build without any errors or warnings
- [x] My changes have been formatted and linted
- [x] My changes include any required corresponding changes to the documentation (including CHANGELOG.md and README.md)
- [ ] My changes have been rebased and squashed to the minimal number (typically 1) of relevant commits
- [x] My changes have a descriptive commit message with a short title, including a `Fixes $XXX -` or `Closes #XXX -` prefix to auto-close the issue that your PR addresses
