### PR TITLE
Adds an option to delete a worktree along with its branch (GLVSC-637)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,7 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/) and this p
 - Adds an "alt" _Fetch_ command for the inline _Pull_ command on branches in views
 - Adds _Open Comparison on Remote_ command to branch comparisons in views
 - Adds _Open in Worktree_ context menu command to branches and pull requests in views and the _Commit Graph_
+- Adds an option to delete a worktree along with its branch from the _Git Delete Worktree_ command
 
 ### Changed
 

--- a/src/commands/git/worktree.ts
+++ b/src/commands/git/worktree.ts
@@ -844,7 +844,9 @@ export class WorktreeGitCommand extends QuickCommand<State> {
 				context.title = getTitle(state.subcommand);
 
 				const result = yield* pickWorktreesStep(state, context, {
-					filter: wt => !wt.main || !wt.opened, // Can't delete the main or opened worktree
+					// Can't delete the main or opened worktree
+					excludeOpened: true,
+					filter: wt => !wt.main,
 					includeStatus: true,
 					picked: state.uris?.map(uri => uri.toString()),
 					placeholder: 'Choose worktrees to delete',

--- a/src/commands/quickCommand.steps.ts
+++ b/src/commands/quickCommand.steps.ts
@@ -1870,12 +1870,14 @@ export function* pickWorktreesStep<
 	state: State,
 	context: Context,
 	{
+		excludeOpened,
 		filter,
 		includeStatus,
 		picked,
 		placeholder,
 		titleContext,
 	}: {
+		excludeOpened?: boolean;
 		filter?: (b: GitWorktree) => boolean;
 		includeStatus?: boolean;
 		picked?: string | string[];
@@ -1885,6 +1887,7 @@ export function* pickWorktreesStep<
 ): StepResultGenerator<GitWorktree[]> {
 	const items = getWorktrees(context.worktrees ?? state.repo, {
 		buttons: [OpenInNewWindowQuickInputButton, RevealInSideBarQuickInputButton],
+		excludeOpened: excludeOpened,
 		filter: filter,
 		includeStatus: includeStatus,
 		picked: picked,


### PR DESCRIPTION
# Description

Adds 2 new options to delete the branch as part of the worktree delete.
Which will after the completion of the worktree(s) delete, will start the delete branch(es) flow (at it confirmation step – which will naturally happen if all the context is provided to that flow)

# Checklist

<!-- Please check off the following -->

- [x] I have followed the guidelines in the Contributing document
- [x] My changes follow the coding style of this project
- [x] My changes build without any errors or warnings
- [x] My changes have been formatted and linted
- [x] My changes include any required corresponding changes to the documentation (including CHANGELOG.md and README.md)
- [x] My changes have been rebased and squashed to the minimal number (typically 1) of relevant commits
- [x] My changes have a descriptive commit message with a short title, including a `Fixes $XXX -` or `Closes #XXX -` prefix to auto-close the issue that your PR addresses
