### PR TITLE
Deleting a branch calls dialog of deleting its worktree (GLVSC-632)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,7 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/) and this p
 - Adds _Open Comparison on Remote_ command to branch comparisons in views
 - Adds _Open in Worktree_ context menu command to branches and pull requests in views and the _Commit Graph_
 - Adds an option to delete a worktree along with its branch from the _Git Delete Worktree_ command
+- When a branch is deleted in _Git Delete Branch_ command, its worktree is also deleted
 
 ### Changed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,7 +20,7 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/) and this p
 - Adds _Open Comparison on Remote_ command to branch comparisons in views
 - Adds _Open in Worktree_ context menu command to branches and pull requests in views and the _Commit Graph_
 - Adds an option to delete a worktree along with its branch from the _Git Delete Worktree_ command
-- When a branch is deleted in _Git Delete Branch_ command, its worktree is also deleted
+- Adds a step to delete the worktree of a branch first if one exists when using the _Git Delete Branch_ command
 
 ### Changed
 

--- a/src/commands/git/worktree.ts
+++ b/src/commands/git/worktree.ts
@@ -954,12 +954,8 @@ export class WorktreeGitCommand extends QuickCommand<State> {
 		context.title = state.uris.length === 1 ? 'Delete Worktree' : 'Delete Worktrees';
 		const label = state.uris.length === 1 ? 'Delete Worktree' : 'Delete Worktrees';
 		const deletingOfSelectedBranches = state.flags.includes('--deleting-of-selected-branches');
-		const selectedBranchesLabelSuffix = !deletingOfSelectedBranches
-			? ''
-			: state.uris.length === 1
-			  ? ' of corresponding branch'
-			  : ' of corresponding branches';
 		const branchesLabel = state.uris.length === 1 ? 'Branch' : 'Branches';
+		const selectedBranchesLabelSuffix = !deletingOfSelectedBranches ? '' : ` of ${branchesLabel}`;
 		const description =
 			state.uris.length === 1
 				? `delete worktree in $(folder) ${getWorkspaceFriendlyPath(state.uris[0])}`


### PR DESCRIPTION
# Description

Or instead, the Delete Worktree flow could just be triggered as an optional step in the Delete Branch flow.


# Checklist

<!-- Please check off the following -->

- [x] I have followed the guidelines in the Contributing document
- [x] My changes follow the coding style of this project
- [x] My changes build without any errors or warnings
- [x] My changes have been formatted and linted
- [x] My changes include any required corresponding changes to the documentation (including CHANGELOG.md and README.md)
- [x] My changes have been rebased and squashed to the minimal number (typically 1) of relevant commits
- [x] My changes have a descriptive commit message with a short title, including a `Fixes $XXX -` or `Closes #XXX -` prefix to auto-close the issue that your PR addresses
