### PR TITLE
Change GK account authentication to no longer use the VS Code authentication system

### DIFF
--- a/src/plus/gk/account/authenticationProvider.ts
+++ b/src/plus/gk/account/authenticationProvider.ts
@@ -3,7 +3,7 @@ import type {
 	AuthenticationProviderAuthenticationSessionsChangeEvent,
 	AuthenticationSession,
 } from 'vscode';
-import { authentication, Disposable, EventEmitter, window } from 'vscode';
+import { Disposable, EventEmitter, window } from 'vscode';
 import { uuid } from '@env/crypto';
 import type { Container, Environment } from '../../../container';
 import { CancellationError } from '../../../errors';
@@ -27,7 +27,6 @@ interface StoredSession {
 
 export const authenticationProviderId = 'gitlens+';
 export const authenticationProviderScopes = ['gitlens'];
-const authenticationLabel = 'GitKraken: GitLens';
 
 export interface AuthenticationProviderOptions {
 	signUp?: boolean;
@@ -57,9 +56,6 @@ export class AccountAuthenticationProvider implements AuthenticationProvider, Di
 
 		this._disposable = Disposable.from(
 			this._authConnection,
-			authentication.registerAuthenticationProvider(authenticationProviderId, authenticationLabel, this, {
-				supportsMultipleAccounts: false,
-			}),
 			this.container.storage.onDidChangeSecrets(() => this.checkForUpdates()),
 		);
 	}

--- a/src/plus/gk/account/authenticationProvider.ts
+++ b/src/plus/gk/account/authenticationProvider.ts
@@ -230,6 +230,20 @@ export class AccountAuthenticationProvider implements AuthenticationProvider, Di
 		}
 	}
 
+	public async getOrCreateSession(
+		scopes: string[],
+		createIfNeeded: boolean,
+	): Promise<AuthenticationSession | undefined> {
+		const session = (await this.getSessions(scopes))[0];
+		if (session != null) {
+			return session;
+		}
+		if (!createIfNeeded) {
+			return undefined;
+		}
+		return this.createSession(scopes);
+	}
+
 	private async createSessionForToken(token: string, scopes: string[]): Promise<AuthenticationSession> {
 		const userInfo = await this._authConnection.getAccountInfo(token);
 		return {

--- a/src/plus/gk/account/subscriptionService.ts
+++ b/src/plus/gk/account/subscriptionService.ts
@@ -1052,7 +1052,10 @@ export class SubscriptionService implements Disposable {
 			if (options != null && createIfNeeded) {
 				this.container.accountAuthentication.setOptionsForScopes(authenticationProviderScopes, options);
 			}
-			session = (await this.container.accountAuthentication.getSessions(authenticationProviderScopes))[0];
+			session = await this.container.accountAuthentication.getOrCreateSession(
+				authenticationProviderScopes,
+				createIfNeeded,
+			);
 		} catch (ex) {
 			session = null;
 			if (options != null && createIfNeeded) {

--- a/src/plus/gk/account/subscriptionService.ts
+++ b/src/plus/gk/account/subscriptionService.ts
@@ -7,7 +7,6 @@ import type {
 	StatusBarItem,
 } from 'vscode';
 import {
-	authentication,
 	CancellationTokenSource,
 	version as codeVersion,
 	Disposable,
@@ -50,7 +49,7 @@ import { getSubscriptionFromCheckIn } from '../checkin';
 import type { ServerConnection } from '../serverConnection';
 import { ensurePlusFeaturesEnabled } from '../utils';
 import { AuthenticationContext } from './authenticationConnection';
-import { authenticationProviderId, authenticationProviderScopes } from './authenticationProvider';
+import { authenticationProviderScopes } from './authenticationProvider';
 import type { Organization } from './organization';
 import { getApplicablePromo } from './promos';
 import type { Subscription } from './subscription';
@@ -1053,10 +1052,7 @@ export class SubscriptionService implements Disposable {
 			if (options != null && createIfNeeded) {
 				this.container.accountAuthentication.setOptionsForScopes(authenticationProviderScopes, options);
 			}
-			session = await authentication.getSession(authenticationProviderId, authenticationProviderScopes, {
-				createIfNone: createIfNeeded,
-				silent: !createIfNeeded,
-			});
+			session = (await this.container.accountAuthentication.getSessions(authenticationProviderScopes))[0];
 		} catch (ex) {
 			session = null;
 			if (options != null && createIfNeeded) {


### PR DESCRIPTION
Currently we leverage the VS Code authentication system for our GK authentication, but this causes unnecessary prompts and limits our control over the experience.

We already implement both sides of the authentication process within GitLens, so we just need to avoid using VS Code as the middleman


### Roadmap
- [x] stop registering AccountAuthenticationProvider in VSCode
- [x] fix get-or-create behavior and honoring `createIfNeeded` and `silent` flags.
- ❌ ~~probably stop implementing AuthenticationProvider~~ ➡️ probably but in a follow-up
- [x] ~~stop relying on authentication events, e.g. stop handling them and make sure that we loos nothing by doing that (or fix the cases that are broken)~~ I've checked that don't relying on such events for GK authentication.

### Testing notes
- Be unauthenticated before the update:
  - general behavior
    - login
    - restart VS Code: you should keep your session
    - logout
    - login again
    - logout
    - restart VS Code: you should keep being unauthenticated.
  - integrations
    - you're able to connect-disconnect rich GitHub integration,
    - they survive restarting the application.
    - disconect GitHub, then go to the Account View, press "Integrations" button, come back to VS Code. Integrations become connected.
- Be authenticated before the update
  - check the integrations behavior from the previous section
  - check the general behavior from the previous section
- Test both "sign-in" and "sign-up" flows, when you're authenticated and unauthenticated in your browser