### PR TITLE
Changes path to typescript sdk in settings to nix style

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -49,5 +49,5 @@
 		"**/dist": true
 	},
 	"typescript.preferences.importModuleSpecifier": "project-relative",
-	"typescript.tsdk": "node_modules\\typescript\\lib"
+	"typescript.tsdk": "node_modules/typescript/lib"
 }


### PR DESCRIPTION
# Description

Changes path to TypeScript SDK in settings to nix style, because otherwise VS Code on MacOS fails with detecting the right TypeScript path

## Testing notes
Expected result: your VS Code understands the nix-style path to TypeScript SDK and the typescript version is detected as 5.6.0-beta

Undesired result:

- VS Code cannot understand the path, so it doesn't see the SDK in the project and switches to its ovn SDK, probably 5.5.4.
- In this case it shows errors in some files. For example in pull.ts (see on the picture)

![image](https://github.com/user-attachments/assets/08df308f-cfa9-4a22-926b-27497f0d4cfb)


# Checklist

<!-- Please check off the following -->

- [x] I have followed the guidelines in the Contributing document
- [x] My changes follow the coding style of this project
- [x] My changes build without any errors or warnings
- [x] My changes have been formatted and linted
- [x] My changes include any required corresponding changes to the documentation (including CHANGELOG.md and README.md)
- [x] My changes have been rebased and squashed to the minimal number (typically 1) of relevant commits
- [x] My changes have a descriptive commit message with a short title, including a `Fixes $XXX -` or `Closes #XXX -` prefix to auto-close the issue that your PR addresses
