### PR TITLE
'Create Branch in Worktree' option in 'Create Branch' shows a repo picker if you have multiple repos open

### DIFF
--- a/src/commands/git/branch.ts
+++ b/src/commands/git/branch.ts
@@ -378,6 +378,7 @@ export class BranchGitCommand extends QuickCommand {
 							subcommand: 'create',
 							reference: state.reference,
 							createBranch: state.name,
+							repo: state.repo,
 						},
 					},
 					this.pickedVia,


### PR DESCRIPTION
It should just use the repo where you chose "create branch" from if you did it in branches view, graph, etc.. If you choose the wrong repo you get prompted for names etc. again


### Details

It has been found in https://github.com/gitkraken/vscode-gitlens/pull/3559
Details about reproducing are in this comment: https://github.com/gitkraken/vscode-gitlens/pull/3559#issuecomment-2346971475