### PR TITLE
Change `branch create` and `branch rename` into normal commands

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,7 +14,7 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/) and this p
 
 ### Changed
 
-- Change `branch create` and `branch rename` terminal-run commands into normal commands
+- Changes how GitLens handles creating and renaming branches to avoid using the terminal &mdash; refs [#3528](https://github.com/gitkraken/vscode-gitlens/issues/3528)
 
 ### Fixed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,8 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/) and this p
 
 ### Changed
 
+- Change `branch create` and `branch rename` terminal-run commands into normal commands
+
 ### Fixed
 
 - Fixes [#3592](https://github.com/gitkraken/vscode-gitlens/issues/3592) - Connecting to an integration via Remotes view (but likely others) doesn't work

--- a/src/commands/git/branch.ts
+++ b/src/commands/git/branch.ts
@@ -393,7 +393,7 @@ export class BranchGitCommand extends QuickCommand {
 			if (state.flags.includes('--switch')) {
 				await state.repo.switch(state.reference.ref, { createBranch: state.name });
 			} else {
-				state.repo.branch(...state.flags, state.name, state.reference.ref);
+				await state.repo.git.branchCreate(state.name, state.reference.ref);
 			}
 		}
 	}
@@ -614,7 +614,7 @@ export class BranchGitCommand extends QuickCommand {
 			state.flags = result;
 
 			endSteps(state);
-			state.repo.branch(...state.flags, state.reference.ref, state.name);
+			await state.repo.git.branchRename(state.reference.ref, state.name);
 		}
 	}
 

--- a/src/commands/git/branch.ts
+++ b/src/commands/git/branch.ts
@@ -5,11 +5,13 @@ import { getNameWithoutRemote, getReferenceLabel, isRevisionReference } from '..
 import { Repository } from '../../git/models/repository';
 import type { GitWorktree } from '../../git/models/worktree';
 import { getWorktreesByBranch } from '../../git/models/worktree';
+import { showGenericErrorMessage } from '../../messages';
 import type { QuickPickItemOfT } from '../../quickpicks/items/common';
 import { createQuickPickSeparator } from '../../quickpicks/items/common';
 import type { FlagsQuickPickItem } from '../../quickpicks/items/flags';
 import { createFlagsQuickPickItem } from '../../quickpicks/items/flags';
 import { ensureArray } from '../../system/array';
+import { Logger } from '../../system/logger';
 import { pluralize } from '../../system/string';
 import type { ViewsWithRepositoryFolders } from '../../views/viewBase';
 import type {
@@ -393,7 +395,13 @@ export class BranchGitCommand extends QuickCommand {
 			if (state.flags.includes('--switch')) {
 				await state.repo.switch(state.reference.ref, { createBranch: state.name });
 			} else {
-				await state.repo.git.branchCreate(state.name, state.reference.ref);
+				try {
+					await state.repo.git.createBranch(state.name, state.reference.ref);
+				} catch (ex) {
+					Logger.error(ex);
+					// TODO likely need some better error handling here
+					return showGenericErrorMessage('Unable to create branch');
+				}
 			}
 		}
 	}
@@ -614,7 +622,13 @@ export class BranchGitCommand extends QuickCommand {
 			state.flags = result;
 
 			endSteps(state);
-			await state.repo.git.branchRename(state.reference.ref, state.name);
+			try {
+				await state.repo.git.renameBranch(state.reference.ref, state.name);
+			} catch (ex) {
+				Logger.error(ex);
+				// TODO likely need some better error handling here
+				return showGenericErrorMessage('Unable to rename branch');
+			}
 		}
 	}
 

--- a/src/env/node/git/git.ts
+++ b/src/env/node/git/git.ts
@@ -506,6 +506,10 @@ export class Git {
 		}
 	}
 
+	branch(repoPath: string, ...args: string[]) {
+		return this.git<string>({ cwd: repoPath }, 'branch', ...args);
+	}
+
 	branch__set_upstream(repoPath: string, branch: string, remote: string, remoteBranch: string) {
 		return this.git<string>({ cwd: repoPath }, 'branch', '--set-upstream-to', `${remote}/${remoteBranch}`, branch);
 	}

--- a/src/env/node/git/localGitProvider.ts
+++ b/src/env/node/git/localGitProvider.ts
@@ -39,7 +39,6 @@ import {
 	WorktreeDeleteErrorReason,
 } from '../../../git/errors';
 import type {
-	GitBranchOptions,
 	GitCaches,
 	GitDir,
 	GitProvider,
@@ -1232,16 +1231,13 @@ export class LocalGitProvider implements GitProvider, Disposable {
 	}
 
 	@log()
-	async branch(repoPath: string, options: GitBranchOptions): Promise<void> {
-		if (options?.create != null) {
-			return this.git.branch(repoPath, options.create.name, options.create.startRef);
-		}
+	async createBranch(repoPath: string, name: string, ref: string): Promise<void> {
+		await this.git.branch(repoPath, name, ref);
+	}
 
-		if (options?.rename != null) {
-			return this.git.branch(repoPath, '-m', options.rename.old, options.rename.new);
-		}
-
-		throw new Error('Invalid branch options');
+	@log()
+	async renameBranch(repoPath: string, oldName: string, newName: string): Promise<void> {
+		await this.git.branch(repoPath, '-m', oldName, newName);
 	}
 
 	@log()

--- a/src/env/node/git/localGitProvider.ts
+++ b/src/env/node/git/localGitProvider.ts
@@ -39,6 +39,7 @@ import {
 	WorktreeDeleteErrorReason,
 } from '../../../git/errors';
 import type {
+	GitBranchOptions,
 	GitCaches,
 	GitDir,
 	GitProvider,
@@ -1228,6 +1229,19 @@ export class LocalGitProvider implements GitProvider, Disposable {
 				ex,
 			);
 		}
+	}
+
+	@log()
+	async branch(repoPath: string, options: GitBranchOptions): Promise<void> {
+		if (options?.create != null) {
+			return this.git.branch(repoPath, options.create.name, options.create.startRef);
+		}
+
+		if (options?.rename != null) {
+			return this.git.branch(repoPath, '-m', options.rename.old, options.rename.new);
+		}
+
+		throw new Error('Invalid branch options');
 	}
 
 	@log()

--- a/src/git/gitProvider.ts
+++ b/src/git/gitProvider.ts
@@ -112,21 +112,14 @@ export interface RepositoryVisibilityInfo {
 	remotesHash?: string;
 }
 
-export type GitBranchOptions = {
-	rename?: {
-		old: string;
-		new: string;
-	};
-	create?: {
-		name: string;
-		startRef: string;
-	};
-};
-
 export interface GitProviderRepository {
+	createBranch?(repoPath: string, name: string, ref: string): Promise<void>;
+	renameBranch?(repoPath: string, oldName: string, newName: string): Promise<void>;
+
 	addRemote?(repoPath: string, name: string, url: string, options?: { fetch?: boolean }): Promise<void>;
 	pruneRemote?(repoPath: string, name: string): Promise<void>;
 	removeRemote?(repoPath: string, name: string): Promise<void>;
+
 	applyUnreachableCommitForPatch?(
 		repoPath: string,
 		ref: string,
@@ -488,7 +481,6 @@ export interface GitProvider extends GitProviderRepository, Disposable {
 	getWorkingUri(repoPath: string, uri: Uri): Promise<Uri | undefined>;
 
 	applyChangesToWorkingFile?(uri: GitUri, ref1?: string, ref2?: string): Promise<void>;
-	branch(_repoPath: string, _options: GitBranchOptions): Promise<void>;
 	clone?(url: string, parentPath: string): Promise<string | undefined>;
 	/**
 	 * Returns the blame of a file

--- a/src/git/gitProvider.ts
+++ b/src/git/gitProvider.ts
@@ -112,6 +112,17 @@ export interface RepositoryVisibilityInfo {
 	remotesHash?: string;
 }
 
+export type GitBranchOptions = {
+	rename?: {
+		old: string;
+		new: string;
+	};
+	create?: {
+		name: string;
+		startRef: string;
+	};
+};
+
 export interface GitProviderRepository {
 	addRemote?(repoPath: string, name: string, url: string, options?: { fetch?: boolean }): Promise<void>;
 	pruneRemote?(repoPath: string, name: string): Promise<void>;
@@ -477,6 +488,7 @@ export interface GitProvider extends GitProviderRepository, Disposable {
 	getWorkingUri(repoPath: string, uri: Uri): Promise<Uri | undefined>;
 
 	applyChangesToWorkingFile?(uri: GitUri, ref1?: string, ref2?: string): Promise<void>;
+	branch(_repoPath: string, _options: GitBranchOptions): Promise<void>;
 	clone?(url: string, parentPath: string): Promise<string | undefined>;
 	/**
 	 * Returns the blame of a file

--- a/src/git/gitProviderService.ts
+++ b/src/git/gitProviderService.ts
@@ -19,6 +19,7 @@ import { SubscriptionPlanId } from '../constants.subscription';
 import type { Container } from '../container';
 import { AccessDeniedError, CancellationError, ProviderNotFoundError, ProviderNotSupportedError } from '../errors';
 import type { FeatureAccess, Features, PlusFeatures, RepoFeatureAccess } from '../features';
+import { showGenericErrorMessage } from '../messages';
 import { getApplicablePromo } from '../plus/gk/account/promos';
 import type { Subscription } from '../plus/gk/account/subscription';
 import { isSubscriptionPaidPlan } from '../plus/gk/account/subscription';
@@ -44,6 +45,7 @@ import { configuration } from '../system/vscode/configuration';
 import { setContext } from '../system/vscode/context';
 import { getBestPath } from '../system/vscode/path';
 import type {
+	GitBranchOptions,
 	GitCaches,
 	GitDir,
 	GitProvider,
@@ -1336,6 +1338,38 @@ export class GitProviderService implements Disposable {
 		}
 
 		return provider.applyUnreachableCommitForPatch(path, ref, options);
+	}
+
+	@log()
+	branchCreate(repoPath: string, name: string, startRef: string): Promise<void> {
+		const { provider, path } = this.getProvider(repoPath);
+		try {
+			return provider.branch(path, {
+				create: {
+					name: name,
+					startRef: startRef,
+				},
+			});
+		} catch (ex) {
+			Logger.error(ex);
+			return showGenericErrorMessage('Unable to create branch');
+		}
+	}
+
+	@log()
+	branchRename(repoPath: string, oldName: string, newName: string): Promise<void> {
+		const { provider, path } = this.getProvider(repoPath);
+		try {
+			return provider.branch(path, {
+				rename: {
+					old: oldName,
+					new: newName,
+				},
+			});
+		} catch (ex) {
+			Logger.error(ex);
+			return showGenericErrorMessage('Unable to rename branch');
+		}
 	}
 
 	@log()

--- a/src/git/gitProviderService.ts
+++ b/src/git/gitProviderService.ts
@@ -19,7 +19,6 @@ import { SubscriptionPlanId } from '../constants.subscription';
 import type { Container } from '../container';
 import { AccessDeniedError, CancellationError, ProviderNotFoundError, ProviderNotSupportedError } from '../errors';
 import type { FeatureAccess, Features, PlusFeatures, RepoFeatureAccess } from '../features';
-import { showGenericErrorMessage } from '../messages';
 import { getApplicablePromo } from '../plus/gk/account/promos';
 import type { Subscription } from '../plus/gk/account/subscription';
 import { isSubscriptionPaidPlan } from '../plus/gk/account/subscription';
@@ -45,7 +44,6 @@ import { configuration } from '../system/vscode/configuration';
 import { setContext } from '../system/vscode/context';
 import { getBestPath } from '../system/vscode/path';
 import type {
-	GitBranchOptions,
 	GitCaches,
 	GitDir,
 	GitProvider,
@@ -1341,35 +1339,19 @@ export class GitProviderService implements Disposable {
 	}
 
 	@log()
-	branchCreate(repoPath: string, name: string, startRef: string): Promise<void> {
+	createBranch(repoPath: string | Uri, name: string, ref: string): Promise<void> {
 		const { provider, path } = this.getProvider(repoPath);
-		try {
-			return provider.branch(path, {
-				create: {
-					name: name,
-					startRef: startRef,
-				},
-			});
-		} catch (ex) {
-			Logger.error(ex);
-			return showGenericErrorMessage('Unable to create branch');
-		}
+		if (provider.createBranch == null) throw new ProviderNotSupportedError(provider.descriptor.name);
+
+		return provider.createBranch(path, name, ref);
 	}
 
 	@log()
-	branchRename(repoPath: string, oldName: string, newName: string): Promise<void> {
+	renameBranch(repoPath: string | Uri, oldName: string, newName: string): Promise<void> {
 		const { provider, path } = this.getProvider(repoPath);
-		try {
-			return provider.branch(path, {
-				rename: {
-					old: oldName,
-					new: newName,
-				},
-			});
-		} catch (ex) {
-			Logger.error(ex);
-			return showGenericErrorMessage('Unable to rename branch');
-		}
+		if (provider.renameBranch == null) throw new ProviderNotSupportedError(provider.descriptor.name);
+
+		return provider.renameBranch(path, oldName, newName);
 	}
 
 	@log()

--- a/src/git/models/repository.ts
+++ b/src/git/models/repository.ts
@@ -39,6 +39,8 @@ export type RepoGitProviderService = Pick<
 		[K in keyof GitProviderService]: RemoveFirstArg<GitProviderService[K]>;
 	},
 	| keyof GitProviderRepository
+	| 'branchCreate'
+	| 'branchRename'
 	| 'getBestRemoteWithIntegration'
 	| 'getBranch'
 	| 'getRemote'
@@ -558,11 +560,6 @@ export class Repository implements Disposable {
 		await this.git.addRemote(name, url, options);
 		const [remote] = await this.git.getRemotes({ filter: r => r.url === url });
 		return remote;
-	}
-
-	@log()
-	branch(...args: string[]) {
-		void this.runTerminalCommand('branch', ...args);
 	}
 
 	@log()

--- a/src/git/models/repository.ts
+++ b/src/git/models/repository.ts
@@ -39,8 +39,6 @@ export type RepoGitProviderService = Pick<
 		[K in keyof GitProviderService]: RemoveFirstArg<GitProviderService[K]>;
 	},
 	| keyof GitProviderRepository
-	| 'branchCreate'
-	| 'branchRename'
 	| 'getBestRemoteWithIntegration'
 	| 'getBranch'
 	| 'getRemote'

--- a/src/plus/integrations/providers/github/githubGitProvider.ts
+++ b/src/plus/integrations/providers/github/githubGitProvider.ts
@@ -26,6 +26,7 @@ import {
 import { Features } from '../../../../features';
 import { GitSearchError } from '../../../../git/errors';
 import type {
+	GitBranchOptions,
 	GitCaches,
 	GitProvider,
 	LeftRightCommitCountResult,
@@ -442,6 +443,9 @@ export class GitHubGitProvider implements GitProvider, Disposable {
 	async getWorkingUri(repoPath: string, uri: Uri) {
 		return this.createVirtualUri(repoPath, undefined, uri.path);
 	}
+
+	@log()
+	async branch(_repoPath: string, _options: GitBranchOptions): Promise<void> {}
 
 	@log()
 	async branchContainsCommit(_repoPath: string, _name: string, _ref: string): Promise<boolean> {

--- a/src/plus/integrations/providers/github/githubGitProvider.ts
+++ b/src/plus/integrations/providers/github/githubGitProvider.ts
@@ -26,7 +26,6 @@ import {
 import { Features } from '../../../../features';
 import { GitSearchError } from '../../../../git/errors';
 import type {
-	GitBranchOptions,
 	GitCaches,
 	GitProvider,
 	LeftRightCommitCountResult,
@@ -443,9 +442,6 @@ export class GitHubGitProvider implements GitProvider, Disposable {
 	async getWorkingUri(repoPath: string, uri: Uri) {
 		return this.createVirtualUri(repoPath, undefined, uri.path);
 	}
-
-	@log()
-	async branch(_repoPath: string, _options: GitBranchOptions): Promise<void> {}
 
 	@log()
 	async branchContainsCommit(_repoPath: string, _name: string, _ref: string): Promise<boolean> {


### PR DESCRIPTION
# Description

This is the first part of #3528 that changes `branch create` and `branch rename` into normal commands.
Since GitLens performs most of the validation for branch names, there wasn't really much to error check here.

Preparing next PR with `branch delete` which will probably contain more validations.

# Checklist

<!-- Please check off the following -->

- [x] I have followed the guidelines in the Contributing document
- [x] My changes follow the coding style of this project
- [x] My changes build without any errors or warnings
- [x] My changes have been formatted and linted
- [x] My changes include any required corresponding changes to the documentation (including CHANGELOG.md and README.md)
- [x] My changes have been rebased and squashed to the minimal number (typically 1) of relevant commits
- [x] My changes have a descriptive commit message with a short title, including a `Fixes $XXX -` or `Closes #XXX -` prefix to auto-close the issue that your PR addresses
