### PR TITLE
fix E2E tests

### DIFF
--- a/tests/e2e/playwright.config.ts
+++ b/tests/e2e/playwright.config.ts
@@ -22,4 +22,5 @@ export default defineConfig({
 			},
 		},
 	],
+	testMatch: 'specs/*.test.ts',
 });

--- a/tests/e2e/specs/baseTest.ts
+++ b/tests/e2e/specs/baseTest.ts
@@ -16,6 +16,8 @@ type TestFixtures = TestOptions & {
 	createTmpDir: () => Promise<string>;
 };
 
+export const MaxTimeout = 10000;
+
 let testProjectPath: string;
 export const test = base.extend<TestFixtures>({
 	vscodeVersion: ['insiders', { option: true }],

--- a/tests/e2e/specs/baseTest.ts
+++ b/tests/e2e/specs/baseTest.ts
@@ -61,7 +61,12 @@ export const test = base.extend<TestFixtures>({
 			await fs.promises.cp(logPath, logOutputPath, { recursive: true });
 		}
 	},
-	createTmpDir: async (_, use) => {
+	// Next line is necessary because of how Playwright works. It expect a destructured pattern here:
+	// https://github.com/microsoft/playwright/issues/14590#issuecomment-1911734641
+	// https://github.com/microsoft/playwright/issues/21566#issuecomment-1464858235
+
+	// eslint-disable-next-line no-empty-pattern
+	createTmpDir: async ({}, use) => {
 		const tempDirs: string[] = [];
 		await use(async () => {
 			const tempDir = await fs.promises.realpath(await fs.promises.mkdtemp(path.join(os.tmpdir(), 'gltest-')));

--- a/tests/e2e/specs/command_palette.test.ts
+++ b/tests/e2e/specs/command_palette.test.ts
@@ -1,10 +1,10 @@
-import { expect, test } from './baseTest';
+import { expect, MaxTimeout, test } from './baseTest';
 
 test.describe('Test GitLens Command Palette commands', () => {
 	test('should open commit graph with the command', async ({ page }) => {
 		// Close any open tabs to ensure a clean state
 		const welcomePageTab = page.locator('div[role="tab"][aria-label="Welcome to GitLens"]');
-		await welcomePageTab.waitFor({ state: 'visible', timeout: 5000 });
+		await welcomePageTab.waitFor({ state: 'visible', timeout: MaxTimeout });
 		void welcomePageTab.locator('div.tab-actions .action-item a.codicon-close').click();
 
 		// Open the command palette by clicking on the View menu and selecting Command Palette
@@ -13,7 +13,7 @@ test.describe('Test GitLens Command Palette commands', () => {
 
 		// Wait for the command palette input to be visible and fill it
 		const commandPaletteInput = page.locator('.quick-input-box input');
-		await commandPaletteInput.waitFor({ state: 'visible', timeout: 5000 });
+		await commandPaletteInput.waitFor({ state: 'visible', timeout: MaxTimeout });
 		await commandPaletteInput.fill('> GitLens: Show Commit graph');
 		await page.waitForTimeout(1000);
 		void page.keyboard.press('Enter');
@@ -21,7 +21,7 @@ test.describe('Test GitLens Command Palette commands', () => {
 		// Click on the first element (GitLens: Show Commit graph)
 		/*
 		const commandPaletteFirstLine = page.locator('.quick-input-widget .monaco-list .monaco-list-row.focused');
-		await commandPaletteFirstLine.waitFor({ state: 'visible', timeout: 5000 });
+		await commandPaletteFirstLine.waitFor({ state: 'visible', timeout: MaxTimeout });
 		await commandPaletteFirstLine.click();
 		*/
 		// Graph should be opened


### PR DESCRIPTION
# Description
E2E tests were giving the following error:
![Captura de pantalla 2024-09-24 a las 13 25 23](https://github.com/user-attachments/assets/3a5b9c0e-9e49-4f19-b1e3-734a260dad7a)

This is caused because Playwright requires that parameter to be a destructured object, but our eslint rules collide with that because we don't allow empty patterns. The solution is to ignore that eslint line for this case.

In addition, I set the maximum timeout from 5s to 10s, as in some cases if VSCode takes too long to load, the test would timeout before even starting GitLens.

# Checklist

<!-- Please check off the following -->

- [x] I have followed the guidelines in the Contributing document
- [x] My changes follow the coding style of this project
- [x] My changes build without any errors or warnings
- [x] My changes have been formatted and linted
- [x] My changes have been rebased and squashed to the minimal number (typically 1) of relevant commits
- [x] My changes have a descriptive commit message with a short title, including a `Fixes $XXX -` or `Closes #XXX -` prefix to auto-close the issue that your PR addresses
