### PR TITLE
Prevents cloud integration sync process from opening gkdev connect page/flow

### DIFF
--- a/src/plus/integrations/authentication/integrationAuthentication.ts
+++ b/src/plus/integrations/authentication/integrationAuthentication.ts
@@ -47,7 +47,9 @@ export interface IntegrationAuthenticationProvider extends Disposable {
 	deleteSession(descriptor?: IntegrationAuthenticationSessionDescriptor): Promise<void>;
 	getSession(
 		descriptor?: IntegrationAuthenticationSessionDescriptor,
-		options?: { createIfNeeded?: boolean; forceNewSession?: boolean; source?: Sources },
+		options?:
+			| { createIfNeeded?: boolean; forceNewSession?: boolean; sync?: never; source?: Sources }
+			| { createIfNeeded?: never; forceNewSession?: never; sync: boolean; source?: Sources },
 	): Promise<ProviderAuthenticationSession | undefined>;
 	get onDidChange(): Event<void>;
 }
@@ -73,7 +75,21 @@ abstract class IntegrationAuthenticationProviderBase<ID extends IntegrationId = 
 	protected abstract fetchOrCreateSession(
 		storedSession: ProviderAuthenticationSession | undefined,
 		descriptor?: IntegrationAuthenticationSessionDescriptor,
-		options?: { createIfNeeded?: boolean; forceNewSession?: boolean; refreshIfExpired?: boolean; source?: Sources },
+		options?:
+			| {
+					createIfNeeded?: boolean;
+					forceNewSession?: boolean;
+					sync?: never;
+					refreshIfExpired?: boolean;
+					source?: Sources;
+			  }
+			| {
+					createIfNeeded?: never;
+					forceNewSession?: never;
+					sync: boolean;
+					refreshIfExpired?: boolean;
+					source?: Sources;
+			  },
 	): Promise<ProviderAuthenticationSession | undefined>;
 
 	protected abstract deleteAllSecrets(sessionId: string): Promise<void>;
@@ -129,7 +145,9 @@ abstract class IntegrationAuthenticationProviderBase<ID extends IntegrationId = 
 	@debug()
 	async getSession(
 		descriptor?: IntegrationAuthenticationSessionDescriptor,
-		options?: { createIfNeeded?: boolean; forceNewSession?: boolean; source?: Sources },
+		options?:
+			| { createIfNeeded?: boolean; forceNewSession?: boolean; sync?: never; source?: Sources }
+			| { createIfNeeded?: never; forceNewSession?: never; sync: boolean; source?: Sources },
 	): Promise<ProviderAuthenticationSession | undefined> {
 		const sessionId = this.getSessionId(descriptor);
 
@@ -254,13 +272,27 @@ export abstract class CloudIntegrationAuthenticationProvider<
 	protected override async fetchOrCreateSession(
 		storedSession: ProviderAuthenticationSession | undefined,
 		descriptor?: IntegrationAuthenticationSessionDescriptor,
-		options?: { createIfNeeded?: boolean; forceNewSession?: boolean; refreshIfExpired?: boolean; source?: Sources },
+		options?:
+			| {
+					createIfNeeded?: boolean;
+					forceNewSession?: boolean;
+					sync?: never;
+					refreshIfExpired?: boolean;
+					source?: Sources;
+			  }
+			| {
+					createIfNeeded?: never;
+					forceNewSession?: never;
+					sync: boolean;
+					refreshIfExpired?: boolean;
+					source?: Sources;
+			  },
 	): Promise<ProviderAuthenticationSession | undefined> {
 		// TODO: This is a stopgap to make sure we're not hammering the api on automatic calls to get the session.
 		// Ultimately we want to timestamp calls to syncCloudIntegrations and use that to determine whether we should
 		// make the call or not.
 		let session =
-			options?.refreshIfExpired || options?.createIfNeeded || options?.forceNewSession
+			options?.refreshIfExpired || options?.createIfNeeded || options?.forceNewSession || options?.sync
 				? await this.fetchSession(descriptor)
 				: undefined;
 


### PR DESCRIPTION
Fixes #3608

From the "sync cloud integrations" process we were setting "create if needed", which in `fetchOrCreateSession` will cause the gkdev connect flow to start (and website to open) if the session could not be fetched from the cloud.

This causes undesirable/unexpected UX for users, especially because it can happen from the background sync for cloud integrations, and can occur daily on each check-in.

In the case of #3608, the user had no local gitlab session, one existed in the cloud, but it was expired and could not be refreshed, causing the prompt to happen regularly on vscode launch or profile change.

This change adds a new `sync` flag to the `ensureSession`/`getSession` auth flow that acts as a softer version of `createIfNeeded`, and will not trigger a `connectCloudIntegration` call in `fetchOrCreateSession` of `CloudIntegrationAuthenticationProvider` if `session` was returned as `undefined` from `fetchSession`, either due to an error or because it didn't exist, since `sync`, unlike `createIfNeeded`, does not satisfy the `shouldCreateSession` check.