### PR TITLE
Slims `Repository` to use proxied `GitProviderService`

### DIFF
--- a/src/commands/closeUnchangedFiles.ts
+++ b/src/commands/closeUnchangedFiles.ts
@@ -27,7 +27,7 @@ export class CloseUnchangedFilesCommand extends Command {
 				const repository = await getRepositoryOrShowPicker('Close All Unchanged Files');
 				if (repository == null) return;
 
-				const status = await this.container.git.getStatusForRepo(repository.uri);
+				const status = await this.container.git.getStatus(repository.uri);
 				if (status == null) {
 					void window.showWarningMessage('Unable to close unchanged files');
 

--- a/src/commands/copyCurrentBranch.ts
+++ b/src/commands/copyCurrentBranch.ts
@@ -24,7 +24,7 @@ export class CopyCurrentBranchCommand extends ActiveEditorCommand {
 		if (repository == null) return;
 
 		try {
-			const branch = await repository.getBranch();
+			const branch = await repository.git.getBranch();
 			if (branch?.name) {
 				await env.clipboard.writeText(branch.name);
 			}

--- a/src/commands/createPullRequestOnRemote.ts
+++ b/src/commands/createPullRequestOnRemote.ts
@@ -35,7 +35,7 @@ export class CreatePullRequestOnRemoteCommand extends Command {
 		if (repo == null) return;
 
 		if (args == null) {
-			const branch = await repo.getBranch();
+			const branch = await repo.git.getBranch();
 			if (branch?.upstream == null) {
 				void window.showErrorMessage(
 					`Unable to create a pull request for branch \`${branch?.name}\` because it has no upstream branch`,
@@ -51,11 +51,11 @@ export class CreatePullRequestOnRemoteCommand extends Command {
 			};
 		}
 
-		const compareRemote = await repo.getRemote(args.remote);
+		const compareRemote = await repo.git.getRemote(args.remote);
 		if (compareRemote?.provider == null) return;
 
 		const providerId = compareRemote.provider.id;
-		const remotes = (await repo.getRemotes({
+		const remotes = (await repo.git.getRemotes({
 			filter: r => r.provider?.id === providerId,
 			sort: true,
 		})) as GitRemote<RemoteProvider>[];

--- a/src/commands/diffWithRevision.ts
+++ b/src/commands/diffWithRevision.ts
@@ -61,7 +61,7 @@ export class DiffWithRevisionCommand extends ActiveEditorCommand {
 							getState: async () => {
 								const items: (CommandQuickPickItem | DirectiveQuickPickItem)[] = [];
 
-								const status = await this.container.git.getStatusForRepo(gitUri.repoPath);
+								const status = await this.container.git.getStatus(gitUri.repoPath);
 								if (status != null) {
 									for (const f of status.files) {
 										if (f.workingTreeStatus === '?' || f.workingTreeStatus === '!') {

--- a/src/commands/externalDiff.ts
+++ b/src/commands/externalDiff.ts
@@ -88,7 +88,7 @@ export class ExternalDiffCommand extends Command {
 				const repository = await getRepositoryOrShowPicker('Open All Changes (difftool)');
 				if (repository == null) return undefined;
 
-				const status = await this.container.git.getStatusForRepo(repository.uri);
+				const status = await this.container.git.getStatus(repository.uri);
 				if (status == null) {
 					return window.showInformationMessage("The repository doesn't have any changes");
 				}

--- a/src/commands/ghpr/openOrCreateWorktree.ts
+++ b/src/commands/ghpr/openOrCreateWorktree.ts
@@ -86,7 +86,7 @@ export class OpenOrCreateWorktreeCommand extends Command {
 		const remoteUrl = remoteUri.toString();
 		const [, remoteDomain, remotePath] = parseGitRemoteUrl(remoteUrl);
 
-		const remotes = await repo.getRemotes({ filter: r => r.matches(remoteDomain, remotePath) });
+		const remotes = await repo.git.getRemotes({ filter: r => r.matches(remoteDomain, remotePath) });
 		const remote = remotes[0] as GitRemote | undefined;
 
 		let addRemote: { name: string; url: string } | undefined;

--- a/src/commands/git/branch.ts
+++ b/src/commands/git/branch.ts
@@ -338,7 +338,7 @@ export class BranchGitCommand extends QuickCommand {
 				const result = yield* pickBranchOrTagStep(state, context, {
 					placeholder: context =>
 						`Choose a branch${context.showTags ? ' or tag' : ''} to create the new branch from`,
-					picked: state.reference?.ref ?? (await state.repo.getBranch())?.ref,
+					picked: state.reference?.ref ?? (await state.repo.git.getBranch())?.ref,
 					titleContext: ' from',
 					value: isRevisionReference(state.reference) ? state.reference.ref : undefined,
 				});

--- a/src/commands/git/cherry-pick.ts
+++ b/src/commands/git/cherry-pick.ts
@@ -131,7 +131,7 @@ export class CherryPickGitCommand extends QuickCommand<State> {
 			}
 
 			if (context.destination == null) {
-				const branch = await state.repo.getBranch();
+				const branch = await state.repo.git.getBranch();
 				if (branch == null) break;
 
 				context.destination = branch;
@@ -179,7 +179,7 @@ export class CherryPickGitCommand extends QuickCommand<State> {
 					{ mode: 'contains' },
 				);
 				if (branches.length) {
-					const branch = await state.repo.getBranch(branches[0]);
+					const branch = await state.repo.git.getBranch(branches[0]);
 					if (branch != null) {
 						context.selectedBranchOrTag = branch;
 					}

--- a/src/commands/git/log.ts
+++ b/src/commands/git/log.ts
@@ -118,7 +118,7 @@ export class LogGitCommand extends QuickCommand<State> {
 			assertStateStepRepository(state);
 
 			if (state.reference === 'HEAD') {
-				const branch = await state.repo.getBranch();
+				const branch = await state.repo.git.getBranch();
 				state.reference = branch;
 			}
 

--- a/src/commands/git/merge.ts
+++ b/src/commands/git/merge.ts
@@ -121,7 +121,7 @@ export class MergeGitCommand extends QuickCommand<State> {
 			}
 
 			if (context.destination == null) {
-				const branch = await state.repo.getBranch();
+				const branch = await state.repo.git.getBranch();
 				if (branch == null) break;
 
 				context.destination = branch;

--- a/src/commands/git/pull.ts
+++ b/src/commands/git/pull.ts
@@ -67,7 +67,7 @@ export class PullGitCommand extends QuickCommand<State> {
 		if (isBranchReference(state.reference)) {
 			// Only resort to a branch fetch if the branch isn't the current one
 			if (!isBranch(state.reference) || !state.reference.current) {
-				const currentBranch = await state.repos[0].getBranch();
+				const currentBranch = await state.repos[0].git.getBranch();
 				if (currentBranch?.name !== state.reference.name) {
 					return state.repos[0].fetch({ branch: state.reference, pull: true });
 				}
@@ -167,7 +167,7 @@ export class PullGitCommand extends QuickCommand<State> {
 				);
 			} else {
 				const [repo] = state.repos;
-				const branch = await repo.getBranch(state.reference.name);
+				const branch = await repo.git.getBranch(state.reference.name);
 
 				if (branch?.upstream == null) {
 					step = this.createConfirmStep(
@@ -193,7 +193,7 @@ export class PullGitCommand extends QuickCommand<State> {
 			}
 		} else {
 			const [repo] = state.repos;
-			const [status, lastFetched] = await Promise.all([repo.getStatus(), repo.getLastFetched()]);
+			const [status, lastFetched] = await Promise.all([repo.git.getStatus(), repo.getLastFetched()]);
 
 			let lastFetchedOn = '';
 			if (lastFetched !== 0) {

--- a/src/commands/git/push.ts
+++ b/src/commands/git/push.ts
@@ -197,10 +197,10 @@ export class PushGitCommand extends QuickCommand<State> {
 						{ placeholder: 'Cannot push a remote branch' },
 					);
 				} else {
-					const branch = await repo.getBranch(state.reference.name);
+					const branch = await repo.git.getBranch(state.reference.name);
 
 					if (branch != null && branch?.upstream == null) {
-						for (const remote of await repo.getRemotes()) {
+						for (const remote of await repo.git.getRemotes()) {
 							items.push(
 								createFlagsQuickPickItem<Flags>(
 									state.flags,
@@ -294,7 +294,7 @@ export class PushGitCommand extends QuickCommand<State> {
 					}
 				}
 			} else {
-				const status = await repo.getStatus();
+				const status = await repo.git.getStatus();
 
 				const branch: GitBranchReference = {
 					refType: 'branch',
@@ -317,7 +317,7 @@ export class PushGitCommand extends QuickCommand<State> {
 							pushDetails = '';
 						}
 
-						for (const remote of await repo.getRemotes()) {
+						for (const remote of await repo.git.getRemotes()) {
 							items.push(
 								createFlagsQuickPickItem<Flags>(
 									state.flags,

--- a/src/commands/git/rebase.ts
+++ b/src/commands/git/rebase.ts
@@ -131,7 +131,7 @@ export class RebaseGitCommand extends QuickCommand<State> {
 			}
 
 			if (context.destination == null) {
-				const branch = await state.repo.getBranch();
+				const branch = await state.repo.git.getBranch();
 				if (branch == null) break;
 
 				context.destination = branch;

--- a/src/commands/git/remote.ts
+++ b/src/commands/git/remote.ts
@@ -288,7 +288,7 @@ export class RemoteGitCommand extends QuickCommand<State> {
 			state.flags = ['-f'];
 		}
 
-		let alreadyExists = (await state.repo.getRemotes({ filter: r => r.name === state.name })).length !== 0;
+		let alreadyExists = (await state.repo.git.getRemotes({ filter: r => r.name === state.name })).length !== 0;
 
 		while (this.canStepsContinue(state)) {
 			if (state.counter < 3 || state.name == null || alreadyExists) {
@@ -298,7 +298,7 @@ export class RemoteGitCommand extends QuickCommand<State> {
 				});
 				if (result === StepResultBreak) continue;
 
-				alreadyExists = (await state.repo.getRemotes({ filter: r => r.name === result })).length !== 0;
+				alreadyExists = (await state.repo.git.getRemotes({ filter: r => r.name === result })).length !== 0;
 				if (alreadyExists) {
 					state.counter--;
 					continue;
@@ -360,7 +360,7 @@ export class RemoteGitCommand extends QuickCommand<State> {
 		while (this.canStepsContinue(state)) {
 			if (state.remote != null) {
 				if (typeof state.remote === 'string') {
-					const [remote] = await state.repo.getRemotes({ filter: r => r.name === state.remote });
+					const [remote] = await state.repo.git.getRemotes({ filter: r => r.name === state.remote });
 					if (remote != null) {
 						state.remote = remote;
 					} else {
@@ -386,7 +386,7 @@ export class RemoteGitCommand extends QuickCommand<State> {
 
 			endSteps(state);
 			try {
-				await state.repo.removeRemote(state.remote.name);
+				await state.repo.git.removeRemote(state.remote.name);
 			} catch (ex) {
 				Logger.error(ex);
 				void showGenericErrorMessage('Unable to remove remote');
@@ -416,7 +416,7 @@ export class RemoteGitCommand extends QuickCommand<State> {
 		while (this.canStepsContinue(state)) {
 			if (state.remote != null) {
 				if (typeof state.remote === 'string') {
-					const [remote] = await state.repo.getRemotes({ filter: r => r.name === state.remote });
+					const [remote] = await state.repo.git.getRemotes({ filter: r => r.name === state.remote });
 					if (remote != null) {
 						state.remote = remote;
 					} else {
@@ -441,7 +441,7 @@ export class RemoteGitCommand extends QuickCommand<State> {
 			if (result === StepResultBreak) continue;
 
 			endSteps(state);
-			void state.repo.pruneRemote(state.remote.name);
+			void state.repo.git.pruneRemote(state.remote.name);
 		}
 	}
 

--- a/src/commands/git/reset.ts
+++ b/src/commands/git/reset.ts
@@ -110,7 +110,7 @@ export class ResetGitCommand extends QuickCommand<State> {
 			}
 
 			if (context.destination == null) {
-				const branch = await state.repo.getBranch();
+				const branch = await state.repo.git.getBranch();
 				if (branch == null) break;
 
 				context.destination = branch;

--- a/src/commands/git/revert.ts
+++ b/src/commands/git/revert.ts
@@ -116,7 +116,7 @@ export class RevertGitCommand extends QuickCommand<State> {
 			}
 
 			if (context.destination == null) {
-				const branch = await state.repo.getBranch();
+				const branch = await state.repo.git.getBranch();
 				if (branch == null) break;
 
 				context.destination = branch;

--- a/src/commands/git/search.ts
+++ b/src/commands/git/search.ts
@@ -208,7 +208,7 @@ export class SearchGitCommand extends QuickCommand<State> {
 			const searchKey = getSearchQueryComparisonKey(search);
 
 			if (context.resultsPromise == null || context.resultsKey !== searchKey) {
-				context.resultsPromise = state.repo.richSearchCommits(search);
+				context.resultsPromise = state.repo.git.richSearchCommits(search);
 				context.resultsKey = searchKey;
 			}
 

--- a/src/commands/git/status.ts
+++ b/src/commands/git/status.ts
@@ -82,7 +82,7 @@ export class StatusGitCommand extends QuickCommand<State> {
 				}
 			}
 
-			context.status = (await state.repo.getStatus())!;
+			context.status = (await state.repo.git.getStatus())!;
 			if (context.status == null) return;
 
 			context.title = `${this.title}${pad(GlyphChars.Dot, 2, 2)}${getReferenceLabel(

--- a/src/commands/git/tag.ts
+++ b/src/commands/git/tag.ts
@@ -243,7 +243,7 @@ export class TagGitCommand extends QuickCommand<State> {
 				const result = yield* pickBranchOrTagStep(state, context, {
 					placeholder: context =>
 						`Choose a branch${context.showTags ? ' or tag' : ''} to create the new tag from`,
-					picked: state.reference?.ref ?? (await state.repo.getBranch())?.ref,
+					picked: state.reference?.ref ?? (await state.repo.git.getBranch())?.ref,
 					titleContext: ' from',
 					value: isRevisionReference(state.reference) ? state.reference.ref : undefined,
 				});

--- a/src/commands/git/worktree.ts
+++ b/src/commands/git/worktree.ts
@@ -380,7 +380,7 @@ export class WorktreeGitCommand extends QuickCommand<State> {
 
 	private async *createCommandSteps(state: CreateStepState, context: Context): AsyncStepResultGenerator<void> {
 		if (context.defaultUri == null) {
-			context.defaultUri = await state.repo.getWorktreesDefaultUri();
+			context.defaultUri = await state.repo.git.getWorktreesDefaultUri();
 		}
 
 		if (state.flags == null) {
@@ -399,7 +399,7 @@ export class WorktreeGitCommand extends QuickCommand<State> {
 				const result = yield* pickBranchOrTagStep(state, context, {
 					placeholder: context =>
 						`Choose a branch${context.showTags ? ' or tag' : ''} to create the new worktree for`,
-					picked: state.reference?.ref ?? (await state.repo.getBranch())?.ref,
+					picked: state.reference?.ref ?? (await state.repo.git.getBranch())?.ref,
 					titleContext: ' for',
 					value: isRevisionReference(state.reference) ? state.reference.ref : undefined,
 				});
@@ -425,7 +425,7 @@ export class WorktreeGitCommand extends QuickCommand<State> {
 
 			if (isRemoteBranch) {
 				state.createBranch = getNameWithoutRemote(state.reference);
-				const branch = await state.repo.getBranch(state.createBranch);
+				const branch = await state.repo.git.getBranch(state.createBranch);
 				if (branch != null && !branch.remote) {
 					state.createBranch = branch.name;
 				}
@@ -436,7 +436,7 @@ export class WorktreeGitCommand extends QuickCommand<State> {
 				if (state.createBranch != null) {
 					let valid = await this.container.git.validateBranchOrTagName(state.repo.path, state.createBranch);
 					if (valid) {
-						const alreadyExists = await state.repo.getBranch(state.createBranch);
+						const alreadyExists = await state.repo.git.getBranch(state.createBranch);
 						valid = alreadyExists == null;
 					}
 
@@ -830,7 +830,7 @@ export class WorktreeGitCommand extends QuickCommand<State> {
 	}
 
 	private async *deleteCommandSteps(state: DeleteStepState, context: Context): StepGenerator {
-		context.worktrees = await state.repo.getWorktrees();
+		context.worktrees = await state.repo.git.getWorktrees();
 
 		if (state.flags == null) {
 			state.flags = [];
@@ -895,7 +895,7 @@ export class WorktreeGitCommand extends QuickCommand<State> {
 							}
 						}
 
-						await state.repo.deleteWorktree(uri, { force: force });
+						await state.repo.git.deleteWorktree(uri, { force: force });
 						if (deleteBranches && worktree?.branch) {
 							branchesToDelete.push(getReferenceFromBranch(worktree?.branch));
 						}
@@ -1012,7 +1012,7 @@ export class WorktreeGitCommand extends QuickCommand<State> {
 		while (this.canStepsContinue(state)) {
 			if (state.counter < 3 || state.worktree == null) {
 				context.title = getTitle(state.subcommand);
-				context.worktrees ??= await state.repo.getWorktrees();
+				context.worktrees ??= await state.repo.git.getWorktrees();
 
 				const result = yield* pickWorktreeStep(state, context, {
 					excludeOpened: true,
@@ -1114,7 +1114,7 @@ export class WorktreeGitCommand extends QuickCommand<State> {
 			context.title = state?.overrides?.title ?? getTitle(state.subcommand);
 
 			if (state.counter < 3 || state.worktree == null) {
-				context.worktrees ??= await state.repo.getWorktrees();
+				context.worktrees ??= await state.repo.git.getWorktrees();
 
 				let placeholder;
 				switch (state.changes.type) {

--- a/src/commands/openAssociatedPullRequestOnRemote.ts
+++ b/src/commands/openAssociatedPullRequestOnRemote.ts
@@ -40,7 +40,7 @@ export class OpenAssociatedPullRequestOnRemoteCommand extends ActiveEditorComman
 				});
 				if (repo == null) return;
 
-				const branch = await repo?.getBranch();
+				const branch = await repo?.git.getBranch();
 				const pr = await branch?.getAssociatedPullRequest({ expiryOverride: true });
 
 				args =

--- a/src/commands/openChangedFiles.ts
+++ b/src/commands/openChangedFiles.ts
@@ -28,7 +28,7 @@ export class OpenChangedFilesCommand extends Command {
 				const repository = await getRepositoryOrShowPicker('Open All Changed Files');
 				if (repository == null) return;
 
-				const status = await this.container.git.getStatusForRepo(repository.uri);
+				const status = await this.container.git.getStatus(repository.uri);
 				if (status == null) {
 					void window.showWarningMessage('Unable to open changed files');
 

--- a/src/commands/openCurrentBranchOnRemote.ts
+++ b/src/commands/openCurrentBranchOnRemote.ts
@@ -25,7 +25,7 @@ export class OpenCurrentBranchOnRemoteCommand extends ActiveEditorCommand {
 		if (repository == null) return;
 
 		try {
-			const branch = await repository.getBranch();
+			const branch = await repository.git.getBranch();
 			if (branch?.name) {
 				void (await executeCommand<OpenOnRemoteCommandArgs>(Commands.OpenOnRemote, {
 					resource: {

--- a/src/commands/openFileAtRevision.ts
+++ b/src/commands/openFileAtRevision.ts
@@ -142,7 +142,7 @@ export class OpenFileAtRevisionCommand extends ActiveEditorCommand {
 									getState: async () => {
 										const items: (CommandQuickPickItem | DirectiveQuickPickItem)[] = [];
 
-										const status = await this.container.git.getStatusForRepo(gitUri.repoPath);
+										const status = await this.container.git.getStatus(gitUri.repoPath);
 										if (status != null) {
 											for (const f of status.files) {
 												if (f.workingTreeStatus === '?' || f.workingTreeStatus === '!') {

--- a/src/commands/openOnlyChangedFiles.ts
+++ b/src/commands/openOnlyChangedFiles.ts
@@ -29,7 +29,7 @@ export class OpenOnlyChangedFilesCommand extends Command {
 				const repository = await getRepositoryOrShowPicker('Open Changed & Close Unchanged Files');
 				if (repository == null) return;
 
-				const status = await this.container.git.getStatusForRepo(repository.uri);
+				const status = await this.container.git.getStatus(repository.uri);
 				if (status == null) {
 					void window.showWarningMessage('Unable to open changed & close unchanged files');
 

--- a/src/commands/remoteProviders.ts
+++ b/src/commands/remoteProviders.ts
@@ -54,7 +54,7 @@ export class ConnectRemoteProviderCommand extends Command {
 			const repos = new Map<Repository, GitRemote<RemoteProvider>>();
 
 			for (const repo of this.container.git.openRepositories) {
-				const remote = await repo.getBestRemoteWithIntegration({ includeDisconnected: true });
+				const remote = await repo.git.getBestRemoteWithIntegration({ includeDisconnected: true });
 				if (remote?.provider != null) {
 					repos.set(repo, remote);
 				}
@@ -149,7 +149,7 @@ export class DisconnectRemoteProviderCommand extends Command {
 			const repos = new Map<Repository, GitRemote<RemoteProvider>>();
 
 			for (const repo of this.container.git.openRepositories) {
-				const remote = await repo.getBestRemoteWithIntegration({ includeDisconnected: false });
+				const remote = await repo.git.getBestRemoteWithIntegration({ includeDisconnected: false });
 				if (remote != null) {
 					repos.set(repo, remote);
 				}

--- a/src/commands/stashSave.ts
+++ b/src/commands/stashSave.ts
@@ -78,7 +78,7 @@ export class StashSaveCommand extends Command {
 			const repo = await this.container.git.getOrOpenRepository(uris[0]);
 
 			args.repoPath = repo?.path;
-			args.onlyStaged = repo != null && hasOnlyStaged ? await repo.supports(Features.StashOnlyStaged) : false;
+			args.onlyStaged = repo != null && hasOnlyStaged ? await repo.git.supports(Features.StashOnlyStaged) : false;
 			if (args.keepStaged == null && !hasStaged) {
 				args.keepStaged = true;
 			}
@@ -117,7 +117,7 @@ export class StashSaveCommand extends Command {
 			const repo = await this.container.git.getOrOpenRepository(uris[0]);
 
 			args.repoPath = repo?.path;
-			args.onlyStaged = repo != null && hasOnlyStaged ? await repo.supports(Features.StashOnlyStaged) : false;
+			args.onlyStaged = repo != null && hasOnlyStaged ? await repo.git.supports(Features.StashOnlyStaged) : false;
 			if (args.keepStaged == null && !hasStaged) {
 				args.keepStaged = true;
 			}

--- a/src/git/actions/commit.ts
+++ b/src/git/actions/commit.ts
@@ -884,7 +884,7 @@ export async function undoCommit(container: Container, commit: GitRevisionRefere
 		return;
 	}
 
-	const status = await container.git.getStatusForRepo(commit.repoPath);
+	const status = await container.git.getStatus(commit.repoPath);
 	if (status?.files.length) {
 		const confirm = { title: 'Undo Commit' };
 		const cancel = { title: 'Cancel', isCloseAffordance: true };

--- a/src/git/models/branch.ts
+++ b/src/git/models/branch.ts
@@ -267,9 +267,7 @@ export async function getTargetBranchName(
 	if (options?.cancellation?.isCancellationRequested) return { value: undefined, paused: false };
 
 	if (targetBase != null) {
-		const [targetBranch] = (
-			await container.git.getBranches(branch.repoPath, { filter: b => b.name === targetBase })
-		).values;
+		const targetBranch = await container.git.getBranch(branch.repoPath, targetBase);
 		if (targetBranch != null) return { value: targetBranch.name, paused: false };
 	}
 
@@ -385,7 +383,7 @@ export async function getLocalBranchByUpstream(
 		qualifiedRemoteBranchName = `remotes/${remoteBranchName}`;
 	}
 
-	branches ??= new PageableResult<GitBranch>(p => repo.getBranches(p != null ? { paging: p } : undefined));
+	branches ??= new PageableResult<GitBranch>(p => repo.git.getBranches(p != null ? { paging: p } : undefined));
 	for await (const branch of branches.values()) {
 		if (
 			!branch.remote &&

--- a/src/git/models/commit.ts
+++ b/src/git/models/commit.ts
@@ -209,7 +209,7 @@ export class GitCommit implements GitRevisionReference {
 			this._etagFileSystem = repository?.etagFileSystem;
 
 			if (this._etagFileSystem != null) {
-				const status = await this.container.git.getStatusForRepo(this.repoPath);
+				const status = await this.container.git.getStatus(this.repoPath);
 				if (status != null) {
 					this._files = status.files.flatMap(f => f.getPseudoFileChanges());
 				}

--- a/src/git/models/pullRequest.ts
+++ b/src/git/models/pullRequest.ts
@@ -377,7 +377,7 @@ export async function ensurePullRequestRemote(
 	const prRemoteUrl = identity.remote.url.replace(/\.git$/, '');
 
 	let found = false;
-	for (const remote of await repo.getRemotes()) {
+	for (const remote of await repo.git.getRemotes()) {
 		if (remote.matches(prRemoteUrl)) {
 			found = true;
 			break;

--- a/src/git/models/repository.ts
+++ b/src/git/models/repository.ts
@@ -1,19 +1,18 @@
 import { md5, uuid } from '@env/crypto';
-import type { CancellationToken, ConfigurationChangeEvent, Event, Uri, WorkspaceFolder } from 'vscode';
+import type { ConfigurationChangeEvent, Event, Uri, WorkspaceFolder } from 'vscode';
 import { Disposable, EventEmitter, ProgressLocation, RelativePattern, window, workspace } from 'vscode';
 import type { CreatePullRequestActionContext } from '../../api/gitlens';
 import type { RepositoriesSorting } from '../../config';
 import { Schemes } from '../../constants';
-import type { SearchQuery } from '../../constants.search';
 import type { Container } from '../../container';
-import type { FeatureAccess, Features, PlusFeatures } from '../../features';
+import type { FeatureAccess, PlusFeatures } from '../../features';
 import { showCreatePullRequestPrompt, showGenericErrorMessage } from '../../messages';
-import type { HostingIntegration } from '../../plus/integrations/integration';
 import type { RepoComparisonKey } from '../../repositories';
 import { asRepoComparisonKey } from '../../repositories';
 import { formatDate, fromNow } from '../../system/date';
 import { gate } from '../../system/decorators/gate';
 import { debug, log, logName } from '../../system/decorators/log';
+import { memoize } from '../../system/decorators/memoize';
 import type { Deferrable } from '../../system/function';
 import { debounce } from '../../system/function';
 import { filter, groupByMap, join, map, min, some } from '../../system/iterable';
@@ -24,30 +23,33 @@ import { basename, normalizePath } from '../../system/path';
 import { sortCompare } from '../../system/string';
 import { executeActionCommand } from '../../system/vscode/command';
 import { configuration } from '../../system/vscode/configuration';
-import type { GitDir, GitProviderDescriptor, GitRepositoryCaches, PagingOptions } from '../gitProvider';
-import type { RemoteProvider } from '../remotes/remoteProvider';
-import type { GitSearch } from '../search';
-import type { BranchSortOptions, GitBranch } from './branch';
+import type { GitProviderDescriptor, GitProviderRepository } from '../gitProvider';
+import type { GitProviderService } from '../gitProviderService';
+import type { GitBranch } from './branch';
 import { getBranchNameWithoutRemote, getRemoteNameFromBranchName } from './branch';
-import type { GitCommit } from './commit';
-import type { GitContributor } from './contributor';
-import type { GitDiffShortStat } from './diff';
-import type { GitLog } from './log';
-import type { GitMergeStatus } from './merge';
-import type { GitRebaseStatus } from './rebase';
 import type { GitBranchReference, GitReference, GitTagReference } from './reference';
 import { getNameWithoutRemote, isBranchReference } from './reference';
 import type { GitRemote } from './remote';
-import type { GitStash } from './stash';
-import type { GitStatus } from './status';
-import type { GitTag, TagSortOptions } from './tag';
 import type { GitWorktree } from './worktree';
+
+type RemoveFirstArg<F> = F extends (first: any, ...args: infer P) => infer R ? (...args: P) => R : never;
+
+export type RepoGitProviderService = Pick<
+	{
+		[K in keyof GitProviderService]: RemoveFirstArg<GitProviderService[K]>;
+	},
+	| keyof GitProviderRepository
+	| 'getBestRemoteWithIntegration'
+	| 'getBranch'
+	| 'getRemote'
+	| 'getTag'
+	| 'getWorktree'
+	| 'supports'
+>;
 
 export interface RepositoriesSortOptions {
 	orderBy?: RepositoriesSorting;
 }
-
-const emptyArray = Object.freeze([]) as unknown as any[];
 
 const millisecondsPerMinute = 60 * 1000;
 const millisecondsPerHour = 60 * 60 * 1000;
@@ -221,7 +223,6 @@ export class Repository implements Disposable {
 	}
 
 	get formattedName(): string {
-		// return this.isMaybeWorktree() === true ? `${this.name} (worktree)` : this.name;
 		return this.name;
 	}
 
@@ -241,7 +242,6 @@ export class Repository implements Disposable {
 		return this._idHash;
 	}
 
-	private _branch: Promise<GitBranch | undefined> | undefined;
 	private readonly _disposable: Disposable;
 	private _fireChangeDebounced: Deferrable<() => void> | undefined = undefined;
 	private _fireFileSystemChangeDebounced: Deferrable<() => void> | undefined = undefined;
@@ -278,7 +278,7 @@ export class Repository implements Disposable {
 		}
 
 		// Update the name if it is a worktree
-		void this.getGitDir().then(gd => {
+		void this.git.getGitDir().then(gd => {
 			if (gd?.commonUri == null) return;
 
 			let path = gd.commonUri.path;
@@ -342,8 +342,6 @@ export class Repository implements Disposable {
 		disposables.push(
 			this.container.events.on('git:cache:reset', e => {
 				if (!e.data.repoPath || e.data.repoPath === this.path) {
-					this.resetCaches(...(e.data.caches ?? emptyArray));
-
 					if (e.data.caches?.includes('providers')) {
 						this.fireChange(RepositoryChange.RemoteProviders);
 					}
@@ -373,7 +371,7 @@ export class Repository implements Disposable {
 			return watcher;
 		}
 
-		const gitDir = await this.getGitDir();
+		const gitDir = await this.git.getGitDir();
 		if (gitDir != null) {
 			if (gitDir?.commonUri == null) {
 				watch.call(this, gitDir.uri, dotGitWatcherGlobCombined);
@@ -396,16 +394,40 @@ export class Repository implements Disposable {
 		return getLoggableName(this);
 	}
 
-	get virtual(): boolean {
-		return this.provider.virtual;
+	private _closed: boolean = false;
+	get closed(): boolean {
+		return this._closed;
 	}
-
-	get path(): string {
-		return this.uri.scheme === Schemes.File ? normalizePath(this.uri.fsPath) : this.uri.toString();
+	set closed(value: boolean) {
+		const changed = this._closed !== value;
+		this._closed = value;
+		if (changed) {
+			Logger.debug(`Repository(${this.id}).closed(${value})`);
+			this.fireChange(this._closed ? RepositoryChange.Closed : RepositoryChange.Opened);
+		}
 	}
 
 	get etag(): number {
 		return this._updatedAt;
+	}
+
+	@memoize()
+	get git(): RepoGitProviderService {
+		const uri = this.uri;
+		return new Proxy(this.container.git, {
+			get: (target, prop: keyof GitProviderService): any => {
+				const value = target[prop];
+				if (typeof value === 'function') {
+					// eslint-disable-next-line @typescript-eslint/no-unsafe-return, @typescript-eslint/no-unsafe-function-type
+					return (...args: any[]) => (value as Function).call(target, uri, ...args);
+				}
+				return value;
+			},
+		}) as unknown as RepoGitProviderService;
+	}
+
+	get path(): string {
+		return this.uri.scheme === Schemes.File ? normalizePath(this.uri.fsPath) : this.uri.toString();
 	}
 
 	private _orderByLastFetched = false;
@@ -418,13 +440,16 @@ export class Repository implements Disposable {
 		return this._updatedAt;
 	}
 
+	get virtual(): boolean {
+		return this.provider.virtual;
+	}
+
 	private onConfigurationChanged(e?: ConfigurationChangeEvent) {
 		if (configuration.changed(e, 'sortRepositoriesBy')) {
 			this._orderByLastFetched = configuration.get('sortRepositoriesBy')?.startsWith('lastFetched:') ?? false;
 		}
 
 		if (e != null && configuration.changed(e, 'remotes', this.folder?.uri)) {
-			this.resetCaches('remotes');
 			this.fireChange(RepositoryChange.Remotes);
 		}
 	}
@@ -465,7 +490,6 @@ export class Repository implements Disposable {
 		if (match != null) {
 			switch (match[1]) {
 				case 'config':
-					this.resetCaches();
 					this.fireChange(RepositoryChange.Config, RepositoryChange.Remotes);
 					return;
 
@@ -478,12 +502,10 @@ export class Repository implements Disposable {
 					return;
 
 				case 'HEAD':
-					this.resetCaches('branches');
 					this.fireChange(RepositoryChange.Head, RepositoryChange.Heads);
 					return;
 
 				case 'ORIG_HEAD':
-					this.resetCaches('branches');
 					this.fireChange(RepositoryChange.Heads);
 					return;
 
@@ -501,12 +523,10 @@ export class Repository implements Disposable {
 					return;
 
 				case 'refs/heads':
-					this.resetCaches('branches');
 					this.fireChange(RepositoryChange.Heads);
 					return;
 
 				case 'refs/remotes':
-					this.resetCaches();
 					this.fireChange(RepositoryChange.Remotes);
 					return;
 
@@ -527,44 +547,17 @@ export class Repository implements Disposable {
 		this.fireChange(RepositoryChange.Unknown);
 	}
 
-	private _closed: boolean = false;
-	get closed(): boolean {
-		return this._closed;
-	}
-	set closed(value: boolean) {
-		const changed = this._closed !== value;
-		this._closed = value;
-		if (changed) {
-			Logger.debug(`Repository(${this.id}).closed(${value})`);
-			this.fireChange(this._closed ? RepositoryChange.Closed : RepositoryChange.Opened);
-		}
-	}
-
 	@log()
 	access(feature?: PlusFeatures): Promise<FeatureAccess> {
 		return this.container.git.access(feature, this.uri);
 	}
 
-	@log()
-	supports(feature: Features): Promise<boolean> {
-		return this.container.git.supports(this.uri, feature);
-	}
-
+	// TODO: Can we remove this -- since no callers use the return value (though maybe they need that await?)
 	@log()
 	async addRemote(name: string, url: string, options?: { fetch?: boolean }): Promise<GitRemote | undefined> {
-		await this.container.git.addRemote(this.uri, name, url, options);
-		const [remote] = await this.getRemotes({ filter: r => r.url === url });
+		await this.git.addRemote(name, url, options);
+		const [remote] = await this.git.getRemotes({ filter: r => r.url === url });
 		return remote;
-	}
-
-	@log()
-	pruneRemote(name: string): Promise<void> {
-		return this.container.git.pruneRemote(this.uri, name);
-	}
-
-	@log()
-	removeRemote(name: string): Promise<void> {
-		return this.container.git.removeRemote(this.uri, name);
 	}
 
 	@log()
@@ -657,7 +650,7 @@ export class Repository implements Disposable {
 		remote?: string;
 	}) {
 		try {
-			await this.container.git.fetch(this.uri, options);
+			await this.git.fetch(options);
 
 			this.fireChange(RepositoryChange.Unknown);
 		} catch (ex) {
@@ -666,47 +659,10 @@ export class Repository implements Disposable {
 		}
 	}
 
-	async getBestRemoteWithIntegration(options?: {
-		filter?: (remote: GitRemote, integration: HostingIntegration) => boolean;
-		includeDisconnected?: boolean;
-	}): Promise<GitRemote<RemoteProvider> | undefined> {
-		return this.container.git.getBestRemoteWithIntegration(this.uri, options);
-	}
-
-	async getBranch(name?: string): Promise<GitBranch | undefined> {
-		if (name) {
-			const {
-				values: [branch],
-			} = await this.getBranches({ filter: b => b.name === name });
-			return branch;
-		}
-
-		if (this._branch == null) {
-			this._branch = this.container.git.getBranch(this.uri);
-		}
-		return this._branch;
-	}
-
-	getBranches(options?: {
-		filter?: (b: GitBranch) => boolean;
-		paging?: PagingOptions;
-		sort?: boolean | BranchSortOptions;
-	}) {
-		return this.container.git.getBranches(this.uri, options);
-	}
-
-	getChangedFilesCount(ref?: string): Promise<GitDiffShortStat | undefined> {
-		return this.container.git.getChangedFilesCount(this.uri, ref);
-	}
-
-	getCommit(ref: string): Promise<GitCommit | undefined> {
-		return this.container.git.getCommit(this.uri, ref);
-	}
-
 	@gate()
 	@log({ exit: true })
 	async getCommonRepository(): Promise<Repository | undefined> {
-		const gitDir = await this.getGitDir();
+		const gitDir = await this.git.getGitDir();
 		if (gitDir?.commonUri == null) return this;
 
 		// If the repository isn't already opened, then open it as a "closed" repo (won't show up in the UI)
@@ -719,7 +675,7 @@ export class Repository implements Disposable {
 
 	@log({ exit: true })
 	async getCommonRepositoryUri(): Promise<Uri | undefined> {
-		const gitDir = await this.getGitDir();
+		const gitDir = await this.git.getGitDir();
 		if (gitDir?.commonUri?.path.endsWith('/.git')) {
 			return gitDir.commonUri.with({
 				path: gitDir.commonUri.path.substring(0, gitDir.commonUri.path.length - 5),
@@ -729,28 +685,10 @@ export class Repository implements Disposable {
 		return gitDir?.commonUri;
 	}
 
-	getContributors(options?: {
-		all?: boolean;
-		merges?: boolean | 'first-parent';
-		ref?: string;
-		stats?: boolean;
-	}): Promise<GitContributor[]> {
-		return this.container.git.getContributors(this.uri, options);
-	}
-
-	private _gitDir: GitDir | undefined;
-	private _gitDirPromise: Promise<GitDir | undefined> | undefined;
-	private getGitDir(): Promise<GitDir | undefined> {
-		if (this._gitDirPromise == null) {
-			this._gitDirPromise = this.container.git.getGitDir(this.uri).then(gd => (this._gitDir = gd));
-		}
-		return this._gitDirPromise;
-	}
-
 	private _lastFetched: number | undefined;
 	@gate()
 	async getLastFetched(): Promise<number> {
-		const lastFetched = await this.container.git.getLastFetchedTimestamp(this.uri);
+		const lastFetched = await this.git.getLastFetchedTimestamp();
 		// If we don't get a number, assume the fetch failed, and don't update the timestamp
 		if (lastFetched != null) {
 			this._lastFetched = lastFetched;
@@ -759,93 +697,15 @@ export class Repository implements Disposable {
 		return this._lastFetched ?? 0;
 	}
 
-	getMergeStatus(): Promise<GitMergeStatus | undefined> {
-		return this.container.git.getMergeStatus(this.uri);
-	}
-
-	getRebaseStatus(): Promise<GitRebaseStatus | undefined> {
-		return this.container.git.getRebaseStatus(this.uri);
-	}
-
-	async getRemote(remote: string): Promise<GitRemote | undefined> {
-		return (await this.getRemotes()).find(r => r.name === remote);
-	}
-
-	async getRemotes(options?: { filter?: (remote: GitRemote) => boolean; sort?: boolean }): Promise<GitRemote[]> {
-		const remotes = await this.container.git.getRemotes(
-			this.uri,
-			options?.sort != null ? { sort: options.sort } : undefined,
-		);
-		return options?.filter != null ? remotes.filter(options.filter) : remotes;
-	}
-
-	getStash(): Promise<GitStash | undefined> {
-		return this.container.git.getStash(this.uri);
-	}
-
-	getStatus(): Promise<GitStatus | undefined> {
-		return this.container.git.getStatusForRepo(this.uri);
-	}
-
-	async getTag(name: string): Promise<GitTag | undefined> {
-		const {
-			values: [tag],
-		} = await this.getTags({ filter: b => b.name === name });
-		return tag;
-	}
-
-	getTags(options?: { filter?: (t: GitTag) => boolean; paging?: PagingOptions; sort?: boolean | TagSortOptions }) {
-		return this.container.git.getTags(this.uri, options);
-	}
-
+	// TODO: Move to GitProviderService?
 	@log()
 	async createWorktree(
 		uri: Uri,
 		options?: { commitish?: string; createBranch?: string; detach?: boolean; force?: boolean },
 	): Promise<GitWorktree | undefined> {
-		await this.container.git.createWorktree(this.uri, uri.fsPath, options);
+		await this.git.createWorktree(uri.fsPath, options);
 		const url = uri.toString();
-		return this.container.git.getWorktree(this.uri, w => w.uri.toString() === url);
-	}
-
-	getWorktrees(): Promise<GitWorktree[]> {
-		return this.container.git.getWorktrees(this.uri);
-	}
-
-	async getWorktreesDefaultUri(): Promise<Uri | undefined> {
-		return this.container.git.getWorktreesDefaultUri(this.uri);
-	}
-
-	deleteWorktree(uri: Uri, options?: { force?: boolean }): Promise<void> {
-		return this.container.git.deleteWorktree(this.uri, uri.fsPath, options);
-	}
-
-	async hasRemotes(): Promise<boolean> {
-		const remotes = await this.getRemotes();
-		return remotes?.length > 0;
-	}
-
-	async hasRemoteWithIntegration(options?: {
-		filter?: (remote: GitRemote, integration: HostingIntegration) => boolean;
-		includeDisconnected?: boolean;
-	}): Promise<boolean> {
-		const remote = await this.getBestRemoteWithIntegration(options);
-		return remote?.provider != null;
-	}
-
-	async hasUpstreamBranch(): Promise<boolean> {
-		const branch = await this.getBranch();
-		return branch?.upstream != null;
-	}
-
-	isMaybeWorktree(): boolean | undefined {
-		if (this._gitDir == null) return undefined;
-
-		return this._gitDir.commonUri != null;
-	}
-
-	async isWorktree(): Promise<boolean> {
-		return (await this.getGitDir())?.commonUri != null;
+		return this.git.getWorktree(w => w.uri.toString() === url);
 	}
 
 	@log()
@@ -872,10 +732,10 @@ export class Repository implements Disposable {
 		try {
 			const withTags = configuration.getCore('git.pullTags', this.uri);
 			if (configuration.getCore('git.fetchOnPull', this.uri)) {
-				await this.container.git.fetch(this.uri);
+				await this.git.fetch();
 			}
 
-			await this.container.git.pull(this.uri, { ...options, tags: withTags });
+			await this.git.pull({ ...options, tags: withTags });
 
 			this.fireChange(RepositoryChange.Unknown);
 		} catch (ex) {
@@ -888,7 +748,7 @@ export class Repository implements Disposable {
 		if (!this.container.actionRunners.count('createPullRequest')) return;
 		if (!(await showCreatePullRequestPrompt(branch.name))) return;
 
-		const remote = await this.getRemote(remoteName);
+		const remote = await this.git.getRemote(remoteName);
 
 		void executeActionCommand<CreatePullRequestActionContext>('createPullRequest', {
 			repoPath: this.path,
@@ -939,7 +799,7 @@ export class Repository implements Disposable {
 
 	private async pushCore(options?: { force?: boolean; reference?: GitReference; publish?: { remote: string } }) {
 		try {
-			await this.container.git.push(this.uri, {
+			await this.git.push({
 				reference: options?.reference,
 				force: options?.force,
 				publish: options?.publish,
@@ -969,19 +829,6 @@ export class Repository implements Disposable {
 		void this.runTerminalCommand('reset', ...args);
 	}
 
-	@log({ singleLine: true })
-	private resetCaches(...caches: GitRepositoryCaches[]) {
-		if (caches.length === 0 || caches.includes('branches')) {
-			this._branch = undefined;
-		}
-
-		// if (caches.length === 0 || caches.includes('remotes')) {
-		// 	this._remotes = undefined;
-		// 	this._remotesDisposable?.dispose();
-		// 	this._remotesDisposable = undefined;
-		// }
-	}
-
 	resume() {
 		if (!this._suspended) return;
 
@@ -1003,22 +850,6 @@ export class Repository implements Disposable {
 		void this.runTerminalCommand('revert', ...args);
 	}
 
-	@debug()
-	richSearchCommits(
-		search: SearchQuery,
-		options?: { limit?: number; ordering?: 'date' | 'author-date' | 'topo'; skip?: number },
-	): Promise<GitLog | undefined> {
-		return this.container.git.richSearchCommits(this.uri, search, options);
-	}
-
-	@debug()
-	searchCommits(
-		search: SearchQuery,
-		options?: { cancellation?: CancellationToken; limit?: number; ordering?: 'date' | 'author-date' | 'topo' },
-	): Promise<GitSearch> {
-		return this.container.git.searchCommits(this.uri, search, options);
-	}
-
 	async setRemoteAsDefault(remote: GitRemote, value: boolean = true) {
 		await this.container.storage.storeWorkspace('remote:default', value ? remote.name : undefined);
 
@@ -1037,7 +868,7 @@ export class Repository implements Disposable {
 	@gate()
 	@log()
 	async stashApply(stashName: string, options?: { deleteAfter?: boolean }) {
-		await this.container.git.stashApply(this.uri, stashName, options);
+		await this.git.stashApply(stashName, options);
 
 		this.fireChange(RepositoryChange.Stash);
 	}
@@ -1045,7 +876,7 @@ export class Repository implements Disposable {
 	@gate()
 	@log()
 	async stashDelete(stashName: string, ref?: string) {
-		await this.container.git.stashDelete(this.uri, stashName, ref);
+		await this.git.stashDelete(stashName, ref);
 
 		this.fireChange(RepositoryChange.Stash);
 	}
@@ -1053,7 +884,7 @@ export class Repository implements Disposable {
 	@gate()
 	@log()
 	async stashRename(stashName: string, ref: string, message: string, stashOnRef?: string) {
-		await this.container.git.stashRename(this.uri, stashName, ref, message, stashOnRef);
+		await this.git.stashRename(stashName, ref, message, stashOnRef);
 
 		this.fireChange(RepositoryChange.Stash);
 	}
@@ -1065,7 +896,7 @@ export class Repository implements Disposable {
 		uris?: Uri[],
 		options?: { includeUntracked?: boolean; keepIndex?: boolean; onlyStaged?: boolean },
 	): Promise<void> {
-		await this.container.git.stashSave(this.uri, message, uris, options);
+		await this.git.stashSave(message, uris, options);
 
 		this.fireChange(RepositoryChange.Stash);
 	}
@@ -1073,7 +904,7 @@ export class Repository implements Disposable {
 	@gate()
 	@log()
 	async stashSaveSnapshot(message?: string): Promise<void> {
-		await this.container.git.stashSaveSnapshot(this.uri, message);
+		await this.git.stashSaveSnapshot(message);
 
 		this.fireChange(RepositoryChange.Stash);
 	}
@@ -1096,7 +927,7 @@ export class Repository implements Disposable {
 
 	private async switchCore(ref: string, options?: { createBranch?: string }) {
 		try {
-			await this.container.git.checkout(this.uri, ref, options);
+			await this.git.checkout(ref, options);
 
 			this.fireChange(RepositoryChange.Unknown);
 		} catch (ex) {
@@ -1274,7 +1105,7 @@ export class Repository implements Disposable {
 
 		this._pendingFileSystemChange = undefined;
 
-		const uris = await this.container.git.excludeIgnoredUris(this.uri, e.uris);
+		const uris = await this.git.excludeIgnoredUris(e.uris);
 		if (uris.length === 0) return;
 
 		if (uris.length !== e.uris.length) {
@@ -1287,7 +1118,7 @@ export class Repository implements Disposable {
 	}
 
 	private async runTerminalCommand(command: string, ...args: string[]) {
-		await this.container.git.runGitCommandViaTerminal?.(this.uri, command, args, { execute: true });
+		await this.git.runGitCommandViaTerminal?.(command, args, { execute: true });
 
 		setTimeout(() => this.fireChange(RepositoryChange.Unknown), 2500);
 	}

--- a/src/git/models/worktree.ts
+++ b/src/git/models/worktree.ts
@@ -93,7 +93,7 @@ export class GitWorktree {
 			// eslint-disable-next-line no-async-promise-executor
 			this._statusPromise = new Promise(async (resolve, reject) => {
 				try {
-					const status = await Container.instance.git.getStatusForRepo(this.uri.fsPath);
+					const status = await Container.instance.git.getStatus(this.uri.fsPath);
 					this._status = status;
 					resolve(status);
 				} catch (ex) {
@@ -228,13 +228,13 @@ export async function getWorktreeForBranch(
 		upstreamNames = [upstreamNames];
 	}
 
-	worktrees ??= await repo.getWorktrees();
+	worktrees ??= await repo.git.getWorktrees();
 	for (const worktree of worktrees) {
 		if (worktree.branch?.name === branchName) return worktree;
 
 		if (upstreamNames == null || worktree.branch == null) continue;
 
-		branches ??= new PageableResult<GitBranch>(p => repo.getBranches(p != null ? { paging: p } : undefined));
+		branches ??= new PageableResult<GitBranch>(p => repo.git.getBranches(p != null ? { paging: p } : undefined));
 		for await (const branch of branches.values()) {
 			if (branch.name === worktree.branch.name) {
 				if (
@@ -346,7 +346,7 @@ export async function getWorktreesByBranch(
 	if (repos == null) return worktreesByBranch;
 
 	async function addWorktrees(repo: Repository) {
-		groupWorktreesByBranch(await repo.getWorktrees(), {
+		groupWorktreesByBranch(await repo.git.getWorktrees(), {
 			includeDefault: options?.includeDefault,
 			worktreesByBranch: worktreesByBranch,
 		});

--- a/src/git/remotes/bitbucket-server.ts
+++ b/src/git/remotes/bitbucket-server.ts
@@ -123,7 +123,7 @@ export class BitbucketServerRemote extends RemoteProvider {
 		} while (index > 0);
 
 		if (possibleBranches.size !== 0) {
-			const { values: branches } = await repository.getBranches({
+			const { values: branches } = await repository.git.getBranches({
 				filter: b => b.remote && possibleBranches.has(b.getNameWithoutRemote()),
 			});
 			for (const branch of branches) {

--- a/src/git/remotes/bitbucket.ts
+++ b/src/git/remotes/bitbucket.ts
@@ -107,7 +107,7 @@ export class BitbucketRemote extends RemoteProvider {
 		} while (index > 0);
 
 		if (possibleBranches.size !== 0) {
-			const { values: branches } = await repository.getBranches({
+			const { values: branches } = await repository.git.getBranches({
 				filter: b => b.remote && possibleBranches.has(b.getNameWithoutRemote()),
 			});
 			for (const branch of branches) {

--- a/src/git/remotes/gerrit.ts
+++ b/src/git/remotes/gerrit.ts
@@ -124,7 +124,7 @@ export class GerritRemote extends RemoteProvider {
 			} while (index > 0);
 
 			if (possibleBranches.size !== 0) {
-				const { values: branches } = await repository.getBranches({
+				const { values: branches } = await repository.git.getBranches({
 					filter: b => b.remote && possibleBranches.has(b.getNameWithoutRemote()),
 				});
 				for (const branch of branches) {
@@ -154,7 +154,7 @@ export class GerritRemote extends RemoteProvider {
 			} while (index > 0);
 
 			if (possibleTags.size !== 0) {
-				const { values: tags } = await repository.getTags({
+				const { values: tags } = await repository.git.getTags({
 					filter: t => possibleTags.has(t.name),
 				});
 				for (const tag of tags) {

--- a/src/git/remotes/gitea.ts
+++ b/src/git/remotes/gitea.ts
@@ -105,7 +105,7 @@ export class GiteaRemote extends RemoteProvider {
 			} while (index < path.length && index !== -1);
 
 			if (possibleBranches.size !== 0) {
-				const { values: branches } = await repository.getBranches({
+				const { values: branches } = await repository.git.getBranches({
 					filter: b => b.remote && possibleBranches.has(b.getNameWithoutRemote()),
 				});
 				for (const branch of branches) {

--- a/src/git/remotes/github.ts
+++ b/src/git/remotes/github.ts
@@ -234,7 +234,7 @@ export class GitHubRemote extends RemoteProvider<GitHubRepositoryDescriptor> {
 		} while (index > 0);
 
 		if (possibleBranches.size !== 0) {
-			const { values: branches } = await repository.getBranches({
+			const { values: branches } = await repository.git.getBranches({
 				filter: b => b.remote && possibleBranches.has(b.getNameWithoutRemote()),
 			});
 			for (const branch of branches) {

--- a/src/git/remotes/gitlab.ts
+++ b/src/git/remotes/gitlab.ts
@@ -327,7 +327,7 @@ export class GitLabRemote extends RemoteProvider<GitLabRepositoryDescriptor> {
 		} while (index > 0);
 
 		if (possibleBranches.size !== 0) {
-			const { values: branches } = await repository.getBranches({
+			const { values: branches } = await repository.git.getBranches({
 				filter: b => b.remote && possibleBranches.has(b.getNameWithoutRemote()),
 			});
 			for (const branch of branches) {

--- a/src/plus/drafts/draftsService.ts
+++ b/src/plus/drafts/draftsService.ts
@@ -754,7 +754,7 @@ export class DraftService implements Disposable {
 	): Promise<ProviderAuth | undefined> {
 		let integration;
 		if (isRepository(repoOrIntegrationId)) {
-			const remoteProvider = await repoOrIntegrationId.getBestRemoteWithIntegration();
+			const remoteProvider = await repoOrIntegrationId.git.getBestRemoteWithIntegration();
 			if (remoteProvider == null) return undefined;
 
 			integration = await remoteProvider.getIntegration();

--- a/src/plus/launchpad/launchpadProvider.ts
+++ b/src/plus/launchpad/launchpadProvider.ts
@@ -572,7 +572,7 @@ export class LaunchpadProvider implements Disposable {
 		async function matchRemotes(repo: Repository) {
 			if (uniqueRemoteUrls.size === 0) return;
 
-			const remotes = await repo.getRemotes();
+			const remotes = await repo.git.getRemotes();
 
 			for (const remote of remotes) {
 				if (uniqueRemoteUrls.size === 0) return;

--- a/src/plus/repos/repositoryIdentityService.ts
+++ b/src/plus/repos/repositoryIdentityService.ts
@@ -78,7 +78,7 @@ export class RepositoryIdentityService implements Disposable {
 			// As a fallback, try to match using the repo id.
 			for (const repo of this.container.git.repositories) {
 				if (remoteDomain != null && remotePath != null) {
-					const matchingRemotes = await repo.getRemotes({
+					const matchingRemotes = await repo.git.getRemotes({
 						filter: r => r.matches(remoteDomain, remotePath),
 					});
 					if (matchingRemotes.length > 0) {
@@ -145,7 +145,7 @@ export class RepositoryIdentityService implements Disposable {
 	) {
 		const repoPath = repo.uri.fsPath;
 
-		const remotes = await repo.getRemotes();
+		const remotes = await repo.git.getRemotes();
 		for (const remote of remotes) {
 			const remoteUrl = remote.provider?.url({ type: RemoteResourceType.Repo });
 			if (remoteUrl != null) {

--- a/src/plus/webviews/focus/focusWebview.ts
+++ b/src/plus/webviews/focus/focusWebview.ts
@@ -309,7 +309,7 @@ export class FocusWebviewProvider implements WebviewProvider<State> {
 		const [, remoteDomain, remotePath] = parseGitRemoteUrl(remoteUrl);
 
 		let remote: GitRemote | undefined;
-		[remote] = await repo.getRemotes({ filter: r => r.matches(remoteDomain, remotePath) });
+		[remote] = await repo.git.getRemotes({ filter: r => r.matches(remoteDomain, remotePath) });
 		let remoteBranchName;
 		if (remote != null) {
 			remoteBranchName = `${remote.name}/${ref}`;
@@ -330,7 +330,7 @@ export class FocusWebviewProvider implements WebviewProvider<State> {
 				fetch: true,
 				reveal: false,
 			});
-			[remote] = await repo.getRemotes({ filter: r => r.url === remoteUrl });
+			[remote] = await repo.git.getRemotes({ filter: r => r.url === remoteUrl });
 			if (remote == null) return;
 
 			remoteBranchName = `${remote.name}/${ref}`;
@@ -602,7 +602,9 @@ export class FocusWebviewProvider implements WebviewProvider<State> {
 			const repos = [];
 			const disposables = [];
 			for (const repo of this.container.git.openRepositories) {
-				const remoteWithIntegration = await repo.getBestRemoteWithIntegration({ includeDisconnected: true });
+				const remoteWithIntegration = await repo.git.getBestRemoteWithIntegration({
+					includeDisconnected: true,
+				});
 				if (
 					remoteWithIntegration == null ||
 					repos.findIndex(repo => repo.remote === remoteWithIntegration) > -1
@@ -687,14 +689,14 @@ export class FocusWebviewProvider implements WebviewProvider<State> {
 					let branches = branchesByRepo.get(entry.repoAndRemote.repo);
 					if (branches == null) {
 						branches = new PageableResult<GitBranch>(paging =>
-							entry.repoAndRemote.repo.getBranches(paging != null ? { paging: paging } : undefined),
+							entry.repoAndRemote.repo.git.getBranches(paging != null ? { paging: paging } : undefined),
 						);
 						branchesByRepo.set(entry.repoAndRemote.repo, branches);
 					}
 
 					let worktrees = worktreesByRepo.get(entry.repoAndRemote.repo);
 					if (worktrees == null) {
-						worktrees = await entry.repoAndRemote.repo.getWorktrees();
+						worktrees = await entry.repoAndRemote.repo.git.getWorktrees();
 						worktreesByRepo.set(entry.repoAndRemote.repo, worktrees);
 					}
 

--- a/src/plus/webviews/graph/graphWebview.ts
+++ b/src/plus/webviews/graph/graphWebview.ts
@@ -1338,7 +1338,7 @@ export class GraphWebviewProvider implements WebviewProvider<State, State, Graph
 		const repo = this.repository;
 		if (repo == null) return undefined;
 
-		const branch = await repo.getBranch();
+		const branch = await repo.git.getBranch();
 		if (branch == null) return undefined;
 
 		const pr = await branch.getAssociatedPullRequest();
@@ -1403,7 +1403,7 @@ export class GraphWebviewProvider implements WebviewProvider<State, State, Graph
 			const cancellation = this.createCancellation('search');
 
 			try {
-				search = await this.repository.searchCommits(e.search, {
+				search = await this.repository.git.searchCommits(e.search, {
 					limit: configuration.get('graph.searchItemLimit') ?? 100,
 					ordering: configuration.get('graph.commitOrdering'),
 					cancellation: cancellation.token,
@@ -1493,7 +1493,7 @@ export class GraphWebviewProvider implements WebviewProvider<State, State, Graph
 		if (!msg.params.alt) {
 			let branch = find(this._graph!.branches.values(), b => b.current);
 			if (branch == null) {
-				branch = await this.repository.getBranch();
+				branch = await this.repository.git.getBranch();
 			}
 			if (branch != null) {
 				pick = branch;
@@ -2266,7 +2266,7 @@ export class GraphWebviewProvider implements WebviewProvider<State, State, Graph
 	private async getWorkingTreeStats(): Promise<GraphWorkingTreeStats | undefined> {
 		if (this.repository == null || this.container.git.repositoryCount === 0) return undefined;
 
-		const status = await this.container.git.getStatusForRepo(this.repository.path);
+		const status = await this.container.git.getStatus(this.repository.path);
 		const workingTreeStatus = status?.getDiffStatus();
 		return {
 			added: workingTreeStatus?.added ?? 0,
@@ -2327,7 +2327,7 @@ export class GraphWebviewProvider implements WebviewProvider<State, State, Graph
 		const promises = Promise.allSettled([
 			this.getGraphAccess(),
 			this.getWorkingTreeStats(),
-			this.repository.getBranch(),
+			this.repository.git.getBranch(),
 			this.repository.getLastFetched(),
 		]);
 
@@ -3271,7 +3271,7 @@ export class GraphWebviewProvider implements WebviewProvider<State, State, Graph
 			const { ref } = item.webviewItemValue;
 
 			const repo = this.container.git.getRepository(ref.repoPath);
-			const branch = await repo?.getBranch(ref.name);
+			const branch = await repo?.git.getBranch(ref.name);
 			const remote = await branch?.getRemote();
 
 			return executeActionCommand<CreatePullRequestActionContext>('createPullRequest', {
@@ -3742,7 +3742,7 @@ async function formatRepositories(repositories: Repository[]): Promise<GraphRepo
 
 	return Promise.all(
 		repositories.map(async r => {
-			const remote = await r.getBestRemoteWithIntegration();
+			const remote = await r.git.getBestRemoteWithIntegration();
 
 			// const integration = await remote?.getIntegration();
 			// const connected = integration ? integration?.maybeConnected ?? (await integration?.isConnected()) : false;

--- a/src/plus/webviews/patchDetails/repositoryChangeset.ts
+++ b/src/plus/webviews/patchDetails/repositoryChangeset.ts
@@ -209,7 +209,7 @@ export class RepositoryWipChangeset implements RepositoryChangeset {
 	}
 
 	private async getFiles(): Promise<{ files: Change['files'] }> {
-		const status = await this.container.git.getStatusForRepo(this.repository.path);
+		const status = await this.container.git.getStatus(this.repository.path);
 
 		const files: GitFileChangeShape[] = [];
 		if (status != null) {

--- a/src/plus/webviews/timeline/timelineWebview.ts
+++ b/src/plus/webviews/timeline/timelineWebview.ts
@@ -200,7 +200,7 @@ export class TimelineWebviewProvider implements WebviewProvider<State, State, Ti
 				const repository = this.container.git.getRepository(this._context.uri);
 				if (repository == null) return;
 
-				const commit = await repository.getCommit(e.params.data.id);
+				const commit = await repository.git.getCommit(e.params.data.id);
 				if (commit == null) return;
 
 				this.container.events.fire(

--- a/src/plus/workspaces/workspacesService.ts
+++ b/src/plus/workspaces/workspacesService.ts
@@ -479,7 +479,7 @@ export class WorkspacesService implements Disposable {
 
 		const repoPath = repo.uri.fsPath;
 
-		const remotes = await repo.getRemotes();
+		const remotes = await repo.git.getRemotes();
 		const remoteUrls: string[] = [];
 		for (const remote of remotes) {
 			const remoteUrl = remote.provider?.url({ type: RemoteResourceType.Repo });
@@ -551,7 +551,7 @@ export class WorkspacesService implements Disposable {
 		if (options?.repos != null && options.repos.length > 0) {
 			// Currently only GitHub is supported.
 			for (const repo of options.repos) {
-				const repoRemotes = await repo.getRemotes({ filter: r => r.domain === 'github.com' });
+				const repoRemotes = await repo.git.getRemotes({ filter: r => r.domain === 'github.com' });
 				if (repoRemotes.length === 0) {
 					await window.showErrorMessage(
 						`Only GitHub is supported for this operation. Please ensure all open repositories are hosted on GitHub.`,
@@ -791,7 +791,7 @@ export class WorkspacesService implements Disposable {
 	): Promise<Repository[]> {
 		const validRepos: Repository[] = [];
 		for (const repo of repos) {
-			const matchingRemotes = await repo.getRemotes({
+			const matchingRemotes = await repo.git.getRemotes({
 				filter: r => r.provider?.id === cloudWorkspaceProviderTypeToRemoteProviderId[provider],
 			});
 			if (matchingRemotes.length) {
@@ -917,7 +917,7 @@ export class WorkspacesService implements Disposable {
 					? repoOrPath
 					: await this.container.git.getOrOpenRepository(Uri.file(repoOrPath), { closeOnOpen: true });
 			if (repo == null) continue;
-			const remote = (await repo.getRemote('origin')) || (await repo.getRemotes())?.[0];
+			const remote = (await repo.git.getRemote('origin')) || (await repo.git.getRemotes())?.[0];
 			const remoteDescriptor = getRemoteDescriptor(remote);
 			if (remoteDescriptor == null) continue;
 			repoInputs.push({
@@ -1052,7 +1052,7 @@ export class WorkspacesService implements Disposable {
 			reposPathMap.set(normalizePath(repo.uri.fsPath.toLowerCase()), repo);
 
 			if (workspace instanceof CloudWorkspace) {
-				const remotes = await repo.getRemotes();
+				const remotes = await repo.git.getRemotes();
 				for (const remote of remotes) {
 					const remoteDescriptor = getRemoteDescriptor(remote);
 					if (remoteDescriptor == null) continue;

--- a/src/quickpicks/contributorsPicker.ts
+++ b/src/quickpicks/contributorsPicker.ts
@@ -78,7 +78,7 @@ export async function showContributorsPicker(
 		quickpick.busy = true;
 		quickpick.show();
 
-		const contributors = await repository.getContributors();
+		const contributors = await repository.git.getContributors();
 		if (!deferred.pending) return;
 
 		const items = await Promise.all(

--- a/src/quickpicks/items/gitWizard.ts
+++ b/src/quickpicks/items/gitWizard.ts
@@ -382,7 +382,7 @@ export async function createRepositoryQuickPickItem(
 ) {
 	let repoStatus;
 	if (options?.branch || options?.status) {
-		repoStatus = await repository.getStatus();
+		repoStatus = await repository.git.getStatus();
 	}
 
 	let description = '';

--- a/src/views/branchesView.ts
+++ b/src/views/branchesView.ts
@@ -82,7 +82,7 @@ export class BranchesViewNode extends RepositoriesSubscribeableNode<BranchesView
 		if (this.children.length === 1) {
 			const [child] = this.children;
 
-			const branches = await child.repo.getBranches({ filter: b => !b.remote });
+			const branches = await child.repo.git.getBranches({ filter: b => !b.remote });
 			if (branches.values.length === 0) {
 				this.view.message = 'No branches could be found.';
 				this.view.title = 'Branches';

--- a/src/views/commitsView.ts
+++ b/src/views/commitsView.ts
@@ -34,7 +34,7 @@ import { registerViewCommand } from './viewCommands';
 export class CommitsRepositoryNode extends RepositoryFolderNode<CommitsView, BranchNode> {
 	async getChildren(): Promise<ViewNode[]> {
 		if (this.child == null) {
-			const branch = await this.repo.getBranch();
+			const branch = await this.repo.git.getBranch();
 			if (branch == null) {
 				this.view.message = 'No commits could be found.';
 
@@ -159,7 +159,7 @@ export class CommitsViewNode extends RepositoriesSubscribeableNode<CommitsView, 
 		if (this.children.length === 1) {
 			const [child] = this.children;
 
-			const branch = await child.repo.getBranch();
+			const branch = await child.repo.git.getBranch();
 			if (branch != null) {
 				const lastFetched = (await child.repo.getLastFetched()) ?? 0;
 

--- a/src/views/nodes/abstract/repositoryFolderNode.ts
+++ b/src/views/nodes/abstract/repositoryFolderNode.ts
@@ -68,7 +68,7 @@ export abstract class RepositoryFolderNode<
 	async getTreeItem(): Promise<TreeItem> {
 		this.splatted = false;
 
-		const branch = await this.repo.getBranch();
+		const branch = await this.repo.git.getBranch();
 		const ahead = (branch?.state.ahead ?? 0) > 0;
 		const behind = (branch?.state.behind ?? 0) > 0;
 

--- a/src/views/nodes/branchNode.ts
+++ b/src/views/nodes/branchNode.ts
@@ -233,7 +233,7 @@ export class BranchNode
 				this.getLog(),
 				this.view.container.git.getBranchesAndTagsTipsFn(this.uri.repoPath, branch.name),
 				this.options.showStatus && branch.current
-					? this.view.container.git.getStatusForRepo(this.uri.repoPath)
+					? this.view.container.git.getStatus(this.uri.repoPath)
 					: undefined,
 				this.options.showStatus && branch.current
 					? this.view.container.git.getMergeStatus(this.uri.repoPath!)
@@ -281,7 +281,7 @@ export class BranchNode
 						this,
 						branch,
 						mergeStatus,
-						status ?? (await this.view.container.git.getStatusForRepo(this.uri.repoPath)),
+						status ?? (await this.view.container.git.getStatus(this.uri.repoPath)),
 						this.root,
 					),
 				);
@@ -296,7 +296,7 @@ export class BranchNode
 						this,
 						branch,
 						rebaseStatus,
-						status ?? (await this.view.container.git.getStatusForRepo(this.uri.repoPath)),
+						status ?? (await this.view.container.git.getStatus(this.uri.repoPath)),
 						this.root,
 					),
 				);

--- a/src/views/nodes/branchesNode.ts
+++ b/src/views/nodes/branchesNode.ts
@@ -35,7 +35,7 @@ export class BranchesNode extends CacheableChildrenViewNode<'branches', ViewsWit
 
 	async getChildren(): Promise<ViewNode[]> {
 		if (this.children == null) {
-			const branches = await this.repo.getBranches({
+			const branches = await this.repo.git.getBranches({
 				// only show local branches
 				filter: b => !b.remote,
 				sort: this.view.config.showCurrentBranchOnTop
@@ -89,7 +89,7 @@ export class BranchesNode extends CacheableChildrenViewNode<'branches', ViewsWit
 		const item = new TreeItem('Branches', TreeItemCollapsibleState.Collapsed);
 		item.id = this.id;
 		item.contextValue = ContextValues.Branches;
-		if (await this.repo.hasRemotes()) {
+		if ((await this.repo.git.getRemotes()).length) {
 			item.contextValue += '+remotes';
 		}
 		// TODO@axosoft-ramint Temporary workaround, remove when our git commands work on closed repos.

--- a/src/views/nodes/contributorsNode.ts
+++ b/src/views/nodes/contributorsNode.ts
@@ -57,7 +57,7 @@ export class ContributorsNode extends CacheableChildrenViewNode<
 
 			const stats = this.options?.stats ?? configuration.get('views.contributors.showStatistics');
 
-			const contributors = await this.repo.getContributors({
+			const contributors = await this.repo.git.getContributors({
 				all: all,
 				merges: this.options?.showMergeCommits,
 				ref: ref,

--- a/src/views/nodes/fileHistoryTrackerNode.ts
+++ b/src/views/nodes/fileHistoryTrackerNode.ts
@@ -76,11 +76,7 @@ export class FileHistoryTrackerNode extends SubscribeableViewNode<'file-history-
 			if (!commitish.sha || commitish.sha === 'HEAD') {
 				branch = await this.view.container.git.getBranch(this.uri.repoPath);
 			} else if (!isSha(commitish.sha)) {
-				({
-					values: [branch],
-				} = await this.view.container.git.getBranches(this.uri.repoPath, {
-					filter: b => b.name === commitish.sha,
-				}));
+				branch = await this.view.container.git.getBranch(this.uri.repoPath, commitish.sha);
 			}
 			this.child = new FileHistoryNode(fileUri, this.view, this, folder, branch);
 		}

--- a/src/views/nodes/lineHistoryTrackerNode.ts
+++ b/src/views/nodes/lineHistoryTrackerNode.ts
@@ -87,11 +87,7 @@ export class LineHistoryTrackerNode extends SubscribeableViewNode<
 			if (!commitish.sha || commitish.sha === 'HEAD') {
 				branch = await this.view.container.git.getBranch(this.uri.repoPath);
 			} else if (!isSha(commitish.sha)) {
-				({
-					values: [branch],
-				} = await this.view.container.git.getBranches(this.uri.repoPath, {
-					filter: b => b.name === commitish.sha,
-				}));
+				branch = await this.view.container.git.getBranch(this.uri.repoPath, commitish.sha);
 			}
 			this.child = new LineHistoryNode(fileUri, this.view, this, branch, selection, editorContents);
 		}

--- a/src/views/nodes/remoteNode.ts
+++ b/src/views/nodes/remoteNode.ts
@@ -40,7 +40,7 @@ export class RemoteNode extends ViewNode<'remote', ViewsWithRemotes> {
 	}
 
 	async getChildren(): Promise<ViewNode[]> {
-		const branches = await this.repo.getBranches({
+		const branches = await this.repo.git.getBranches({
 			// only show remote branches for this remote
 			filter: b => b.remote && b.name.startsWith(this.remote.name),
 			sort: true,

--- a/src/views/nodes/remotesNode.ts
+++ b/src/views/nodes/remotesNode.ts
@@ -32,7 +32,7 @@ export class RemotesNode extends CacheableChildrenViewNode<'remotes', ViewsWithR
 
 	async getChildren(): Promise<ViewNode[]> {
 		if (this.children == null) {
-			const remotes = await this.repo.getRemotes({ sort: true });
+			const remotes = await this.repo.git.getRemotes({ sort: true });
 			if (remotes.length === 0) {
 				return [new MessageNode(this.view, this, 'No remotes could be found')];
 			}

--- a/src/views/nodes/repositoryNode.ts
+++ b/src/views/nodes/repositoryNode.ts
@@ -55,7 +55,7 @@ export class RepositoryNode extends SubscribeableViewNode<'repository', ViewsWit
 		this.updateContext({ ...context, repository: this.repo });
 		this._uniqueId = getViewNodeId(this.type, this.context);
 
-		this._status = this.repo.getStatus();
+		this._status = this.repo.git.getStatus();
 	}
 
 	override get id(): string {
@@ -175,7 +175,7 @@ export class RepositoryNode extends SubscribeableViewNode<'repository', ViewsWit
 				children.push(new RemotesNode(this.uri, this.view, this, this.repo));
 			}
 
-			if (this.view.config.showStashes && (await this.repo.supports(Features.Stashes))) {
+			if (this.view.config.showStashes && (await this.repo.git.supports(Features.Stashes))) {
 				children.push(new StashesNode(this.uri, this.view, this, this.repo));
 			}
 
@@ -183,7 +183,7 @@ export class RepositoryNode extends SubscribeableViewNode<'repository', ViewsWit
 				children.push(new TagsNode(this.uri, this.view, this, this.repo));
 			}
 
-			if (this.view.config.showWorktrees && (await this.repo.supports(Features.Worktrees))) {
+			if (this.view.config.showWorktrees && (await this.repo.git.supports(Features.Worktrees))) {
 				children.push(new WorktreesNode(this.uri, this.view, this, this.repo));
 			}
 
@@ -342,7 +342,7 @@ export class RepositoryNode extends SubscribeableViewNode<'repository', ViewsWit
 		super.refresh(reset);
 
 		if (reset) {
-			this._status = this.repo.getStatus();
+			this._status = this.repo.git.getStatus();
 		}
 
 		await this.ensureSubscription();
@@ -409,7 +409,7 @@ export class RepositoryNode extends SubscribeableViewNode<'repository', ViewsWit
 		},
 	})
 	private async onFileSystemChanged(_e: RepositoryFileSystemChangeEvent) {
-		this._status = this.repo.getStatus();
+		this._status = this.repo.git.getStatus();
 
 		if (this.children !== undefined) {
 			const status = await this._status;

--- a/src/views/nodes/stashesNode.ts
+++ b/src/views/nodes/stashesNode.ts
@@ -33,7 +33,7 @@ export class StashesNode extends CacheableChildrenViewNode<'stashes', ViewsWithS
 
 	async getChildren(): Promise<ViewNode[]> {
 		if (this.children == null) {
-			const stash = await this.repo.getStash();
+			const stash = await this.repo.git.getStash();
 			if (stash == null) return [new MessageNode(this.view, this, 'No stashes could be found.')];
 
 			this.children = [...map(stash.commits.values(), c => new StashNode(this.view, this, c))];

--- a/src/views/nodes/tagsNode.ts
+++ b/src/views/nodes/tagsNode.ts
@@ -34,7 +34,7 @@ export class TagsNode extends CacheableChildrenViewNode<'tags', ViewsWithTagsNod
 
 	async getChildren(): Promise<ViewNode[]> {
 		if (this.children == null) {
-			const tags = await this.repo.getTags({ sort: true });
+			const tags = await this.repo.git.getTags({ sort: true });
 			if (tags.values.length === 0) return [new MessageNode(this.view, this, 'No tags could be found.')];
 
 			// TODO@eamodio handle paging

--- a/src/views/nodes/worktreesNode.ts
+++ b/src/views/nodes/worktreesNode.ts
@@ -40,7 +40,7 @@ export class WorktreesNode extends CacheableChildrenViewNode<'worktrees', ViewsW
 			const access = await this.repo.access(PlusFeatures.Worktrees);
 			if (!access.allowed) return [];
 
-			const worktrees = await this.repo.getWorktrees();
+			const worktrees = await this.repo.git.getWorktrees();
 			if (worktrees.length === 0) return [new MessageNode(this.view, this, 'No worktrees could be found.')];
 
 			this.children = await mapAsync(sortWorktrees(worktrees), async w => {

--- a/src/views/remotesView.ts
+++ b/src/views/remotesView.ts
@@ -74,7 +74,7 @@ export class RemotesViewNode extends RepositoriesSubscribeableNode<RemotesView, 
 		if (this.children.length === 1) {
 			const [child] = this.children;
 
-			const remotes = await child.repo.getRemotes();
+			const remotes = await child.repo.git.getRemotes();
 			if (remotes.length === 0) {
 				this.view.message = 'No remotes could be found.';
 				this.view.title = 'Remotes';

--- a/src/views/stashesView.ts
+++ b/src/views/stashesView.ts
@@ -60,7 +60,7 @@ export class StashesViewNode extends RepositoriesSubscribeableNode<StashesView, 
 		if (this.children.length === 1) {
 			const [child] = this.children;
 
-			const stash = await child.repo.getStash();
+			const stash = await child.repo.git.getStash();
 			if (stash == null || stash.commits.size === 0) {
 				this.view.message = 'No stashes could be found.';
 				this.view.title = 'Stashes';

--- a/src/views/tagsView.ts
+++ b/src/views/tagsView.ts
@@ -61,7 +61,7 @@ export class TagsViewNode extends RepositoriesSubscribeableNode<TagsView, TagsRe
 		if (this.children.length === 1) {
 			const [child] = this.children;
 
-			const tags = await child.repo.getTags();
+			const tags = await child.repo.git.getTags();
 			if (tags.values.length === 0) {
 				this.view.message = 'No tags could be found.';
 				this.view.title = 'Tags';

--- a/src/webviews/commitDetails/commitDetailsWebview.ts
+++ b/src/webviews/commitDetails/commitDetailsWebview.ts
@@ -1283,7 +1283,7 @@ export class CommitDetailsWebviewProvider
 		repository: Repository,
 		branchName: string,
 	): Promise<{ branch: GitBranch; pullRequest: PullRequest | undefined; codeSuggestions: Draft[] } | undefined> {
-		const branch = await repository.getBranch(branchName);
+		const branch = await repository.git.getBranch(branchName);
 		if (branch == null) return undefined;
 
 		if (this.mode === 'commit') {
@@ -1515,7 +1515,7 @@ export class CommitDetailsWebviewProvider
 	}
 
 	private async getWipChange(repository: Repository): Promise<WipChange | undefined> {
-		const status = await this.container.git.getStatusForRepo(repository.path);
+		const status = await this.container.git.getStatus(repository.path);
 		if (status == null) return undefined;
 
 		const files: GitFileChangeShape[] = [];


### PR DESCRIPTION
This avoids reimplementing many `GitProviderService` methods on `Repository`
