### PR TITLE
Attempts to pre-open PR branch when using Switch or Open in Worktree

### DIFF
--- a/src/git/models/pullRequest.ts
+++ b/src/git/models/pullRequest.ts
@@ -309,7 +309,7 @@ export function getVirtualUriForPullRequest(pr: PullRequest): Uri | undefined {
 export async function getOrOpenPullRequestRepository(
 	container: Container,
 	pr: PullRequest,
-	options?: { promptIfNeeded?: boolean },
+	options?: { promptIfNeeded?: boolean; skipVirtual?: boolean },
 ): Promise<Repository | undefined> {
 	const identity = getRepositoryIdentityForPullRequest(pr);
 	let repo = await container.repositoryIdentity.getRepository(identity, {
@@ -318,7 +318,7 @@ export async function getOrOpenPullRequestRepository(
 		prompt: false,
 	});
 
-	if (repo == null) {
+	if (repo == null && !options?.skipVirtual) {
 		const virtualUri = getVirtualUriForPullRequest(pr);
 		if (virtualUri != null) {
 			repo = await container.git.getOrOpenRepository(virtualUri, { closeOnOpen: true, detectNested: false });

--- a/src/plus/launchpad/launchpadProvider.ts
+++ b/src/plus/launchpad/launchpadProvider.ts
@@ -16,7 +16,11 @@ import type { Account } from '../../git/models/author';
 import type { GitBranch } from '../../git/models/branch';
 import { getLocalBranchByUpstream } from '../../git/models/branch';
 import type { PullRequest, SearchedPullRequest } from '../../git/models/pullRequest';
-import { getComparisonRefsForPullRequest, getRepositoryIdentityForPullRequest } from '../../git/models/pullRequest';
+import {
+	getComparisonRefsForPullRequest,
+	getOrOpenPullRequestRepository,
+	getRepositoryIdentityForPullRequest,
+} from '../../git/models/pullRequest';
 import type { GitRemote } from '../../git/models/remote';
 import type { Repository } from '../../git/models/repository';
 import type { CodeSuggestionCounts, Draft } from '../../gk/models/drafts';
@@ -488,8 +492,11 @@ export class LaunchpadProvider implements Disposable {
 		);
 		if (deepLinkUrl == null) return;
 
+		const prRepo = await getOrOpenPullRequestRepository(this.container, item.underlyingPullRequest, {
+			skipVirtual: true,
+		});
 		this._codeSuggestions?.delete(item.uuid);
-		await this.container.deepLinks.processDeepLinkUri(deepLinkUrl, false);
+		await this.container.deepLinks.processDeepLinkUri(deepLinkUrl, false, prRepo);
 	}
 
 	@log<LaunchpadProvider['openChanges']>({ args: { 0: i => `${i.id} (${i.provider.name} ${i.type})` } })

--- a/src/views/viewCommands.ts
+++ b/src/views/viewCommands.ts
@@ -27,6 +27,7 @@ import {
 	ensurePullRequestRefs,
 	getComparisonRefsForPullRequest,
 	getOpenedPullRequestRepo,
+	getOrOpenPullRequestRepository,
 	getRepositoryIdentityForPullRequest,
 } from '../git/models/pullRequest';
 import { createReference, shortenRevision } from '../git/models/reference';
@@ -807,7 +808,11 @@ export class ViewCommands {
 				repoIdentity.remote.url,
 				DeepLinkActionType.SwitchToPullRequestWorktree,
 			);
-			return this.container.deepLinks.processDeepLinkUri(deepLink, false);
+
+			const prRepo = await getOrOpenPullRequestRepository(this.container, pr, {
+				skipVirtual: true,
+			});
+			return this.container.deepLinks.processDeepLinkUri(deepLink, false, prRepo);
 		}
 	}
 


### PR DESCRIPTION
Closes #3627

Leverages `getOrOpenPullRequestRepository` to try to pre-identify the PR's repo, which then skips the "repo match" step in the deep link flow.

Note: this has undesirable effects with virtual repos, so I added a `skipVirtual` open to skip opening virtual uris for now. A bigger refactor of target opening logic (moving it out of the deep link service into its own service) will probably include better virtual repo support in the flow, but for now it doesn't work for most cases of `Open in Worktree`.