### PR TITLE
Completes the cloud integration reauth flow by disconnecting cloud token

### DIFF
--- a/src/constants.telemetry.ts
+++ b/src/constants.telemetry.ts
@@ -65,6 +65,12 @@ export type TelemetryEvents = {
 		'integration.connected.ids': string | undefined;
 	};
 
+	/** Sent when disconnecting a provider from the api fails*/
+	'cloudIntegrations/disconnect/failed': {
+		code: number | undefined;
+		'integration.id': string | undefined;
+	};
+
 	/** Sent when getting connected providers from the api fails*/
 	'cloudIntegrations/getConnections/failed': {
 		code: number | undefined;

--- a/src/plus/integrations/authentication/integrationAuthentication.ts
+++ b/src/plus/integrations/authentication/integrationAuthentication.ts
@@ -286,7 +286,10 @@ export abstract class CloudIntegrationAuthenticationProvider<
 			  },
 	): Promise<ProviderAuthenticationSession | undefined> {
 		if (options?.forceNewSession) {
-			await this.disconnectSession();
+			if (!(await this.disconnectSession())) {
+				return undefined;
+			}
+
 			void this.connectCloudIntegration(false, options?.source);
 			return undefined;
 		}


### PR DESCRIPTION
Closes #3618

When doing a reauth with a cloud integration, disconnects the token from the backend before initiating a connect flow.