### PR TITLE
Adds graph and visual file history telemetry

### DIFF
--- a/docs/telemetry-events.md
+++ b/docs/telemetry-events.md
@@ -335,6 +335,179 @@ or
 }
 ```
 
+### graph/shown
+
+```typescript
+{
+  'id': string,
+  'instanceId': string,
+  'host': 'editor' | 'view',
+  'duration': number,
+  'loading': false | true,
+  'context.repository.id': string,
+  'context.repository.scheme': string,
+  'context.repository.closed': false | true,
+  'context.repository.folder.scheme': string,
+  'context.repository.provider.id': string,
+  'context.config.allowMultiple': false | true,
+  'context.config.avatars': false | true,
+  'context.config.branchesVisibility': 'all' | 'smart' | 'current',
+  'context.config.commitOrdering': 'date' | 'author-date' | 'topo',
+  'context.config.dateFormat': string,
+  'context.config.dateStyle': 'absolute' | 'relative',
+  'context.config.defaultItemLimit': number,
+  'context.config.dimMergeCommits': false | true,
+  'context.config.highlightRowsOnRefHover': false | true,
+  'context.config.layout': 'editor' | 'panel',
+  'context.config.minimap.enabled': false | true,
+  'context.config.minimap.dataType': 'commits' | 'lines',
+  'context.config.minimap.additionalTypes': string,
+  'context.config.onlyFollowFirstParent': false | true,
+  'context.config.pageItemLimit': number,
+  'context.config.pullRequests.enabled': false | true,
+  'context.config.scrollMarkers.enabled': false | true,
+  'context.config.scrollMarkers.additionalTypes': string,
+  'context.config.scrollRowPadding': number,
+  'context.config.searchItemLimit': number,
+  'context.config.showDetailsView': false | 'open' | 'selection',
+  'context.config.showGhostRefsOnRowHover': false | true,
+  'context.config.showRemoteNames': false | true,
+  'context.config.showUpstreamStatus': false | true,
+  'context.config.sidebar.enabled': false | true,
+  'context.config.statusBar.enabled': false | true
+}
+```
+
+### graph/columns/changed
+
+> Sent when the user interacts with the graph
+
+```typescript
+{}
+```
+
+### graph/exclude/toggled
+
+```typescript
+{
+  'key': string,
+  'value': false | true
+}
+```
+
+### graph/jumpToRef
+
+```typescript
+{
+  'alt': false | true
+}
+```
+
+### graph/minimap/daySelected
+
+```typescript
+undefined
+```
+
+### graph/repository/changed
+
+```typescript
+undefined
+```
+
+### graph/repository/openOnRemote
+
+```typescript
+{
+  'id': string,
+  'instanceId': string,
+  'host': 'editor' | 'view'
+}
+```
+
+### graph/row/hovered
+
+```typescript
+undefined
+```
+
+### graph/row/selected
+
+```typescript
+{
+  'rows': number
+}
+```
+
+### graph/rows/loaded
+
+```typescript
+{
+  'duration': number,
+  'rows': number
+}
+```
+
+### graph/sidebar/action
+
+```typescript
+{
+  'action': string
+}
+```
+
+### graph/searched
+
+```typescript
+{
+  'types': string,
+  'duration': number,
+  'matches': number
+}
+```
+
+### graph/branchesVisibility/changed
+
+```typescript
+{
+  'branchesVisibility': 'all' | 'smart' | 'current'
+}
+```
+
+### timeline/period/change
+
+> Sent when the user interacts with the visual file history
+
+```typescript
+{
+  'period': string
+}
+```
+
+### timeline/chart/selectCommit
+
+```typescript
+undefined
+```
+
+### timeline/chart/toggleLegend
+
+```typescript
+undefined
+```
+
+### timeline/openInEditor
+
+```typescript
+undefined
+```
+
+### timeline/editorChanged
+
+```typescript
+undefined
+```
+
 ### launchpad/title/action
 
 > Sent when the user takes an action on a launchpad item
@@ -345,7 +518,7 @@ or
   'initialState.group': string,
   'initialState.selectTopItem': false | true,
   'items.error': string,
-  'action': 'feedback' | 'open-on-gkdev' | 'refresh' | 'settings' | 'connect'
+  'action': 'settings' | 'feedback' | 'open-on-gkdev' | 'refresh' | 'connect'
 }
 ```
 
@@ -381,7 +554,7 @@ or
   'groups.draft.collapsed': false | true,
   'groups.other.collapsed': false | true,
   'groups.snoozed.collapsed': false | true,
-  'action': 'feedback' | 'open-on-gkdev' | 'refresh' | 'settings' | 'connect'
+  'action': 'settings' | 'feedback' | 'open-on-gkdev' | 'refresh' | 'connect'
 }
 ```
 
@@ -757,7 +930,7 @@ void
   'repository.visibility': 'private' | 'public' | 'local',
   'repoPrivacy': 'private' | 'public' | 'local',
   'filesChanged': number,
-  'source': 'settings' | 'code-suggest' | 'account' | 'cloud-patches' | 'commandPalette' | 'deeplink' | 'graph' | 'home' | 'inspect' | 'inspect-overview' | 'integrations' | 'launchpad' | 'launchpad-indicator' | 'launchpad-view' | 'notification' | 'patchDetails' | 'prompt' | 'quick-wizard' | 'remoteProvider' | 'timeline' | 'trial-indicator' | 'scm-input' | 'subscription' | 'walkthrough' | 'welcome' | 'worktrees'
+  'source': 'graph' | 'patchDetails' | 'settings' | 'timeline' | 'welcome' | 'home' | 'code-suggest' | 'account' | 'cloud-patches' | 'commandPalette' | 'deeplink' | 'inspect' | 'inspect-overview' | 'integrations' | 'launchpad' | 'launchpad-indicator' | 'launchpad-view' | 'notification' | 'prompt' | 'quick-wizard' | 'remoteProvider' | 'trial-indicator' | 'scm-input' | 'subscription' | 'walkthrough' | 'worktrees'
 }
 ```
 
@@ -911,7 +1084,7 @@ or
 
 ```typescript
 {
-  'usage.key': 'settingsWebview:shown' | 'graphWebview:shown' | 'patchDetailsWebview:shown' | 'timelineWebview:shown' | 'welcomeWebview:shown' | 'launchpadView:shown' | 'worktreesView:shown' | 'branchesView:shown' | 'commitsView:shown' | 'contributorsView:shown' | 'draftsView:shown' | 'fileHistoryView:shown' | 'lineHistoryView:shown' | 'pullRequestView:shown' | 'remotesView:shown' | 'repositoriesView:shown' | 'searchAndCompareView:shown' | 'stashesView:shown' | 'tagsView:shown' | 'workspacesView:shown' | 'graphView:shown' | 'homeView:shown' | 'patchDetailsView:shown' | 'timelineView:shown' | 'commitDetailsView:shown' | 'graphDetailsView:shown' | 'rebaseEditor:shown',
+  'usage.key': 'graphWebview:shown' | 'patchDetailsWebview:shown' | 'settingsWebview:shown' | 'timelineWebview:shown' | 'welcomeWebview:shown' | 'graphView:shown' | 'patchDetailsView:shown' | 'timelineView:shown' | 'commitDetailsView:shown' | 'graphDetailsView:shown' | 'homeView:shown' | 'commitsView:shown' | 'stashesView:shown' | 'tagsView:shown' | 'launchpadView:shown' | 'worktreesView:shown' | 'branchesView:shown' | 'contributorsView:shown' | 'draftsView:shown' | 'fileHistoryView:shown' | 'lineHistoryView:shown' | 'pullRequestView:shown' | 'remotesView:shown' | 'repositoriesView:shown' | 'searchAndCompareView:shown' | 'workspacesView:shown' | 'rebaseEditor:shown',
   'usage.count': number
 }
 ```
@@ -923,6 +1096,186 @@ or
 ```typescript
 {
   'step': 'integrations' | 'launchpad' | 'get-started' | 'core-features' | 'pro-features' | 'pro-trial' | 'pro-upgrade' | 'pro-reactivate' | 'pro-paid' | 'visualize' | 'code-collab' | 'more'
+}
+```
+
+### graph/showAborted
+
+```typescript
+{
+  'id': string,
+  'instanceId': string,
+  'host': 'editor' | 'view',
+  'duration': number,
+  'loading': false | true
+}
+```
+
+### patchDetails/showAborted
+
+```typescript
+{
+  'id': string,
+  'instanceId': string,
+  'host': 'editor' | 'view',
+  'duration': number,
+  'loading': false | true
+}
+```
+
+### settings/showAborted
+
+```typescript
+{
+  'id': string,
+  'instanceId': string,
+  'host': 'editor' | 'view',
+  'duration': number,
+  'loading': false | true
+}
+```
+
+### timeline/showAborted
+
+```typescript
+{
+  'id': string,
+  'instanceId': string,
+  'host': 'editor' | 'view',
+  'duration': number,
+  'loading': false | true
+}
+```
+
+### welcome/showAborted
+
+```typescript
+{
+  'id': string,
+  'instanceId': string,
+  'host': 'editor' | 'view',
+  'duration': number,
+  'loading': false | true
+}
+```
+
+### commitDetails/showAborted
+
+```typescript
+{
+  'id': string,
+  'instanceId': string,
+  'host': 'editor' | 'view',
+  'duration': number,
+  'loading': false | true
+}
+```
+
+### graphDetails/showAborted
+
+```typescript
+{
+  'id': string,
+  'instanceId': string,
+  'host': 'editor' | 'view',
+  'duration': number,
+  'loading': false | true
+}
+```
+
+### home/showAborted
+
+```typescript
+{
+  'id': string,
+  'instanceId': string,
+  'host': 'editor' | 'view',
+  'duration': number,
+  'loading': false | true
+}
+```
+
+### patchDetails/shown
+
+```typescript
+{
+  'id': string,
+  'instanceId': string,
+  'host': 'editor' | 'view',
+  'duration': number,
+  'loading': false | true
+}
+```
+
+### settings/shown
+
+```typescript
+{
+  'id': string,
+  'instanceId': string,
+  'host': 'editor' | 'view',
+  'duration': number,
+  'loading': false | true
+}
+```
+
+### timeline/shown
+
+```typescript
+{
+  'id': string,
+  'instanceId': string,
+  'host': 'editor' | 'view',
+  'duration': number,
+  'loading': false | true
+}
+```
+
+### welcome/shown
+
+```typescript
+{
+  'id': string,
+  'instanceId': string,
+  'host': 'editor' | 'view',
+  'duration': number,
+  'loading': false | true
+}
+```
+
+### commitDetails/shown
+
+```typescript
+{
+  'id': string,
+  'instanceId': string,
+  'host': 'editor' | 'view',
+  'duration': number,
+  'loading': false | true
+}
+```
+
+### graphDetails/shown
+
+```typescript
+{
+  'id': string,
+  'instanceId': string,
+  'host': 'editor' | 'view',
+  'duration': number,
+  'loading': false | true
+}
+```
+
+### home/shown
+
+```typescript
+{
+  'id': string,
+  'instanceId': string,
+  'host': 'editor' | 'view',
+  'duration': number,
+  'loading': false | true
 }
 ```
 

--- a/src/constants.telemetry.ts
+++ b/src/constants.telemetry.ts
@@ -1,3 +1,4 @@
+import type { GraphBranchesVisibility } from './config';
 import type { AIModels, AIProviders } from './constants.ai';
 import type { Commands } from './constants.commands';
 import type { IntegrationId, SupportedCloudIntegrationIds } from './constants.integrations';
@@ -161,6 +162,20 @@ export type TelemetryEvents = {
 
 	/** Sent when a "Graph" command is executed */
 	'graph/command': Omit<CommandEventData, 'context'>;
+
+	/** Sent when the user interacts with the graph */
+	'graph/column/changed': { column: string /* column props */ };
+	'graph/exclude/toggle': { key: string; value: boolean };
+	'graph/jump-to-ref': { alt: boolean };
+	'graph/minimap/daySelected': undefined;
+	'graph/repository/change': undefined;
+	'graph/repository/openOnRemote': undefined;
+	'graph/row/hover': undefined;
+	'graph/row/more': { duration: number };
+	'graph/row/selected': { rows: number };
+	'graph/sidebar/action': { action: string };
+	'graph/search': { types: string; duration: number };
+	'graph/visibility/changed': { branchesVisibility: GraphBranchesVisibility };
 
 	/** Sent when the user takes an action on a launchpad item */
 	'launchpad/title/action': LaunchpadEventData & {

--- a/src/constants.telemetry.ts
+++ b/src/constants.telemetry.ts
@@ -3,7 +3,14 @@ import type { AIModels, AIProviders } from './constants.ai';
 import type { Commands } from './constants.commands';
 import type { IntegrationId, SupportedCloudIntegrationIds } from './constants.integrations';
 import type { SubscriptionState } from './constants.subscription';
-import type { CustomEditorTypes, TreeViewTypes, WebviewTypes, WebviewViewTypes } from './constants.views';
+import type {
+	CustomEditorTypes,
+	TreeViewTypes,
+	WebviewIds,
+	WebviewTypes,
+	WebviewViewIds,
+	WebviewViewTypes,
+} from './constants.views';
 import type { GitContributionTiers } from './git/models/contributor';
 
 export type TelemetryGlobalContext = {
@@ -370,7 +377,26 @@ export type TelemetryEvents = {
 			| 'integrations'
 			| 'more';
 	};
-};
+} & Record<
+	`${WebviewTypes | WebviewViewTypes}/showAborted`,
+	{
+		id: WebviewIds | WebviewViewIds;
+		instanceId: string | undefined;
+		host: 'editor' | 'view';
+		duration: number;
+		loading: boolean;
+	}
+> &
+	Record<
+		`${WebviewTypes | WebviewViewTypes}/shown`,
+		{
+			id: WebviewIds | WebviewViewIds;
+			instanceId: string | undefined;
+			host: 'editor' | 'view';
+			duration: number;
+			loading: boolean;
+		} & Record<`context.${string}`, string | number | boolean>
+	>;
 
 type AIEventDataBase = {
 	'model.id': AIModels;

--- a/src/constants.telemetry.ts
+++ b/src/constants.telemetry.ts
@@ -177,6 +177,13 @@ export type TelemetryEvents = {
 	'graph/search': { types: string; duration: number };
 	'graph/visibility/changed': { branchesVisibility: GraphBranchesVisibility };
 
+	/** Sent when the user interacts with the visual file history */
+	'timeline/period/change': { period: string };
+	'timeline/chart/selectCommit': undefined;
+	'timeline/chart/toggleLegend': undefined;
+	'timeline/openInEditor': undefined;
+	'timeline/editorChanged': undefined;
+
 	/** Sent when the user takes an action on a launchpad item */
 	'launchpad/title/action': LaunchpadEventData & {
 		action: 'feedback' | 'open-on-gkdev' | 'refresh' | 'settings' | 'connect';

--- a/src/constants.telemetry.ts
+++ b/src/constants.telemetry.ts
@@ -173,7 +173,7 @@ export type TelemetryEvents = {
 	/** Sent when the user interacts with the graph */
 	'graph/column/changed': { column: string /* column props */ };
 	'graph/exclude/toggle': { key: string; value: boolean };
-	'graph/jump-to-ref': { alt: boolean };
+	'graph/jumpToRef': { alt: boolean };
 	'graph/minimap/daySelected': undefined;
 	'graph/repository/change': undefined;
 	'graph/repository/openOnRemote': undefined;

--- a/src/constants.telemetry.ts
+++ b/src/constants.telemetry.ts
@@ -171,7 +171,7 @@ export type TelemetryEvents = {
 	'graph/command': Omit<CommandEventData, 'context'>;
 
 	/** Sent when the user interacts with the graph */
-	'graph/column/changed': { column: string /* column props */ };
+	'graph/columns/changed': Record<`column.${string}`, boolean | string | number>;
 	'graph/exclude/toggle': { key: string; value: boolean };
 	'graph/jumpToRef': { alt: boolean };
 	'graph/minimap/daySelected': undefined;

--- a/src/plus/webviews/graph/graphWebview.ts
+++ b/src/plus/webviews/graph/graphWebview.ts
@@ -356,7 +356,7 @@ export class GraphWebviewProvider implements WebviewProvider<State, State, Graph
 		loading: boolean,
 		_options?: WebviewShowOptions,
 		...args: WebviewShowingArgs<GraphWebviewShowingArgs, State>
-	): Promise<boolean> {
+	): Promise<[boolean, Record<`context.${string}`, string | number | boolean> | undefined]> {
 		this._firstSelection = true;
 
 		this._etag = this.container.git.etag;
@@ -386,7 +386,7 @@ export class GraphWebviewProvider implements WebviewProvider<State, State, Graph
 			if (this._graph != null) {
 				if (this._graph?.ids.has(id)) {
 					void this.notifyDidChangeSelection();
-					return true;
+					return [true, undefined];
 				}
 
 				void this.onGetMoreRows({ id: id }, true);
@@ -412,7 +412,7 @@ export class GraphWebviewProvider implements WebviewProvider<State, State, Graph
 			}
 		}
 
-		return true;
+		return [true, undefined];
 	}
 
 	onRefresh(force?: boolean) {

--- a/src/plus/webviews/graph/graphWebview.ts
+++ b/src/plus/webviews/graph/graphWebview.ts
@@ -917,11 +917,13 @@ export class GraphWebviewProvider implements WebviewProvider<State, State, Graph
 	private onColumnsChanged(e: UpdateColumnsParams) {
 		this.updateColumns(e.config);
 
-		for (const [key, _value] of Object.entries(e.config)) {
-			this.container.telemetry.sendEvent('graph/column/changed', {
-				column: key,
-			});
+		const sendEvent: Record<`column.${string}`, boolean | string | number> = {};
+		for (const [key, config] of Object.entries(e.config)) {
+			for (const [prop, value] of Object.entries(config)) {
+				sendEvent[`column.${key}.${prop}`] = value;
+			}
 		}
+		this.container.telemetry.sendEvent('graph/columns/changed', sendEvent);
 	}
 
 	private onRefsVisibilityChanged(e: UpdateRefsVisibilityParams) {

--- a/src/plus/webviews/graph/registration.ts
+++ b/src/plus/webviews/graph/registration.ts
@@ -33,6 +33,7 @@ export function registerGraphWebviewPanel(controller: WebviewsController) {
 			title: 'Commit Graph',
 			contextKeyPrefix: `gitlens:webview:graph`,
 			trackingFeature: 'graphWebview',
+			type: 'graph',
 			plusFeature: true,
 			column: ViewColumn.Active,
 			webviewHostOptions: {
@@ -56,6 +57,7 @@ export function registerGraphWebviewView(controller: WebviewsController) {
 			title: 'Commit Graph',
 			contextKeyPrefix: `gitlens:webviewView:graph`,
 			trackingFeature: 'graphView',
+			type: 'graph',
 			plusFeature: true,
 			webviewHostOptions: {
 				retainContextWhenHidden: true,

--- a/src/plus/webviews/patchDetails/patchDetailsWebview.ts
+++ b/src/plus/webviews/patchDetails/patchDetailsWebview.ts
@@ -187,7 +187,7 @@ export class PatchDetailsWebviewProvider
 		_loading: boolean,
 		options: WebviewShowOptions,
 		...args: PatchDetailsWebviewShowingArgs
-	): Promise<boolean> {
+	): Promise<[boolean, Record<`context.${string}`, string | number | boolean> | undefined]> {
 		const [arg] = args;
 		if (arg?.mode === 'view' && arg.draft != null) {
 			await this.updateViewDraftState(arg.draft);
@@ -201,9 +201,9 @@ export class PatchDetailsWebviewProvider
 			this.updateCreateDraftState(create);
 		}
 
-		if (options?.preserveVisibility && !this.host.visible) return false;
+		if (options?.preserveVisibility && !this.host.visible) return [false, undefined];
 
-		return true;
+		return [true, undefined];
 	}
 
 	includeBootstrap(): Promise<Serialized<State>> {

--- a/src/plus/webviews/patchDetails/registration.ts
+++ b/src/plus/webviews/patchDetails/registration.ts
@@ -30,6 +30,7 @@ export function registerPatchDetailsWebviewView(controller: WebviewsController) 
 			title: 'Patch',
 			contextKeyPrefix: `gitlens:webviewView:patchDetails`,
 			trackingFeature: 'patchDetailsView',
+			type: 'patchDetails',
 			plusFeature: true,
 			webviewHostOptions: {
 				retainContextWhenHidden: false,
@@ -66,6 +67,7 @@ export function registerPatchDetailsWebviewPanel(controller: WebviewsController)
 			title: 'Patch',
 			contextKeyPrefix: `gitlens:webview:patchDetails`,
 			trackingFeature: 'patchDetailsWebview',
+			type: 'patchDetails',
 			plusFeature: true,
 			column: ViewColumn.Active,
 			webviewHostOptions: {

--- a/src/plus/webviews/timeline/registration.ts
+++ b/src/plus/webviews/timeline/registration.ts
@@ -19,6 +19,7 @@ export function registerTimelineWebviewPanel(controller: WebviewsController) {
 			title: 'Visual File History',
 			contextKeyPrefix: `gitlens:webview:timeline`,
 			trackingFeature: 'timelineWebview',
+			type: 'timeline',
 			plusFeature: true,
 			column: ViewColumn.Active,
 			webviewHostOptions: {
@@ -44,6 +45,7 @@ export function registerTimelineWebviewView(controller: WebviewsController) {
 			title: 'Visual File History',
 			contextKeyPrefix: `gitlens:webviewView:timeline`,
 			trackingFeature: 'timelineView',
+			type: 'timeline',
 			plusFeature: true,
 			webviewHostOptions: {
 				retainContextWhenHidden: false,

--- a/src/plus/webviews/timeline/timelineWebview.ts
+++ b/src/plus/webviews/timeline/timelineWebview.ts
@@ -114,7 +114,7 @@ export class TimelineWebviewProvider implements WebviewProvider<State, State, Ti
 		loading: boolean,
 		_options?: WebviewShowOptions,
 		...args: WebviewShowingArgs<TimelineWebviewShowingArgs, State>
-	): boolean {
+	): [boolean, Record<`context.${string}`, string | number | boolean> | undefined] {
 		const [arg] = args;
 		if (arg != null) {
 			if (arg instanceof Uri) {
@@ -138,7 +138,7 @@ export class TimelineWebviewProvider implements WebviewProvider<State, State, Ti
 			this.updateState();
 		}
 
-		return true;
+		return [true, undefined];
 	}
 
 	includeBootstrap(): Promise<State> {

--- a/src/plus/webviews/timeline/timelineWebview.ts
+++ b/src/plus/webviews/timeline/timelineWebview.ts
@@ -162,6 +162,7 @@ export class TimelineWebviewProvider implements WebviewProvider<State, State, Ti
 						if (this._context.uri == null) return;
 
 						void executeCommand(Commands.ShowInTimeline, this._context.uri);
+						this.container.telemetry.sendEvent('timeline/openInEditor', undefined);
 					},
 					this,
 				),
@@ -214,6 +215,8 @@ export class TimelineWebviewProvider implements WebviewProvider<State, State, Ti
 					{ source: this.host.id },
 				);
 
+				this.container.telemetry.sendEvent('timeline/chart/selectCommit', undefined);
+
 				if (!this.container.commitDetailsView.ready) {
 					void this.container.commitDetailsView.show({ preserveFocus: true }, {
 						commit: commit,
@@ -227,6 +230,7 @@ export class TimelineWebviewProvider implements WebviewProvider<State, State, Ti
 			case UpdatePeriodCommand.is(e):
 				if (this.updatePendingContext({ period: e.params.period })) {
 					this.updateState(true);
+					this.container.telemetry.sendEvent('timeline/period/change', { period: e.params.period });
 				}
 				break;
 		}
@@ -245,6 +249,7 @@ export class TimelineWebviewProvider implements WebviewProvider<State, State, Ti
 		if (!this.updatePendingEditor(editor)) return;
 
 		this.updateState();
+		this.container.telemetry.sendEvent('timeline/editorChanged', undefined);
 	}
 
 	@debug({ args: false })

--- a/src/system/object.ts
+++ b/src/system/object.ts
@@ -48,7 +48,7 @@ type FlattenJoin<T extends object, P extends string | undefined> = {
 		    };
 }[keyof T];
 
-type Flatten<
+export type Flatten<
 	T extends object | null | undefined,
 	P extends string | undefined,
 	JoinArrays extends boolean,

--- a/src/webviews/apps/plus/graph/GraphWrapper.tsx
+++ b/src/webviews/apps/plus/graph/GraphWrapper.tsx
@@ -86,6 +86,7 @@ import { GlSearchBox } from '../../shared/components/search/react';
 import type { SearchNavigationEventDetail } from '../../shared/components/search/search-box';
 import type { DateTimeFormat } from '../../shared/date';
 import { formatDate, fromNow } from '../../shared/date';
+import { emitTelemetrySentEvent } from '../../shared/telemetry';
 import { GitActionsButtons } from './actions/gitActionsButtons';
 import { GlGraphHover } from './hover/graphHover.react';
 import type { GraphMinimapDaySelectedEventDetail } from './minimap/minimap';
@@ -464,6 +465,8 @@ export function GraphWrapper({
 		}
 
 		graphRef.current?.selectCommits([sha], false, true);
+
+		queueMicrotask(() => e.target && emitTelemetrySentEvent(e.target, { name: 'graph/minimap/daySelected' }));
 	};
 
 	const handleOnMinimapToggle = (_e: React.MouseEvent) => {
@@ -1007,6 +1010,9 @@ export function GraphWrapper({
 										style={{ marginRight: '-0.5rem' }}
 										aria-label={`Open Repository on ${repo.provider.name}`}
 										slot="anchor"
+										onClick={e =>
+											emitTelemetrySentEvent(e.target, { name: 'graph/repository/openOnRemote' })
+										}
 									>
 										<span
 											className={

--- a/src/webviews/apps/plus/graph/GraphWrapper.tsx
+++ b/src/webviews/apps/plus/graph/GraphWrapper.tsx
@@ -67,7 +67,7 @@ import {
 import { createCommandLink } from '../../../../system/commands';
 import { filterMap, first, groupByFilterMap, join } from '../../../../system/iterable';
 import { createWebviewCommandLink } from '../../../../system/webview';
-import type { IpcNotification } from '../../../protocol';
+import type { IpcNotification, TelemetrySendEventParams } from '../../../protocol';
 import { DidChangeHostWindowFocusNotification } from '../../../protocol';
 import { GlButton } from '../../shared/components/button.react';
 import { GlCheckbox } from '../../shared/components/checkbox';
@@ -466,7 +466,9 @@ export function GraphWrapper({
 
 		graphRef.current?.selectCommits([sha], false, true);
 
-		queueMicrotask(() => e.target && emitTelemetrySentEvent(e.target, { name: 'graph/minimap/daySelected' }));
+		queueMicrotask(
+			() => e.target && emitTelemetrySentEvent(e.target, { name: 'graph/minimap/daySelected', data: {} }),
+		);
 	};
 
 	const handleOnMinimapToggle = (_e: React.MouseEvent) => {
@@ -1011,7 +1013,12 @@ export function GraphWrapper({
 										aria-label={`Open Repository on ${repo.provider.name}`}
 										slot="anchor"
 										onClick={e =>
-											emitTelemetrySentEvent(e.target, { name: 'graph/repository/openOnRemote' })
+											emitTelemetrySentEvent<
+												TelemetrySendEventParams<'graph/repository/openOnRemote'>
+											>(e.target, {
+												name: 'graph/repository/openOnRemote',
+												data: {},
+											})
 										}
 									>
 										<span

--- a/src/webviews/apps/plus/graph/graph.tsx
+++ b/src/webviews/apps/plus/graph/graph.tsx
@@ -566,7 +566,12 @@ export class GraphApp extends App<State> {
 
 	private async onHoverRowPromise(row: GraphRow) {
 		try {
-			return await this.sendRequest(GetRowHoverRequest, { type: row.type as GitGraphRowType, id: row.sha });
+			const request = await this.sendRequest(GetRowHoverRequest, {
+				type: row.type as GitGraphRowType,
+				id: row.sha,
+			});
+			this._telemetry.sendEvent({ name: 'graph/row/hover' });
+			return request;
 		} catch (ex) {
 			return { id: row.sha, markdown: { status: 'rejected' as const, reason: ex } };
 		}
@@ -576,6 +581,7 @@ export class GraphApp extends App<State> {
 		try {
 			// Assuming we have a command to get the ref details
 			const rsp = await this.sendRequest(ChooseRefRequest, { alt: alt });
+			this._telemetry.sendEvent({ name: 'graph/jump-to-ref', data: { alt: alt } });
 			return rsp;
 		} catch {
 			return undefined;
@@ -650,6 +656,7 @@ export class GraphApp extends App<State> {
 
 	private onSelectionChanged(rows: GraphRow[]) {
 		const selection = rows.filter(r => r != null).map(r => ({ id: r.sha, type: r.type as GitGraphRowType }));
+		this._telemetry.sendEvent({ name: 'graph/row/selected', data: { rows: selection.length } });
 		this.sendCommand(UpdateSelectionCommand, {
 			selection: selection,
 		});

--- a/src/webviews/apps/plus/graph/graph.tsx
+++ b/src/webviews/apps/plus/graph/graph.tsx
@@ -581,7 +581,7 @@ export class GraphApp extends App<State> {
 		try {
 			// Assuming we have a command to get the ref details
 			const rsp = await this.sendRequest(ChooseRefRequest, { alt: alt });
-			this._telemetry.sendEvent({ name: 'graph/jump-to-ref', data: { alt: alt } });
+			this._telemetry.sendEvent({ name: 'graph/jumpToRef', data: { alt: alt } });
 			return rsp;
 		} catch {
 			return undefined;

--- a/src/webviews/apps/plus/graph/graph.tsx
+++ b/src/webviews/apps/plus/graph/graph.tsx
@@ -570,7 +570,7 @@ export class GraphApp extends App<State> {
 				type: row.type as GitGraphRowType,
 				id: row.sha,
 			});
-			this._telemetry.sendEvent({ name: 'graph/row/hover' });
+			this._telemetry.sendEvent({ name: 'graph/row/hovered', data: {} });
 			return request;
 		} catch (ex) {
 			return { id: row.sha, markdown: { status: 'rejected' as const, reason: ex } };

--- a/src/webviews/apps/plus/graph/sidebar/sidebar.ts
+++ b/src/webviews/apps/plus/graph/sidebar/sidebar.ts
@@ -9,6 +9,7 @@ import type { Disposable } from '../../../shared/events';
 import type { HostIpc } from '../../../shared/ipc';
 import '../../../shared/components/code-icon';
 import '../../../shared/components/overlays/tooltip';
+import { emitTelemetrySentEvent } from '../../../shared/telemetry';
 
 interface Icon {
 	type: IconTypes;
@@ -147,7 +148,7 @@ export class GlGraphSideBar extends LitElement {
 		if (this.include != null && !this.include.includes(icon.type)) return;
 
 		return html`<gl-tooltip placement="right" content="${icon.tooltip}">
-			<a class="item" href="command:${icon.command}">
+			<a class="item" href="command:${icon.command}" @click=${() => this.sendTelemetry(icon.command)}>
 				<code-icon icon="${icon.icon}"></code-icon>
 				${this._countsTask.render({
 					pending: () =>
@@ -159,6 +160,13 @@ export class GlGraphSideBar extends LitElement {
 				})}
 			</a>
 		</gl-tooltip>`;
+	}
+
+	private sendTelemetry(command: string) {
+		emitTelemetrySentEvent(this, {
+			name: 'graph/sidebar/action',
+			data: { action: command },
+		});
 	}
 }
 

--- a/src/webviews/apps/plus/timeline/chart.ts
+++ b/src/webviews/apps/plus/timeline/chart.ts
@@ -506,10 +506,10 @@ export class TimelineChart implements Disposable {
 		});
 	}
 
-	private onToggleLegend(id: string) {
-		console.log('timeline/chart/toggleLegend', id);
+	private onToggleLegend(_id: string) {
 		emitTelemetrySentEvent(this.$container, {
 			name: 'timeline/chart/toggleLegend',
+			data: {},
 		});
 	}
 }

--- a/src/webviews/apps/plus/timeline/chart.ts
+++ b/src/webviews/apps/plus/timeline/chart.ts
@@ -8,6 +8,7 @@ import { defer } from '../../../../system/promise';
 import { formatDate, fromNow } from '../../shared/date';
 import type { Disposable, Event } from '../../shared/events';
 import { Emitter } from '../../shared/events';
+import { emitTelemetrySentEvent } from '../../shared/telemetry';
 
 export interface DataPointClickEvent {
 	data: {
@@ -412,6 +413,9 @@ export class TimelineChart implements Disposable {
 				show: !this.compact,
 				// hide: this.compact ? [...this._authorsByIndex.values()] : undefined,
 				padding: 10,
+				item: {
+					onclick: this.onToggleLegend.bind(this),
+				},
 			},
 			point: {
 				sensitivity: 'radius',
@@ -499,6 +503,13 @@ export class TimelineChart implements Disposable {
 				id: commit.commit,
 				selected: true, //selected?.[0]?.id === d.id,
 			},
+		});
+	}
+
+	private onToggleLegend(id: string) {
+		console.log('timeline/chart/toggleLegend', id);
+		emitTelemetrySentEvent(this.$container, {
+			name: 'timeline/chart/toggleLegend',
 		});
 	}
 }

--- a/src/webviews/apps/shared/app.ts
+++ b/src/webviews/apps/shared/app.ts
@@ -7,7 +7,7 @@ import { debounce } from '../../../system/function';
 import type { WebviewFocusChangedParams } from '../../protocol';
 import { DidChangeWebviewFocusNotification, WebviewFocusChangedCommand, WebviewReadyCommand } from '../../protocol';
 import { GlElement } from './components/element';
-import { ipcContext, loggerContext, LoggerContext } from './context';
+import { ipcContext, LoggerContext, loggerContext, telemetryContext, TelemetryContext } from './context';
 import type { Disposable } from './events';
 import { HostIpc } from './ipc';
 
@@ -30,6 +30,9 @@ export abstract class GlApp<
 
 	@provide({ context: loggerContext })
 	protected _logger!: LoggerContext;
+
+	@provide({ context: telemetryContext })
+	protected _telemetry!: TelemetryContext;
 
 	@property({ type: Object })
 	state!: State;
@@ -65,6 +68,7 @@ export abstract class GlApp<
 				}
 			}),
 			this._ipc,
+			(this._telemetry = new TelemetryContext(this._ipc)),
 		);
 		this._ipc.sendCommand(WebviewReadyCommand, undefined);
 

--- a/src/webviews/apps/shared/appBase.ts
+++ b/src/webviews/apps/shared/appBase.ts
@@ -1,5 +1,7 @@
 /*global window document*/
 import { ContextProvider } from '@lit/context';
+import type { TimeInput } from '@opentelemetry/api';
+import type { Source, TelemetryEvents } from '../../../constants.telemetry';
 import type { CustomEditorIds, WebviewIds, WebviewViewIds } from '../../../constants.views';
 import { debounce } from '../../../system/function';
 import type { LogScope } from '../../../system/logger.scope';
@@ -11,7 +13,12 @@ import type {
 	IpcRequest,
 	WebviewFocusChangedParams,
 } from '../../protocol';
-import { DidChangeWebviewFocusNotification, WebviewFocusChangedCommand, WebviewReadyCommand } from '../../protocol';
+import {
+	DidChangeWebviewFocusNotification,
+	TelemetrySendEventCommand,
+	WebviewFocusChangedCommand,
+	WebviewReadyCommand,
+} from '../../protocol';
 import { ipcContext, loggerContext, LoggerContext } from './context';
 import { DOM } from './dom';
 import type { Disposable } from './events';
@@ -189,6 +196,22 @@ export abstract class App<
 		params: IpcCallParamsType<T>,
 	): Promise<IpcCallResponseParamsType<T>> {
 		return this._hostIpc.sendRequest(requestType, params);
+	}
+
+	protected sendTelemetryEvent<T extends keyof TelemetryEvents>(
+		name: T,
+		data?: TelemetryEvents[T],
+		source?: Source,
+		startTime?: TimeInput,
+		endTime?: TimeInput,
+	): void {
+		this._hostIpc.sendCommand(TelemetrySendEventCommand, {
+			name: name,
+			data: data,
+			source: source,
+			startTime: startTime,
+			endTime: endTime,
+		});
 	}
 
 	protected setState(state: Partial<State>) {

--- a/src/webviews/apps/shared/context.ts
+++ b/src/webviews/apps/shared/context.ts
@@ -1,8 +1,12 @@
 import { createContext } from '@lit/context';
+import type { TimeInput } from '@opentelemetry/api';
+import type { Source, TelemetryEvents } from '../../../constants.telemetry';
 import { Logger } from '../../../system/logger';
 import type { LogScope } from '../../../system/logger.scope';
 import { getNewLogScope } from '../../../system/logger.scope';
 import { padOrTruncateEnd } from '../../../system/string';
+import { TelemetrySendEventCommand } from '../../protocol';
+import type { Disposable } from './events';
 import type { HostIpc } from './ipc';
 
 export class LoggerContext {
@@ -35,5 +39,35 @@ export class LoggerContext {
 	}
 }
 
+export class TelemetryContext implements Disposable {
+	private readonly ipc: HostIpc;
+	private readonly disposables: Disposable[] = [];
+
+	constructor(ipc: HostIpc) {
+		this.ipc = ipc;
+	}
+
+	sendEvent<T extends keyof TelemetryEvents>(
+		name: T,
+		data?: TelemetryEvents[T],
+		source?: Source,
+		startTime?: TimeInput,
+		endTime?: TimeInput,
+	): void {
+		this.ipc.sendCommand(TelemetrySendEventCommand, {
+			name: name,
+			data: data,
+			source: source,
+			startTime: startTime,
+			endTime: endTime,
+		});
+	}
+
+	dispose(): void {
+		this.disposables.forEach(d => d.dispose());
+	}
+}
+
 export const ipcContext = createContext<HostIpc>('ipc');
 export const loggerContext = createContext<LoggerContext>('logger');
+export const telemetryContext = createContext<unknown>('telemetry');

--- a/src/webviews/apps/shared/context.ts
+++ b/src/webviews/apps/shared/context.ts
@@ -1,10 +1,9 @@
 import { createContext } from '@lit/context';
-import type { TimeInput } from '@opentelemetry/api';
-import type { Source, TelemetryEvents } from '../../../constants.telemetry';
 import { Logger } from '../../../system/logger';
 import type { LogScope } from '../../../system/logger.scope';
 import { getNewLogScope } from '../../../system/logger.scope';
 import { padOrTruncateEnd } from '../../../system/string';
+import type { TelemetrySendEventParams } from '../../protocol';
 import { TelemetrySendEventCommand } from '../../protocol';
 import type { Disposable } from './events';
 import type { HostIpc } from './ipc';
@@ -47,20 +46,8 @@ export class TelemetryContext implements Disposable {
 		this.ipc = ipc;
 	}
 
-	sendEvent<T extends keyof TelemetryEvents>(
-		name: T,
-		data?: TelemetryEvents[T],
-		source?: Source,
-		startTime?: TimeInput,
-		endTime?: TimeInput,
-	): void {
-		this.ipc.sendCommand(TelemetrySendEventCommand, {
-			name: name,
-			data: data,
-			source: source,
-			startTime: startTime,
-			endTime: endTime,
-		});
+	sendEvent(detail: TelemetrySendEventParams): void {
+		this.ipc.sendCommand(TelemetrySendEventCommand, detail);
 	}
 
 	dispose(): void {

--- a/src/webviews/apps/shared/telemetry.ts
+++ b/src/webviews/apps/shared/telemetry.ts
@@ -1,0 +1,18 @@
+import type { TelemetrySendEventParams } from '../../protocol';
+
+export const telemetryEventName = 'gl-telemetry-fired';
+
+export function emitTelemetrySentEvent<T extends TelemetrySendEventParams>(el: EventTarget, params: T) {
+	el.dispatchEvent(
+		new CustomEvent<T>(telemetryEventName, {
+			bubbles: true,
+			detail: params,
+		}),
+	);
+}
+
+declare global {
+	interface WindowEventMap {
+		[telemetryEventName]: CustomEvent<TelemetrySendEventParams>;
+	}
+}

--- a/src/webviews/commitDetails/commitDetailsWebview.ts
+++ b/src/webviews/commitDetails/commitDetailsWebview.ts
@@ -226,12 +226,15 @@ export class CommitDetailsWebviewProvider
 		_loading: boolean,
 		options?: WebviewShowOptions,
 		...args: WebviewShowingArgs<CommitDetailsWebviewShowingArgs, Serialized<State>>
-	): Promise<boolean> {
+	): Promise<[boolean, Record<`context.${string}`, string | number | boolean> | undefined]> {
 		const [arg] = args;
 		if ((arg as ShowWipArgs)?.type === 'wip') {
-			return this.onShowingWip(arg as ShowWipArgs);
+			return [await this.onShowingWip(arg as ShowWipArgs), undefined];
 		}
-		return this.onShowingCommit(arg as Partial<CommitSelectedEvent['data']> | undefined, options);
+		return [
+			await this.onShowingCommit(arg as Partial<CommitSelectedEvent['data']> | undefined, options),
+			undefined,
+		];
 	}
 
 	private get inReview(): boolean {

--- a/src/webviews/commitDetails/registration.ts
+++ b/src/webviews/commitDetails/registration.ts
@@ -13,6 +13,7 @@ export function registerCommitDetailsWebviewView(controller: WebviewsController)
 			title: 'Inspect',
 			contextKeyPrefix: `gitlens:webviewView:commitDetails`,
 			trackingFeature: 'commitDetailsView',
+			type: 'commitDetails',
 			plusFeature: false,
 			webviewHostOptions: {
 				retainContextWhenHidden: false,
@@ -35,6 +36,7 @@ export function registerGraphDetailsWebviewView(controller: WebviewsController) 
 			title: 'Commit Graph Inspect',
 			contextKeyPrefix: `gitlens:webviewView:graphDetails`,
 			trackingFeature: 'graphDetailsView',
+			type: 'graphDetails',
 			plusFeature: false,
 			webviewHostOptions: {
 				retainContextWhenHidden: false,

--- a/src/webviews/home/homeWebview.ts
+++ b/src/webviews/home/homeWebview.ts
@@ -53,17 +53,17 @@ export class HomeWebviewProvider implements WebviewProvider<State, State, HomeWe
 		loading: boolean,
 		_options?: WebviewShowOptions,
 		...args: WebviewShowingArgs<HomeWebviewShowingArgs, State>
-	) {
+	): [boolean, Record<`context.${string}`, string | number | boolean> | undefined] {
 		const [arg] = args as HomeWebviewShowingArgs;
 		if (arg?.focusAccount === true) {
 			if (!loading && this.host.ready && this.host.visible) {
 				queueMicrotask(() => void this.host.notify(DidFocusAccount, undefined));
-				return true;
+				return [true, undefined];
 			}
 			this._pendingFocusAccount = true;
 		}
 
-		return true;
+		return [true, undefined];
 	}
 
 	private onChangeConnectionState() {

--- a/src/webviews/home/registration.ts
+++ b/src/webviews/home/registration.ts
@@ -11,6 +11,7 @@ export function registerHomeWebviewView(controller: WebviewsController) {
 			title: 'Home',
 			contextKeyPrefix: `gitlens:webviewView:home`,
 			trackingFeature: 'homeView',
+			type: 'home',
 			plusFeature: false,
 			webviewHostOptions: {
 				retainContextWhenHidden: false,

--- a/src/webviews/protocol.ts
+++ b/src/webviews/protocol.ts
@@ -1,4 +1,6 @@
+import type { TimeInput } from '@opentelemetry/api';
 import type { Config } from '../config';
+import type { Source, TelemetryEvents } from '../constants.telemetry';
 import type {
 	CustomEditorIds,
 	CustomEditorTypes,
@@ -91,6 +93,15 @@ export interface UpdateConfigurationParams {
 	uri?: string;
 }
 export const UpdateConfigurationCommand = new IpcCommand<UpdateConfigurationParams>('core', 'configuration/update');
+
+export interface TelemetrySendEventParams<T extends keyof TelemetryEvents = keyof TelemetryEvents> {
+	name: T;
+	data?: TelemetryEvents[T];
+	source?: Source;
+	startTime?: TimeInput;
+	endTime?: TimeInput;
+}
+export const TelemetrySendEventCommand = new IpcCommand<TelemetrySendEventParams>('core', 'telemetry/sendEvent');
 
 // NOTIFICATIONS
 

--- a/src/webviews/protocol.ts
+++ b/src/webviews/protocol.ts
@@ -1,6 +1,6 @@
 import type { TimeInput } from '@opentelemetry/api';
 import type { Config } from '../config';
-import type { Source, TelemetryEvents } from '../constants.telemetry';
+import type { Source, TelemetryEvents, WebviewTelemetryContext } from '../constants.telemetry';
 import type {
 	CustomEditorIds,
 	CustomEditorTypes,
@@ -96,7 +96,7 @@ export const UpdateConfigurationCommand = new IpcCommand<UpdateConfigurationPara
 
 export interface TelemetrySendEventParams<T extends keyof TelemetryEvents = keyof TelemetryEvents> {
 	name: T;
-	data?: TelemetryEvents[T];
+	data: Omit<TelemetryEvents[T], keyof WebviewTelemetryContext>;
 	source?: Source;
 	startTime?: TimeInput;
 	endTime?: TimeInput;

--- a/src/webviews/settings/registration.ts
+++ b/src/webviews/settings/registration.ts
@@ -16,6 +16,7 @@ export function registerSettingsWebviewPanel(controller: WebviewsController) {
 			title: 'GitLens Settings',
 			contextKeyPrefix: `gitlens:webview:settings`,
 			trackingFeature: 'settingsWebview',
+			type: 'settings',
 			plusFeature: false,
 			column: ViewColumn.Active,
 			webviewHostOptions: {

--- a/src/webviews/settings/settingsWebview.ts
+++ b/src/webviews/settings/settingsWebview.ts
@@ -95,7 +95,7 @@ export class SettingsWebviewProvider implements WebviewProvider<State, State, Se
 		loading: boolean,
 		_options: { column?: ViewColumn; preserveFocus?: boolean },
 		...args: SettingsWebviewShowingArgs
-	): boolean | Promise<boolean> {
+	): [boolean, Record<`context.${string}`, string | number | boolean> | undefined] {
 		const anchor = args[0];
 		if (anchor && typeof anchor === 'string') {
 			if (!loading && this.host.ready && this.host.visible) {
@@ -106,13 +106,13 @@ export class SettingsWebviewProvider implements WebviewProvider<State, State, Se
 							scrollBehavior: 'smooth',
 						}),
 				);
-				return true;
+				return [true, undefined];
 			}
 
 			this._pendingJumpToAnchor = anchor;
 		}
 
-		return true;
+		return [true, undefined];
 	}
 
 	onActiveChanged(active: boolean): void {

--- a/src/webviews/webviewController.ts
+++ b/src/webviews/webviewController.ts
@@ -28,6 +28,7 @@ import {
 	DidChangeHostWindowFocusNotification,
 	DidChangeWebviewFocusNotification,
 	ExecuteCommand,
+	TelemetrySendEventCommand,
 	WebviewFocusChangedCommand,
 	WebviewReadyCommand,
 } from './protocol';
@@ -385,6 +386,10 @@ export class WebviewController<
 				} else {
 					void executeCommand(e.params.command as Commands);
 				}
+				break;
+
+			case TelemetrySendEventCommand.is(e):
+				this.container.telemetry.sendEvent(e.params.name, e.params.data, e.params.source);
 				break;
 
 			default:

--- a/src/webviews/webviewProvider.ts
+++ b/src/webviews/webviewProvider.ts
@@ -26,7 +26,9 @@ export interface WebviewProvider<State, SerializedState = State, ShowingArgs ext
 		loading: boolean,
 		options: WebviewShowOptions,
 		...args: WebviewShowingArgs<ShowingArgs, SerializedState>
-	): boolean | Promise<boolean>;
+	):
+		| [boolean, Record<`context.${string}`, string | number | boolean> | undefined]
+		| Promise<[boolean, Record<`context.${string}`, string | number | boolean> | undefined]>;
 	registerCommands?(): Disposable[];
 
 	includeBootstrap?(): SerializedState | Promise<SerializedState>;

--- a/src/webviews/webviewProvider.ts
+++ b/src/webviews/webviewProvider.ts
@@ -1,4 +1,5 @@
 import type { Disposable, Uri, ViewBadge } from 'vscode';
+import type { WebviewTelemetryContext } from '../constants.telemetry';
 import type { WebviewContext } from '../system/webview';
 import type {
 	IpcCallMessageType,
@@ -22,13 +23,15 @@ export interface WebviewProvider<State, SerializedState = State, ShowingArgs ext
 	 */
 	canReuseInstance?(...args: WebviewShowingArgs<ShowingArgs, SerializedState>): boolean | undefined;
 	getSplitArgs?(): WebviewShowingArgs<ShowingArgs, SerializedState>;
+	getTelemetryContext?(): Record<`context.${string}`, string | number | boolean | undefined> &
+		WebviewTelemetryContext;
 	onShowing?(
 		loading: boolean,
 		options: WebviewShowOptions,
 		...args: WebviewShowingArgs<ShowingArgs, SerializedState>
 	):
-		| [boolean, Record<`context.${string}`, string | number | boolean> | undefined]
-		| Promise<[boolean, Record<`context.${string}`, string | number | boolean> | undefined]>;
+		| [boolean, Record<`context.${string}`, string | number | boolean | undefined> | undefined]
+		| Promise<[boolean, Record<`context.${string}`, string | number | boolean | undefined> | undefined]>;
 	registerCommands?(): Disposable[];
 
 	includeBootstrap?(): SerializedState | Promise<SerializedState>;
@@ -73,6 +76,7 @@ export interface WebviewHost<
 	clearPendingIpcNotifications(): void;
 	sendPendingIpcNotifications(): void;
 
+	getTelemetryContext(): WebviewTelemetryContext;
 	isHost(type: 'editor'): this is WebviewHost<WebviewPanelDescriptor>;
 	isHost(type: 'view'): this is WebviewHost<WebviewViewDescriptor>;
 

--- a/src/webviews/webviewsController.ts
+++ b/src/webviews/webviewsController.ts
@@ -29,6 +29,7 @@ export interface WebviewPanelDescriptor {
 	readonly title: string;
 	readonly contextKeyPrefix: `gitlens:webview:${WebviewTypes}`;
 	readonly trackingFeature: TrackedUsageFeatures;
+	readonly type: WebviewTypes;
 	readonly plusFeature: boolean;
 	readonly column?: ViewColumn;
 	readonly webviewOptions?: WebviewOptions;
@@ -79,6 +80,7 @@ export interface WebviewViewDescriptor {
 	readonly title: string;
 	readonly contextKeyPrefix: `gitlens:webviewView:${WebviewViewTypes}`;
 	readonly trackingFeature: TrackedUsageFeatures;
+	readonly type: WebviewViewTypes;
 	readonly plusFeature: boolean;
 	readonly webviewOptions?: WebviewOptions;
 	readonly webviewHostOptions?: {

--- a/src/webviews/welcome/registration.ts
+++ b/src/webviews/welcome/registration.ts
@@ -13,6 +13,7 @@ export function registerWelcomeWebviewPanel(controller: WebviewsController) {
 			title: 'Welcome to GitLens',
 			contextKeyPrefix: `gitlens:webview:welcome`,
 			trackingFeature: 'welcomeWebview',
+			type: 'welcome',
 			plusFeature: false,
 			column: ViewColumn.Active,
 			webviewHostOptions: {


### PR DESCRIPTION
- Adds new telemetry events for graph
- Adds new telemetry events for visual file history
- Adds `type` to the webview descriptor and used as a key in new `showAborted` and `shown` events
- Refactors `onShowing` hook to return a tuple which adds an optional context record that is mixed-in to the new `show*` events
- Adds telemetry context into the webview app and a low-level custom event handler