### PR TITLE
Uses root repo path for worktree create

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/) and this p
 
 - Fixes [#3650](https://github.com/gitkraken/vscode-gitlens/issues/3650) - "Create & Switch to Local Branch" from remote branch no longer prefills local branch name to match remote branch name
 - Fixes [#3651](https://github.com/gitkraken/vscode-gitlens/issues/3651) - "Open on Remote (Web)" does not use tracked branch name
+- Fixes [#3657](https://github.com/gitkraken/vscode-gitlens/issues/3657) - Creating a worktree from within a worktree chooses the wrong path
 
 ## [15.6.0] - 2024-10-07
 

--- a/src/commands/git/worktree.ts
+++ b/src/commands/git/worktree.ts
@@ -689,7 +689,9 @@ export class WorktreeGitCommand extends QuickCommand<State> {
 		const repoUri = (await state.repo.getCommonRepositoryUri()) ?? state.repo.uri;
 		const trailer = `${basename(repoUri.path)}.worktrees`;
 
-		if (repoUri.toString() !== pickedUri.toString()) {
+		if (context.pickedRootFolder != null) {
+			recommendedRootUri = context.pickedRootFolder;
+		} else if (repoUri.toString() !== pickedUri.toString()) {
 			if (isDescendant(pickedUri, repoUri)) {
 				recommendedRootUri = Uri.joinPath(repoUri, '..', trailer);
 			} else if (basename(pickedUri.path) === trailer) {
@@ -707,11 +709,8 @@ export class WorktreeGitCommand extends QuickCommand<State> {
 		const pickedFriendlyPath = truncateLeft(getWorkspaceFriendlyPath(pickedUri), 60);
 		const branchName = state.reference != null ? getNameWithoutRemote(state.reference) : undefined;
 
-		const recommendedFriendlyPath = `<root>/${truncateLeft(
-			`${trailer}/${branchName?.replace(/\\/g, '/') ?? ''}`,
-			65,
-		)}`;
-		const recommendedNewBranchFriendlyPath = `<root>/${trailer}/${state.createBranch || '<new-branch-name>'}`;
+		const recommendedFriendlyPath = `<root>/${truncateLeft(branchName?.replace(/\\/g, '/') ?? '', 65)}`;
+		const recommendedNewBranchFriendlyPath = `<root>/${state.createBranch || '<new-branch-name>'}`;
 
 		const isBranch = isBranchReference(state.reference);
 		const isRemoteBranch = isBranchReference(state.reference) && state.reference?.remote;
@@ -788,7 +787,10 @@ export class WorktreeGitCommand extends QuickCommand<State> {
 					[],
 					{
 						label: 'Change Root Folder...',
-						description: `$(folder) ${truncateLeft(pickedFriendlyPath, 65)}`,
+						description: `$(folder) ${truncateLeft(
+							context.pickedRootFolder ? pickedFriendlyPath : `${pickedFriendlyPath}/${trailer}`,
+							65,
+						)}`,
 						picked: false,
 					},
 					'changeRoot',

--- a/src/git/gitProviderService.ts
+++ b/src/git/gitProviderService.ts
@@ -2968,7 +2968,8 @@ export class GitProviderService implements Disposable {
 		if (defaultUri != null) return defaultUri;
 
 		// If we don't have a default set, default it to the parent folder of the repo folder
-		defaultUri = this.getRepository(rp)?.uri;
+		const repo = this.getRepository(rp);
+		defaultUri = (await repo?.getCommonRepositoryUri()) ?? repo?.uri;
 		if (defaultUri != null) {
 			defaultUri = Uri.joinPath(defaultUri, '..');
 		}


### PR DESCRIPTION
Fixes #3657

This needs some vetting of all the different worktree create options (default folder, choosing a new root, etc) to make sure it doesn't regress any behavior.

I also added an additional commit to honor a chosen root folder rather than always adding the "trailer" (e.g. `<repo>.worktrees` ) onto the root