### PR TITLE
Improves launchpad draft item UX

### DIFF
--- a/src/plus/launchpad/launchpad.ts
+++ b/src/plus/launchpad/launchpad.ts
@@ -465,6 +465,8 @@ export class LaunchpadCommand extends QuickCommand<State> {
 										: ''
 								} \u00a0 ${i.isNew ? '(New since last view)' : ''}`,
 								detail: `      ${i.viewer.pinned ? '$(pinned) ' : ''}${
+									i.isDraft && ui !== 'draft' ? '$(git-pull-request-draft) ' : ''
+								}${
 									i.actionableCategory === 'other'
 										? ''
 										: `${actionGroupMap.get(i.actionableCategory)![0]} \u2022  `

--- a/src/plus/launchpad/launchpadProvider.ts
+++ b/src/plus/launchpad/launchpadProvider.ts
@@ -953,11 +953,16 @@ export function groupAndSortLaunchpadItems(items?: LaunchpadItem[]) {
 
 		if (item.isDraft) {
 			grouped.get('draft')!.push(item);
-		} else {
-			const group = launchpadCategoryToGroupMap.get(item.actionableCategory)!;
+		}
+
+		const group = launchpadCategoryToGroupMap.get(item.actionableCategory)!;
+		if (!item.isDraft || group === 'needs-review') {
 			grouped.get(group)!.push(item);
 		}
 	}
+
+	// Re-sort needs review category so draft items are at the bottom
+	grouped.get('needs-review')!.sort((a, b) => (a.isDraft ? 1 : -1) - (b.isDraft ? 1 : -1));
 
 	// Re-sort pinned and draft groups by updated date
 	grouped.get('pinned')!.sort((a, b) => b.updatedDate.getTime() - a.updatedDate.getTime());


### PR DESCRIPTION
Also puts draft items that need your review into the "needs your review" category, below non-draft items - closes #3654

Adds a draft icon to the detail section of draft items when they are not in the "draft" category, to the right of the "pinned" icon - closes #3655