### PR TITLE
Add support to localhost urls while debugging

### DIFF
--- a/src/container.ts
+++ b/src/container.ts
@@ -98,7 +98,7 @@ import type { WebviewViewProxy } from './webviews/webviewsController';
 import { WebviewsController } from './webviews/webviewsController';
 import { registerWelcomeWebviewPanel } from './webviews/welcome/registration';
 
-export type Environment = 'local' | 'dev' | 'staging' | 'production';
+export type Environment = 'dev' | 'staging' | 'production';
 
 export class Container {
 	static #instance: Container | undefined;
@@ -527,7 +527,6 @@ export class Container {
 	get env(): Environment {
 		if (this.prereleaseOrDebugging) {
 			const env = configuration.getAny('gitkraken.env');
-			if (env === 'local') return 'local';
 			if (env === 'dev') return 'dev';
 			if (env === 'staging') return 'staging';
 		}
@@ -920,17 +919,17 @@ export class Container {
 
 	@memoize()
 	private get baseGkDevUri(): Uri {
+		if (this.prereleaseOrDebugging) {
+			const url: string | undefined = configuration.getAny('gitkraken.url.gkdev.base');
+			if (url) return Uri.parse(url);
+		}
+
 		if (this.env === 'staging') {
 			return Uri.parse('https://staging.gitkraken.dev');
 		}
 
 		if (this.env === 'dev') {
 			return Uri.parse('https://dev.gitkraken.dev');
-		}
-
-		if (this.env === 'local') {
-			const url: string | undefined = configuration.getAny('gitkraken.url.gkdev.base');
-			return Uri.parse(url ?? 'http://localhost:3000');
 		}
 
 		return Uri.parse('https://gitkraken.dev');

--- a/src/container.ts
+++ b/src/container.ts
@@ -98,7 +98,7 @@ import type { WebviewViewProxy } from './webviews/webviewsController';
 import { WebviewsController } from './webviews/webviewsController';
 import { registerWelcomeWebviewPanel } from './webviews/welcome/registration';
 
-export type Environment = 'dev' | 'staging' | 'production';
+export type Environment = 'local' | 'dev' | 'staging' | 'production';
 
 export class Container {
 	static #instance: Container | undefined;
@@ -527,6 +527,7 @@ export class Container {
 	get env(): Environment {
 		if (this.prereleaseOrDebugging) {
 			const env = configuration.getAny('gitkraken.env');
+			if (env === 'local') return 'local';
 			if (env === 'dev') return 'dev';
 			if (env === 'staging') return 'staging';
 		}
@@ -925,6 +926,11 @@ export class Container {
 
 		if (this.env === 'dev') {
 			return Uri.parse('https://dev.gitkraken.dev');
+		}
+
+		if (this.env === 'local') {
+			const url: string | undefined = configuration.getAny('gitkraken.url.gkdev.base');
+			return Uri.parse(url ?? 'http://localhost:3000');
 		}
 
 		return Uri.parse('https://gitkraken.dev');

--- a/src/plus/gk/serverConnection.ts
+++ b/src/plus/gk/serverConnection.ts
@@ -48,17 +48,17 @@ export class ServerConnection implements Disposable {
 
 	@memoize()
 	private get baseApiUri(): Uri {
+		if (this.container.prereleaseOrDebugging) {
+			const url: string | undefined = configuration.getAny('gitkraken.url.api');
+			if (url) return Uri.parse(url);
+		}
+
 		if (this.container.env === 'staging') {
 			return Uri.parse('https://stagingapi.gitkraken.com');
 		}
 
 		if (this.container.env === 'dev') {
 			return Uri.parse('https://devapi.gitkraken.com');
-		}
-
-		if (this.container.env === 'local') {
-			const url: string | undefined = configuration.getAny('gitkraken.url.api');
-			return Uri.parse(url ?? 'http://localhost:3000');
 		}
 
 		return Uri.parse('https://api.gitkraken.com');
@@ -70,17 +70,17 @@ export class ServerConnection implements Disposable {
 
 	@memoize()
 	private get baseGkDevApiUri(): Uri {
+		if (this.container.prereleaseOrDebugging) {
+			const url: string | undefined = configuration.getAny('gitkraken.url.gkdev.api');
+			if (url) return Uri.parse(url);
+		}
+
 		if (this.container.env === 'staging') {
 			return Uri.parse('https://staging-api.gitkraken.dev');
 		}
 
 		if (this.container.env === 'dev') {
 			return Uri.parse('https://dev-api.gitkraken.dev');
-		}
-
-		if (this.container.env === 'local') {
-			const url: string | undefined = configuration.getAny('gitkraken.url.gkdev.api');
-			return Uri.parse(url ?? 'http://localhost:3000');
 		}
 
 		return Uri.parse('https://api.gitkraken.dev');

--- a/src/plus/gk/serverConnection.ts
+++ b/src/plus/gk/serverConnection.ts
@@ -27,6 +27,7 @@ import { memoize } from '../../system/decorators/memoize';
 import { Logger } from '../../system/logger';
 import type { LogScope } from '../../system/logger.scope';
 import { getLogScope } from '../../system/logger.scope';
+import { configuration } from '../../system/vscode/configuration';
 
 interface FetchOptions {
 	cancellation?: CancellationToken;
@@ -55,6 +56,11 @@ export class ServerConnection implements Disposable {
 			return Uri.parse('https://devapi.gitkraken.com');
 		}
 
+		if (this.container.env === 'local') {
+			const url: string | undefined = configuration.getAny('gitkraken.url.api');
+			return Uri.parse(url ?? 'http://localhost:3000');
+		}
+
 		return Uri.parse('https://api.gitkraken.com');
 	}
 
@@ -70,6 +76,11 @@ export class ServerConnection implements Disposable {
 
 		if (this.container.env === 'dev') {
 			return Uri.parse('https://dev-api.gitkraken.dev');
+		}
+
+		if (this.container.env === 'local') {
+			const url: string | undefined = configuration.getAny('gitkraken.url.gkdev.api');
+			return Uri.parse(url ?? 'http://localhost:3000');
 		}
 
 		return Uri.parse('https://api.gitkraken.dev');


### PR DESCRIPTION
# Description

These changes will allow testing local development on APIs and backend services of gk-dev. With this, you can now set the following settings in `settings.json` (made up urls for the example):
```json
{
	"gitkraken.env": "local",
	"gitkraken.url": {
		"api": "http://localhost:1314/api",
		"gkdev": {
			"base": "http://localhost:1314",
			"api": "http://localhost:1314/gkdev/api"
		}
	}
}
```

NOTE: URLs will only be applied when `gitkraken.env` is set to `local`. Also, the `local` environment has the same restrictions as `dev` and `staging` (only available if it's pre-release or debugging).

# Checklist

<!-- Please check off the following -->

- [x] I have followed the guidelines in the Contributing document
- [x] My changes follow the coding style of this project
- [x] My changes build without any errors or warnings
- [x] My changes have been formatted and linted
- [x] My changes include any required corresponding changes to the documentation (including CHANGELOG.md and README.md)
- [x] My changes have been rebased and squashed to the minimal number (typically 1) of relevant commits
- [x] My changes have a descriptive commit message with a short title, including a `Fixes $XXX -` or `Closes #XXX -` prefix to auto-close the issue that your PR addresses
