### PR TITLE
Opens all changes after open in worktree flow finished for PRs

### DIFF
--- a/src/commands/git/switch.ts
+++ b/src/commands/git/switch.ts
@@ -34,7 +34,7 @@ interface Context {
 
 interface State {
 	repos: string | string[] | Repository | Repository[];
-	onWorkspaceChanging?: (() => Promise<void>) | (() => void);
+	onWorkspaceChanging?: ((isNewWorktree?: boolean) => Promise<void>) | ((isNewWorktree?: boolean) => void);
 	reference: GitReference;
 	createBranch?: string;
 	fastForwardTo?: GitReference;

--- a/src/commands/git/worktree.ts
+++ b/src/commands/git/worktree.ts
@@ -102,7 +102,7 @@ interface CreateState {
 		title?: string;
 	};
 
-	onWorkspaceChanging?: (() => Promise<void>) | (() => void);
+	onWorkspaceChanging?: ((isNewWorktree?: boolean) => Promise<void>) | ((isNewWorktree?: boolean) => void);
 	skipWorktreeConfirmations?: boolean;
 }
 
@@ -139,7 +139,8 @@ interface OpenState {
 		};
 	};
 
-	onWorkspaceChanging?: (() => Promise<void>) | (() => void);
+	onWorkspaceChanging?: ((isNewWorktree?: boolean) => Promise<void>) | ((isNewWorktree?: boolean) => void);
+	isNewWorktree?: boolean;
 	skipWorktreeConfirmations?: boolean;
 }
 
@@ -628,6 +629,7 @@ export class WorktreeGitCommand extends QuickCommand<State> {
 						confirm: action === 'prompt',
 						openOnly: true,
 						overrides: { disallowBack: true },
+						isNewWorktree: true,
 						skipWorktreeConfirmations: state.skipWorktreeConfirmations,
 						onWorkspaceChanging: state.onWorkspaceChanging,
 					} satisfies OpenStepState,
@@ -1081,7 +1083,7 @@ export class WorktreeGitCommand extends QuickCommand<State> {
 
 				const location = convertOpenFlagsToLocation(state.flags);
 				if (location === 'currentWindow' || location === 'newWindow') {
-					await state.onWorkspaceChanging?.();
+					await state.onWorkspaceChanging?.(state.isNewWorktree);
 				}
 
 				openWorkspace(state.worktree.uri, { location: convertOpenFlagsToLocation(state.flags), name: name });

--- a/src/uris/deepLinks/deepLink.ts
+++ b/src/uris/deepLinks/deepLink.ts
@@ -391,7 +391,6 @@ export const deepLinkStateTransitionTable: Record<string, Record<string, DeepLin
 		[DeepLinkServiceAction.OpenGraph]: DeepLinkServiceState.OpenGraph,
 		[DeepLinkServiceAction.OpenFile]: DeepLinkServiceState.OpenFile,
 		[DeepLinkServiceAction.OpenSwitch]: DeepLinkServiceState.SwitchToRef,
-		[DeepLinkServiceAction.OpenAllPrChanges]: DeepLinkServiceState.OpenAllPrChanges,
 		[DeepLinkServiceAction.OpenComparison]: DeepLinkServiceState.OpenComparison,
 		[DeepLinkServiceAction.DeepLinkErrored]: DeepLinkServiceState.Idle,
 		[DeepLinkServiceAction.DeepLinkCancelled]: DeepLinkServiceState.Idle,

--- a/src/uris/deepLinks/deepLink.ts
+++ b/src/uris/deepLinks/deepLink.ts
@@ -100,6 +100,7 @@ export interface DeepLink {
 	secondaryTargetId?: string;
 	secondaryRemoteUrl?: string;
 	action?: string;
+	prId?: string;
 	params?: URLSearchParams;
 }
 
@@ -178,6 +179,7 @@ export function parseDeepLinkUri(uri: Uri): DeepLink | undefined {
 				secondaryRemoteUrl: secondaryRemoteUrl,
 				action: action,
 				params: urlParams,
+				prId: urlParams.get('prId') ?? undefined,
 			};
 		}
 		case DeepLinkType.Draft: {
@@ -239,6 +241,7 @@ export const enum DeepLinkServiceState {
 	OpenInspect,
 	SwitchToRef,
 	RunCommand,
+	OpenAllPrChanges,
 }
 
 export const enum DeepLinkServiceAction {
@@ -271,6 +274,7 @@ export const enum DeepLinkServiceAction {
 	OpenFile,
 	OpenInspect,
 	OpenSwitch,
+	OpenAllPrChanges,
 }
 
 export type DeepLinkRepoOpenType = 'clone' | 'folder' | 'workspace' | 'current';
@@ -387,6 +391,7 @@ export const deepLinkStateTransitionTable: Record<string, Record<string, DeepLin
 		[DeepLinkServiceAction.OpenGraph]: DeepLinkServiceState.OpenGraph,
 		[DeepLinkServiceAction.OpenFile]: DeepLinkServiceState.OpenFile,
 		[DeepLinkServiceAction.OpenSwitch]: DeepLinkServiceState.SwitchToRef,
+		[DeepLinkServiceAction.OpenAllPrChanges]: DeepLinkServiceState.OpenAllPrChanges,
 		[DeepLinkServiceAction.OpenComparison]: DeepLinkServiceState.OpenComparison,
 		[DeepLinkServiceAction.DeepLinkErrored]: DeepLinkServiceState.Idle,
 		[DeepLinkServiceAction.DeepLinkCancelled]: DeepLinkServiceState.Idle,
@@ -417,6 +422,12 @@ export const deepLinkStateTransitionTable: Record<string, Record<string, DeepLin
 		[DeepLinkServiceAction.DeepLinkCancelled]: DeepLinkServiceState.Idle,
 	},
 	[DeepLinkServiceState.OpenInspect]: {
+		[DeepLinkServiceAction.OpenAllPrChanges]: DeepLinkServiceState.OpenAllPrChanges,
+		[DeepLinkServiceAction.DeepLinkResolved]: DeepLinkServiceState.Idle,
+		[DeepLinkServiceAction.DeepLinkErrored]: DeepLinkServiceState.Idle,
+		[DeepLinkServiceAction.DeepLinkCancelled]: DeepLinkServiceState.Idle,
+	},
+	[DeepLinkServiceState.OpenAllPrChanges]: {
 		[DeepLinkServiceAction.DeepLinkResolved]: DeepLinkServiceState.Idle,
 		[DeepLinkServiceAction.DeepLinkErrored]: DeepLinkServiceState.Idle,
 		[DeepLinkServiceAction.DeepLinkCancelled]: DeepLinkServiceState.Idle,

--- a/src/uris/deepLinks/deepLinkService.ts
+++ b/src/uris/deepLinks/deepLinkService.ts
@@ -241,8 +241,9 @@ export class DeepLinkService implements Disposable {
 
 	@debug()
 	private async processPendingDeepLink(pendingDeepLink: StoredDeepLinkContext | undefined) {
-		if (pendingDeepLink?.url == null) return;
+		if (pendingDeepLink == null) return;
 		void this.container.storage.delete('deepLinks:pending');
+		if (pendingDeepLink?.url == null) return;
 		const link = parseDeepLinkUri(Uri.parse(pendingDeepLink.url));
 		if (link == null) return;
 

--- a/src/uris/deepLinks/deepLinkService.ts
+++ b/src/uris/deepLinks/deepLinkService.ts
@@ -4,7 +4,7 @@ import { Commands } from '../../constants.commands';
 import type { StoredDeepLinkContext, StoredNamedRef } from '../../constants.storage';
 import type { Container } from '../../container';
 import { executeGitCommand } from '../../git/actions';
-import { openFileAtRevision } from '../../git/actions/commit';
+import { openComparisonChanges, openFileAtRevision } from '../../git/actions/commit';
 import type { GitBranch } from '../../git/models/branch';
 import { getBranchNameWithoutRemote } from '../../git/models/branch';
 import type { GitCommit } from '../../git/models/commit';
@@ -19,6 +19,7 @@ import { missingRepositoryId } from '../../gk/models/repositoryIdentities';
 import { ensureAccount, ensurePaidPlan } from '../../plus/utils';
 import type { ShowInCommitGraphCommandArgs } from '../../plus/webviews/graph/protocol';
 import { createQuickPickSeparator } from '../../quickpicks/items/common';
+import { debug } from '../../system/decorators/log';
 import { once } from '../../system/event';
 import { Logger } from '../../system/logger';
 import { normalizePath } from '../../system/path';
@@ -68,10 +69,7 @@ export class DeepLinkService implements Disposable {
 		this._disposables.push(container.uri.onDidReceiveUri(async (uri: Uri) => this.processDeepLinkUri(uri)));
 
 		const pendingDeepLink = this.container.storage.get('deepLinks:pending');
-		if (pendingDeepLink != null) {
-			void this.container.storage.delete('deepLinks:pending');
-			void this.processPendingDeepLink(pendingDeepLink);
-		}
+		void this.processPendingDeepLink(pendingDeepLink);
 	}
 
 	dispose() {
@@ -241,9 +239,10 @@ export class DeepLinkService implements Disposable {
 		}
 	}
 
-	private async processPendingDeepLink(pendingDeepLink: StoredDeepLinkContext) {
-		if (pendingDeepLink.url == null) return;
-
+	@debug()
+	private async processPendingDeepLink(pendingDeepLink: StoredDeepLinkContext | undefined) {
+		if (pendingDeepLink?.url == null) return;
+		void this.container.storage.delete('deepLinks:pending');
 		const link = parseDeepLinkUri(Uri.parse(pendingDeepLink.url));
 		if (link == null) return;
 
@@ -509,6 +508,7 @@ export class DeepLinkService implements Disposable {
 	// TODO @axosoft-ramint: Move all the logic for matching a repo, prompting to add repo, matching remote, etc. for a target (branch, PR, etc.)
 	// to a separate service where it can be used outside of the context of deep linking. Then the deep link service should leverage it,
 	// and we should stop using deep links to process things like Launchpad switch actions, Open in Worktree command, etc.
+	@debug()
 	private async processDeepLink(
 		initialAction: DeepLinkServiceAction = DeepLinkServiceAction.DeepLinkEventFired,
 		useProgress: boolean = true,
@@ -1078,7 +1078,6 @@ export class DeepLinkService implements Disposable {
 				}
 				case DeepLinkServiceState.GoToTarget: {
 					// Need to re-fetch the remotes in case we opened in a new window
-
 					if (targetType === DeepLinkType.Repository) {
 						if (
 							this._context.action === DeepLinkActionType.Switch ||
@@ -1373,7 +1372,6 @@ export class DeepLinkService implements Disposable {
 				case DeepLinkServiceState.OpenInspect: {
 					// If we arrive at this step, clear any stored data used for the "new window" option
 					await this.container.storage.delete('deepLinks:pending');
-
 					if (!repo) {
 						action = DeepLinkServiceAction.DeepLinkErrored;
 						message = 'Missing repository.';
@@ -1386,6 +1384,34 @@ export class DeepLinkService implements Disposable {
 						repository: repo,
 						source: 'launchpad',
 					} satisfies ShowWipArgs);
+					action = DeepLinkServiceAction.OpenAllPrChanges;
+					break;
+				}
+				case DeepLinkServiceState.OpenAllPrChanges: {
+					const prId = this._context.params?.get('prId');
+					const prHeadRef = this._context.params?.get('prHeadRef');
+					const prBaseRef = this._context.params?.get('prBaseRef');
+					const prTitle = this._context.params?.get('prTitle');
+					if (!repoPath || !prId || !prHeadRef || !prBaseRef) {
+						action = DeepLinkServiceAction.DeepLinkErrored;
+						if (!repoPath) {
+							message = 'No repository path was provided.';
+						} else if (!prId) {
+							message = 'No pull request id provided.';
+						} else {
+							message = 'No pull request refs was provided.';
+						}
+						break;
+					}
+					await openComparisonChanges(
+						this.container,
+						{
+							repoPath: repoPath,
+							lhs: prBaseRef,
+							rhs: prHeadRef,
+						},
+						{ title: `Changes in Pull Request ${prTitle ? `"${prTitle}"` : `#${prId}`}` },
+					);
 					action = DeepLinkServiceAction.DeepLinkResolved;
 					break;
 				}

--- a/src/views/viewCommands.ts
+++ b/src/views/viewCommands.ts
@@ -786,6 +786,23 @@ export class ViewCommands {
 		if (!node.is('branch') && !node.is('pullrequest') && !node.is('launchpad-item')) return;
 
 		if (node.is('branch')) {
+			const pr = await node.branch.getAssociatedPullRequest();
+			if (pr != null) {
+				const remoteUrl =
+					(await node.branch.getRemote())?.url ?? getRepositoryIdentityForPullRequest(pr).remote.url;
+				if (remoteUrl != null) {
+					const deepLink = getPullRequestBranchDeepLink(
+						this.container,
+						node.branch.getNameWithoutRemote(),
+						remoteUrl,
+						DeepLinkActionType.SwitchToPullRequestWorktree,
+						pr,
+					);
+
+					return this.container.deepLinks.processDeepLinkUri(deepLink, false, node.repo);
+				}
+			}
+
 			return executeGitCommand({
 				command: 'switch',
 				state: {

--- a/src/views/viewCommands.ts
+++ b/src/views/viewCommands.ts
@@ -808,6 +808,7 @@ export class ViewCommands {
 				pr.refs.head.branch,
 				repoIdentity.remote.url,
 				DeepLinkActionType.SwitchToPullRequestWorktree,
+				pr,
 			);
 
 			const prRepo = await getOrOpenPullRequestRepository(this.container, pr, {


### PR DESCRIPTION
# Description


https://github.com/user-attachments/assets/a4ebac45-b003-47de-9e44-4ad742b697b9


# Checklist

<!-- Please check off the following -->

- [ ] I have followed the guidelines in the Contributing document
- [ ] My changes follow the coding style of this project
- [ ] My changes build without any errors or warnings
- [ ] My changes have been formatted and linted
- [ ] My changes include any required corresponding changes to the documentation (including CHANGELOG.md and README.md)
- [ ] My changes have been rebased and squashed to the minimal number (typically 1) of relevant commits
- [ ] My changes have a descriptive commit message with a short title, including a `Fixes $XXX -` or `Closes #XXX -` prefix to auto-close the issue that your PR addresses
