### PR TITLE
Update trial messaging

### DIFF
--- a/README.md
+++ b/README.md
@@ -293,7 +293,7 @@ Yes. All features are free to use on all repos, **except** for `Pro` features, w
 
 While GitLens offers a remarkable set of free features, a subset of `Pro` features tailored for professional developers and teams, require a trial or paid plan for use on privately-hosted repos &mdash; use on local or publicly-hosted repos is free for everyone. Additionally `Preview` features may require a paid plan in the future and some, if cloud-backed, require a GitKraken account.
 
-Preview `Pro` features instantly for free for 3 days without an account, or start a free GitLens Pro trial to get an additional 7 days and gain access to `Pro` features to experience the full power of GitLens.
+Preview `Pro` features instantly for free for 3 days without an account, or start a free GitLens Pro trial to get an additional 14 days and gain access to `Pro` features to experience the full power of GitLens.
 
 ## Are `Pro` and `Preview` features free to use?
 

--- a/package.json
+++ b/package.json
@@ -19299,12 +19299,12 @@
 			},
 			{
 				"view": "gitlens.views.launchpad",
-				"contents": "[Continue](command:gitlens.plus.reactivateProTrial?%7B%22source%22%3A%22launchpad-view%22%7D)\n\nReactivate your Pro trial and experience Launchpad and all the new Pro features — free for another 7 days!",
+				"contents": "[Continue](command:gitlens.plus.reactivateProTrial?%7B%22source%22%3A%22launchpad-view%22%7D)\n\nReactivate your Pro trial and experience Launchpad and all the new Pro features — free for another 14 days!",
 				"when": "!gitlens:launchpad:connect && gitlens:plus:required && gitlens:plus:state == 5"
 			},
 			{
 				"view": "gitlens.views.scm.grouped",
-				"contents": "[Continue](command:gitlens.plus.reactivateProTrial?%7B%22source%22%3A%22launchpad-view%22%7D)\n\nReactivate your Pro trial and experience Launchpad and all the new Pro features — free for another 7 days!",
+				"contents": "[Continue](command:gitlens.plus.reactivateProTrial?%7B%22source%22%3A%22launchpad-view%22%7D)\n\nReactivate your Pro trial and experience Launchpad and all the new Pro features — free for another 14 days!",
 				"when": "!gitlens:launchpad:connect && gitlens:plus:required && gitlens:plus:state == 5 && gitlens:views:scm:grouped:view == launchpad"
 			},
 			{
@@ -19406,12 +19406,12 @@
 			},
 			{
 				"view": "gitlens.views.worktrees",
-				"contents": "[Continue](command:gitlens.plus.reactivateProTrial?%7B%22source%22%3A%22worktrees%22%7D)\n\nReactivate your Pro trial and experience Worktrees and all the new Pro features — free for another 7 days!",
+				"contents": "[Continue](command:gitlens.plus.reactivateProTrial?%7B%22source%22%3A%22worktrees%22%7D)\n\nReactivate your Pro trial and experience Worktrees and all the new Pro features — free for another 14 days!",
 				"when": "gitlens:plus:required && gitlens:plus:state == 5"
 			},
 			{
 				"view": "gitlens.views.scm.grouped",
-				"contents": "[Continue](command:gitlens.plus.reactivateProTrial?%7B%22source%22%3A%22worktrees%22%7D)\n\nReactivate your Pro trial and experience Worktrees and all the new Pro features — free for another 7 days!",
+				"contents": "[Continue](command:gitlens.plus.reactivateProTrial?%7B%22source%22%3A%22worktrees%22%7D)\n\nReactivate your Pro trial and experience Worktrees and all the new Pro features — free for another 14 days!",
 				"when": "gitlens:plus:required && gitlens:plus:state == 5 && gitlens:views:scm:grouped:view == worktrees"
 			},
 			{

--- a/package.json
+++ b/package.json
@@ -19218,6 +19218,11 @@
 				"contents": "[Launchpad](command:gitlens.views.launchpad.info \"Learn about Launchpad\") — organizes your pull requests into actionable groups to help you focus and keep your team unblocked."
 			},
 			{
+				"view": "gitlens.views.launchpad",
+				"contents": "Pro feature — requires a paid plan for use on privately-hosted repos.",
+				"when": "!gitlens:plus"
+			},
+			{
 				"view": "gitlens.views.scm.grouped",
 				"contents": "[Launchpad](command:gitlens.views.launchpad.info \"Learn about Launchpad\") — organizes your pull requests into actionable groups to help you focus and keep your team unblocked.",
 				"when": "gitlens:views:scm:grouped:view == launchpad"
@@ -19244,23 +19249,13 @@
 			},
 			{
 				"view": "gitlens.views.launchpad",
-				"contents": "[Continue](command:gitlens.plus.startPreviewTrial?%7B%22source%22%3A%22launchpad-view%22%7D)\n\nContinuing gives you 3 days to preview Launchpad and other local Pro features for 3 days. [Start 7-day Pro trial](command:gitlens.plus.signUp?%7B%22source%22%3A%22launchpad-view%22%7D) or [sign in](command:gitlens.plus.login?%7B%22source%22%3A%22launchpad-view%22%7D) for full access to Pro features.",
-				"when": "!gitlens:launchpad:connect && gitlens:plus:required && gitlens:plus:state == 0"
-			},
-			{
-				"view": "gitlens.views.scm.grouped",
-				"contents": "[Continue](command:gitlens.plus.startPreviewTrial?%7B%22source%22%3A%22launchpad-view%22%7D)\n\nContinuing gives you 3 days to preview Launchpad and other local Pro features for 3 days. [Start 7-day Pro trial](command:gitlens.plus.signUp?%7B%22source%22%3A%22launchpad-view%22%7D) or [sign in](command:gitlens.plus.login?%7B%22source%22%3A%22launchpad-view%22%7D) for full access to Pro features.",
-				"when": "!gitlens:launchpad:connect && gitlens:plus:required && gitlens:plus:state == 0 && gitlens:views:scm:grouped:view == launchpad"
-			},
-			{
-				"view": "gitlens.views.launchpad",
 				"contents": "[Try GitLens Pro](command:gitlens.plus.signUp?%7B%22source%22%3A%22launchpad-view%22%7D)\n\nGet 14 days of GitLens Pro for free - no credit card required. Or [sign in](command:gitlens.plus.login?%7B%22source%22%3A%22launchpad-view%22%7D).",
-				"when": "!gitlens:launchpad:connect && gitlens:plus:required && gitlens:plus:state == 2"
+				"when": "!gitlens:launchpad:connect && gitlens:plus:required && (gitlens:plus:state == 2 || gitlens:plus:state == 0)"
 			},
 			{
 				"view": "gitlens.views.scm.grouped",
 				"contents": "[Try GitLens Pro](command:gitlens.plus.signUp?%7B%22source%22%3A%22launchpad-view%22%7D)\n\nGet 14 days of GitLens Pro for free - no credit card required. Or [sign in](command:gitlens.plus.login?%7B%22source%22%3A%22launchpad-view%22%7D).",
-				"when": "!gitlens:launchpad:connect && gitlens:plus:required && gitlens:plus:state == 2 && gitlens:views:scm:grouped:view == launchpad"
+				"when": "!gitlens:launchpad:connect && gitlens:plus:required && (gitlens:plus:state == 0 || gitlens:plus:state == 2) && gitlens:views:scm:grouped:view == launchpad"
 			},
 			{
 				"view": "gitlens.views.launchpad",
@@ -19311,11 +19306,6 @@
 				"view": "gitlens.views.scm.grouped",
 				"contents": "[Continue](command:gitlens.plus.reactivateProTrial?%7B%22source%22%3A%22launchpad-view%22%7D)\n\nReactivate your Pro trial and experience Launchpad and all the new Pro features — free for another 7 days!",
 				"when": "!gitlens:launchpad:connect && gitlens:plus:required && gitlens:plus:state == 5 && gitlens:views:scm:grouped:view == launchpad"
-			},
-			{
-				"view": "gitlens.views.launchpad",
-				"contents": "Pro feature — requires a paid plan for use on privately-hosted repos.",
-				"when": "!gitlens:launchpad:connect"
 			},
 			{
 				"view": "gitlens.views.scm.grouped",
@@ -19371,23 +19361,13 @@
 			},
 			{
 				"view": "gitlens.views.worktrees",
-				"contents": "Use on privately-hosted repos requires [GitLens Pro](https://help.gitkraken.com/gitlens/gitlens-community-vs-gitlens-pro/).\n[Continue](command:gitlens.plus.startPreviewTrial?%7B%22source%22%3A%22worktrees%22%7D)\n\nContinuing gives you 3 days to preview Worktrees and other local Pro features for 3 days. [Start 7-day Pro trial](command:gitlens.plus.signUp?%7B%22source%22%3A%22worktrees%22%7D) or [sign in](command:gitlens.plus.login?%7B%22source%22%3A%22worktrees%22%7D) for full access to Pro features.",
-				"when": "gitlens:plus:required && gitlens:plus:state == 0"
-			},
-			{
-				"view": "gitlens.views.scm.grouped",
-				"contents": "[Continue](command:gitlens.plus.startPreviewTrial?%7B%22source%22%3A%22worktrees%22%7D)\n\nContinuing gives you 3 days to preview Worktrees and other local Pro features for 3 days. [Start 7-day Pro trial](command:gitlens.plus.signUp?%7B%22source%22%3A%22worktrees%22%7D) or [sign in](command:gitlens.plus.login?%7B%22source%22%3A%22worktrees%22%7D) for full access to Pro features.",
-				"when": "gitlens:plus:required && gitlens:plus:state == 0 && gitlens:views:scm:grouped:view == worktrees"
-			},
-			{
-				"view": "gitlens.views.worktrees",
 				"contents": "Use on privately-hosted repos requires [GitLens Pro](https://help.gitkraken.com/gitlens/gitlens-community-vs-gitlens-pro/).\n[Try GitLens Pro](command:gitlens.plus.signUp?%7B%22source%22%3A%22worktrees%22%7D)\n\nGet 14 days of GitLens Pro for free - no credit card required. Or [sign in](command:gitlens.plus.login?%7B%22source%22%3A%22worktrees%22%7D).",
-				"when": "gitlens:plus:required && gitlens:plus:state == 2"
+				"when": "gitlens:plus:required && (gitlens:plus:state == 2 || gitlens:plus:state == 0)"
 			},
 			{
 				"view": "gitlens.views.scm.grouped",
 				"contents": "[Try GitLens Pro](command:gitlens.plus.signUp?%7B%22source%22%3A%22worktrees%22%7D)\n\nGet 14 days of GitLens Pro for free - no credit card required. Or [sign in](command:gitlens.plus.login?%7B%22source%22%3A%22worktrees%22%7D).",
-				"when": "gitlens:plus:required && gitlens:plus:state == 2 && gitlens:views:scm:grouped:view == worktrees"
+				"when": "gitlens:plus:required && (gitlens:plus:state == 0 || gitlens:plus:state == 2) && gitlens:views:scm:grouped:view == worktrees"
 			},
 			{
 				"view": "gitlens.views.worktrees",

--- a/package.json
+++ b/package.json
@@ -19210,7 +19210,7 @@
 			},
 			{
 				"view": "gitlens.views.drafts",
-				"contents": "[Start Pro Trial](command:gitlens.plus.signUp?%7B%22source%22%3A%22cloud-patches%22%7D)\n\nStart your free 7-day Pro trial to try Cloud Patches and other Pro features, or [sign in](command:gitlens.plus.login?%7B%22source%22%3A%22cloud-patches%22%7D).",
+				"contents": "Preview feature - requires an account and may require [GitLens Pro](https://help.gitkraken.com/gitlens/gitlens-community-vs-gitlens-pro/) in the future.\n[Try GitLens Pro](command:gitlens.plus.signUp?%7B%22source%22%3A%22cloud-patches%22%7D)\n\nGet 14 days of GitLens Pro for free - no credit card required. Or [sign in](command:gitlens.plus.login?%7B%22source%22%3A%22cloud-patches%22%7D).",
 				"when": "!gitlens:plus"
 			},
 			{
@@ -19254,12 +19254,12 @@
 			},
 			{
 				"view": "gitlens.views.launchpad",
-				"contents": "[Start Pro Trial](command:gitlens.plus.signUp?%7B%22source%22%3A%22launchpad-view%22%7D)\n\nStart your free 7-day Pro trial to try Launchpad and other Pro features, or [sign in](command:gitlens.plus.login?%7B%22source%22%3A%22launchpad-view%22%7D).",
+				"contents": "[Try GitLens Pro](command:gitlens.plus.signUp?%7B%22source%22%3A%22launchpad-view%22%7D)\n\nGet 14 days of GitLens Pro for free - no credit card required. Or [sign in](command:gitlens.plus.login?%7B%22source%22%3A%22launchpad-view%22%7D).",
 				"when": "!gitlens:launchpad:connect && gitlens:plus:required && gitlens:plus:state == 2"
 			},
 			{
 				"view": "gitlens.views.scm.grouped",
-				"contents": "[Start Pro Trial](command:gitlens.plus.signUp?%7B%22source%22%3A%22launchpad-view%22%7D)\n\nStart your free 7-day Pro trial to try Launchpad and other Pro features, or [sign in](command:gitlens.plus.login?%7B%22source%22%3A%22launchpad-view%22%7D).",
+				"contents": "[Try GitLens Pro](command:gitlens.plus.signUp?%7B%22source%22%3A%22launchpad-view%22%7D)\n\nGet 14 days of GitLens Pro for free - no credit card required. Or [sign in](command:gitlens.plus.login?%7B%22source%22%3A%22launchpad-view%22%7D).",
 				"when": "!gitlens:launchpad:connect && gitlens:plus:required && gitlens:plus:state == 2 && gitlens:views:scm:grouped:view == launchpad"
 			},
 			{
@@ -19333,7 +19333,7 @@
 			},
 			{
 				"view": "gitlens.views.workspaces",
-				"contents": "[Start Pro Trial](command:gitlens.plus.signUp?%7B%22source%22%3A%22workspaces%22%7D)\n\nStart your free 7-day Pro trial to try GitKraken (GK) Workspaces and other Pro features, or [sign in](command:gitlens.plus.login?%7B%22source%22%3A%22workspaces%22%7D).",
+				"contents": "Use on privately-hosted repos requires [GitLens Pro](https://help.gitkraken.com/gitlens/gitlens-community-vs-gitlens-pro/).\n[Start Pro Trial](command:gitlens.plus.signUp?%7B%22source%22%3A%22workspaces%22%7D)\n\nStart your free 7-day Pro trial to try GitKraken (GK) Workspaces and other Pro features, or [sign in](command:gitlens.plus.login?%7B%22source%22%3A%22workspaces%22%7D).",
 				"when": "!gitlens:plus"
 			},
 			{
@@ -19371,7 +19371,7 @@
 			},
 			{
 				"view": "gitlens.views.worktrees",
-				"contents": "[Continue](command:gitlens.plus.startPreviewTrial?%7B%22source%22%3A%22worktrees%22%7D)\n\nContinuing gives you 3 days to preview Worktrees and other local Pro features for 3 days. [Start 7-day Pro trial](command:gitlens.plus.signUp?%7B%22source%22%3A%22worktrees%22%7D) or [sign in](command:gitlens.plus.login?%7B%22source%22%3A%22worktrees%22%7D) for full access to Pro features.",
+				"contents": "Use on privately-hosted repos requires [GitLens Pro](https://help.gitkraken.com/gitlens/gitlens-community-vs-gitlens-pro/).\n[Continue](command:gitlens.plus.startPreviewTrial?%7B%22source%22%3A%22worktrees%22%7D)\n\nContinuing gives you 3 days to preview Worktrees and other local Pro features for 3 days. [Start 7-day Pro trial](command:gitlens.plus.signUp?%7B%22source%22%3A%22worktrees%22%7D) or [sign in](command:gitlens.plus.login?%7B%22source%22%3A%22worktrees%22%7D) for full access to Pro features.",
 				"when": "gitlens:plus:required && gitlens:plus:state == 0"
 			},
 			{
@@ -19381,7 +19381,7 @@
 			},
 			{
 				"view": "gitlens.views.worktrees",
-				"contents": "[Start Pro Trial](command:gitlens.plus.signUp?%7B%22source%22%3A%22worktrees%22%7D)\n\nStart your free 7-day Pro trial to try Worktrees and other Pro features, or [sign in](command:gitlens.plus.login?%7B%22source%22%3A%22worktrees%22%7D).",
+				"contents": "Use on privately-hosted repos requires [GitLens Pro](https://help.gitkraken.com/gitlens/gitlens-community-vs-gitlens-pro/).\n[Start Pro Trial](command:gitlens.plus.signUp?%7B%22source%22%3A%22worktrees%22%7D)\n\nStart your free 7-day Pro trial to try Worktrees and other Pro features, or [sign in](command:gitlens.plus.login?%7B%22source%22%3A%22worktrees%22%7D).",
 				"when": "gitlens:plus:required && gitlens:plus:state == 2"
 			},
 			{
@@ -19420,11 +19420,6 @@
 				"when": "gitlens:plus:required && gitlens:plus:state == 4 && gitlens:promo == gitlens16 && gitlens:views:scm:grouped:view == worktrees"
 			},
 			{
-				"view": "gitlens.views.worktrees",
-				"contents": "Your Pro trial has ended. Please upgrade for full access to Worktrees and other Pro features.",
-				"when": "gitlens:plus:required && gitlens:plus:state == 4"
-			},
-			{
 				"view": "gitlens.views.scm.grouped",
 				"contents": "Your Pro trial has ended. Please upgrade for full access to Worktrees and other Pro features.",
 				"when": "gitlens:plus:required && gitlens:plus:state == 4 && gitlens:views:scm:grouped:view == worktrees"
@@ -19438,10 +19433,6 @@
 				"view": "gitlens.views.scm.grouped",
 				"contents": "[Continue](command:gitlens.plus.reactivateProTrial?%7B%22source%22%3A%22worktrees%22%7D)\n\nReactivate your Pro trial and experience Worktrees and all the new Pro features — free for another 7 days!",
 				"when": "gitlens:plus:required && gitlens:plus:state == 5 && gitlens:views:scm:grouped:view == worktrees"
-			},
-			{
-				"view": "gitlens.views.worktrees",
-				"contents": "Pro feature — requires a paid plan for use on privately-hosted repos."
 			},
 			{
 				"view": "gitlens.views.scm.grouped",

--- a/package.json
+++ b/package.json
@@ -19333,7 +19333,7 @@
 			},
 			{
 				"view": "gitlens.views.workspaces",
-				"contents": "Use on privately-hosted repos requires [GitLens Pro](https://help.gitkraken.com/gitlens/gitlens-community-vs-gitlens-pro/).\n[Start Pro Trial](command:gitlens.plus.signUp?%7B%22source%22%3A%22workspaces%22%7D)\n\nStart your free 7-day Pro trial to try GitKraken (GK) Workspaces and other Pro features, or [sign in](command:gitlens.plus.login?%7B%22source%22%3A%22workspaces%22%7D).",
+				"contents": "Use on privately-hosted repos requires [GitLens Pro](https://help.gitkraken.com/gitlens/gitlens-community-vs-gitlens-pro/).\n[Try GitLens Pro](command:gitlens.plus.signUp?%7B%22source%22%3A%22workspaces%22%7D)\n\nGet 14 days of GitLens Pro for free - no credit card required. Or [sign in](command:gitlens.plus.login?%7B%22source%22%3A%22workspaces%22%7D).",
 				"when": "!gitlens:plus"
 			},
 			{
@@ -19381,12 +19381,12 @@
 			},
 			{
 				"view": "gitlens.views.worktrees",
-				"contents": "Use on privately-hosted repos requires [GitLens Pro](https://help.gitkraken.com/gitlens/gitlens-community-vs-gitlens-pro/).\n[Start Pro Trial](command:gitlens.plus.signUp?%7B%22source%22%3A%22worktrees%22%7D)\n\nStart your free 7-day Pro trial to try Worktrees and other Pro features, or [sign in](command:gitlens.plus.login?%7B%22source%22%3A%22worktrees%22%7D).",
+				"contents": "Use on privately-hosted repos requires [GitLens Pro](https://help.gitkraken.com/gitlens/gitlens-community-vs-gitlens-pro/).\n[Try GitLens Pro](command:gitlens.plus.signUp?%7B%22source%22%3A%22worktrees%22%7D)\n\nGet 14 days of GitLens Pro for free - no credit card required. Or [sign in](command:gitlens.plus.login?%7B%22source%22%3A%22worktrees%22%7D).",
 				"when": "gitlens:plus:required && gitlens:plus:state == 2"
 			},
 			{
 				"view": "gitlens.views.scm.grouped",
-				"contents": "[Start Pro Trial](command:gitlens.plus.signUp?%7B%22source%22%3A%22worktrees%22%7D)\n\nStart your free 7-day Pro trial to try Worktrees and other Pro features, or [sign in](command:gitlens.plus.login?%7B%22source%22%3A%22worktrees%22%7D).",
+				"contents": "[Try GitLens Pro](command:gitlens.plus.signUp?%7B%22source%22%3A%22worktrees%22%7D)\n\nGet 14 days of GitLens Pro for free - no credit card required. Or [sign in](command:gitlens.plus.login?%7B%22source%22%3A%22worktrees%22%7D).",
 				"when": "gitlens:plus:required && gitlens:plus:state == 2 && gitlens:views:scm:grouped:view == worktrees"
 			},
 			{

--- a/package.json
+++ b/package.json
@@ -19201,7 +19201,7 @@
 			},
 			{
 				"view": "gitlens.views.drafts",
-				"contents": "Cloud Patches ᴘʀᴇᴠɪᴇᴡ — easily and securely share code with your teammates or other developers, accessible from anywhere, streamlining your workflow with better collaboration."
+				"contents": "Cloud Patches ᴘʀᴇᴠɪᴇᴡ — easily and securely share code with your teammates and other developers without adding noise to your repository."
 			},
 			{
 				"view": "gitlens.views.drafts",
@@ -19212,10 +19212,6 @@
 				"view": "gitlens.views.drafts",
 				"contents": "[Start Pro Trial](command:gitlens.plus.signUp?%7B%22source%22%3A%22cloud-patches%22%7D)\n\nStart your free 7-day Pro trial to try Cloud Patches and other Pro features, or [sign in](command:gitlens.plus.login?%7B%22source%22%3A%22cloud-patches%22%7D).",
 				"when": "!gitlens:plus"
-			},
-			{
-				"view": "gitlens.views.drafts",
-				"contents": "Preview feature ☁️ — requires an account and may require a paid plan in the future."
 			},
 			{
 				"view": "gitlens.views.launchpad",
@@ -19346,7 +19342,7 @@
 			},
 			{
 				"view": "gitlens.views.worktrees",
-				"contents": "[Worktrees](https://help.gitkraken.com/gitlens/side-bar/#worktrees-view-pro) ᴾᴿᴼ — minimize context switching by allowing you to work on multiple branches simultaneously."
+				"contents": "[Worktrees](https://help.gitkraken.com/gitlens/side-bar/#worktrees-view-pro) ᴾᴿᴼ — minimize context switching by working on multiple branches simultaneously."
 			},
 			{
 				"view": "gitlens.views.scm.grouped",
@@ -19395,7 +19391,7 @@
 			},
 			{
 				"view": "gitlens.views.worktrees",
-				"contents": "[Upgrade to Pro](command:gitlens.plus.upgrade?%7B%22source%22%3A%22worktrees%22%7D)",
+				"contents": "Use on privately-hosted repos requires [GitLens Pro](https://help.gitkraken.com/gitlens/gitlens-community-vs-gitlens-pro?%7B%22source%22%3A%22worktrees%22%7D).\n\n[Upgrade to Pro](command:gitlens.plus.upgrade?%7B%22source%22%3A%22worktrees%22%7D)",
 				"when": "gitlens:plus:required && gitlens:plus:state == 4"
 			},
 			{

--- a/src/constants.subscription.ts
+++ b/src/constants.subscription.ts
@@ -1,5 +1,5 @@
 export const proPreviewLengthInDays = 3;
-export const proTrialLengthInDays = 7;
+export const proTrialLengthInDays = 14;
 
 export type PromoKeys = 'gitlens16' | 'pro50';
 

--- a/src/constants.ts
+++ b/src/constants.ts
@@ -169,6 +169,7 @@ export const urls = Object.freeze({
 	desktop: `https://gitkraken.com/git-client?${utm}`,
 
 	releaseNotes: `https://help.gitkraken.com/gitlens/gitlens-release-notes-current/?${utm}`,
+	gitlensProVsCommunity: `https://help.gitkraken.com/gitlens/gitlens-community-vs-gitlens-pro/?${utm}`,
 });
 
 export type WalkthroughSteps =

--- a/src/plus/gk/account/subscriptionService.ts
+++ b/src/plus/gk/account/subscriptionService.ts
@@ -708,19 +708,14 @@ export class SubscriptionService implements Disposable {
 		this.changeSubscription(subscription);
 
 		setTimeout(async () => {
-			const confirm: MessageItem = { title: 'Continue' };
-			const learn: MessageItem = { title: 'See Pro Features' };
-			const result = await window.showInformationMessage(
-				`You can now preview local Pro features for ${
+			await window.showInformationMessage(
+				`You can now preview the Commit Graph on privately-hosted repos for ${
 					days < 1 ? '1 day' : pluralize('day', days)
-				}, or [start your free ${proTrialLengthInDays}-day Pro trial](command:gitlens.plus.signUp "Start Pro Trial") for full access to Pro features.`,
-				confirm,
-				learn,
+				}, or [start your free ${proTrialLengthInDays}-day Pro trial](command:gitlens.plus.signUp "Start Pro Trial") for full access to all [GitLens Pro](${
+					urls.gitlensProVsCommunity
+				}) features.`,
+				{ title: 'Continue' },
 			);
-
-			if (result === learn) {
-				void this.learnAboutPro({ source: 'notification', detail: { action: 'preview-started' } }, source);
-			}
 		}, 1);
 	}
 

--- a/src/quickpicks/items/directive.ts
+++ b/src/quickpicks/items/directive.ts
@@ -65,7 +65,7 @@ export function createDirectiveQuickPickItem(
 				break;
 			case Directive.StartProTrial:
 				label = 'Start Pro Trial';
-				detail = `Start your free ${proTrialLengthInDays}-day Pro trial for full access to Pro features`;
+				detail = `Start your free ${proTrialLengthInDays}-day GitLens Pro trial - no credit card required.`;
 				break;
 			case Directive.RequiresVerification:
 				label = 'Resend Email';
@@ -74,7 +74,7 @@ export function createDirectiveQuickPickItem(
 			case Directive.RequiresPaidSubscription:
 				label = 'Upgrade to Pro';
 				if (detail != null) {
-					description ??= ' \u2014\u00a0\u00a0 a paid plan is required to use this Pro feature';
+					description ??= ' - access Launchpad and all Pro features with GitLens Pro';
 				} else {
 					detail = 'Upgrading to a paid plan is required to use this Pro feature';
 				}

--- a/src/webviews/apps/plus/shared/components/feature-gate-plus-state.ts
+++ b/src/webviews/apps/plus/shared/components/feature-gate-plus-state.ts
@@ -98,6 +98,8 @@ export class GlFeatureGatePlusState extends LitElement {
 		const appearance = (this.appearance ?? 'alert') === 'alert' ? 'alert' : nothing;
 		const promo = this.state ? getApplicablePromo(this.state, 'gate') : undefined;
 
+		const feature = this.source?.source || '';
+
 		switch (this.state) {
 			case SubscriptionState.VerificationRequired:
 				return html`
@@ -120,6 +122,12 @@ export class GlFeatureGatePlusState extends LitElement {
 
 			case SubscriptionState.Community:
 				return html`
+					${feature !== 'graph'
+						? html`<p>
+								Use on privately-hosted repos requires
+								<a href="${urls.gitlensProVsCommunity}">GitLens Pro</a>.
+						  </p>`
+						: nothing}
 					<gl-button
 						appearance="${appearance}"
 						href="${generateCommandLink(Commands.PlusStartPreviewTrial, this.source)}"

--- a/src/webviews/apps/plus/shared/components/feature-gate-plus-state.ts
+++ b/src/webviews/apps/plus/shared/components/feature-gate-plus-state.ts
@@ -122,13 +122,34 @@ export class GlFeatureGatePlusState extends LitElement {
 
 			case SubscriptionState.Community:
 			case SubscriptionState.ProPreviewExpired:
-				return html`
-					${feature !== 'graph'
-						? html`<p>
-								Use on privately-hosted repos requires
-								<a href="${urls.gitlensProVsCommunity}">GitLens Pro</a>.
-						  </p>`
-						: nothing}
+				if (feature === 'graph' && this.state === SubscriptionState.Community) {
+					return html`
+						<gl-button
+							appearance="${appearance}"
+							href="${generateCommandLink(Commands.PlusStartPreviewTrial, this.source)}"
+							>Continue</gl-button
+						>
+						<p>
+							Continuing gives you 3 days to preview
+							${this.featureWithArticleIfNeeded
+								? `${this.featureWithArticleIfNeeded}  and other `
+								: ''}local
+							Pro features.<br />
+							${appearance !== 'alert' ? html`<br />` : ''} For full access to Pro features
+							<a href="${generateCommandLink(Commands.PlusSignUp, this.source)}"
+								>start your free ${proTrialLengthInDays}-day Pro trial</a
+							>
+							or
+							<a href="${generateCommandLink(Commands.PlusLogin, this.source)}" title="Sign In">sign in</a
+							>.
+						</p>
+					`;
+				}
+
+				return html`<p>
+						Use on privately-hosted repos requires
+						<a href="${urls.gitlensProVsCommunity}">GitLens Pro</a>.
+					</p>
 					<gl-button
 						appearance="${appearance}"
 						href="${generateCommandLink(Commands.PlusSignUp, this.source)}"
@@ -137,8 +158,7 @@ export class GlFeatureGatePlusState extends LitElement {
 					<p>
 						Get ${proTrialLengthInDays} days of GitLens Pro for free - no credit card required. Or
 						<a href="${generateCommandLink(Commands.PlusLogin, this.source)}" title="Sign In">sign in</a>.
-					</p>
-				`;
+					</p> `;
 
 			case SubscriptionState.ProTrialExpired:
 				return html`<p>

--- a/src/webviews/apps/plus/shared/components/feature-gate-plus-state.ts
+++ b/src/webviews/apps/plus/shared/components/feature-gate-plus-state.ts
@@ -121,6 +121,7 @@ export class GlFeatureGatePlusState extends LitElement {
 				`;
 
 			case SubscriptionState.Community:
+			case SubscriptionState.ProPreviewExpired:
 				return html`
 					${feature !== 'graph'
 						? html`<p>
@@ -130,34 +131,11 @@ export class GlFeatureGatePlusState extends LitElement {
 						: nothing}
 					<gl-button
 						appearance="${appearance}"
-						href="${generateCommandLink(Commands.PlusStartPreviewTrial, this.source)}"
-						>Continue</gl-button
-					>
-					<p>
-						Continuing gives you 3 days to preview
-						${this.featureWithArticleIfNeeded ? `${this.featureWithArticleIfNeeded}  and other ` : ''}local
-						Pro features.<br />
-						${appearance !== 'alert' ? html`<br />` : ''} For full access to Pro features
-						<a href="${generateCommandLink(Commands.PlusSignUp, this.source)}"
-							>start your free ${proTrialLengthInDays}-day Pro trial</a
-						>
-						or
-						<a href="${generateCommandLink(Commands.PlusLogin, this.source)}" title="Sign In">sign in</a>.
-					</p>
-				`;
-
-			case SubscriptionState.ProPreviewExpired:
-				return html`
-					<p>
-						Use on privately-hosted repos requires <a href="${urls.gitlensProVsCommunity}">GitLens Pro</a>.
-					</p>
-					<gl-button
-						appearance="${appearance}"
 						href="${generateCommandLink(Commands.PlusSignUp, this.source)}"
 						>&nbsp;Try GitLens Pro&nbsp;</gl-button
 					>
 					<p>
-						Start your free ${proTrialLengthInDays}-day GitLens Pro trial - no credit card required. Or
+						Get ${proTrialLengthInDays} days of GitLens Pro for free - no credit card required. Or
 						<a href="${generateCommandLink(Commands.PlusLogin, this.source)}" title="Sign In">sign in</a>.
 					</p>
 				`;

--- a/src/webviews/apps/plus/shared/components/feature-gate-plus-state.ts
+++ b/src/webviews/apps/plus/shared/components/feature-gate-plus-state.ts
@@ -1,5 +1,6 @@
 import { css, html, LitElement, nothing } from 'lit';
 import { customElement, property, query } from 'lit/decorators.js';
+import { urls } from '../../../../../constants';
 import { Commands } from '../../../../../constants.commands';
 import { proTrialLengthInDays, SubscriptionState } from '../../../../../constants.subscription';
 import type { Source } from '../../../../../constants.telemetry';
@@ -139,31 +140,30 @@ export class GlFeatureGatePlusState extends LitElement {
 
 			case SubscriptionState.ProPreviewExpired:
 				return html`
+					<p>
+						Use on privately-hosted repos requires <a href="${urls.gitlensProVsCommunity}">GitLens Pro</a>.
+					</p>
 					<gl-button
 						appearance="${appearance}"
 						href="${generateCommandLink(Commands.PlusSignUp, this.source)}"
-						>Start Pro Trial</gl-button
+						>&nbsp;Try GitLens Pro&nbsp;</gl-button
 					>
 					<p>
-						Start your free ${proTrialLengthInDays}-day Pro trial to try
-						${this.featureWithArticleIfNeeded ? `${this.featureWithArticleIfNeeded} and other ` : ''}Pro
-						features, or
+						Start your free ${proTrialLengthInDays}-day GitLens Pro trial - no credit card required. Or
 						<a href="${generateCommandLink(Commands.PlusLogin, this.source)}" title="Sign In">sign in</a>.
 					</p>
 				`;
 
 			case SubscriptionState.ProTrialExpired:
-				return html` <gl-button
+				return html`<p>
+						Use on privately-hosted repos requires <a href="${urls.gitlensProVsCommunity}">GitLens Pro</a>.
+					</p>
+					<gl-button
 						appearance="${appearance}"
 						href="${generateCommandLink(Commands.PlusUpgrade, this.source)}"
 						>Upgrade to Pro</gl-button
 					>
-					${this.renderPromo(promo)}
-					<p>
-						Your Pro trial has ended. Please upgrade for full access to
-						${this.featureWithArticleIfNeeded ? `${this.featureWithArticleIfNeeded} and other ` : ''}Pro
-						features.
-					</p>`;
+					${this.renderPromo(promo)}`;
 
 			case SubscriptionState.ProTrialReactivationEligible:
 				return html`

--- a/src/webviews/apps/plus/shared/components/home-account-content.ts
+++ b/src/webviews/apps/plus/shared/components/home-account-content.ts
@@ -361,11 +361,14 @@ export class GLHomeAccountContent extends LitElement {
 			case SubscriptionState.ProTrialExpired:
 				return html`
 					<div class="account">
-						<p>Your Pro trial has ended. You can now only use Pro features on publicly-hosted repos.</p>
+						<p>
+							Thank you for trying <a href="${urls.gitlensProVsCommunity}">GitLens Pro</a>. <br /><br />
+							Continue leveraging Pro features and workflows on privately-hosted repos by upgrading today.
+						</p>
 						<button-container>
 							<gl-button full href="command:gitlens.plus.upgrade">Upgrade to Pro</gl-button>
 						</button-container>
-						${this.renderPromo(promo)} ${this.renderIncludesDevEx()}
+						${this.renderPromo(promo)}
 					</div>
 				`;
 
@@ -395,15 +398,16 @@ export class GLHomeAccountContent extends LitElement {
 				return html`
 					<div class="account">
 						<p>
-							Sign up for access to Pro features and the
-							<a href="${urls.platform}">GitKraken DevEx platform</a>, or
-							<a href="command:gitlens.plus.login">sign in</a>.
+							Unlock advanced workflows and professional developer features with
+							<a href="${urls.gitlensProVsCommunity}">GitLens Pro</a>.
 						</p>
 						<button-container>
-							<gl-button full href="command:gitlens.plus.signUp">Sign Up</gl-button>
+							<gl-button full href="command:gitlens.plus.signUp">Try GitLens Pro</gl-button>
 						</button-container>
-						<p>Signing up starts your free ${proTrialLengthInDays}-day Pro trial.</p>
-						${this.renderIncludesDevEx()}
+						<p>
+							Get ${proTrialLengthInDays} days of GitLens Pro for free - no credit card required. Or
+							<a href="command:gitlens.plus.login">sign in</a>.
+						</p>
 					</div>
 				`;
 		}

--- a/src/webviews/apps/plus/shared/components/vscode.css.ts
+++ b/src/webviews/apps/plus/shared/components/vscode.css.ts
@@ -2,14 +2,18 @@ import { css } from 'lit';
 
 export const linkStyles = css`
 	a {
-		color: var(--link-foreground);
-		text-decoration: var(--link-decoration-default, none);
+		border: 0;
+		color: var(--color-link-foreground);
+		font-weight: 400;
+		outline: none;
+		text-decoration: none;
+	}
+	a:not([href]):not([tabindex]):focus,
+	a:not([href]):not([tabindex]):hover {
+		color: inherit;
+		text-decoration: none;
 	}
 	a:focus {
-		outline-color: var(--focus-border);
-	}
-	a:hover {
-		color: var(--link-foreground-active);
-		text-decoration: underline;
+		outline-color: var(--color-focus-border);
 	}
 `;


### PR DESCRIPTION
# Description

Solves https://github.com/gitkraken/vscode-gitlens/issues/3715

This PR changes trial messages for Pro Trial available and Trial expired states in:
- Account view
- Launchpad
- Visual File History
- Worktrees
- Cloud Patches
- Verify Email

- Changes to Graph's 3 day feature preview trial messages are addressed [here](https://github.com/gitkraken/vscode-gitlens/pull/3714).
- Changes for 7 -> 14 day trial are addressed [here](https://github.com/gitkraken/vscode-gitlens/pull/3694).

# Checklist

<!-- Please check off the following -->

- [x] I have followed the guidelines in the Contributing document
- [x] My changes follow the coding style of this project
- [x] My changes build without any errors or warnings
- [x] My changes have been formatted and linted
- [ ] My changes include any required corresponding changes to the documentation (including CHANGELOG.md and README.md)
- [x] My changes have been rebased and squashed to the minimal number (typically 1) of relevant commits
- [x] My changes have a descriptive commit message with a short title, including a `Fixes $XXX -` or `Closes #XXX -` prefix to auto-close the issue that your PR addresses
