### PR TITLE
fix: [Feature Preview] compare hours elapsed within range instead of dates

### DIFF
--- a/src/features.ts
+++ b/src/features.ts
@@ -60,11 +60,13 @@ export function getFeaturePreviewLabel(feature: FeaturePreviews) {
 	}
 }
 
+const hoursInMs = 3600000;
+
 export function isFeaturePreviewActive(featurePreview?: FeaturePreview) {
 	const usages = featurePreview?.usages;
 	if (usages == null || usages.length === 0) return false;
 
-	const remainingHours = (new Date(usages[usages.length - 1].expiresOn).getTime() - new Date().getTime()) / 3600000;
+	const remainingHours = (new Date(usages[usages.length - 1].expiresOn).getTime() - new Date().getTime()) / hoursInMs;
 	return (
 		usages.length <= proFeaturePreviewUsages &&
 		remainingHours > 0 &&
@@ -74,7 +76,9 @@ export function isFeaturePreviewActive(featurePreview?: FeaturePreview) {
 
 export function isFeaturePreviewExpired(featurePreview: FeaturePreview) {
 	const usages = featurePreview.usages;
-	const remainingHours = (new Date(usages[usages.length - 1].expiresOn).getTime() - new Date().getTime()) / 3600000;
+	if (usages == null || usages.length === 0) return false;
+
+	const remainingHours = (new Date(usages[usages.length - 1].expiresOn).getTime() - new Date().getTime()) / hoursInMs;
 	return (
 		usages.length > proFeaturePreviewUsages ||
 		(usages.length === proFeaturePreviewUsages && remainingHours <= 0) ||

--- a/src/features.ts
+++ b/src/features.ts
@@ -1,5 +1,5 @@
 import type { StoredFeaturePreviewUsagePeriod } from './constants.storage';
-import { proFeaturePreviewUsages } from './constants.subscription';
+import { proFeaturePreviewUsageDurationInDays, proFeaturePreviewUsages } from './constants.subscription';
 import type { RepositoryVisibility } from './git/gitProvider';
 import type { RequiredSubscriptionPlans, Subscription } from './plus/gk/account/subscription';
 import { capitalize } from './system/string';
@@ -64,13 +64,20 @@ export function isFeaturePreviewActive(featurePreview?: FeaturePreview) {
 	const usages = featurePreview?.usages;
 	if (usages == null || usages.length === 0) return false;
 
-	return usages.length <= proFeaturePreviewUsages && new Date(usages[usages.length - 1].expiresOn) > new Date();
+	const remainingHours = (new Date(usages[usages.length - 1].expiresOn).getTime() - new Date().getTime()) / 3600000;
+	return (
+		usages.length <= proFeaturePreviewUsages &&
+		remainingHours > 0 &&
+		remainingHours < 24 * proFeaturePreviewUsageDurationInDays
+	);
 }
 
 export function isFeaturePreviewExpired(featurePreview: FeaturePreview) {
 	const usages = featurePreview.usages;
+	const remainingHours = (new Date(usages[usages.length - 1].expiresOn).getTime() - new Date().getTime()) / 3600000;
 	return (
 		usages.length > proFeaturePreviewUsages ||
-		(usages.length === proFeaturePreviewUsages && new Date(usages[usages.length - 1].expiresOn) < new Date())
+		(usages.length === proFeaturePreviewUsages && remainingHours <= 0) ||
+		remainingHours >= 24 * proFeaturePreviewUsageDurationInDays
 	);
 }


### PR DESCRIPTION
# Description

Now we compare the elapsed time between an accepted range instead of plain dates.

# Checklist

<!-- Please check off the following -->

- [x] I have followed the guidelines in the Contributing document
- [x] My changes follow the coding style of this project
- [x] My changes build without any errors or warnings
- [x] My changes have been formatted and linted
- [ ] My changes include any required corresponding changes to the documentation (including CHANGELOG.md and README.md)
- [x] My changes have been rebased and squashed to the minimal number (typically 1) of relevant commits
- [x] My changes have a descriptive commit message with a short title, including a `Fixes $XXX -` or `Closes #XXX -` prefix to auto-close the issue that your PR addresses
