### PR TITLE
Opens multidiff view on open all changes from the home view

### DIFF
--- a/src/constants.commands.ts
+++ b/src/constants.commands.ts
@@ -248,6 +248,7 @@ export const enum Commands {
 	ViewsCopy = 'gitlens.views.copy',
 	ViewsCopyAsMarkdown = 'gitlens.views.copyAsMarkdown',
 	ViewsCopyUrl = 'gitlens.views.copyUrl',
+	ViewsOpenAllChangedFileDiffs = 'gitlens.views.openChangedFileDiffs',
 	ViewsOpenDirectoryDiff = 'gitlens.views.openDirectoryDiff',
 	ViewsOpenDirectoryDiffWithWorking = 'gitlens.views.openDirectoryDiffWithWorking',
 	ViewsOpenUrl = 'gitlens.views.openUrl',

--- a/src/webviews/apps/plus/home/components/active-work.ts
+++ b/src/webviews/apps/plus/home/components/active-work.ts
@@ -219,7 +219,7 @@ export class GlActiveWork extends SignalWatcher(LitElement) {
 				html`<action-item
 					label="Open Pull Request Changes"
 					icon="request-changes"
-					href=${createCommandLink('gitlens.home.openPullRequestComparison', branchRefs)}
+					href=${createCommandLink('gitlens.home.openPullRequestChanges', branchRefs)}
 				></action-item>`,
 			);
 			actions.push(

--- a/src/webviews/apps/plus/home/components/branch-section.ts
+++ b/src/webviews/apps/plus/home/components/branch-section.ts
@@ -117,6 +117,9 @@ export const headingLoaderStyles = css`
 `;
 
 export const branchCardStyles = css`
+	:host {
+		--gl-card-hover-background: color-mix(in lab, var(--vscode-sideBar-background) 100%, #fff 8%);
+	}
 	.branch-item {
 		position: relative;
 	}
@@ -196,6 +199,10 @@ export const branchCardStyles = css`
 		background-color: var(--gl-card-background);
 	}
 
+	.branch-item:hover .branch-item__actions,
+	.branch-item:focus-within .branch-item__actions {
+		background-color: var(--gl-card-hover-background);
+	}
 	.branch-item:not(:focus-within):not(:hover) .branch-item__actions {
 		${srOnlyStyles}
 	}

--- a/src/webviews/apps/plus/home/components/branch-section.ts
+++ b/src/webviews/apps/plus/home/components/branch-section.ts
@@ -117,9 +117,6 @@ export const headingLoaderStyles = css`
 `;
 
 export const branchCardStyles = css`
-	:host {
-		--gl-card-hover-background: color-mix(in lab, var(--vscode-sideBar-background) 100%, #fff 8%);
-	}
 	.branch-item {
 		position: relative;
 	}
@@ -196,13 +193,9 @@ export const branchCardStyles = css`
 		right: 0.4rem;
 		bottom: 0.4rem;
 		padding: 0.2rem 0.4rem;
-		background-color: var(--gl-card-background);
-	}
-
-	.branch-item:hover .branch-item__actions,
-	.branch-item:focus-within .branch-item__actions {
 		background-color: var(--gl-card-hover-background);
 	}
+
 	.branch-item:not(:focus-within):not(:hover) .branch-item__actions {
 		${srOnlyStyles}
 	}
@@ -358,7 +351,7 @@ export class GlBranchCard extends LitElement {
 				html`<action-item
 					label="Open Pull Request Changes"
 					icon="request-changes"
-					href=${this.createCommandLink('gitlens.home.openPullRequestComparison')}
+					href=${this.createCommandLink('gitlens.home.openPullRequestChanges')}
 				></action-item>`,
 			);
 			actions.push(

--- a/src/webviews/home/homeWebview.ts
+++ b/src/webviews/home/homeWebview.ts
@@ -773,11 +773,11 @@ export class HomeWebviewProvider implements WebviewProvider<State, State, HomeWe
 		if (pr?.refs?.base == null || pr.refs.head == null) return;
 
 		const comparisonRefs = getComparisonRefsForPullRequest(refs.repoPath, pr.refs);
-		return this.container.views.searchAndCompare.compare(
-			comparisonRefs.repoPath,
-			comparisonRefs.head,
-			comparisonRefs.base,
-		);
+		return this.container.views.searchAndCompare
+			.compare(comparisonRefs.repoPath, comparisonRefs.head, comparisonRefs.base)
+			.then(compareNode => {
+				executeCommand(Commands.ViewsOpenAllChangedFileDiffs, compareNode);
+			});
 	}
 
 	private async pullRequestViewOnRemote(refs: BranchRef, clipboard?: boolean) {


### PR DESCRIPTION
# Description

https://github.com/user-attachments/assets/2e14aaa2-550a-4aa7-b6d3-138d41c2844e

The thing I don't like is that for each action click a new compare node is created. Do we need to clear the nodes somehow or search duplicates before adding?

# Checklist

<!-- Please check off the following -->

- [ ] I have followed the guidelines in the Contributing document
- [ ] My changes follow the coding style of this project
- [ ] My changes build without any errors or warnings
- [ ] My changes have been formatted and linted
- [ ] My changes include any required corresponding changes to the documentation (including CHANGELOG.md and README.md)
- [ ] My changes have been rebased and squashed to the minimal number (typically 1) of relevant commits
- [ ] My changes have a descriptive commit message with a short title, including a `Fixes $XXX -` or `Closes #XXX -` prefix to auto-close the issue that your PR addresses
