### PR TITLE
Feat: Add context menu command to reset current branch to tag

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,10 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/) and this p
 
 ## [16.0.1] - 2024-11-15
 
+### Added
+
+- Adds context menu command in _Commit Graph_ to reset Current Branch to a tag.
+
 ### Changed
 
 - Changes the _Search & Compare_ view to be separate (detached) from the new grouped _GitLens_ view

--- a/package.json
+++ b/package.json
@@ -9079,6 +9079,13 @@
 				"enablement": "!operationInProgress"
 			},
 			{
+				"command": "gitlens.graph.resetToTag",
+				"title": "Reset Current Branch to Tag...",
+				"category": "GitLens",
+				"icon": "$(gitlens-reset)",
+				"enablement": "!operationInProgress"
+			},
+			{
 				"command": "gitlens.graph.createWorktree",
 				"title": "Create Worktree...",
 				"icon": "$(add)",
@@ -12430,6 +12437,10 @@
 				},
 				{
 					"command": "gitlens.graph.switchToTag",
+					"when": "false"
+				},
+				{
+					"command": "gitlens.graph.resetToTag",
 					"when": "false"
 				},
 				{
@@ -16413,14 +16424,19 @@
 					"group": "1_gitlens_actions@1"
 				},
 				{
+					"command": "gitlens.graph.resetToTag",
+					"when": "!gitlens:readonly && !gitlens:untrusted && !gitlens:hasVirtualFolders && webviewItem =~ /gitlens:tag\\b/",
+					"group": "1_gitlens_actions@2"
+				},
+				{
 					"command": "gitlens.graph.deleteTag",
 					"when": "!gitlens:readonly && !gitlens:untrusted && !gitlens:hasVirtualFolders && webviewItem == gitlens:tag",
-					"group": "1_gitlens_actions@2"
+					"group": "1_gitlens_actions@3"
 				},
 				{
 					"command": "gitlens.graph.createBranch",
 					"when": "!gitlens:readonly && !gitlens:untrusted && !gitlens:hasVirtualFolders && webviewItem =~ /gitlens:tag\\b/",
-					"group": "1_gitlens_actions@3"
+					"group": "1_gitlens_actions@4"
 				},
 				{
 					"command": "gitlens.graph.hideTag",

--- a/package.json
+++ b/package.json
@@ -9015,6 +9015,13 @@
 				"enablement": "!operationInProgress"
 			},
 			{
+				"command": "gitlens.graph.resetToTag",
+				"title": "Reset Current Branch to Tag...",
+				"category": "GitLens",
+				"icon": "$(gitlens-reset)",
+				"enablement": "!operationInProgress"
+			},
+			{
 				"command": "gitlens.graph.resetToTip",
 				"title": "Reset Current Branch to Tip...",
 				"enablement": "!operationInProgress"
@@ -9076,13 +9083,6 @@
 				"command": "gitlens.graph.switchToTag",
 				"title": "Switch to Tag...",
 				"icon": "$(gitlens-switch)",
-				"enablement": "!operationInProgress"
-			},
-			{
-				"command": "gitlens.graph.resetToTag",
-				"title": "Reset Current Branch to Tag...",
-				"category": "GitLens",
-				"icon": "$(gitlens-reset)",
 				"enablement": "!operationInProgress"
 			},
 			{
@@ -16304,6 +16304,11 @@
 					"group": "1_gitlens_actions@4"
 				},
 				{
+					"command": "gitlens.graph.resetToTag",
+					"when": "!gitlens:readonly && !gitlens:untrusted && !gitlens:hasVirtualFolders && !listMultiSelection && webviewItem =~ /gitlens:tag\\b/",
+					"group": "1_gitlens_actions@2"
+				},
+				{
 					"command": "gitlens.graph.resetToTip",
 					"when": "!gitlens:readonly && !gitlens:untrusted && !gitlens:hasVirtualFolders && webviewItem =~ /gitlens:branch\\b/",
 					"group": "1_gitlens_actions@4"
@@ -16422,11 +16427,6 @@
 					"command": "gitlens.graph.switchToTag",
 					"when": "!gitlens:readonly && !gitlens:untrusted && !gitlens:hasVirtualFolders && webviewItem =~ /gitlens:tag\\b/",
 					"group": "1_gitlens_actions@1"
-				},
-				{
-					"command": "gitlens.graph.resetToTag",
-					"when": "!gitlens:readonly && !gitlens:untrusted && !gitlens:hasVirtualFolders && webviewItem =~ /gitlens:tag\\b/",
-					"group": "1_gitlens_actions@2"
 				},
 				{
 					"command": "gitlens.graph.deleteTag",

--- a/src/commands/git/reset.ts
+++ b/src/commands/git/reset.ts
@@ -1,7 +1,7 @@
 import type { Container } from '../../container';
 import type { GitBranch } from '../../git/models/branch';
 import type { GitLog } from '../../git/models/log';
-import type { GitReference, GitRevisionReference } from '../../git/models/reference';
+import type { GitReference, GitRevisionReference, GitTagReference } from '../../git/models/reference';
 import { getReferenceLabel } from '../../git/models/reference';
 import type { Repository } from '../../git/models/repository';
 import type { FlagsQuickPickItem } from '../../quickpicks/items/flags';
@@ -31,7 +31,7 @@ type Flags = '--hard' | '--soft';
 
 interface State {
 	repo: string | Repository;
-	reference: GitRevisionReference;
+	reference: GitRevisionReference | GitTagReference;
 	flags: Flags[];
 }
 

--- a/src/git/actions/repository.ts
+++ b/src/git/actions/repository.ts
@@ -2,7 +2,7 @@ import type { ResetGitCommandArgs } from '../../commands/git/reset';
 import { Container } from '../../container';
 import type { ViewsWithRepositoryFolders } from '../../views/viewBase';
 import { executeGitCommand } from '../actions';
-import type { GitBranchReference, GitReference, GitRevisionReference } from '../models/reference';
+import type { GitBranchReference, GitReference, GitRevisionReference, GitTagReference } from '../models/reference';
 import type { Repository } from '../models/repository';
 
 export function cherryPick(repo?: string | Repository, refs?: GitRevisionReference | GitRevisionReference[]) {
@@ -40,7 +40,7 @@ export function rebase(repo?: string | Repository, ref?: GitReference, interacti
 
 export function reset(
 	repo?: string | Repository,
-	ref?: GitRevisionReference,
+	ref?: GitRevisionReference | GitTagReference,
 	flags?: NonNullable<ResetGitCommandArgs['state']>['flags'],
 ) {
 	return executeGitCommand({

--- a/src/plus/webviews/graph/graphWebview.ts
+++ b/src/plus/webviews/graph/graphWebview.ts
@@ -554,6 +554,7 @@ export class GraphWebviewProvider implements WebviewProvider<State, State, Graph
 			this.host.registerWebviewCommand('gitlens.graph.createTag', this.createTag),
 			this.host.registerWebviewCommand('gitlens.graph.deleteTag', this.deleteTag),
 			this.host.registerWebviewCommand('gitlens.graph.switchToTag', this.switchTo),
+			this.host.registerWebviewCommand('gitlens.graph.resetToTag', this.resetToTag),
 
 			this.host.registerWebviewCommand('gitlens.graph.createWorktree', this.createWorktree),
 
@@ -3337,6 +3338,13 @@ export class GraphWebviewProvider implements WebviewProvider<State, State, Graph
 		if (ref == null) return Promise.resolve();
 
 		return RepoActions.switchTo(ref.repoPath, ref);
+	}
+
+	@log()
+	private resetToTag(item?: GraphItemContext) {
+		const ref = this.getGraphItemRef(item, 'tag');
+		if (ref == null) return Promise.resolve();
+		return RepoActions.reset(ref.repoPath, ref);
 	}
 
 	@log()


### PR DESCRIPTION
# Description

This PR introduces a new option in the Commit Graph context menu for resetting the current branch to a tag.
![Captura de pantalla 2024-11-18 a las 12 30 59](https://github.com/user-attachments/assets/054db4b0-70b1-4398-a526-84302476176a)


Solves #2373 


# Checklist

<!-- Please check off the following -->

- [x] I have followed the guidelines in the Contributing document
- [x] My changes follow the coding style of this project
- [x] My changes build without any errors or warnings
- [x] My changes have been formatted and linted
- [x] My changes include any required corresponding changes to the documentation (including CHANGELOG.md and README.md)
- [x] My changes have been rebased and squashed to the minimal number (typically 1) of relevant commits
- [x] My changes have a descriptive commit message with a short title, including a `Fixes $XXX -` or `Closes #XXX -` prefix to auto-close the issue that your PR addresses
