### PR TITLE
Start Work: Stop hiding the quickpick when clicking the "globe" icon

### DIFF
--- a/src/plus/startWork/startWork.ts
+++ b/src/plus/startWork/startWork.ts
@@ -499,7 +499,7 @@ export class StartWorkCommand extends QuickCommand<State> {
 			onDidClickItemButton: (_quickpick, button, { item }) => {
 				if (button === OpenOnGitHubQuickInputButton && !isStartWorkTypeItem(item)) {
 					this.open(item);
-					return true;
+					return undefined;
 				}
 				return false;
 			},


### PR DESCRIPTION
Stop hiding the quickpick when clicking the "globe" icon to open that issue in the browser (#3742)

# Checklist

<!-- Please check off the following -->

- [x] I have followed the guidelines in the Contributing document
- [x] My changes follow the coding style of this project
- [x] My changes build without any errors or warnings
- [x] My changes have been formatted and linted
- [x] My changes include any required corresponding changes to the documentation (including CHANGELOG.md and README.md)
- [x] My changes have been rebased and squashed to the minimal number (typically 1) of relevant commits
- [x] My changes have a descriptive commit message with a short title, including a `Fixes $XXX -` or `Closes #XXX -` prefix to auto-close the issue that your PR addresses
