### PR TITLE
Uses correct counts in rebase command condition/messaging

### DIFF
--- a/src/commands/git/rebase.ts
+++ b/src/commands/git/rebase.ts
@@ -150,7 +150,7 @@ export class RebaseGitCommand extends QuickCommand<State> {
 				});
 
 				const result: StepResult<GitReference> = yield* pickBranchOrTagStep(state as RebaseStepState, context, {
-					placeholder: context => `Choose a branch${context.showTags ? ' or tag' : ''} to rebase`,
+					placeholder: context => `Choose a branch${context.showTags ? ' or tag' : ''} to rebase onto`,
 					picked: context.selectedBranchOrTag?.ref,
 					value: context.selectedBranchOrTag == null ? state.destination?.ref : undefined,
 					additionalButtons: [pickCommitToggle],

--- a/src/commands/quickCommand.steps.ts
+++ b/src/commands/quickCommand.steps.ts
@@ -2148,7 +2148,7 @@ async function getShowCommitOrStashStepItems<
 				command: 'rebase',
 				state: {
 					repo: state.repo,
-					reference: state.reference,
+					destination: state.reference,
 				},
 			}),
 			new GitWizardQuickPickItem('Switch to Commit...', {

--- a/src/git/actions/repository.ts
+++ b/src/git/actions/repository.ts
@@ -34,7 +34,7 @@ export function push(repos?: string | string[] | Repository | Repository[], forc
 export function rebase(repo?: string | Repository, ref?: GitReference, interactive: boolean = true) {
 	return executeGitCommand({
 		command: 'rebase',
-		state: { repo: repo, reference: ref, flags: interactive ? ['--interactive'] : [] },
+		state: { repo: repo, destination: ref, flags: interactive ? ['--interactive'] : [] },
 	});
 }
 


### PR DESCRIPTION
Fixes #3747

Updates property names to be clearer in rebase command, and uses the correct side of the left-right commit count to:

1. Determine if the current branch is caught up to the destination
2. Determine how many commits will be rebased on top of the destination

Repro steps:

1. Choose a rebase command: "rebase current branch onto branch", "rebase current branch onto tip", or "GitLens: Git Rebase" command palette command.

2. Before: Quickpick prevents rebase and states that the current branch is already up-to-date with the destination when it is not. After: Quickpick should allow the rebase, and give the correct number of commits that will be rebased on top of the destination.