### PR TITLE
Adds stashes into Commit view

### DIFF
--- a/package.json
+++ b/package.json
@@ -1743,6 +1743,13 @@
 				"title": "Commits View",
 				"order": 110,
 				"properties": {
+					"gitlens.views.commits.showStashes": {
+						"type": "boolean",
+						"default": false,
+						"markdownDescription": "Specifies whether to show stashes in the _Commits_ view",
+						"scope": "window",
+						"order": 9
+					},
 					"gitlens.views.commits.showBranchComparison": {
 						"type": [
 							"boolean",
@@ -2070,7 +2077,7 @@
 					},
 					"gitlens.views.repositories.showStashes": {
 						"type": "boolean",
-						"default": true,
+						"default": false,
 						"markdownDescription": "Specifies whether to show the stashes for each repository in the _Repositories_ view",
 						"scope": "window",
 						"order": 33
@@ -2191,6 +2198,13 @@
 						"markdownDescription": "Specifies whether to show the _Repositories_ view in a compact display density",
 						"scope": "window",
 						"order": 90
+					},
+					"gitlens.views.repositories.branches.showStashes": {
+						"type": "boolean",
+						"default": false,
+						"markdownDescription": "Specifies whether to show stashes in the _Commits_ and _Branches_ sections of the _Repositories_ view",
+						"scope": "window",
+						"order": 95
 					},
 					"gitlens.views.repositories.branches.showBranchComparison": {
 						"type": [
@@ -2355,6 +2369,13 @@
 				"title": "Branches View",
 				"order": 170,
 				"properties": {
+					"gitlens.views.branches.showStashes": {
+						"type": "boolean",
+						"default": false,
+						"markdownDescription": "Specifies whether to show stashes in the _Branches_ view",
+						"scope": "window",
+						"order": 9
+					},
 					"gitlens.views.branches.showBranchComparison": {
 						"type": [
 							"boolean",
@@ -2755,6 +2776,13 @@
 						"markdownDescription": "Specifies how and when to open a worktree after it is created",
 						"scope": "resource",
 						"order": 12
+					},
+					"gitlens.views.worktrees.showStashes": {
+						"type": "boolean",
+						"default": false,
+						"markdownDescription": "Specifies whether to show stashes in the _Worktrees_ view",
+						"scope": "window",
+						"order": 19
 					},
 					"gitlens.views.worktrees.showBranchComparison": {
 						"type": [
@@ -3229,7 +3257,7 @@
 					},
 					"gitlens.views.workspaces.showStashes": {
 						"type": "boolean",
-						"default": true,
+						"default": false,
 						"markdownDescription": "Specifies whether to show the stashes for each repository in the _Cloud Workspaces_ view",
 						"scope": "window",
 						"order": 33
@@ -3336,6 +3364,13 @@
 						"markdownDescription": "Specifies whether to show the _Cloud Workspaces_ view in a compact display density",
 						"scope": "window",
 						"order": 90
+					},
+					"gitlens.views.workspaces.branches.showStashes": {
+						"type": "boolean",
+						"default": false,
+						"markdownDescription": "Specifies whether to show stashes in the _Commits_ and _Branches_ sections of the _Cloud Workspaces_ view",
+						"scope": "window",
+						"order": 9
 					},
 					"gitlens.views.workspaces.branches.showBranchComparison": {
 						"type": [
@@ -7674,6 +7709,14 @@
 				"title": "Hide Branch Pull Requests"
 			},
 			{
+				"command": "gitlens.views.branches.setShowStashesOn",
+				"title": "Show Stashes"
+			},
+			{
+				"command": "gitlens.views.branches.setShowStashesOff",
+				"title": "Hide Stashes"
+			},
+			{
 				"command": "gitlens.views.commitDetails.refresh",
 				"title": "Refresh",
 				"icon": "$(refresh)"
@@ -7758,6 +7801,14 @@
 			{
 				"command": "gitlens.views.commits.setShowBranchPullRequestOff",
 				"title": "Hide Current Branch Pull Request"
+			},
+			{
+				"command": "gitlens.views.commits.setShowStashesOn",
+				"title": "Show Stashes"
+			},
+			{
+				"command": "gitlens.views.commits.setShowStashesOff",
+				"title": "Hide Stashes"
 			},
 			{
 				"command": "gitlens.views.contributors.copy",
@@ -8803,6 +8854,14 @@
 			{
 				"command": "gitlens.views.worktrees.setShowBranchPullRequestOff",
 				"title": "Hide Branch Pull Requests"
+			},
+			{
+				"command": "gitlens.views.worktrees.setShowStashesOn",
+				"title": "Show Stashes"
+			},
+			{
+				"command": "gitlens.views.worktrees.setShowStashesOff",
+				"title": "Hide Stashes"
 			},
 			{
 				"command": "gitlens.enableDebugLogging",
@@ -11225,6 +11284,14 @@
 					"when": "false"
 				},
 				{
+					"command": "gitlens.views.branches.setShowStashesOn",
+					"when": "false"
+				},
+				{
+					"command": "gitlens.views.branches.setShowStashesOff",
+					"when": "false"
+				},
+				{
 					"command": "gitlens.views.commitDetails.refresh",
 					"when": "false"
 				},
@@ -11298,6 +11365,14 @@
 				},
 				{
 					"command": "gitlens.views.commits.setShowBranchPullRequestOff",
+					"when": "false"
+				},
+				{
+					"command": "gitlens.views.commits.setShowStashesOn",
+					"when": "false"
+				},
+				{
+					"command": "gitlens.views.commits.setShowStashesOff",
 					"when": "false"
 				},
 				{
@@ -12194,6 +12269,14 @@
 				},
 				{
 					"command": "gitlens.views.worktrees.setShowBranchPullRequestOff",
+					"when": "false"
+				},
+				{
+					"command": "gitlens.views.worktrees.setShowStashesOn",
+					"when": "false"
+				},
+				{
+					"command": "gitlens.views.worktrees.setShowStashesOff",
 					"when": "false"
 				},
 				{
@@ -13230,6 +13313,16 @@
 					"group": "5_gitlens@2"
 				},
 				{
+					"command": "gitlens.views.branches.setShowStashesOn",
+					"when": "view == gitlens.views.branches && !config.gitlens.views.branches.showStashes && !gitlens:hasVirtualFolders",
+					"group": "5_gitlens@11"
+				},
+				{
+					"command": "gitlens.views.branches.setShowStashesOff",
+					"when": "view == gitlens.views.branches && config.gitlens.views.branches.showStashes && !gitlens:hasVirtualFolders",
+					"group": "5_gitlens@11"
+				},
+				{
 					"command": "gitlens.pushRepositories",
 					"when": "gitlens:repos:withRemotes && !gitlens:readonly && !gitlens:untrusted && !gitlens:hasVirtualFolders && view == gitlens.views.commits",
 					"group": "navigation@1"
@@ -13337,7 +13430,17 @@
 				{
 					"command": "gitlens.views.commits.setShowBranchPullRequestOff",
 					"when": "view == gitlens.views.commits && config.gitlens.views.commits.pullRequests.enabled && config.gitlens.views.commits.pullRequests.showForBranches",
-					"group": "5_gitlens@4"
+					"group": "5_gitlens@3"
+				},
+				{
+					"command": "gitlens.views.commits.setShowStashesOn",
+					"when": "view == gitlens.views.commits && !config.gitlens.views.commits.showStashes && !gitlens:hasVirtualFolders",
+					"group": "5_gitlens@11"
+				},
+				{
+					"command": "gitlens.views.commits.setShowStashesOff",
+					"when": "view == gitlens.views.commits && config.gitlens.views.commits.showStashes && !gitlens:hasVirtualFolders",
+					"group": "5_gitlens@11"
 				},
 				{
 					"command": "gitlens.showGraph",
@@ -14290,14 +14393,24 @@
 					"group": "5_gitlens@2"
 				},
 				{
+					"command": "gitlens.views.worktrees.setShowStashesOn",
+					"when": "view == gitlens.views.worktrees && !config.gitlens.views.worktrees.showStashes && !gitlens:hasVirtualFolders",
+					"group": "5_gitlens@11"
+				},
+				{
+					"command": "gitlens.views.worktrees.setShowStashesOff",
+					"when": "view == gitlens.views.worktrees && config.gitlens.views.worktrees.showStashes && !gitlens:hasVirtualFolders",
+					"group": "5_gitlens@11"
+				},
+				{
 					"command": "gitlens.views.setShowRelativeDateMarkersOn",
 					"when": "view =~ /^gitlens\\.views\\.(branches|commits|contributors|fileHistory|lineHistory|remotes|repositories|tags|worktrees)/ && !config.gitlens.views.showRelativeDateMarkers",
-					"group": "5_gitlens@3"
+					"group": "5_gitlens@10"
 				},
 				{
 					"command": "gitlens.views.setShowRelativeDateMarkersOff",
 					"when": "view =~ /^gitlens\\.views\\.(branches|commits|contributors|fileHistory|lineHistory|remotes|repositories|tags|worktrees)/ && config.gitlens.views.showRelativeDateMarkers",
-					"group": "5_gitlens@3"
+					"group": "5_gitlens@10"
 				},
 				{
 					"submenu": "gitlens/graph/configuration",
@@ -17421,12 +17534,12 @@
 				},
 				{
 					"command": "gitlens.views.repositories.setShowStashesOn",
-					"when": "!config.gitlens.views.repositories.showStashes",
+					"when": "!config.gitlens.views.repositories.showStashes && !gitlens:hasVirtualFolders",
 					"group": "2_gitlens@5"
 				},
 				{
 					"command": "gitlens.views.repositories.setShowStashesOff",
-					"when": "config.gitlens.views.repositories.showStashes",
+					"when": "config.gitlens.views.repositories.showStashes && !gitlens:hasVirtualFolders",
 					"group": "2_gitlens@5"
 				},
 				{
@@ -17756,12 +17869,12 @@
 				{
 					"command": "gitlens.views.setShowRelativeDateMarkersOn",
 					"when": "view == gitlens.views.scm.grouped && gitlens:views:scm:grouped:view =~ /(branches|commits|contributors|remotes|repositories|tags|worktrees)/ && !config.gitlens.views.showRelativeDateMarkers",
-					"group": "5_gitlens@3"
+					"group": "5_gitlens@10"
 				},
 				{
 					"command": "gitlens.views.setShowRelativeDateMarkersOff",
 					"when": "view == gitlens.views.scm.grouped && gitlens:views:scm:grouped:view =~ /(branches|commits|contributors|remotes|repositories|tags|worktrees)/ && config.gitlens.views.showRelativeDateMarkers",
-					"group": "5_gitlens@3"
+					"group": "5_gitlens@10"
 				},
 				{
 					"command": "gitlens.views.branches.setLayoutToList",
@@ -17817,6 +17930,16 @@
 					"command": "gitlens.views.branches.setShowBranchPullRequestOff",
 					"when": "view == gitlens.views.scm.grouped && gitlens:views:scm:grouped:view == branches && config.gitlens.views.branches.pullRequests.enabled && config.gitlens.views.branches.pullRequests.showForBranches",
 					"group": "5_gitlens@2"
+				},
+				{
+					"command": "gitlens.views.branches.setShowStashesOn",
+					"when": "view == gitlens.views.scm.grouped && gitlens:views:scm:grouped:view == branches && !config.gitlens.views.branches.showStashes && !gitlens:hasVirtualFolders",
+					"group": "5_gitlens@11"
+				},
+				{
+					"command": "gitlens.views.branches.setShowStashesOff",
+					"when": "view == gitlens.views.scm.grouped && gitlens:views:scm:grouped:view == branches && config.gitlens.views.branches.showStashes && !gitlens:hasVirtualFolders",
+					"group": "5_gitlens@11"
 				},
 				{
 					"command": "gitlens.showSettingsPage!branches-view",
@@ -17876,7 +17999,17 @@
 				{
 					"command": "gitlens.views.commits.setShowBranchPullRequestOff",
 					"when": "view == gitlens.views.scm.grouped && gitlens:views:scm:grouped:view == commits && config.gitlens.views.commits.pullRequests.enabled && config.gitlens.views.commits.pullRequests.showForBranches",
-					"group": "5_gitlens@4"
+					"group": "5_gitlens@3"
+				},
+				{
+					"command": "gitlens.views.commits.setShowStashesOn",
+					"when": "view == gitlens.views.scm.grouped && gitlens:views:scm:grouped:view == commits && !config.gitlens.views.commits.showStashes && !gitlens:hasVirtualFolders",
+					"group": "5_gitlens@11"
+				},
+				{
+					"command": "gitlens.views.commits.setShowStashesOff",
+					"when": "view == gitlens.views.scm.grouped && gitlens:views:scm:grouped:view == commits && config.gitlens.views.commits.showStashes && !gitlens:hasVirtualFolders",
+					"group": "5_gitlens@11"
 				},
 				{
 					"command": "gitlens.showSettingsPage!commits-view",
@@ -18197,6 +18330,16 @@
 					"command": "gitlens.views.worktrees.setShowBranchPullRequestOff",
 					"when": "view == gitlens.views.scm.grouped && gitlens:views:scm:grouped:view == worktrees && config.gitlens.views.worktrees.pullRequests.enabled && config.gitlens.views.worktrees.pullRequests.showForBranches",
 					"group": "5_gitlens@2"
+				},
+				{
+					"command": "gitlens.views.worktrees.setShowStashesOn",
+					"when": "view == gitlens.views.scm.grouped && gitlens:views:scm:grouped:view == worktrees && !config.gitlens.views.worktrees.showStashes && !gitlens:hasVirtualFolders",
+					"group": "5_gitlens@11"
+				},
+				{
+					"command": "gitlens.views.worktrees.setShowStashesOff",
+					"when": "view == gitlens.views.scm.grouped && gitlens:views:scm:grouped:view == worktrees && config.gitlens.views.worktrees.showStashes && !gitlens:hasVirtualFolders",
+					"group": "5_gitlens@11"
 				},
 				{
 					"command": "gitlens.showSettingsPage!worktrees-view",

--- a/src/config.ts
+++ b/src/config.ts
@@ -700,6 +700,7 @@ export interface BranchesViewConfig {
 	};
 	readonly reveal: boolean;
 	readonly showBranchComparison: false | Extract<ViewShowBranchComparison, 'branch'>;
+	readonly showStashes: boolean;
 }
 
 export interface CommitsViewConfig {
@@ -713,6 +714,7 @@ export interface CommitsViewConfig {
 	};
 	readonly reveal: boolean;
 	readonly showBranchComparison: false | ViewShowBranchComparison;
+	readonly showStashes: boolean;
 }
 
 export interface CommitDetailsViewConfig {
@@ -806,6 +808,7 @@ export interface RepositoriesViewConfig {
 	readonly branches: {
 		readonly layout: ViewBranchesLayout;
 		readonly showBranchComparison: false | Extract<ViewShowBranchComparison, 'branch'>;
+		readonly showStashes: boolean;
 	};
 	readonly compact: boolean;
 	readonly files: ViewsFilesConfig;
@@ -860,6 +863,7 @@ export interface WorktreesViewConfig {
 	};
 	readonly reveal: boolean;
 	readonly showBranchComparison: false | Extract<ViewShowBranchComparison, 'branch'>;
+	readonly showStashes: boolean;
 }
 
 export interface WorkspacesViewConfig {
@@ -867,6 +871,7 @@ export interface WorkspacesViewConfig {
 	readonly branches: {
 		readonly layout: ViewBranchesLayout;
 		readonly showBranchComparison: false | Extract<ViewShowBranchComparison, 'branch'>;
+		readonly showStashes: boolean;
 	};
 	readonly compact: boolean;
 	readonly files: ViewsFilesConfig;

--- a/src/constants.commands.ts
+++ b/src/constants.commands.ts
@@ -337,7 +337,8 @@ export type TreeViewCommands = `gitlens.views.${
 			| `setFilesLayoutTo${'Auto' | 'List' | 'Tree'}`
 			| `setShowAvatars${'On' | 'Off'}`
 			| `setShowBranchComparison${'On' | 'Off'}`
-			| `setShowBranchPullRequest${'On' | 'Off'}`}`
+			| `setShowBranchPullRequest${'On' | 'Off'}`
+			| `setShowStashes${'On' | 'Off'}`}`
 	| `commits.${
 			| 'copy'
 			| 'refresh'
@@ -346,7 +347,8 @@ export type TreeViewCommands = `gitlens.views.${
 			| `setShowAvatars${'On' | 'Off'}`
 			| `setShowBranchComparison${'On' | 'Off'}`
 			| `setShowBranchPullRequest${'On' | 'Off'}`
-			| `setShowMergeCommits${'On' | 'Off'}`}`
+			| `setShowMergeCommits${'On' | 'Off'}`
+			| `setShowStashes${'On' | 'Off'}`}`
 	| `contributors.${
 			| 'copy'
 			| 'refresh'
@@ -451,7 +453,8 @@ export type TreeViewCommands = `gitlens.views.${
 			| `setFilesLayoutTo${'Auto' | 'List' | 'Tree'}`
 			| `setShowAvatars${'On' | 'Off'}`
 			| `setShowBranchComparison${'On' | 'Off'}`
-			| `setShowBranchPullRequest${'On' | 'Off'}`}`}`;
+			| `setShowBranchPullRequest${'On' | 'Off'}`
+			| `setShowStashes${'On' | 'Off'}`}`}`;
 
 type ExtractSuffix<Prefix extends string, U> = U extends `${Prefix}${infer V}` ? V : never;
 type FilterCommands<Prefix extends string, U> = U extends `${Prefix}${infer V}` ? `${Prefix}${V}` : never;

--- a/src/env/node/git/git.ts
+++ b/src/env/node/git/git.ts
@@ -1591,7 +1591,7 @@ export class Git {
 	async rev_list(
 		repoPath: string,
 		ref: string,
-		options?: { all?: boolean; maxParents?: number },
+		options?: { all?: boolean; maxParents?: number; since?: string },
 	): Promise<string[] | undefined> {
 		const params = ['rev-list'];
 		if (options?.all) {
@@ -1600,6 +1600,10 @@ export class Git {
 
 		if (options?.maxParents != null) {
 			params.push(`--max-parents=${options.maxParents}`);
+		}
+
+		if (options?.since) {
+			params.push(`--since="${options.since}"`, '--date-order');
 		}
 
 		const rawData = await this.git<string>(

--- a/src/git/gitProviderService.ts
+++ b/src/git/gitProviderService.ts
@@ -2029,6 +2029,7 @@ export class GitProviderService implements Disposable {
 			ordering?: 'date' | 'author-date' | 'topo' | null;
 			ref?: string;
 			since?: string;
+			stashes?: boolean;
 		},
 	): Promise<GitLog | undefined> {
 		const { provider, path } = this.getProvider(repoPath);

--- a/src/git/models/commit.ts
+++ b/src/git/models/commit.ts
@@ -226,7 +226,7 @@ export class GitCommit implements GitRevisionReference {
 		}
 
 		const [commitResult, untrackedResult] = await Promise.allSettled([
-			this.refType !== 'stash' ? this.container.git.getCommit(this.repoPath, this.sha) : undefined,
+			this.container.git.getCommit(this.repoPath, this.sha),
 			// Check for any untracked files -- since git doesn't return them via `git stash list` :(
 			// See https://stackoverflow.com/questions/12681529/
 			this.refType === 'stash' && !this._stashUntrackedFilesLoaded

--- a/src/views/branchesView.ts
+++ b/src/views/branchesView.ts
@@ -178,6 +178,8 @@ export class BranchesView extends ViewBase<'branches', BranchesViewNode, Branche
 				() => this.setShowBranchPullRequest(false),
 				this,
 			),
+			registerViewCommand(this.getQualifiedCommand('setShowStashesOn'), () => this.setShowStashes(true), this),
+			registerViewCommand(this.getQualifiedCommand('setShowStashesOff'), () => this.setShowStashes(false), this),
 		];
 	}
 
@@ -352,5 +354,9 @@ export class BranchesView extends ViewBase<'branches', BranchesViewNode, Branche
 	private async setShowBranchPullRequest(enabled: boolean) {
 		await configuration.updateEffective(`views.${this.configKey}.pullRequests.showForBranches` as const, enabled);
 		await configuration.updateEffective(`views.${this.configKey}.pullRequests.enabled` as const, enabled);
+	}
+
+	private setShowStashes(enabled: boolean) {
+		return configuration.updateEffective(`views.${this.configKey}.showStashes` as const, enabled);
 	}
 }

--- a/src/views/commitsView.ts
+++ b/src/views/commitsView.ts
@@ -57,6 +57,7 @@ export class CommitsRepositoryNode extends RepositoryFolderNode<CommitsView, Bra
 					showComparison: this.view.config.showBranchComparison,
 					showStatusDecorationOnly: true,
 					showMergeCommits: !this.view.state.hideMergeCommits,
+					showStashes: this.view.config.showStashes,
 					showTracking: true,
 					authors: authors,
 				},
@@ -310,6 +311,8 @@ export class CommitsView extends ViewBase<'commits', CommitsViewNode, CommitsVie
 				() => this.setShowBranchPullRequest(false),
 				this,
 			),
+			registerViewCommand(this.getQualifiedCommand('setShowStashesOn'), () => this.setShowStashes(true), this),
+			registerViewCommand(this.getQualifiedCommand('setShowStashesOff'), () => this.setShowStashes(false), this),
 		];
 	}
 
@@ -508,5 +511,9 @@ export class CommitsView extends ViewBase<'commits', CommitsViewNode, CommitsVie
 	private async setShowBranchPullRequest(enabled: boolean) {
 		await configuration.updateEffective(`views.${this.configKey}.pullRequests.showForBranches` as const, enabled);
 		await configuration.updateEffective(`views.${this.configKey}.pullRequests.enabled` as const, enabled);
+	}
+
+	private setShowStashes(enabled: boolean) {
+		return configuration.updateEffective(`views.${this.configKey}.showStashes` as const, enabled);
 	}
 }

--- a/src/views/nodes/branchesNode.ts
+++ b/src/views/nodes/branchesNode.ts
@@ -62,6 +62,7 @@ export class BranchesNode extends CacheableChildrenViewNode<'branches', ViewsWit
 								this.view.type === 'repositories'
 									? this.view.config.branches.showBranchComparison
 									: this.view.config.showBranchComparison,
+							showStashes: this.view.config.showStashes,
 						},
 					),
 			);

--- a/src/views/nodes/remoteNode.ts
+++ b/src/views/nodes/remoteNode.ts
@@ -52,6 +52,7 @@ export class RemoteNode extends ViewNode<'remote', ViewsWithRemotes> {
 			b =>
 				new BranchNode(GitUri.fromRepoPath(this.uri.repoPath!, b.ref), this.view, this, this.repo, b, false, {
 					showComparison: false,
+					showStashes: false,
 					showTracking: false,
 				}),
 		);

--- a/src/views/nodes/repositoryNode.ts
+++ b/src/views/nodes/repositoryNode.ts
@@ -159,6 +159,7 @@ export class RepositoryNode extends SubscribeableViewNode<'repository', ViewsWit
 						new BranchNode(this.uri, this.view, this, this.repo, branch, true, {
 							showAsCommits: true,
 							showComparison: false,
+							showStashes: this.view.config.branches.showStashes,
 							showStatusDecorationOnly: true,
 							showStatus: false,
 							showTracking: false,

--- a/src/views/worktreesView.ts
+++ b/src/views/worktreesView.ts
@@ -175,6 +175,8 @@ export class WorktreesView extends ViewBase<'worktrees', WorktreesViewNode, Work
 				() => this.setShowBranchPullRequest(false),
 				this,
 			),
+			registerViewCommand(this.getQualifiedCommand('setShowStashesOn'), () => this.setShowStashes(true), this),
+			registerViewCommand(this.getQualifiedCommand('setShowStashesOff'), () => this.setShowStashes(false), this),
 		];
 	}
 
@@ -279,5 +281,9 @@ export class WorktreesView extends ViewBase<'worktrees', WorktreesViewNode, Work
 	private async setShowBranchPullRequest(enabled: boolean) {
 		await configuration.updateEffective(`views.${this.configKey}.pullRequests.showForBranches` as const, enabled);
 		await configuration.updateEffective(`views.${this.configKey}.pullRequests.enabled` as const, enabled);
+	}
+
+	private setShowStashes(enabled: boolean) {
+		return configuration.updateEffective(`views.${this.configKey}.showStashes` as const, enabled);
 	}
 }


### PR DESCRIPTION
I think this is ready for review/testing, as it works for any views that use "branch nodes", e.g. Commits, Branches, Worktrees, Repositories views. 

~~We will need to figure out how to get it to work with the Commit Graph without having to refresh all the commits (and stashes) based on the selected "Branches Visibility"~~

~~@axosoft-ramint maybe instead of filtering the stash commits, we just also return a set of "reachable" commits, and then be able to pass both sets into the Graph or something.~~

We will need to handle the Commit Graph differently.