### PR TITLE
(WIP) Refactoring out view nodes to better deal with id collisions and storage

### DIFF
--- a/src/views/branchesView.ts
+++ b/src/views/branchesView.ts
@@ -76,7 +76,7 @@ export class BranchesViewNode extends RepositoriesSubscribeableNode<BranchesView
 
 			const splat = repositories.length === 1;
 			this.children = repositories.map(
-				r => new BranchesRepositoryNode(GitUri.fromRepoPath(r.path), this.view, this, r, splat),
+				r => new BranchesRepositoryNode(GitUri.fromRepoPath(r.path), this.view, this, splat, r),
 			);
 		}
 

--- a/src/views/commitsView.ts
+++ b/src/views/commitsView.ts
@@ -136,7 +136,7 @@ export class CommitsViewNode extends RepositoriesSubscribeableNode<CommitsView, 
 			const splat = repositories.length === 1;
 			this.children = repositories.map(
 				r =>
-					new CommitsRepositoryNode(GitUri.fromRepoPath(r.path), this.view, this, r, splat, {
+					new CommitsRepositoryNode(GitUri.fromRepoPath(r.path), this.view, this, splat, r, {
 						showBranchAndLastFetched: true,
 					}),
 			);

--- a/src/views/contributorsView.ts
+++ b/src/views/contributorsView.ts
@@ -76,7 +76,7 @@ export class ContributorsViewNode extends RepositoriesSubscribeableNode<Contribu
 
 			const splat = repositories.length === 1;
 			this.children = repositories.map(
-				r => new ContributorsRepositoryNode(GitUri.fromRepoPath(r.path), this.view, this, r, splat),
+				r => new ContributorsRepositoryNode(GitUri.fromRepoPath(r.path), this.view, this, splat, r),
 			);
 		}
 

--- a/src/views/launchpadView.ts
+++ b/src/views/launchpadView.ts
@@ -46,10 +46,6 @@ export class LaunchpadItemNode extends CacheableChildrenViewNode<'launchpad-item
 		this.repoPath = repoPath;
 	}
 
-	override get id(): string {
-		return this._uniqueId;
-	}
-
 	override toClipboard(type?: ClipboardType): string {
 		const url = this.getUrl();
 		switch (type) {

--- a/src/views/nodes/UncommittedFilesNode.ts
+++ b/src/views/nodes/UncommittedFilesNode.ts
@@ -31,10 +31,6 @@ export class UncommittedFilesNode extends ViewNode<'uncommitted-files', ViewsWit
 		this._uniqueId = getViewNodeId(this.type, this.context);
 	}
 
-	override get id(): string {
-		return this._uniqueId;
-	}
-
 	get repoPath(): string {
 		return this.status.repoPath;
 	}

--- a/src/views/nodes/abstract/repositoriesSubscribeableNode.ts
+++ b/src/views/nodes/abstract/repositoriesSubscribeableNode.ts
@@ -13,10 +13,8 @@ export abstract class RepositoriesSubscribeableNode<
 	TView extends View = View,
 	TChild extends ViewNode = ViewNode,
 > extends SubscribeableViewNode<'repositories', TView, TChild> {
-	protected override splatted = true;
-
 	constructor(view: TView) {
-		super('repositories', unknownGitUri, view);
+		super('repositories', unknownGitUri, view, undefined, true);
 	}
 
 	override async getSplattedChild() {

--- a/src/views/nodes/abstract/repositoryFolderNode.ts
+++ b/src/views/nodes/abstract/repositoryFolderNode.ts
@@ -19,22 +19,18 @@ export abstract class RepositoryFolderNode<
 	TView extends View = View,
 	TChild extends ViewNode = ViewNode,
 > extends SubscribeableViewNode<'repo-folder', TView> {
-	protected override splatted = true;
-
 	constructor(
 		uri: GitUri,
 		view: TView,
 		protected override readonly parent: ViewNode,
-		public readonly repo: Repository,
 		splatted: boolean,
+		public readonly repo: Repository,
 		private readonly options?: { showBranchAndLastFetched?: boolean },
 	) {
-		super('repo-folder', uri, view, parent);
+		super('repo-folder', uri, view, parent, splatted);
 
 		this.updateContext({ repository: this.repo });
 		this._uniqueId = getViewNodeId(this.type, this.context);
-
-		this.splatted = splatted;
 	}
 
 	private _child: TChild | undefined;
@@ -66,8 +62,6 @@ export abstract class RepositoryFolderNode<
 	}
 
 	async getTreeItem(): Promise<TreeItem> {
-		this.splatted = false;
-
 		const branch = await this.repo.git.getBranch();
 		const ahead = (branch?.state.ahead ?? 0) > 0;
 		const behind = (branch?.state.behind ?? 0) > 0;

--- a/src/views/nodes/abstract/repositoryFolderNode.ts
+++ b/src/views/nodes/abstract/repositoryFolderNode.ts
@@ -49,10 +49,6 @@ export abstract class RepositoryFolderNode<
 		this.child = undefined;
 	}
 
-	override get id(): string {
-		return this._uniqueId;
-	}
-
 	override toClipboard(): string {
 		return this.repo.path;
 	}

--- a/src/views/nodes/abstract/subscribeableViewNode.ts
+++ b/src/views/nodes/abstract/subscribeableViewNode.ts
@@ -21,8 +21,8 @@ export abstract class SubscribeableViewNode<
 
 	protected loaded: boolean = false;
 
-	constructor(type: Type, uri: GitUri, view: TView, parent?: ViewNode) {
-		super(type, uri, view, parent);
+	constructor(type: Type, uri: GitUri, view: TView, parent?: ViewNode, splatted?: boolean) {
+		super(type, uri, view, parent, splatted);
 
 		const disposables = [
 			weakEvent(this.view.onDidChangeVisibility, this.onVisibilityChanged, this),

--- a/src/views/nodes/abstract/viewNode.ts
+++ b/src/views/nodes/abstract/viewNode.ts
@@ -253,7 +253,7 @@ export abstract class ViewNode<
 	}
 
 	protected _uniqueId!: string;
-	protected splatted = false;
+	splatted = false;
 	// NOTE: @eamodio uncomment to track node leaks
 	// readonly uuid = uuid();
 
@@ -262,8 +262,12 @@ export abstract class ViewNode<
 		// public readonly id: string | undefined,
 		uri: GitUri,
 		public readonly view: TView,
-		protected parent?: ViewNode,
+		protected parent?: ViewNode | undefined,
+		//** Indicates if this node is only shown as its children, not itself */
+		splatted?: boolean,
 	) {
+		this.splatted = splatted ?? false;
+
 		// NOTE: @eamodio uncomment to track node leaks
 		// queueMicrotask(() => this.view.registerNode(this));
 		this._uri = uri;
@@ -339,20 +343,24 @@ export abstract class ViewNode<
 
 	getSplattedChild?(): Promise<ViewNode | undefined>;
 
+	protected get storedId(): string | undefined {
+		return this.id;
+	}
+
 	deleteState<T extends StateKey<State> = StateKey<State>>(key?: T): void {
-		if (this.id == null) {
+		if (this.storedId == null) {
 			debugger;
 			throw new Error('Id is required to delete state');
 		}
-		this.view.nodeState.deleteState(this.id, key as string);
+		this.view.nodeState.deleteState(this.storedId, key as string);
 	}
 
 	getState<T extends StateKey<State> = StateKey<State>>(key: T): StateValue<State, T> | undefined {
-		if (this.id == null) {
+		if (this.storedId == null) {
 			debugger;
 			throw new Error('Id is required to get state');
 		}
-		return this.view.nodeState.getState(this.id, key as string);
+		return this.view.nodeState.getState(this.storedId, key as string);
 	}
 
 	storeState<T extends StateKey<State> = StateKey<State>>(
@@ -360,11 +368,11 @@ export abstract class ViewNode<
 		value: StateValue<State, T>,
 		sticky?: boolean,
 	): void {
-		if (this.id == null) {
+		if (this.storedId == null) {
 			debugger;
 			throw new Error('Id is required to store state');
 		}
-		this.view.nodeState.storeState(this.id, key as string, value, sticky);
+		this.view.nodeState.storeState(this.storedId, key as string, value, sticky);
 	}
 }
 

--- a/src/views/nodes/abstract/viewRefNode.ts
+++ b/src/views/nodes/abstract/viewRefNode.ts
@@ -17,8 +17,9 @@ export abstract class ViewRefNode<
 		uri: GitUri,
 		view: TView,
 		protected override readonly parent: ViewNode,
+		splatted?: boolean,
 	) {
-		super(type, uri, view, parent);
+		super(type, uri, view, parent, splatted);
 	}
 
 	abstract get ref(): TReference;

--- a/src/views/nodes/autolinkedItemNode.ts
+++ b/src/views/nodes/autolinkedItemNode.ts
@@ -22,10 +22,6 @@ export class AutolinkedItemNode extends ViewNode<'autolink', ViewsWithCommits> {
 		this._uniqueId = getViewNodeId(`${this.type}+${item.id}`, this.context);
 	}
 
-	override get id(): string {
-		return this._uniqueId;
-	}
-
 	override async toClipboard(type?: ClipboardType): Promise<string> {
 		const enriched = await this.maybeEnriched;
 		switch (type) {

--- a/src/views/nodes/autolinkedItemsNode.ts
+++ b/src/views/nodes/autolinkedItemsNode.ts
@@ -30,10 +30,6 @@ export class AutolinkedItemsNode extends CacheableChildrenViewNode<'autolinks', 
 		this._uniqueId = getViewNodeId(this.type, this.context);
 	}
 
-	override get id(): string {
-		return this._uniqueId;
-	}
-
 	async getChildren(): Promise<ViewNode[]> {
 		if (this.children == null) {
 			const commits = [...this.log.commits.values()];

--- a/src/views/nodes/branchNode.ts
+++ b/src/views/nodes/branchNode.ts
@@ -83,7 +83,9 @@ export class BranchNode
 		super('branch', uri, view, parent, root);
 
 		this.updateContext({ repository: repo, branch: branch, root: root });
-		this._uniqueId = getViewNodeId(this.type, this.context);
+		// this._uniqueId = getViewNodeId(this.type, this.context);
+		this._uniqueId = `${this.type}(${this.branch.id})`;
+
 		this.limit = this.view.getNodeLastKnownLimit(this);
 
 		this.options = {
@@ -104,10 +106,6 @@ export class BranchNode
 	override dispose() {
 		super.dispose();
 		this.children = undefined;
-	}
-
-	override get id(): string {
-		return this._uniqueId;
 	}
 
 	override toClipboard(): string {

--- a/src/views/nodes/branchNode.ts
+++ b/src/views/nodes/branchNode.ts
@@ -69,7 +69,6 @@ export class BranchNode
 	limit: number | undefined;
 
 	private readonly options: Options;
-	protected override splatted = true;
 
 	constructor(
 		uri: GitUri,
@@ -81,7 +80,7 @@ export class BranchNode
 		public readonly root: boolean,
 		options?: Partial<Options>,
 	) {
-		super('branch', uri, view, parent);
+		super('branch', uri, view, parent, root);
 
 		this.updateContext({ repository: repo, branch: branch, root: root });
 		this._uniqueId = getViewNodeId(this.type, this.context);
@@ -418,8 +417,6 @@ export class BranchNode
 	}
 
 	async getTreeItem(): Promise<TreeItem> {
-		this.splatted = false;
-
 		const parts = await getBranchNodeParts(this.view.container, this.branch, this.current, {
 			pendingPullRequest: this.getState('pendingPullRequest'),
 			showAsCommits: this.options.showAsCommits,

--- a/src/views/nodes/branchOrTagFolderNode.ts
+++ b/src/views/nodes/branchOrTagFolderNode.ts
@@ -22,10 +22,6 @@ export class BranchOrTagFolderNode extends ViewNode<'branch-tag-folder'> {
 		this._uniqueId = getViewNodeId(`${this.type}+${folderType}+${relativePath ?? folderName}`, this.context);
 	}
 
-	override get id(): string {
-		return this._uniqueId;
-	}
-
 	override toClipboard(): string {
 		return this.folderName;
 	}

--- a/src/views/nodes/branchTrackingStatusNode.ts
+++ b/src/views/nodes/branchTrackingStatusNode.ts
@@ -56,12 +56,8 @@ export class BranchTrackingStatusNode
 			branchStatusUpstreamType: upstreamType,
 			root: root,
 		});
-		this._uniqueId = getViewNodeId(this.type, this.context);
+		// this._uniqueId = getViewNodeId(this.type, this.context);
 		this.limit = this.view.getNodeLastKnownLimit(this);
-	}
-
-	override get id(): string {
-		return this._uniqueId;
 	}
 
 	get repoPath(): string {

--- a/src/views/nodes/branchesNode.ts
+++ b/src/views/nodes/branchesNode.ts
@@ -25,10 +25,6 @@ export class BranchesNode extends CacheableChildrenViewNode<'branches', ViewsWit
 		this._uniqueId = getViewNodeId(this.type, this.context);
 	}
 
-	override get id(): string {
-		return this._uniqueId;
-	}
-
 	get repoPath(): string {
 		return this.repo.path;
 	}

--- a/src/views/nodes/branchesNode.ts
+++ b/src/views/nodes/branchesNode.ts
@@ -19,7 +19,7 @@ export class BranchesNode extends CacheableChildrenViewNode<'branches', ViewsWit
 		protected override readonly parent: ViewNode,
 		public readonly repo: Repository,
 	) {
-		super('branches', uri, view, parent);
+		super('branches', uri, view, parent, true);
 
 		this.updateContext({ repository: repo });
 		this._uniqueId = getViewNodeId(this.type, this.context);

--- a/src/views/nodes/codeSuggestionsNode.ts
+++ b/src/views/nodes/codeSuggestionsNode.ts
@@ -20,10 +20,6 @@ export class CodeSuggestionsNode extends CacheableChildrenViewNode<'drafts-code-
 		this._uniqueId = getViewNodeId(this.type, this.context);
 	}
 
-	override get id(): string {
-		return this._uniqueId;
-	}
-
 	async getChildren(): Promise<ViewNode[]> {
 		if (this.children == null) {
 			const drafts = await this.getSuggestedChanges();

--- a/src/views/nodes/commitFileNode.ts
+++ b/src/views/nodes/commitFileNode.ts
@@ -39,11 +39,9 @@ export abstract class CommitFileNodeBase<
 		super(type, GitUri.fromFile(file, commit.repoPath, commit.sha), view, parent, file);
 
 		this.updateContext({ commit: commit, file: file });
-		this._uniqueId = getViewNodeId(type, this.context);
-	}
+		this._uniqueId = `${this.type}(${this.commit.repoPath}|${this.commit.sha}:${this.file.path}+${this.file.status})`;
 
-	override get id(): string {
-		return this._uniqueId;
+		// this._uniqueId = getViewNodeId(type, this.context);
 	}
 
 	override toClipboard(): string {

--- a/src/views/nodes/commitNode.ts
+++ b/src/views/nodes/commitNode.ts
@@ -54,10 +54,6 @@ export class CommitNode extends ViewRefNode<'commit', ViewsWithCommits | FileHis
 		this.children = undefined;
 	}
 
-	override get id(): string {
-		return this._uniqueId;
-	}
-
 	override toClipboard(): string {
 		return `${this.commit.shortSha}: ${this.commit.summary}`;
 	}

--- a/src/views/nodes/compareResultsNode.ts
+++ b/src/views/nodes/compareResultsNode.ts
@@ -58,10 +58,6 @@ export class CompareResultsNode extends SubscribeableViewNode<
 		}
 	}
 
-	override get id(): string {
-		return this._uniqueId;
-	}
-
 	protected override etag(): number {
 		return this._storedAt;
 	}

--- a/src/views/nodes/contributorNode.ts
+++ b/src/views/nodes/contributorNode.ts
@@ -39,10 +39,6 @@ export class ContributorNode extends ViewNode<'contributor', ViewsWithContributo
 		this.limit = this.view.getNodeLastKnownLimit(this);
 	}
 
-	override get id(): string {
-		return this._uniqueId;
-	}
-
 	override toClipboard(type?: ClipboardType): string {
 		const text = `${this.contributor.name}${this.contributor.email ? ` <${this.contributor.email}>` : ''}`;
 		switch (type) {

--- a/src/views/nodes/contributorsNode.ts
+++ b/src/views/nodes/contributorsNode.ts
@@ -30,10 +30,6 @@ export class ContributorsNode extends CacheableChildrenViewNode<
 		this._uniqueId = getViewNodeId(this.type, this.context);
 	}
 
-	override get id(): string {
-		return this._uniqueId;
-	}
-
 	get repoPath(): string {
 		return this.repo.path;
 	}

--- a/src/views/nodes/contributorsNode.ts
+++ b/src/views/nodes/contributorsNode.ts
@@ -17,8 +17,6 @@ export class ContributorsNode extends CacheableChildrenViewNode<
 	ViewsWithContributorsNode,
 	ContributorNode
 > {
-	protected override splatted = true;
-
 	constructor(
 		uri: GitUri,
 		view: ViewsWithContributorsNode,
@@ -26,7 +24,7 @@ export class ContributorsNode extends CacheableChildrenViewNode<
 		public readonly repo: Repository,
 		private readonly options?: { all?: boolean; showMergeCommits?: boolean; stats?: boolean },
 	) {
-		super('contributors', uri, view, parent);
+		super('contributors', uri, view, parent, true);
 
 		this.updateContext({ repository: repo });
 		this._uniqueId = getViewNodeId(this.type, this.context);
@@ -83,8 +81,6 @@ export class ContributorsNode extends CacheableChildrenViewNode<
 	}
 
 	getTreeItem(): TreeItem {
-		this.splatted = false;
-
 		const item = new TreeItem('Contributors', TreeItemCollapsibleState.Collapsed);
 		item.id = this.id;
 		item.contextValue = ContextValues.Contributors;

--- a/src/views/nodes/draftNode.ts
+++ b/src/views/nodes/draftNode.ts
@@ -22,10 +22,6 @@ export class DraftNode extends ViewNode<'draft', ViewsWithCommits | DraftsView> 
 		this._uniqueId = getViewNodeId(this.type, this.context);
 	}
 
-	override get id(): string {
-		return this._uniqueId;
-	}
-
 	override toClipboard(): string {
 		return this.getUrl();
 	}

--- a/src/views/nodes/fileHistoryNode.ts
+++ b/src/views/nodes/fileHistoryNode.ts
@@ -45,10 +45,6 @@ export class FileHistoryNode
 		this.limit = this.view.getNodeLastKnownLimit(this);
 	}
 
-	override get id(): string {
-		return this._uniqueId;
-	}
-
 	override toClipboard(): string {
 		return this.uri.fileName;
 	}

--- a/src/views/nodes/fileHistoryNode.ts
+++ b/src/views/nodes/fileHistoryNode.ts
@@ -29,8 +29,6 @@ export class FileHistoryNode
 {
 	limit: number | undefined;
 
-	protected override splatted = true;
-
 	constructor(
 		uri: GitUri,
 		view: FileHistoryView,
@@ -38,7 +36,7 @@ export class FileHistoryNode
 		private readonly folder: boolean,
 		private readonly branch: GitBranch | undefined,
 	) {
-		super('file-history', uri, view, parent);
+		super('file-history', uri, view, parent, true);
 
 		if (branch != null) {
 			this.updateContext({ branch: branch });
@@ -148,8 +146,6 @@ export class FileHistoryNode
 	}
 
 	getTreeItem(): TreeItem {
-		this.splatted = false;
-
 		const label = this.label;
 		const item = new TreeItem(label, TreeItemCollapsibleState.Expanded);
 		item.contextValue = ContextValues.FileHistory;

--- a/src/views/nodes/fileHistoryTrackerNode.ts
+++ b/src/views/nodes/fileHistoryTrackerNode.ts
@@ -22,10 +22,9 @@ import { FileHistoryNode } from './fileHistoryNode';
 
 export class FileHistoryTrackerNode extends SubscribeableViewNode<'file-history-tracker', FileHistoryView> {
 	private _base: string | undefined;
-	protected override splatted = true;
 
 	constructor(view: FileHistoryView) {
-		super('file-history-tracker', unknownGitUri, view);
+		super('file-history-tracker', unknownGitUri, view, undefined, true);
 	}
 
 	override dispose() {
@@ -85,8 +84,6 @@ export class FileHistoryTrackerNode extends SubscribeableViewNode<'file-history-
 	}
 
 	getTreeItem(): TreeItem {
-		this.splatted = false;
-
 		const item = new TreeItem('File History', TreeItemCollapsibleState.Expanded);
 		item.contextValue = ContextValues.ActiveFileHistory;
 

--- a/src/views/nodes/fileRevisionAsCommitNode.ts
+++ b/src/views/nodes/fileRevisionAsCommitNode.ts
@@ -42,6 +42,8 @@ export class FileRevisionAsCommitNode extends ViewRefFileNode<
 		} = {},
 	) {
 		super('file-commit', GitUri.fromFile(file, commit.repoPath, commit.sha), view, parent, file);
+
+		this._uniqueId = `${this.type}(${this.commit.repoPath}|${this.commit.sha}:${this.file.path}+${this.file.status})`;
 	}
 
 	override toClipboard(): string {

--- a/src/views/nodes/folderNode.ts
+++ b/src/views/nodes/folderNode.ts
@@ -35,10 +35,6 @@ export class FolderNode extends ViewNode<'folder', ViewsWithCommits | StashesVie
 		this._uniqueId = getViewNodeId(`${this.type}+${relativePath ?? folderName}`, this.context);
 	}
 
-	override get id(): string {
-		return this._uniqueId;
-	}
-
 	override toClipboard(): string {
 		return this.folderName;
 	}

--- a/src/views/nodes/lineHistoryNode.ts
+++ b/src/views/nodes/lineHistoryNode.ts
@@ -30,8 +30,6 @@ export class LineHistoryNode
 {
 	limit: number | undefined;
 
-	protected override splatted = true;
-
 	constructor(
 		uri: GitUri,
 		view: FileHistoryView | LineHistoryView,
@@ -40,7 +38,7 @@ export class LineHistoryNode
 		public readonly selection: Selection,
 		private readonly editorContents: string | undefined,
 	) {
-		super('line-history', uri, view, parent);
+		super('line-history', uri, view, parent, true);
 
 		if (branch != null) {
 			this.updateContext({ branch: branch });
@@ -163,8 +161,6 @@ export class LineHistoryNode
 	}
 
 	getTreeItem(): TreeItem {
-		this.splatted = false;
-
 		const label = this.label;
 		const item = new TreeItem(label, TreeItemCollapsibleState.Expanded);
 		item.contextValue = ContextValues.LineHistory;

--- a/src/views/nodes/lineHistoryNode.ts
+++ b/src/views/nodes/lineHistoryNode.ts
@@ -52,10 +52,6 @@ export class LineHistoryNode
 		this.limit = this.view.getNodeLastKnownLimit(this);
 	}
 
-	override get id(): string {
-		return this._uniqueId;
-	}
-
 	override toClipboard(): string {
 		return this.uri.fileName;
 	}

--- a/src/views/nodes/lineHistoryTrackerNode.ts
+++ b/src/views/nodes/lineHistoryTrackerNode.ts
@@ -28,10 +28,9 @@ export class LineHistoryTrackerNode extends SubscribeableViewNode<
 	private _base: string | undefined;
 	private _editorContents: string | undefined;
 	private _selection: Selection | undefined;
-	protected override splatted = true;
 
 	constructor(view: FileHistoryView | LineHistoryView) {
-		super('line-history-tracker', unknownGitUri, view);
+		super('line-history-tracker', unknownGitUri, view, undefined, true);
 	}
 
 	override dispose() {
@@ -96,8 +95,6 @@ export class LineHistoryTrackerNode extends SubscribeableViewNode<
 	}
 
 	getTreeItem(): TreeItem {
-		this.splatted = false;
-
 		const item = new TreeItem('Line History', TreeItemCollapsibleState.Expanded);
 		item.contextValue = ContextValues.ActiveLineHistory;
 

--- a/src/views/nodes/pullRequestNode.ts
+++ b/src/views/nodes/pullRequestNode.ts
@@ -53,12 +53,10 @@ export class PullRequestNode extends CacheableChildrenViewNode<'pullrequest', Vi
 		}
 
 		this.updateContext({ pullRequest: pullRequest });
-		this._uniqueId = getViewNodeId(this.type, this.context);
-		this.repoPath = repoPath;
-	}
+		// this._uniqueId = getViewNodeId(this.type, this.context);
+		this._uniqueId = `${this.type}(${this.pullRequest.url})`;
 
-	override get id(): string {
-		return this._uniqueId;
+		this.repoPath = repoPath;
 	}
 
 	override toClipboard(type?: ClipboardType): string {

--- a/src/views/nodes/reflogNode.ts
+++ b/src/views/nodes/reflogNode.ts
@@ -30,10 +30,6 @@ export class ReflogNode
 		this.limit = this.view.getNodeLastKnownLimit(this);
 	}
 
-	override get id(): string {
-		return this._uniqueId;
-	}
-
 	async getChildren(): Promise<ViewNode[]> {
 		if (this.children === undefined) {
 			const children = [];

--- a/src/views/nodes/reflogRecordNode.ts
+++ b/src/views/nodes/reflogRecordNode.ts
@@ -27,10 +27,6 @@ export class ReflogRecordNode extends ViewNode<'reflog-record', ViewsWithCommits
 		this.limit = this.view.getNodeLastKnownLimit(this);
 	}
 
-	override get id(): string {
-		return this._uniqueId;
-	}
-
 	async getChildren(): Promise<ViewNode[]> {
 		const log = await this.getLog();
 		if (log === undefined) return [new MessageNode(this.view, this, 'No commits could be found.')];

--- a/src/views/nodes/remoteNode.ts
+++ b/src/views/nodes/remoteNode.ts
@@ -27,10 +27,6 @@ export class RemoteNode extends ViewNode<'remote', ViewsWithRemotes> {
 		this._uniqueId = getViewNodeId(this.type, this.context);
 	}
 
-	override get id(): string {
-		return this._uniqueId;
-	}
-
 	override toClipboard(): string {
 		return this.remote.name;
 	}

--- a/src/views/nodes/remotesNode.ts
+++ b/src/views/nodes/remotesNode.ts
@@ -22,10 +22,6 @@ export class RemotesNode extends CacheableChildrenViewNode<'remotes', ViewsWithR
 		this._uniqueId = getViewNodeId(this.type, this.context);
 	}
 
-	override get id(): string {
-		return this._uniqueId;
-	}
-
 	get repoPath(): string {
 		return this.repo.path;
 	}

--- a/src/views/nodes/repositoryNode.ts
+++ b/src/views/nodes/repositoryNode.ts
@@ -58,10 +58,6 @@ export class RepositoryNode extends SubscribeableViewNode<'repository', ViewsWit
 		this._status = this.repo.git.getStatus();
 	}
 
-	override get id(): string {
-		return this._uniqueId;
-	}
-
 	override toClipboard(): string {
 		return this.repo.path;
 	}

--- a/src/views/nodes/resultsCommitsNode.ts
+++ b/src/views/nodes/resultsCommitsNode.ts
@@ -51,7 +51,7 @@ export class ResultsCommitsNode<View extends ViewsWithCommits = ViewsWithCommits
 		options?: Partial<Options>,
 		splatted?: boolean,
 	) {
-		super('results-commits', GitUri.fromRepoPath(repoPath), view, parent);
+		super('results-commits', GitUri.fromRepoPath(repoPath), view, parent, splatted);
 
 		if (_results.direction != null) {
 			this.updateContext({ branchStatusUpstreamType: _results.direction });
@@ -60,9 +60,6 @@ export class ResultsCommitsNode<View extends ViewsWithCommits = ViewsWithCommits
 		this.limit = this.view.getNodeLastKnownLimit(this);
 
 		this._options = { autolinks: true, expand: true, ...options };
-		if (splatted != null) {
-			this.splatted = splatted;
-		}
 	}
 
 	override get id(): string {

--- a/src/views/nodes/resultsCommitsNode.ts
+++ b/src/views/nodes/resultsCommitsNode.ts
@@ -62,10 +62,6 @@ export class ResultsCommitsNode<View extends ViewsWithCommits = ViewsWithCommits
 		this._options = { autolinks: true, expand: true, ...options };
 	}
 
-	override get id(): string {
-		return this._uniqueId;
-	}
-
 	get ref1(): string | undefined {
 		return this._results.comparison?.ref1;
 	}

--- a/src/views/nodes/resultsFilesNode.ts
+++ b/src/views/nodes/resultsFilesNode.ts
@@ -52,10 +52,6 @@ export class ResultsFilesNode extends ViewNode<'results-files', ViewsWithCommits
 		this._options = { expand: true, timeout: 100, ...options };
 	}
 
-	override get id(): string {
-		return this._uniqueId;
-	}
-
 	get filter(): FilesQueryFilter | undefined {
 		return this.getState('filter');
 	}

--- a/src/views/nodes/searchResultsNode.ts
+++ b/src/views/nodes/searchResultsNode.ts
@@ -62,10 +62,6 @@ export class SearchResultsNode extends ViewNode<'search-results', SearchAndCompa
 		}
 	}
 
-	override get id(): string {
-		return this._uniqueId;
-	}
-
 	override toClipboard(): string {
 		return this.search.query;
 	}

--- a/src/views/nodes/stashNode.ts
+++ b/src/views/nodes/stashNode.ts
@@ -29,10 +29,6 @@ export class StashNode extends ViewRefNode<'stash', ViewsWithStashes, GitStashRe
 		this._uniqueId = getViewNodeId(this.type, this.context);
 	}
 
-	override get id(): string {
-		return this._uniqueId;
-	}
-
 	override toClipboard(): string {
 		return this.commit.stashName;
 	}

--- a/src/views/nodes/stashesNode.ts
+++ b/src/views/nodes/stashesNode.ts
@@ -23,10 +23,6 @@ export class StashesNode extends CacheableChildrenViewNode<'stashes', ViewsWithS
 		this._uniqueId = getViewNodeId(this.type, this.context);
 	}
 
-	override get id(): string {
-		return this._uniqueId;
-	}
-
 	get repoPath(): string {
 		return this.repo.path;
 	}

--- a/src/views/nodes/statusFileNode.ts
+++ b/src/views/nodes/statusFileNode.ts
@@ -66,6 +66,7 @@ export class StatusFileNode extends ViewFileNode<'status-file', ViewsWithCommits
 
 		super('status-file', GitUri.fromFile(file, repoPath, ref), view, parent, file);
 
+		this._uniqueId = `${this.type}(${this.repoPath}|${this.file.path}+${this.file.status})`;
 		this._files = files;
 		this._type = type;
 		this._hasStagedChanges = hasStagedChanges;

--- a/src/views/nodes/statusFilesNode.ts
+++ b/src/views/nodes/statusFilesNode.ts
@@ -26,10 +26,6 @@ export class StatusFilesNode extends ViewNode<'status-files', ViewsWithWorkingTr
 		this._uniqueId = getViewNodeId(this.type, this.context);
 	}
 
-	override get id(): string {
-		return this._uniqueId;
-	}
-
 	get repoPath(): string {
 		return this.status.repoPath;
 	}

--- a/src/views/nodes/tagNode.ts
+++ b/src/views/nodes/tagNode.ts
@@ -34,10 +34,6 @@ export class TagNode extends ViewRefNode<'tag', ViewsWithTags, GitTagReference> 
 		this.limit = this.view.getNodeLastKnownLimit(this);
 	}
 
-	override get id(): string {
-		return this._uniqueId;
-	}
-
 	override toClipboard(): string {
 		return this.tag.name;
 	}

--- a/src/views/nodes/tagsNode.ts
+++ b/src/views/nodes/tagsNode.ts
@@ -24,10 +24,6 @@ export class TagsNode extends CacheableChildrenViewNode<'tags', ViewsWithTagsNod
 		this._uniqueId = getViewNodeId(this.type, this.context);
 	}
 
-	override get id(): string {
-		return this._uniqueId;
-	}
-
 	get repoPath(): string {
 		return this.repo.path;
 	}

--- a/src/views/nodes/workspaceMissingRepositoryNode.ts
+++ b/src/views/nodes/workspaceMissingRepositoryNode.ts
@@ -24,10 +24,6 @@ export class WorkspaceMissingRepositoryNode extends ViewNode<'workspace-missing-
 		this._uniqueId = getViewNodeId(this.type, this.context);
 	}
 
-	override get id(): string {
-		return this._uniqueId;
-	}
-
 	override toClipboard(): string {
 		return this.name;
 	}

--- a/src/views/nodes/workspaceNode.ts
+++ b/src/views/nodes/workspaceNode.ts
@@ -31,10 +31,6 @@ export class WorkspaceNode extends SubscribeableViewNode<
 		this._uniqueId = getViewNodeId(this.type, this.context);
 	}
 
-	override get id(): string {
-		return this._uniqueId;
-	}
-
 	override toClipboard(): string {
 		return this.workspace.name;
 	}

--- a/src/views/nodes/worktreeNode.ts
+++ b/src/views/nodes/worktreeNode.ts
@@ -190,8 +190,6 @@ export class WorktreeNode extends CacheableChildrenViewNode<'worktree', ViewsWit
 	}
 
 	async getTreeItem(): Promise<TreeItem> {
-		this.splatted = false;
-
 		let description = '';
 		let icon: IconPath | undefined;
 		let hasChanges = false;

--- a/src/views/nodes/worktreeNode.ts
+++ b/src/views/nodes/worktreeNode.ts
@@ -53,10 +53,6 @@ export class WorktreeNode extends CacheableChildrenViewNode<'worktree', ViewsWit
 		this.limit = this.view.getNodeLastKnownLimit(this);
 	}
 
-	override get id(): string {
-		return this._uniqueId;
-	}
-
 	override toClipboard(): string {
 		return this.worktree.uri.fsPath;
 	}

--- a/src/views/nodes/worktreesNode.ts
+++ b/src/views/nodes/worktreesNode.ts
@@ -28,10 +28,6 @@ export class WorktreesNode extends CacheableChildrenViewNode<'worktrees', ViewsW
 		this._uniqueId = getViewNodeId(this.type, this.context);
 	}
 
-	override get id(): string {
-		return this._uniqueId;
-	}
-
 	get repoPath(): string {
 		return this.repo.path;
 	}

--- a/src/views/remotesView.ts
+++ b/src/views/remotesView.ts
@@ -68,7 +68,7 @@ export class RemotesViewNode extends RepositoriesSubscribeableNode<RemotesView, 
 
 			const splat = repositories.length === 1;
 			this.children = repositories.map(
-				r => new RemotesRepositoryNode(GitUri.fromRepoPath(r.path), this.view, this, r, splat),
+				r => new RemotesRepositoryNode(GitUri.fromRepoPath(r.path), this.view, this, splat, r),
 			);
 		}
 

--- a/src/views/searchAndCompareView.ts
+++ b/src/views/searchAndCompareView.ts
@@ -29,11 +29,10 @@ import { disposeChildren, ViewBase } from './viewBase';
 import { registerViewCommand } from './viewCommands';
 
 export class SearchAndCompareViewNode extends ViewNode<'search-compare', SearchAndCompareView> {
-	protected override splatted = true;
 	private comparePicker: ComparePickerNode | undefined;
 
 	constructor(view: SearchAndCompareView) {
-		super('search-compare', unknownGitUri, view);
+		super('search-compare', unknownGitUri, view, undefined, true);
 	}
 
 	override dispose() {
@@ -73,8 +72,6 @@ export class SearchAndCompareViewNode extends ViewNode<'search-compare', SearchA
 	}
 
 	getTreeItem(): TreeItem {
-		this.splatted = false;
-
 		const item = new TreeItem('SearchAndCompare', TreeItemCollapsibleState.Expanded);
 		item.contextValue = ContextValues.SearchAndCompare;
 		return item;

--- a/src/views/stashesView.ts
+++ b/src/views/stashesView.ts
@@ -54,7 +54,7 @@ export class StashesViewNode extends RepositoriesSubscribeableNode<StashesView, 
 
 			const splat = repositories.length === 1;
 			this.children = repositories.map(
-				r => new StashesRepositoryNode(GitUri.fromRepoPath(r.path), this.view, this, r, splat),
+				r => new StashesRepositoryNode(GitUri.fromRepoPath(r.path), this.view, this, splat, r),
 			);
 		}
 

--- a/src/views/tagsView.ts
+++ b/src/views/tagsView.ts
@@ -55,7 +55,7 @@ export class TagsViewNode extends RepositoriesSubscribeableNode<TagsView, TagsRe
 
 			const splat = repositories.length === 1;
 			this.children = repositories.map(
-				r => new TagsRepositoryNode(GitUri.fromRepoPath(r.path), this.view, this, r, splat),
+				r => new TagsRepositoryNode(GitUri.fromRepoPath(r.path), this.view, this, splat, r),
 			);
 		}
 

--- a/src/views/viewBase.ts
+++ b/src/views/viewBase.ts
@@ -426,13 +426,21 @@ export abstract class ViewBase<
 		if (this.root == null || force) {
 			this.root?.dispose();
 			this.root = this.getRoot();
+			// if (this.root.childrenIds.size > 0) {
+			// 	debugger;
+			// 	this.root.childrenIds.clear();
+			// }
 		}
 
 		return this.root;
 	}
 
 	getChildren(node?: ViewNode): ViewNode[] | Promise<ViewNode[]> {
-		if (node != null) return node.getChildren();
+		if (node != null) {
+			// node.childrenIds.clear();
+			node.childrenCount = 0;
+			return node.getChildren();
+		}
 
 		const root = this.ensureRoot();
 		const children = root.getChildren();
@@ -462,7 +470,20 @@ export abstract class ViewBase<
 			debugger;
 			node.splatted = false;
 		}
-		return node.getTreeItem();
+
+		const item = node.getTreeItem();
+		if (isPromise(item)) {
+			return item.then(i => {
+				i.id = node.treeId;
+				console.log('#######', node.type, node.splatted, node.id, i.id);
+
+				return i;
+			});
+		}
+
+		item.id = node.treeId;
+		console.log('#######', node.type, node.splatted, node.id, item.id);
+		return item;
 	}
 
 	getViewDescription(count?: number) {

--- a/src/views/viewBase.ts
+++ b/src/views/viewBase.ts
@@ -246,14 +246,14 @@ export abstract class ViewBase<
 				}
 
 				if (typeof item.tooltip === 'string') {
-					item.tooltip = `${item.tooltip}\n\n---\ncontext: ${item.contextValue}\nnode: ${node.toString()}${
-						parent != null ? `\nparent: ${parent.toString()}` : ''
-					}`;
+					item.tooltip = `${item.tooltip}\n\n---\ncontext: ${
+						item.contextValue
+					}\nnode: ${node.toString()}\nparent: ${parent?.toString()}`;
 				} else {
 					item.tooltip.appendMarkdown(
-						`\n\n---\n\ncontext: \`${item.contextValue}\`\\\nnode: \`${node.toString()}\`${
-							parent != null ? `\\\nparent: \`${parent.toString()}\`` : ''
-						}`,
+						`\n\n---\n\ncontext: \`${
+							item.contextValue
+						}\`\\\nnode: \`${node.toString()}\` \\\nparent: \`${parent?.toString()}\``,
 					);
 				}
 			}
@@ -458,6 +458,10 @@ export abstract class ViewBase<
 	}
 
 	getTreeItem(node: ViewNode): TreeItem | Promise<TreeItem> {
+		if (node.splatted) {
+			debugger;
+			node.splatted = false;
+		}
 		return node.getTreeItem();
 	}
 

--- a/src/views/worktreesView.ts
+++ b/src/views/worktreesView.ts
@@ -65,7 +65,7 @@ export class WorktreesViewNode extends RepositoriesSubscribeableNode<WorktreesVi
 
 			const splat = repositories.length === 1;
 			this.children = repositories.map(
-				r => new WorktreesRepositoryNode(GitUri.fromRepoPath(r.path), this.view, this, r, splat),
+				r => new WorktreesRepositoryNode(GitUri.fromRepoPath(r.path), this.view, this, splat, r),
 			);
 		}
 


### PR DESCRIPTION
Requires a lot more work, but once it lands we should be able to save & restore selected nodes when switching between "tabs" on the GitLens view