### PR TITLE
#3531 Change `cherry-pick` terminal-run commands into normal commands w/ proper error handling

### DIFF
--- a/src/env/node/git/localGitProvider.ts
+++ b/src/env/node/git/localGitProvider.ts
@@ -1077,6 +1077,30 @@ export class LocalGitProvider implements GitProvider, Disposable {
 	}
 
 	@log()
+	async cherryPick(repoPath: string, ref: string, options: { noCommit?: boolean; edit?: boolean }): Promise<void> {
+		const args: string[] = [];
+		if (options?.noCommit) {
+			args.push('-n');
+		}
+
+		if (options?.edit) {
+			args.push('-e');
+		}
+
+		args.push(ref);
+
+		try {
+			await this.git.cherryPick(repoPath, args);
+		} catch (ex) {
+			if (ex instanceof CherryPickError) {
+				throw ex.WithRef(ref);
+			}
+
+			throw ex;
+		}
+	}
+
+	@log()
 	async applyChangesToWorkingFile(uri: GitUri, ref1?: string, ref2?: string) {
 		const scope = getLogScope();
 
@@ -1225,7 +1249,7 @@ export class LocalGitProvider implements GitProvider, Disposable {
 
 		// Apply the patch using a cherry pick without committing
 		try {
-			await this.git.cherrypick(targetPath, ref, { noCommit: true, errors: GitErrorHandling.Throw });
+			await this.git.cherryPick(targetPath, ref, { noCommit: true, errors: GitErrorHandling.Throw });
 		} catch (ex) {
 			Logger.error(ex, scope);
 			if (ex instanceof CherryPickError) {

--- a/src/git/gitProvider.ts
+++ b/src/git/gitProvider.ts
@@ -126,6 +126,8 @@ export interface GitProviderRepository {
 	pruneRemote?(repoPath: string, name: string): Promise<void>;
 	removeRemote?(repoPath: string, name: string): Promise<void>;
 
+	cherryPick?(repoPath: string, ref: string, options: { noCommit?: boolean; edit?: boolean }): Promise<void>;
+
 	applyUnreachableCommitForPatch?(
 		repoPath: string,
 		ref: string,

--- a/src/git/gitProviderService.ts
+++ b/src/git/gitProviderService.ts
@@ -42,6 +42,7 @@ import { registerCommand } from '../system/vscode/command';
 import { configuration } from '../system/vscode/configuration';
 import { setContext } from '../system/vscode/context';
 import { getBestPath } from '../system/vscode/path';
+import type { GitErrorHandling } from './commandOptions';
 import type {
 	BranchContributorOverview,
 	GitCaches,
@@ -1332,6 +1333,26 @@ export class GitProviderService implements Disposable {
 		if (provider.removeRemote == null) throw new ProviderNotSupportedError(provider.descriptor.name);
 
 		return provider.removeRemote(path, name);
+	}
+
+	@log()
+	cherryPick(repoPath: string | Uri, ref: string, flags: string[] | undefined = []): Promise<void> {
+		const { provider, path } = this.getProvider(repoPath);
+		if (provider.cherryPick == null) throw new ProviderNotSupportedError(provider.descriptor.name);
+
+		const options: { noCommit?: boolean; edit?: boolean; errors?: GitErrorHandling } = {};
+		for (const flag of flags) {
+			switch (flag) {
+				case '--no-commit':
+					options.noCommit = true;
+					break;
+				case '--edit':
+					options.edit = true;
+					break;
+			}
+		}
+
+		return provider.cherryPick(path, ref, options);
 	}
 
 	@log()

--- a/src/git/models/repository.ts
+++ b/src/git/models/repository.ts
@@ -633,11 +633,6 @@ export class Repository implements Disposable {
 		}
 	}
 
-	@log()
-	cherryPick(...args: string[]) {
-		void this.runTerminalCommand('cherry-pick', ...args);
-	}
-
 	containsUri(uri: Uri) {
 		return this === this.container.git.getRepository(uri);
 	}


### PR DESCRIPTION
# Description

Creates the git `cherry-pick` command to move away from `runTerminalCommand`.


Solves #3531

# Checklist

<!-- Please check off the following -->

- [ ] I have followed the guidelines in the Contributing document
- [ ] My changes follow the coding style of this project
- [ ] My changes build without any errors or warnings
- [ ] My changes have been formatted and linted
- [ ] My changes include any required corresponding changes to the documentation (including CHANGELOG.md and README.md)
- [ ] My changes have been rebased and squashed to the minimal number (typically 1) of relevant commits
- [ ] My changes have a descriptive commit message with a short title, including a `Fixes $XXX -` or `Closes #XXX -` prefix to auto-close the issue that your PR addresses
