### PR TITLE
#3534: Change `rebase` terminal-run commands into normal commands w/ proper error handling

### DIFF
--- a/src/env/node/git/git.ts
+++ b/src/env/node/git/git.ts
@@ -107,6 +107,8 @@ export const GitErrors = {
 	tagNotFound: /tag .* not found/i,
 	invalidTagName: /invalid tag name/i,
 	remoteRejected: /rejected because the remote contains work/i,
+	unresolvedConflicts: /^error: could not apply .*\n^hint: Resolve all conflicts.*$/im,
+	rebaseMergeInProgress: /^fatal: It seems that there is already a rebase-merge directory/i,
 };
 
 const GitWarnings = {
@@ -178,6 +180,8 @@ const tagErrorAndReason: [RegExp, TagErrorReason][] = [
 const rebaseErrorAndReason: [RegExp, RebaseErrorReason][] = [
 	[GitErrors.uncommittedChanges, RebaseErrorReason.WorkingChanges],
 	[GitErrors.changesWouldBeOverwritten, RebaseErrorReason.OverwrittenChanges],
+	[GitErrors.unresolvedConflicts, RebaseErrorReason.UnresolvedConflicts],
+	[GitErrors.rebaseMergeInProgress, RebaseErrorReason.RebaseMergeInProgress],
 ];
 
 export class Git {
@@ -1101,7 +1105,7 @@ export class Git {
 
 	async rebase(repoPath: string, args: string[] | undefined = [], configs: string[] | undefined = []): Promise<void> {
 		try {
-			void (await this.git<string>({ cwd: repoPath }, ...configs, 'rebase', '--autostash', ...args));
+			void (await this.git<string>({ cwd: repoPath }, ...configs, 'rebase', ...args));
 		} catch (ex) {
 			const msg: string = ex?.toString() ?? '';
 			for (const [regex, reason] of rebaseErrorAndReason) {
@@ -1111,6 +1115,42 @@ export class Git {
 			}
 
 			throw new RebaseError(RebaseErrorReason.Other, ex);
+		}
+	}
+
+	async check_active_rebase(repoPath: string): Promise<boolean> {
+		try {
+			const data = await this.git<string>({ cwd: repoPath }, 'rev-parse', '--verify', 'REBASE_HEAD');
+			return Boolean(data.length);
+		} catch {
+			return false;
+		}
+	}
+
+	async check_active_cherry_pick(repoPath: string): Promise<boolean> {
+		try {
+			const data = await this.git<string>({ cwd: repoPath }, 'rev-parse', '--verify', 'CHERRY_PICK_HEAD');
+			return Boolean(data.length);
+		} catch (_ex) {
+			return true;
+		}
+	}
+
+	async check_active_merge(repoPath: string): Promise<boolean> {
+		try {
+			const data = await this.git<string>({ cwd: repoPath }, 'rev-parse', '--verify', 'MERGE_HEAD');
+			return Boolean(data.length);
+		} catch (_ex) {
+			return true;
+		}
+	}
+
+	async check_active_cherry_revert(repoPath: string): Promise<boolean> {
+		try {
+			const data = await this.git<string>({ cwd: repoPath }, 'rev-parse', '--verify', 'REVERT_HEAD');
+			return Boolean(data.length);
+		} catch (_ex) {
+			return true;
 		}
 	}
 

--- a/src/env/node/git/localGitProvider.ts
+++ b/src/env/node/git/localGitProvider.ts
@@ -31,6 +31,7 @@ import {
 	PullError,
 	PushError,
 	PushErrorReason,
+	RebaseError,
 	StashApplyError,
 	StashApplyErrorReason,
 	StashPushError,
@@ -1655,6 +1656,37 @@ export class LocalGitProvider implements GitProvider, Disposable {
 			if (!PullError.is(ex)) throw ex;
 
 			void window.showErrorMessage(ex.message);
+		}
+	}
+
+	@log()
+	async rebase(
+		repoPath: string,
+		ref: string,
+		configs?: { sequenceEditor?: string },
+		options?: { interactive?: boolean } = {},
+	): Promise<void> {
+		const configFlags = [];
+		const args = [];
+
+		if (configs?.sequenceEditor != null) {
+			configFlags.push('-c', `sequence.editor="${configs.sequenceEditor}"`);
+		}
+
+		if (options?.interactive) {
+			args.push('--interactive');
+		}
+
+		args.push(ref);
+
+		try {
+			await this.git.rebase(repoPath, args, configFlags);
+		} catch (ex) {
+			if (RebaseError.is(ex)) {
+				throw ex.WithRef(ref);
+			}
+
+			throw ex;
 		}
 	}
 

--- a/src/git/actions/repository.ts
+++ b/src/git/actions/repository.ts
@@ -34,7 +34,7 @@ export function push(repos?: string | string[] | Repository | Repository[], forc
 export function rebase(repo?: string | Repository, ref?: GitReference, interactive: boolean = true) {
 	return executeGitCommand({
 		command: 'rebase',
-		state: { repo: repo, destination: ref, flags: interactive ? ['--interactive'] : [] },
+		state: { repo: repo, destination: ref, options: { interactive: interactive, autostash: true } },
 	});
 }
 

--- a/src/git/errors.ts
+++ b/src/git/errors.ts
@@ -571,6 +571,8 @@ export class TagError extends Error {
 export const enum RebaseErrorReason {
 	WorkingChanges,
 	OverwrittenChanges,
+	UnresolvedConflicts,
+	RebaseMergeInProgress,
 	Other,
 }
 
@@ -592,6 +594,10 @@ export class RebaseError extends Error {
 				return `${baseMessage} because there are uncommitted changes`;
 			case RebaseErrorReason.OverwrittenChanges:
 				return `${baseMessage} because some local changes would be overwritten`;
+			case RebaseErrorReason.UnresolvedConflicts:
+				return `${baseMessage} due to conflicts. Resolve the conflicts first and continue the rebase`;
+			case RebaseErrorReason.RebaseMergeInProgress:
+				return `${baseMessage} because a rebase is already in progress`;
 			default:
 				return baseMessage;
 		}

--- a/src/git/gitProvider.ts
+++ b/src/git/gitProvider.ts
@@ -125,6 +125,12 @@ export interface GitProviderRepository {
 	addRemote?(repoPath: string, name: string, url: string, options?: { fetch?: boolean }): Promise<void>;
 	pruneRemote?(repoPath: string, name: string): Promise<void>;
 	removeRemote?(repoPath: string, name: string): Promise<void>;
+	rebase?(
+		repoPath: string,
+		ref: string,
+		configs?: { sequenceEditor?: string },
+		options?: { interactive?: boolean },
+	): Promise<void>;
 
 	applyUnreachableCommitForPatch?(
 		repoPath: string,

--- a/src/git/gitProvider.ts
+++ b/src/git/gitProvider.ts
@@ -117,6 +117,15 @@ export interface BranchContributorOverview {
 	readonly contributors?: GitContributor[];
 }
 
+export type RebaseOptions = {
+	abort?: boolean;
+	autostash?: boolean;
+	checkActiveRebase?: boolean;
+	continue?: boolean;
+	interactive?: boolean;
+	skip?: boolean;
+};
+
 export interface GitProviderRepository {
 	createBranch?(repoPath: string, name: string, ref: string): Promise<void>;
 	renameBranch?(repoPath: string, oldName: string, newName: string): Promise<void>;
@@ -127,9 +136,10 @@ export interface GitProviderRepository {
 	removeRemote?(repoPath: string, name: string): Promise<void>;
 	rebase?(
 		repoPath: string,
-		ref: string,
+		upstream: string | null,
+		ref: string | null,
 		configs?: { sequenceEditor?: string },
-		options?: { interactive?: boolean },
+		options?: RebaseOptions,
 	): Promise<void>;
 
 	applyUnreachableCommitForPatch?(

--- a/src/git/gitProviderService.ts
+++ b/src/git/gitProviderService.ts
@@ -55,6 +55,7 @@ import type {
 	PagingOptions,
 	PreviousComparisonUrisResult,
 	PreviousLineComparisonUrisResult,
+	RebaseOptions,
 	RepositoryVisibility,
 	RepositoryVisibilityInfo,
 	ScmRepository,
@@ -1345,14 +1346,15 @@ export class GitProviderService implements Disposable {
 	@log()
 	rebase(
 		repoPath: string | Uri,
-		ref: string,
-		configs: { sequenceEditor?: string },
-		options: { interactive?: boolean } = {},
+		upstream: string | null,
+		ref: string | null,
+		configs?: { sequenceEditor?: string },
+		options: RebaseOptions = {},
 	): Promise<void> {
 		const { provider, path } = this.getProvider(repoPath);
 		if (provider.rebase == null) throw new ProviderNotSupportedError(provider.descriptor.name);
 
-		return provider.rebase(path, ref, configs, options);
+		return provider.rebase(path, upstream, ref, configs, options);
 	}
 
 	@log()

--- a/src/git/gitProviderService.ts
+++ b/src/git/gitProviderService.ts
@@ -1343,6 +1343,21 @@ export class GitProviderService implements Disposable {
 	}
 
 	@log()
+	rebase(repoPath: string | Uri, ref: string, configs: { sequenceEditor?: string }, args: string[] | undefined = []) {
+		const { provider, path } = this.getProvider(repoPath);
+		if (provider.rebase == null) throw new ProviderNotSupportedError(provider.descriptor.name);
+
+		const options: { interactive?: boolean } = {};
+		for (const arg of args) {
+			if (arg === '--interactive') {
+				options.interactive = true;
+			}
+		}
+
+		return provider.rebase(path, ref, configs, options);
+	}
+
+	@log()
 	async applyUnreachableCommitForPatch(
 		repoPath: string | Uri,
 		ref: string,

--- a/src/git/gitProviderService.ts
+++ b/src/git/gitProviderService.ts
@@ -1343,16 +1343,14 @@ export class GitProviderService implements Disposable {
 	}
 
 	@log()
-	rebase(repoPath: string | Uri, ref: string, configs: { sequenceEditor?: string }, args: string[] | undefined = []) {
+	rebase(
+		repoPath: string | Uri,
+		ref: string,
+		configs: { sequenceEditor?: string },
+		options: { interactive?: boolean } = {},
+	): Promise<void> {
 		const { provider, path } = this.getProvider(repoPath);
 		if (provider.rebase == null) throw new ProviderNotSupportedError(provider.descriptor.name);
-
-		const options: { interactive?: boolean } = {};
-		for (const arg of args) {
-			if (arg === '--interactive') {
-				options.interactive = true;
-			}
-		}
 
 		return provider.rebase(path, ref, configs, options);
 	}

--- a/src/git/models/repository.ts
+++ b/src/git/models/repository.ts
@@ -843,14 +843,6 @@ export class Repository implements Disposable {
 	}
 
 	@log()
-	rebase(configs: string[] | undefined, ...args: string[]) {
-		void this.runTerminalCommand(
-			configs != null && configs.length !== 0 ? `${configs.join(' ')} rebase` : 'rebase',
-			...args,
-		);
-	}
-
-	@log()
 	reset(...args: string[]) {
 		void this.runTerminalCommand('reset', ...args);
 	}


### PR DESCRIPTION
# Description

Creates the git `rebase` command to move away from `runTerminalCommand`.

Solves https://github.com/gitkraken/vscode-gitlens/issues/3534

# Checklist

<!-- Please check off the following -->

- [x] I have followed the guidelines in the Contributing document
- [x] My changes follow the coding style of this project
- [x] My changes build without any errors or warnings
- [x] My changes have been formatted and linted
- [ ] My changes include any required corresponding changes to the documentation (including CHANGELOG.md and README.md)
- [x] My changes have been rebased and squashed to the minimal number (typically 1) of relevant commits
- [x] My changes have a descriptive commit message with a short title, including a `Fixes $XXX -` or `Closes #XXX -` prefix to auto-close the issue that your PR addresses
