### PR TITLE
Utilizes paging to get more Jira issues

### DIFF
--- a/src/plus/integrations/providers/jira.ts
+++ b/src/plus/integrations/providers/jira.ts
@@ -12,6 +12,7 @@ import { IssueFilter, providersMetadata, toAccount, toSearchedIssue } from './mo
 
 const metadata = providersMetadata[IssueIntegrationId.Jira];
 const authProvider = Object.freeze({ id: metadata.id, scopes: metadata.scopes });
+const maxPagesPerRequest = 10;
 
 export interface JiraBaseDescriptor extends ResourceDescriptor {
 	id: string;
@@ -234,16 +235,25 @@ export class JiraIntegration extends IssueIntegration<IssueIntegrationId.Jira> {
 		const results: SearchedIssue[] = [];
 		for (const resource of myResources) {
 			try {
-				const userLogin = (await this.getProviderAccountForResource(session, resource))?.username;
-				const resourceIssues = await api.getIssuesForResourceForCurrentUser(this.id, resource.id, {
-					accessToken: session.accessToken,
-				});
-				const formattedIssues = resourceIssues
-					?.map(issue => toSearchedIssue(issue, this, undefined, userLogin))
-					.filter((result): result is SearchedIssue => result != null);
-				if (formattedIssues != null) {
-					results.push(...formattedIssues);
-				}
+			    const userLogin = (await this.getProviderAccountForResource(session, resource))?.username;
+			    let cursor = undefined;
+			    let hasMore = false;
+			    let requestCount = 0;
+			    do {
+				    const resourceIssues = await api.getIssuesForResourceForCurrentUser(this.id, resource.id, {
+					    accessToken: session.accessToken,
+					    cursor: cursor,
+				    });
+				    requestCount += 1;
+				    hasMore = resourceIssues.paging?.more ?? false;
+				    cursor = resourceIssues.paging?.cursor;
+				    const formattedIssues = resourceIssues.values
+					    .map(issue => toSearchedIssue(issue, this, undefined, userLogin))
+					    .filter((result): result is SearchedIssue => result != null);
+				    if (formattedIssues.length > 0) {
+					    results.push(...formattedIssues);
+				    }
+			    } while (requestCount < maxPagesPerRequest && hasMore);
 			} catch (ex) {
 				// TODO: We need a better way to message the failure to the user here.
 				// This is a stopgap to prevent one bag org from throwing and preventing any issues from being returned.


### PR DESCRIPTION
Fixes current bug in which only 10 Jira issues maximum show up in Start Work (unable to create an issue due to a GitHub bug, will link the issue when I can create it).

There is an update to the shared provider library which increases the results per page from 10 to 100 - will look at bumping our library version as a separate task since there are some refactors needed to make it happy (and other risks that need to be tested).