### PR TITLE
Updates Launchpad search UX to avoid always searching with the API

### DIFF
--- a/src/git/models/pullRequest.ts
+++ b/src/git/models/pullRequest.ts
@@ -7,10 +7,10 @@ import { formatDate, fromNow } from '../../system/date';
 import { memoize } from '../../system/decorators/memoize';
 import type { LeftRightCommitCountResult } from '../gitProvider';
 import type { IssueOrPullRequest, IssueRepository, IssueOrPullRequestState as PullRequestState } from './issue';
-import type { PullRequestURLIdentity } from './pullRequest.utils';
+import type { PullRequestUrlIdentity } from './pullRequest.utils';
 import type { ProviderReference } from './remoteProvider';
 import type { Repository } from './repository';
-import { createRevisionRange , shortenRevision } from './revision.utils';
+import { createRevisionRange, shortenRevision } from './revision.utils';
 
 export type { PullRequestState };
 
@@ -420,7 +420,7 @@ export async function getOpenedPullRequestRepo(
 
 export function doesPullRequestSatisfyRepositoryURLIdentity(
 	pr: EnrichablePullRequest | undefined,
-	{ ownerAndRepo, prNumber }: PullRequestURLIdentity,
+	{ ownerAndRepo, prNumber }: PullRequestUrlIdentity,
 ): boolean {
 	if (pr == null) {
 		return false;

--- a/src/git/models/pullRequest.utils.ts
+++ b/src/git/models/pullRequest.utils.ts
@@ -2,12 +2,16 @@
 // To avoid this file has been created that can collect more simple functions which
 // don't require Container and can be tested.
 
-export type PullRequestURLIdentity = {
+import type { HostingIntegrationId } from '../../constants.integrations';
+
+export interface PullRequestUrlIdentity {
+	provider?: HostingIntegrationId;
+
 	ownerAndRepo?: string;
 	prNumber?: string;
-};
+}
 
-export function getPullRequestIdentityValuesFromSearch(search: string): PullRequestURLIdentity {
+export function getPullRequestIdentityValuesFromSearch(search: string): PullRequestUrlIdentity {
 	let ownerAndRepo: string | undefined = undefined;
 	let prNumber: string | undefined = undefined;
 

--- a/src/plus/integrations/providers/github/models.ts
+++ b/src/plus/integrations/providers/github/models.ts
@@ -508,3 +508,12 @@ export function fromCommitFileStatus(
 	}
 	return undefined;
 }
+
+export function isGitHubPullRequestUrl(search: string): boolean {
+	try {
+		const url = new URL(search);
+		return url.host === 'github.com' && url.pathname.includes('/pull/');
+	} catch {
+		return false;
+	}
+}

--- a/src/plus/integrations/providers/gitlab/models.ts
+++ b/src/plus/integrations/providers/gitlab/models.ts
@@ -150,3 +150,12 @@ export function fromGitLabMergeRequestProvidersApi(pr: ProviderPullRequest, prov
 	};
 	return fromProviderPullRequest(wrappedPr, provider);
 }
+
+export function isGitLabPullRequestUrl(search: string): boolean {
+	try {
+		const url = new URL(search);
+		return url.host === 'gitlab.com' && url.pathname.includes('/merge_requests/');
+	} catch {
+		return false;
+	}
+}

--- a/src/plus/launchpad/launchpad.ts
+++ b/src/plus/launchpad/launchpad.ts
@@ -682,7 +682,7 @@ export class LaunchpadCommand extends QuickCommand<State> {
 				quickpick.items = getLaunchpadQuickPickItems(context.result.items, true);
 
 				// Show just the option to toggle search on if nothing found
-				if (quickpick.activeItems.length === 0 && !isSupportedLaunchpadPullRequestUrl(value)) {
+				if (quickpick.activeItems.length === 0 && !isSupportedLaunchpadPullRequestSearchUrl(value)) {
 					quickpick.items = [toggleSearchOnItem];
 					return true;
 				}
@@ -721,7 +721,7 @@ export class LaunchpadCommand extends QuickCommand<State> {
 				}
 
 				// If a supported PR URL was entered but no existing items match outside of search mode, turn on search mode and search the API.
-				if (isSupportedLaunchpadPullRequestUrl(value)) {
+				if (isSupportedLaunchpadPullRequestSearchUrl(value)) {
 					context.isSearching = true;
 					await updateItems(quickpick, true);
 				} else if (quickpick.activeItems.length === 0 || quickpick.activeItems[0] === toggleSearchOnItem) {
@@ -1593,13 +1593,23 @@ function isLaunchpadTargetActionQuickPickItem(item: any): item is QuickPickItemO
 }
 
 function isGitHubPullRequestUrl(search: string) {
-	return search.includes('github.com') && search.includes('/pull/');
+	try {
+		const url = new URL(search);
+		return url.host === 'github.com' && url.pathname.includes('/pull/');
+	} catch {
+		return false;
+	}
 }
 
 function isGitLabPullRequestUrl(search: string) {
-	return search.includes('gitlab.com') && search.includes('/merge_requests/');
+	try {
+		const url = new URL(search);
+		return url.host === 'gitlab.com' && url.pathname.includes('/merge_requests/');
+	} catch {
+		return false;
+	}
 }
 
-function isSupportedLaunchpadPullRequestUrl(search: string) {
+function isSupportedLaunchpadPullRequestSearchUrl(search: string) {
 	return isGitHubPullRequestUrl(search) || isGitLabPullRequestUrl(search);
 }

--- a/src/plus/launchpad/launchpad.ts
+++ b/src/plus/launchpad/launchpad.ts
@@ -73,6 +73,7 @@ import {
 	launchpadGroups,
 	supportedLaunchpadIntegrations,
 } from './launchpadProvider';
+import { isSupportedLaunchpadPullRequestSearchUrl } from './utils';
 
 const actionGroupMap = new Map<LaunchpadActionCategory, string[]>([
 	['mergeable', ['Ready to Merge', 'Ready to merge']],
@@ -1590,26 +1591,4 @@ function updateTelemetryContext(context: Context) {
 
 function isLaunchpadTargetActionQuickPickItem(item: any): item is QuickPickItemOfT<LaunchpadTargetAction> {
 	return item?.item?.action != null && item?.item?.target != null;
-}
-
-function isGitHubPullRequestUrl(search: string) {
-	try {
-		const url = new URL(search);
-		return url.host === 'github.com' && url.pathname.includes('/pull/');
-	} catch {
-		return false;
-	}
-}
-
-function isGitLabPullRequestUrl(search: string) {
-	try {
-		const url = new URL(search);
-		return url.host === 'gitlab.com' && url.pathname.includes('/merge_requests/');
-	} catch {
-		return false;
-	}
-}
-
-function isSupportedLaunchpadPullRequestSearchUrl(search: string) {
-	return isGitHubPullRequestUrl(search) || isGitLabPullRequestUrl(search);
 }

--- a/src/plus/launchpad/launchpadIndicator.ts
+++ b/src/plus/launchpad/launchpadIndicator.ts
@@ -368,7 +368,7 @@ export class LaunchpadIndicator implements Disposable {
 									source: 'launchpad-indicator',
 									state: {
 										initialGroup: 'mergeable',
-										selectTopItem: labelType === 'item',
+										selectTopItem: true,
 									},
 								} satisfies Omit<LaunchpadCommandArgs, 'command'>),
 							)} "Open Ready to Merge in Launchpad")`,
@@ -429,7 +429,10 @@ export class LaunchpadIndicator implements Disposable {
 							}](command:gitlens.showLaunchpad?${encodeURIComponent(
 								JSON.stringify({
 									source: 'launchpad-indicator',
-									state: { initialGroup: 'blocked', selectTopItem: labelType === 'item' },
+									state: {
+										initialGroup: 'blocked',
+										selectTopItem: true,
+									},
 								} satisfies Omit<LaunchpadCommandArgs, 'command'>),
 							)} "Open Blocked in Launchpad")`,
 						);
@@ -465,7 +468,7 @@ export class LaunchpadIndicator implements Disposable {
 									source: 'launchpad-indicator',
 									state: {
 										initialGroup: 'follow-up',
-										selectTopItem: labelType === 'item',
+										selectTopItem: true,
 									},
 								} satisfies Omit<LaunchpadCommandArgs, 'command'>),
 							)} "Open Follow-Up in Launchpad")`,
@@ -488,7 +491,7 @@ export class LaunchpadIndicator implements Disposable {
 									source: 'launchpad-indicator',
 									state: {
 										initialGroup: 'needs-review',
-										selectTopItem: labelType === 'item',
+										selectTopItem: true,
 									},
 								} satisfies Omit<LaunchpadCommandArgs, 'command'>),
 							)} "Open Needs Your Review in Launchpad")`,

--- a/src/plus/launchpad/utils.ts
+++ b/src/plus/launchpad/utils.ts
@@ -1,5 +1,7 @@
 import type { Container } from '../../container';
 import { configuration } from '../../system/vscode/configuration';
+import { isGitHubPullRequestUrl } from '../integrations/providers/github/models';
+import { isGitLabPullRequestUrl } from '../integrations/providers/gitlab/models';
 import type { LaunchpadSummaryResult } from './launchpadIndicator';
 import { generateLaunchpadSummary } from './launchpadIndicator';
 import type { LaunchpadGroup } from './launchpadProvider';
@@ -15,4 +17,8 @@ export async function getLaunchpadSummary(container: Container): Promise<Launchp
 
 	const groups: LaunchpadGroup[] = configuration.get('launchpad.indicator.groups') ?? [];
 	return generateLaunchpadSummary(result.items, groups);
+}
+
+export function isSupportedLaunchpadPullRequestSearchUrl(search: string): boolean {
+	return isGitHubPullRequestUrl(search) || isGitLabPullRequestUrl(search);
 }

--- a/src/plus/launchpad/utils.ts
+++ b/src/plus/launchpad/utils.ts
@@ -1,7 +1,14 @@
 import type { Container } from '../../container';
+import type { PullRequestUrlIdentity } from '../../git/models/pullRequest.utils';
 import { configuration } from '../../system/vscode/configuration';
-import { isGitHubPullRequestUrl } from '../integrations/providers/github/models';
-import { isGitLabPullRequestUrl } from '../integrations/providers/gitlab/models';
+import {
+	getGitHubPullRequestIdentityFromMaybeUrl,
+	isMaybeGitHubPullRequestUrl,
+} from '../integrations/providers/github/models';
+import {
+	getGitLabPullRequestIdentityFromMaybeUrl,
+	isMaybeGitLabPullRequestUrl,
+} from '../integrations/providers/gitlab/models';
 import type { LaunchpadSummaryResult } from './launchpadIndicator';
 import { generateLaunchpadSummary } from './launchpadIndicator';
 import type { LaunchpadGroup } from './launchpadProvider';
@@ -19,6 +26,17 @@ export async function getLaunchpadSummary(container: Container): Promise<Launchp
 	return generateLaunchpadSummary(result.items, groups);
 }
 
-export function isSupportedLaunchpadPullRequestSearchUrl(search: string): boolean {
-	return isGitHubPullRequestUrl(search) || isGitLabPullRequestUrl(search);
+export function isMaybeSupportedLaunchpadPullRequestSearchUrl(search: string): boolean {
+	return isMaybeGitHubPullRequestUrl(search) || isMaybeGitLabPullRequestUrl(search);
+}
+
+// TODO: Needs to be generalized for other providers
+export function getPullRequestIdentityFromMaybeUrl(url: string): PullRequestUrlIdentity {
+	const github = getGitHubPullRequestIdentityFromMaybeUrl(url);
+	if (github.prNumber != null) return github;
+
+	const gitlab = getGitLabPullRequestIdentityFromMaybeUrl(url);
+	if (gitlab.prNumber != null) return gitlab;
+
+	return { prNumber: undefined, ownerAndRepo: undefined, provider: undefined };
 }

--- a/src/system/vscode/asyncDebouncer.ts
+++ b/src/system/vscode/asyncDebouncer.ts
@@ -1,4 +1,4 @@
-import type { CancellationToken, Disposable } from 'vscode';
+import type { CancellationToken, Disposable as CodeDisposable } from 'vscode';
 import { CancellationTokenSource } from 'vscode';
 import { CancellationError } from '../../errors';
 import type { Deferrable } from '../function';
@@ -20,7 +20,9 @@ export interface AsyncTask<T> {
  *
  * Despite being able to accept synchronous tasks, we always return a promise here. It's implemeted this way for simplicity.
  */
-export function createAsyncDebouncer<T>(delay: number): Disposable & Deferrable<(task: AsyncTask<T>) => Promise<T>> {
+export function createAsyncDebouncer<T>(
+	delay: number,
+): Disposable & CodeDisposable & Deferrable<(task: AsyncTask<T>) => Promise<T>> {
 	let lastTask: AsyncTask<T> | undefined;
 	let timer: ReturnType<typeof setTimeout> | undefined;
 	let curDeferred: Deferred<T> | undefined;
@@ -130,6 +132,7 @@ export function createAsyncDebouncer<T>(delay: number): Disposable & Deferrable<
 
 	debounce.cancel = cancel;
 	debounce.dispose = dispose;
+	debounce[Symbol.dispose] = dispose;
 	debounce.flush = flush;
 	debounce.pending = pending;
 	return debounce;


### PR DESCRIPTION
Closes #3855 

Current approach has some hacky workarounds to accommodate:

- Directly moving into search mode when a PR url is pasted in
- Not losing the content of the search box when toggling search mode on
- Showing the option to toggle search mode on if no results are found when searching with it off

Suggestions welcome
