### PR TITLE
Refines issue model and adds getIssue to supported integrations

### DIFF
--- a/src/cache.ts
+++ b/src/cache.ts
@@ -3,7 +3,7 @@ import type { Disposable } from './api/gitlens';
 import type { Container } from './container';
 import type { Account } from './git/models/author';
 import type { DefaultBranch } from './git/models/defaultBranch';
-import type { IssueOrPullRequest } from './git/models/issue';
+import type { Issue, IssueOrPullRequest } from './git/models/issue';
 import type { PullRequest } from './git/models/pullRequest';
 import type { RepositoryMetadata } from './git/models/repositoryMetadata';
 import type { HostingIntegration, IntegrationBase, ResourceDescriptor } from './plus/integrations/integration';
@@ -12,6 +12,8 @@ import { isPromise } from './system/promise';
 type Caches = {
 	defaultBranch: { key: `repo:${string}`; value: DefaultBranch };
 	// enrichedAutolinksBySha: { key: `sha:${string}:${string}`; value: Map<string, EnrichedAutolink> };
+	issuesById: { key: `id:${string}:${string}`; value: Issue };
+	issuesByIdAndResource: { key: `id:${string}:${string}:${string}`; value: Issue };
 	issuesOrPrsById: { key: `id:${string}:${string}`; value: IssueOrPullRequest };
 	issuesOrPrsByIdAndRepo: { key: `id:${string}:${string}:${string}`; value: IssueOrPullRequest };
 	prByBranch: { key: `branch:${string}:${string}`; value: PullRequest };
@@ -120,6 +122,27 @@ export class CacheProvider implements Disposable {
 		}
 		return this.get(
 			'issuesOrPrsByIdAndRepo',
+			`id:${id}:${key}:${JSON.stringify(resource)}}`,
+			etag,
+			cacheable,
+			options,
+		);
+	}
+
+	getIssue(
+		id: string,
+		resource: ResourceDescriptor,
+		integration: IntegrationBase | undefined,
+		cacheable: Cacheable<Issue>,
+		options?: { expiryOverride?: boolean | number },
+	): CacheResult<Issue> {
+		const { key, etag } = getResourceKeyAndEtag(resource, integration);
+
+		if (resource == null) {
+			return this.get('issuesById', `id:${id}:${key}`, etag, cacheable, options);
+		}
+		return this.get(
+			'issuesByIdAndResource',
 			`id:${id}:${key}:${JSON.stringify(resource)}}`,
 			etag,
 			cacheable,
@@ -259,6 +282,18 @@ function getExpiresAt<T extends Cache>(cache: T, value: CacheValue<T> | undefine
 		case 'repoMetadata':
 		case 'currentAccount':
 			return 0; // Never expires
+		case 'issuesById':
+		case 'issuesByIdAndResource': {
+			if (value == null) return 0; // Never expires
+
+			// Open issues expire after 1 hour, but closed issues expire after 12 hours unless recently updated and then expire in 1 hour
+
+			const issue = value as CacheValue<'issuesById'>;
+			if (!issue.closed) return defaultExpiresAt;
+
+			const updatedAgo = now - (issue.closedDate ?? issue.updatedDate).getTime();
+			return now + (updatedAgo > 14 * 24 * 60 * 60 * 1000 ? 12 : 1) * 60 * 60 * 1000;
+		}
 		case 'issuesOrPrsById':
 		case 'issuesOrPrsByIdAndRepo': {
 			if (value == null) return 0; // Never expires

--- a/src/git/models/issue.ts
+++ b/src/git/models/issue.ts
@@ -52,12 +52,19 @@ export interface IssueRepository {
 	url?: string;
 }
 
+export interface IssueProject {
+	id: string;
+	name: string;
+	resourceId: string;
+}
+
 export interface IssueShape extends IssueOrPullRequest {
 	author: IssueMember;
 	assignees: IssueMember[];
 	repository?: IssueRepository;
 	labels?: IssueLabel[];
 	body?: string;
+	project?: IssueProject;
 }
 
 export interface SearchedIssue {
@@ -224,6 +231,14 @@ export function serializeIssue(value: IssueShape): IssueShape {
 						repo: value.repository.repo,
 						url: value.repository.url,
 				  },
+		project:
+			value.project == null
+				? undefined
+				: {
+						id: value.project.id,
+						name: value.project.name,
+						resourceId: value.project.resourceId,
+				  },
 		assignees: value.assignees.map(assignee => ({
 			id: assignee.id,
 			name: assignee.name,
@@ -258,13 +273,14 @@ export class Issue implements IssueShape {
 		public readonly closed: boolean,
 		public readonly state: IssueOrPullRequestState,
 		public readonly author: IssueMember,
-		public readonly repository: IssueRepository,
 		public readonly assignees: IssueMember[],
+		public readonly repository?: IssueRepository,
 		public readonly closedDate?: Date,
 		public readonly labels?: IssueLabel[],
 		public readonly commentsCount?: number,
 		public readonly thumbsUpCount?: number,
 		public readonly body?: string,
+		public readonly project?: IssueProject,
 	) {}
 }
 

--- a/src/plus/integrations/providers/azureDevOps.ts
+++ b/src/plus/integrations/providers/azureDevOps.ts
@@ -3,7 +3,7 @@ import { HostingIntegrationId } from '../../../constants.integrations';
 import type { PagedResult } from '../../../git/gitProvider';
 import type { Account } from '../../../git/models/author';
 import type { DefaultBranch } from '../../../git/models/defaultBranch';
-import type { IssueOrPullRequest, SearchedIssue } from '../../../git/models/issue';
+import type { Issue, IssueOrPullRequest, SearchedIssue } from '../../../git/models/issue';
 import type {
 	PullRequest,
 	PullRequestMergeMethod,
@@ -104,6 +104,14 @@ export class AzureDevOpsIntegration extends HostingIntegration<
 		_repo: AzureRepositoryDescriptor,
 		_id: string,
 	): Promise<IssueOrPullRequest | undefined> {
+		return Promise.resolve(undefined);
+	}
+
+	protected override async getProviderIssue(
+		_session: AuthenticationSession,
+		_repo: AzureRepositoryDescriptor,
+		_id: string,
+	): Promise<Issue | undefined> {
 		return Promise.resolve(undefined);
 	}
 

--- a/src/plus/integrations/providers/bitbucket.ts
+++ b/src/plus/integrations/providers/bitbucket.ts
@@ -2,7 +2,7 @@ import type { AuthenticationSession, CancellationToken } from 'vscode';
 import { HostingIntegrationId } from '../../../constants.integrations';
 import type { Account } from '../../../git/models/author';
 import type { DefaultBranch } from '../../../git/models/defaultBranch';
-import type { IssueOrPullRequest, SearchedIssue } from '../../../git/models/issue';
+import type { Issue, IssueOrPullRequest, SearchedIssue } from '../../../git/models/issue';
 import type {
 	PullRequest,
 	PullRequestMergeMethod,
@@ -83,6 +83,14 @@ export class BitbucketIntegration extends HostingIntegration<
 		_repo: BitbucketRepositoryDescriptor,
 		_id: string,
 	): Promise<IssueOrPullRequest | undefined> {
+		return Promise.resolve(undefined);
+	}
+
+	protected override async getProviderIssue(
+		_session: AuthenticationSession,
+		_repo: BitbucketRepositoryDescriptor,
+		_id: string,
+	): Promise<Issue | undefined> {
 		return Promise.resolve(undefined);
 	}
 

--- a/src/plus/integrations/providers/github.ts
+++ b/src/plus/integrations/providers/github.ts
@@ -4,7 +4,7 @@ import type { Sources } from '../../../constants.telemetry';
 import type { Container } from '../../../container';
 import type { Account, UnidentifiedAuthor } from '../../../git/models/author';
 import type { DefaultBranch } from '../../../git/models/defaultBranch';
-import type { IssueOrPullRequest, SearchedIssue } from '../../../git/models/issue';
+import type { Issue, IssueOrPullRequest, SearchedIssue } from '../../../git/models/issue';
 import type {
 	PullRequest,
 	PullRequestMergeMethod,
@@ -18,7 +18,7 @@ import type {
 	IntegrationAuthenticationProviderDescriptor,
 	IntegrationAuthenticationService,
 } from '../authentication/integrationAuthentication';
-import type { SupportedIntegrationIds } from '../integration';
+import type { RepositoryDescriptor, SupportedIntegrationIds } from '../integration';
 import { HostingIntegration } from '../integration';
 import { providersMetadata } from './models';
 import type { ProvidersApi } from './providersApi';
@@ -35,11 +35,7 @@ const enterpriseAuthProvider: IntegrationAuthenticationProviderDescriptor = Obje
 	scopes: enterpriseMetadata.scopes,
 });
 
-export type GitHubRepositoryDescriptor = {
-	key: string;
-	owner: string;
-	name: string;
-};
+export type GitHubRepositoryDescriptor = RepositoryDescriptor;
 
 abstract class GitHubIntegrationBase<ID extends SupportedIntegrationIds> extends HostingIntegration<
 	ID,
@@ -99,6 +95,17 @@ abstract class GitHubIntegrationBase<ID extends SupportedIntegrationIds> extends
 				baseUrl: this.apiBaseUrl,
 			},
 		);
+	}
+
+	protected override async getProviderIssue(
+		{ accessToken }: AuthenticationSession,
+		repo: GitHubRepositoryDescriptor,
+		id: string,
+	): Promise<Issue | undefined> {
+		return (await this.container.github)?.getIssue(this, accessToken, repo.owner, repo.name, Number(id), {
+			baseUrl: this.apiBaseUrl,
+			includeBody: true,
+		});
 	}
 
 	protected override async getProviderPullRequest(

--- a/src/plus/integrations/providers/github/github.ts
+++ b/src/plus/integrations/providers/github/github.ts
@@ -19,7 +19,7 @@ import {
 import type { PagedResult, RepositoryVisibility } from '../../../../git/gitProvider';
 import type { Account, UnidentifiedAuthor } from '../../../../git/models/author';
 import type { DefaultBranch } from '../../../../git/models/defaultBranch';
-import type { IssueOrPullRequest, SearchedIssue } from '../../../../git/models/issue';
+import type { Issue, IssueOrPullRequest, SearchedIssue } from '../../../../git/models/issue';
 import type { PullRequest, SearchedPullRequest } from '../../../../git/models/pullRequest';
 import { PullRequestMergeMethod } from '../../../../git/models/pullRequest';
 import type { GitRevisionRange } from '../../../../git/models/reference';
@@ -615,6 +615,73 @@ export class GitHubApi implements Disposable {
 				url: issue.url,
 				state: fromGitHubIssueOrPullRequestState(issue.state),
 			};
+		} catch (ex) {
+			if (ex instanceof RequestNotFoundError) return undefined;
+
+			throw this.handleException(ex, provider, scope);
+		}
+	}
+
+	@debug<GitHubApi['getIssue']>({ args: { 0: p => p.name, 1: '<token>' } })
+	async getIssue(
+		provider: Provider,
+		token: string,
+		owner: string,
+		repo: string,
+		number: number,
+		options?: {
+			baseUrl?: string;
+			avatarSize?: number;
+			includeBody?: boolean;
+		},
+	): Promise<Issue | undefined> {
+		const scope = getLogScope();
+
+		interface QueryResult {
+			repository:
+				| {
+						issue: GitHubIssue | null | undefined;
+				  }
+				| null
+				| undefined;
+		}
+
+		try {
+			const query = `query getIssue(
+			$owner: String!
+			$repo: String!
+			$number: Int!
+			$avatarSize: Int
+		) {
+			repository(name: $repo, owner: $owner) {
+				issue(number: $number) {
+					${gqIssueFragment}${
+						options?.includeBody
+							? `
+						body
+						`
+							: ''
+					}
+				}
+			}
+		}`;
+
+			const rsp = await this.graphql<QueryResult>(
+				provider,
+				token,
+				query,
+				{
+					...options,
+					owner: owner,
+					repo: repo,
+					number: number,
+				},
+				scope,
+			);
+
+			if (rsp?.repository?.issue == null) return undefined;
+
+			return fromGitHubIssue(rsp.repository.issue, provider);
 		} catch (ex) {
 			if (ex instanceof RequestNotFoundError) return undefined;
 

--- a/src/plus/integrations/providers/github/models.ts
+++ b/src/plus/integrations/providers/github/models.ts
@@ -418,18 +418,18 @@ export function fromGitHubIssue(value: GitHubIssue, provider: Provider): Issue {
 			avatarUrl: value.author.avatarUrl,
 			url: value.author.url,
 		},
-		{
-			owner: value.repository.owner.login,
-			repo: value.repository.name,
-			accessLevel: fromGitHubViewerPermissionToAccessLevel(value.repository.viewerPermission),
-			url: value.repository.url,
-		},
 		value.assignees.nodes.map(assignee => ({
 			id: assignee.login,
 			name: assignee.login,
 			avatarUrl: assignee.avatarUrl,
 			url: assignee.url,
 		})),
+		{
+			owner: value.repository.owner.login,
+			repo: value.repository.name,
+			accessLevel: fromGitHubViewerPermissionToAccessLevel(value.repository.viewerPermission),
+			url: value.repository.url,
+		},
 		value.closedAt == null ? undefined : new Date(value.closedAt),
 		value.labels?.nodes == null
 			? undefined

--- a/src/plus/integrations/providers/models.ts
+++ b/src/plus/integrations/providers/models.ts
@@ -237,7 +237,9 @@ export type GetPullRequestsForAzureProjectsFn = (
 export type MergePullRequestFn = GitProvider['mergePullRequest'];
 
 export type GetIssueFn = (
-	input: { resourceId: string; number: string },
+	input:
+		| { resourceId: string; number: string } // jira
+		| { namespace: string; name: string; number: string }, // gitlab
 	options?: EnterpriseOptions,
 ) => Promise<{ data: ProviderIssue }>;
 
@@ -522,6 +524,11 @@ export function toSearchedIssue(
 					avatarUrl: assignee.avatarUrl ?? undefined,
 					url: assignee.url ?? undefined,
 				})) ?? [],
+			project: {
+				id: issue.project?.id ?? '',
+				name: issue.project?.name ?? '',
+				resourceId: issue.project?.resourceId ?? '',
+			},
 			repository:
 				issue.repository?.owner?.login != null
 					? {

--- a/src/plus/integrations/providers/providersApi.ts
+++ b/src/plus/integrations/providers/providersApi.ts
@@ -21,6 +21,7 @@ import type {
 	GetAzureResourcesForUserFn,
 	GetCurrentUserFn,
 	GetCurrentUserForInstanceFn,
+	GetIssueFn,
 	GetIssuesForAzureProjectFn,
 	GetIssuesForRepoFn,
 	GetIssuesForReposFn,
@@ -124,6 +125,7 @@ export class ProvidersApi {
 				getPullRequestsForUserFn: providerApis.gitlab.getPullRequestsAssociatedWithUser.bind(
 					providerApis.gitlab,
 				) as GetPullRequestsForUserFn,
+				getIssueFn: providerApis.gitlab.getIssue.bind(providerApis.gitlab) as GetIssueFn,
 				getIssuesForReposFn: providerApis.gitlab.getIssuesForRepos.bind(
 					providerApis.gitlab,
 				) as GetIssuesForReposFn,
@@ -207,7 +209,7 @@ export class ProvidersApi {
 					providerApis.jira,
 				),
 				getJiraProjectsForResourcesFn: providerApis.jira.getJiraProjectsForResources.bind(providerApis.jira),
-				getIssueFn: providerApis.jira.getIssue.bind(providerApis.jira),
+				getIssueFn: providerApis.jira.getIssue.bind(providerApis.jira) as GetIssueFn,
 				getIssuesForProjectFn: providerApis.jira.getIssuesForProject.bind(providerApis.jira),
 				getIssuesForResourceForCurrentUserFn: providerApis.jira.getIssuesForResourceForCurrentUser.bind(
 					providerApis.jira,
@@ -807,8 +809,7 @@ export class ProvidersApi {
 
 	async getIssue(
 		providerId: IntegrationId,
-		resourceId: string,
-		issueId: string,
+		input: { resourceId: string; number: string } | { namespace: string; name: string; number: string },
 		options?: { accessToken?: string },
 	): Promise<ProviderIssue | undefined> {
 		const { provider, token } = await this.ensureProviderTokenAndFunction(
@@ -818,7 +819,7 @@ export class ProvidersApi {
 		);
 
 		try {
-			const result = await provider.getIssueFn?.({ resourceId: resourceId, number: issueId }, { token: token });
+			const result = await provider.getIssueFn?.(input, { token: token });
 
 			return result?.data;
 		} catch (e) {


### PR DESCRIPTION
Refines the issue model to be more supportive of Jira issues now that we're working with them more:
 - Repository info on an issue would now be optional
 - Adds optional project property with information on project and resource

Improves typing on resource descriptors in preparation for encoding them with a branch's associated issues in the git config

Adds getIssue and getProviderIssue to the base integration model, and implements for GitHub, GitLab and Jira. Updates provider API functionality to accommodate both GitLab and Jira.