### PR TITLE
Supports local issue association with branches

### DIFF
--- a/src/constants.ts
+++ b/src/constants.ts
@@ -50,6 +50,7 @@ export const enum CharCode {
 export type GitConfigKeys =
 	| `branch.${string}.${'gk' | 'vscode'}-merge-base`
 	| `branch.${string}.gk-target-base`
+	| `branch.${string}.gk-associated-issues`
 	| `branch.${string}.github-pr-owner-number`;
 
 export const enum GlyphChars {

--- a/src/git/models/branch.ts
+++ b/src/git/models/branch.ts
@@ -10,7 +10,8 @@ import {
 	getBranchTrackingWithoutRemote,
 	getRemoteNameFromBranchName,
 	getRemoteNameSlashIndex,
- isDetachedHead } from './branch.utils';
+	isDetachedHead,
+} from './branch.utils';
 import type { PullRequest, PullRequestState } from './pullRequest';
 import type { GitBranchReference } from './reference';
 import type { GitRemote } from './remote';

--- a/src/plus/integrations/providers/models.ts
+++ b/src/plus/integrations/providers/models.ts
@@ -1,6 +1,7 @@
 import type {
 	Account,
 	ActionablePullRequest,
+	AnyEntityIdentifierInput,
 	AzureDevOps,
 	AzureOrganization,
 	AzureProject,
@@ -891,3 +892,11 @@ export type EnrichablePullRequest = ProviderPullRequest & {
 };
 
 export const getActionablePullRequests = GitProviderUtils.getActionablePullRequests;
+
+export type GitConfigEntityIdentifier = AnyEntityIdentifierInput & {
+	metadata: {
+		id: string;
+		owner: { key: string; name: string; id: string | undefined; owner: string | undefined };
+		createdDate: string;
+	};
+};

--- a/src/plus/integrations/providers/utils.ts
+++ b/src/plus/integrations/providers/utils.ts
@@ -1,10 +1,16 @@
 import type { AnyEntityIdentifierInput, EntityIdentifier } from '@gitkraken/provider-apis';
 import { EntityIdentifierProviderType, EntityType, EntityVersion } from '@gitkraken/provider-apis';
 import type { IntegrationId } from '../../../constants.integrations';
-import { HostingIntegrationId, SelfHostedIntegrationId } from '../../../constants.integrations';
-import type { IssueOrPullRequest } from '../../../git/models/issue';
+import { HostingIntegrationId, IssueIntegrationId, SelfHostedIntegrationId } from '../../../constants.integrations';
+import type { Container } from '../../../container';
+import type { Issue, IssueOrPullRequest, IssueShape } from '../../../git/models/issue';
+import type { PullRequest } from '../../../git/models/pullRequest';
+import { Logger } from '../../../system/logger';
 import { equalsIgnoreCase } from '../../../system/string';
 import type { LaunchpadItem } from '../../launchpad/launchpadProvider';
+import type { IssueResourceDescriptor, RepositoryDescriptor } from '../integration';
+import { isIssueResourceDescriptor, isRepositoryDescriptor } from '../integration';
+import type { GitConfigEntityIdentifier } from './models';
 
 function isGitHubDotCom(domain: string): boolean {
 	return equalsIgnoreCase(domain, 'github.com');
@@ -16,6 +22,10 @@ function isGitLabDotCom(domain: string): boolean {
 
 function isLaunchpadItem(item: IssueOrPullRequest | LaunchpadItem): item is LaunchpadItem {
 	return (item as LaunchpadItem).uuid !== undefined;
+}
+
+function isIssue(item: IssueOrPullRequest | LaunchpadItem): item is Issue {
+	return item.type === 'issue';
 }
 
 export function getEntityIdentifierInput(entity: IssueOrPullRequest | LaunchpadItem): AnyEntityIdentifierInput {
@@ -34,13 +44,23 @@ export function getEntityIdentifierInput(entity: IssueOrPullRequest | LaunchpadI
 		provider = EntityIdentifierProviderType.GitlabSelfHosted;
 		domain = entity.provider.domain;
 	}
+	let projectId = null;
+	let resourceId = null;
+	if (provider === EntityIdentifierProviderType.Jira) {
+		if (!isIssue(entity) || entity.project == null) {
+			throw new Error('Jira issues must have a project');
+		}
+
+		projectId = entity.project.id;
+		resourceId = entity.project.resourceId;
+	}
 
 	return {
 		accountOrOrgId: null, // needed for Trello issues, once supported
 		organizationName: null, // needed for Azure issues and PRs, once supported
-		projectId: null, // needed for Jira issues, Trello issues, and Azure issues and PRs, once supported
+		projectId: projectId, // needed for Jira issues, Trello issues, and Azure issues and PRs, once supported
 		repoId: null, // needed for Azure and BitBucket PRs, once supported
-		resourceId: null, // needed for Jira issues, once supported
+		resourceId: resourceId, // needed for Jira issues
 		provider: provider,
 		entityType: entityType,
 		version: EntityVersion.One,
@@ -49,12 +69,20 @@ export function getEntityIdentifierInput(entity: IssueOrPullRequest | LaunchpadI
 	};
 }
 
-export function getProviderIdFromEntityIdentifier(entityIdentifier: EntityIdentifier): IntegrationId | undefined {
+export function getProviderIdFromEntityIdentifier(
+	entityIdentifier: EntityIdentifier | AnyEntityIdentifierInput,
+): IntegrationId | undefined {
 	switch (entityIdentifier.provider) {
 		case EntityIdentifierProviderType.Github:
 			return HostingIntegrationId.GitHub;
 		case EntityIdentifierProviderType.GithubEnterprise:
 			return SelfHostedIntegrationId.GitHubEnterprise;
+		case EntityIdentifierProviderType.Gitlab:
+			return HostingIntegrationId.GitLab;
+		case EntityIdentifierProviderType.GitlabSelfHosted:
+			return SelfHostedIntegrationId.GitLabSelfHosted;
+		case EntityIdentifierProviderType.Jira:
+			return IssueIntegrationId.Jira;
 		default:
 			return undefined;
 	}
@@ -66,7 +94,138 @@ function fromStringToEntityIdentifierProviderType(str: string): EntityIdentifier
 			return EntityIdentifierProviderType.Github;
 		case 'gitlab':
 			return EntityIdentifierProviderType.Gitlab;
+		case 'jira':
+			return EntityIdentifierProviderType.Jira;
 		default:
 			throw new Error(`Unknown provider type '${str}'`);
 	}
+}
+
+export function encodeIssueOrPullRequestForGitConfig(
+	entity: Issue | PullRequest,
+	owner: RepositoryDescriptor | IssueResourceDescriptor,
+): GitConfigEntityIdentifier {
+	const encodedOwner: GitConfigEntityIdentifier['metadata']['owner'] = {
+		key: owner.key,
+		name: owner.name,
+		id: undefined,
+		owner: undefined,
+	};
+	if (isRepositoryDescriptor(owner)) {
+		encodedOwner.owner = owner.owner;
+	} else if (isIssueResourceDescriptor(owner)) {
+		encodedOwner.id = owner.id;
+	} else {
+		throw new Error('Invalid owner');
+	}
+
+	return {
+		...getEntityIdentifierInput(entity),
+		metadata: {
+			id: entity.id,
+			owner: encodedOwner,
+			createdDate: new Date().toISOString(),
+		},
+	};
+}
+
+export function isGitConfigEntityIdentifier(entity: unknown): entity is GitConfigEntityIdentifier {
+	return (
+		entity != null &&
+		typeof entity === 'object' &&
+		'provider' in entity &&
+		entity.provider != null &&
+		'entityType' in entity &&
+		entity.entityType != null &&
+		'version' in entity &&
+		entity.version != null &&
+		'entityId' in entity &&
+		entity.entityId != null &&
+		'metadata' in entity &&
+		entity.metadata != null &&
+		typeof entity.metadata === 'object' &&
+		'id' in entity.metadata &&
+		entity.metadata.id != null &&
+		'owner' in entity.metadata &&
+		entity.metadata.owner != null &&
+		'createdDate' in entity.metadata &&
+		entity.metadata.createdDate != null
+	);
+}
+
+export function isGitConfigEntityIdentifiers(entities: unknown): entities is GitConfigEntityIdentifier[] {
+	return Array.isArray(entities) && entities.every(entity => isGitConfigEntityIdentifier(entity));
+}
+
+export function decodeEntityIdentifiersFromGitConfig(str: string): GitConfigEntityIdentifier[] {
+	const decoded = JSON.parse(str);
+
+	if (!isGitConfigEntityIdentifiers(decoded)) {
+		debugger;
+		Logger.error('Invalid entity identifiers in git config');
+		return [];
+	}
+
+	for (const decodedEntity of decoded) {
+		if (
+			decodedEntity.provider === EntityIdentifierProviderType.Jira &&
+			(decodedEntity.resourceId == null || decodedEntity.projectId == null)
+		) {
+			debugger;
+			Logger.error('Invalid Jira issue in git config');
+			continue;
+		}
+	}
+
+	return decoded;
+}
+
+export async function getIssueFromGitConfigEntityIdentifier(
+	container: Container,
+	identifier: GitConfigEntityIdentifier,
+): Promise<Issue | undefined> {
+	if (identifier.entityType !== EntityType.Issue) {
+		return undefined;
+	}
+
+	// TODO: Centralize where we represent all supported providers for issues
+	if (
+		identifier.provider !== EntityIdentifierProviderType.Jira &&
+		identifier.provider !== EntityIdentifierProviderType.Github &&
+		identifier.provider !== EntityIdentifierProviderType.Gitlab
+	) {
+		return undefined;
+	}
+
+	const integrationId = getProviderIdFromEntityIdentifier(identifier);
+	if (integrationId == null) {
+		return undefined;
+	}
+
+	const integration = await container.integrations.get(integrationId);
+	if (integration == null) {
+		return undefined;
+	}
+
+	return integration.getIssue(
+		{
+			id: identifier.metadata.owner.id,
+			key: identifier.metadata.owner.key,
+			owner: identifier.metadata.owner.owner,
+			name: identifier.metadata.owner.name,
+		},
+		identifier.metadata.id,
+	);
+}
+
+export function getIssueOwner(issue: IssueShape): RepositoryDescriptor | IssueResourceDescriptor | undefined {
+	return issue.repository
+		? {
+				key: `${issue.repository.owner}/${issue.repository.repo}`,
+				owner: issue.repository.owner,
+				name: issue.repository.repo,
+		  }
+		: issue.project
+		  ? { key: issue.project.resourceId, id: issue.project.resourceId, name: issue.project.resourceId }
+		  : undefined;
 }

--- a/src/plus/startWork/startWork.ts
+++ b/src/plus/startWork/startWork.ts
@@ -225,6 +225,7 @@ export class StartWorkCommand extends QuickCommand<State> {
 						suggestNameOnly: true,
 						suggestRepoOnly: true,
 						confirmOptions: ['--switch', '--worktree'],
+						associateWithIssue: issue,
 					},
 				},
 				this.pickedVia,
@@ -386,7 +387,6 @@ export class StartWorkCommand extends QuickCommand<State> {
 			return {
 				label:
 					i.item.issue.title.length > 60 ? `${i.item.issue.title.substring(0, 60)}...` : i.item.issue.title,
-				// description: `${i.repoAndOwner}#${i.id}, by @${i.author}`,
 				description: `\u00a0 ${
 					i.item.issue.repository ? `${i.item.issue.repository.owner}/${i.item.issue.repository.repo}#` : ''
 				}${i.item.issue.id} \u00a0`,

--- a/src/webviews/apps/plus/home/components/active-work.ts
+++ b/src/webviews/apps/plus/home/components/active-work.ts
@@ -223,7 +223,7 @@ export class GlActiveBranchCard extends GlBranchCardBase {
 		return html`
 			${this.renderBranchIndicator()}${this.renderBranchItem(
 				this.renderBranchStateActions(),
-			)}${this.renderPrItem()}${this.renderAutolinksItem()}
+			)}${this.renderPrItem()}${this.renderIssuesItem()}
 		`;
 	}
 

--- a/src/webviews/apps/plus/home/components/branch-card.ts
+++ b/src/webviews/apps/plus/home/components/branch-card.ts
@@ -224,19 +224,20 @@ export abstract class GlBranchCardBase extends GlElement {
 		this.toggleExpanded(true);
 	}
 
-	protected renderAutolinks() {
-		const { autolinks } = this.branch;
-		if (!autolinks) return nothing;
+	protected renderIssues() {
+		const { autolinks, issues } = this.branch;
+		const issuesSource = issues?.length ? issues : autolinks;
+		if (!issuesSource?.length) return nothing;
 
 		return html`
-			${autolinks.map(autolink => {
+			${issuesSource.map(issue => {
 				return html`
 					<p class="branch-item__grouping">
 						<span class="branch-item__icon">
-							<issue-icon state=${autolink.state} issue-id=${autolink.id}></issue-icon>
+							<issue-icon state=${issue.state} issue-id=${issue.id}></issue-icon>
 						</span>
-						<a href=${autolink.url} class="branch-item__name">${autolink.title}</a>
-						<span class="branch-item__identifier">#${autolink.id}</span>
+						<a href=${issue.url} class="branch-item__name">${issue.title}</a>
+						<span class="branch-item__identifier">#${issue.id}</span>
 					</p>
 				`;
 			})}
@@ -383,12 +384,12 @@ export abstract class GlBranchCardBase extends GlElement {
 		`;
 	}
 
-	protected renderAutolinksItem() {
-		if (!this.branch.autolinks?.length) return nothing;
+	protected renderIssuesItem() {
+		if (!this.branch.issues?.length && !this.branch.autolinks?.length) return nothing;
 
 		return html`
 			<gl-work-item ?expanded=${this.expanded} ?nested=${!this.branch.opened}>
-				<div class="branch-item__section">${this.renderAutolinks()}</div>
+				<div class="branch-item__section">${this.renderIssues()}</div>
 			</gl-work-item>
 		`;
 	}
@@ -408,7 +409,7 @@ export class GlBranchCard extends GlBranchCardBase {
 		return html`
 			<gl-card class="branch-item" focusable .indicator=${this.cardIndicator}>
 				<div class="branch-item__container">
-					${this.renderBranchItem(this.renderActions())}${this.renderPrItem()}${this.renderAutolinksItem()}
+					${this.renderBranchItem(this.renderActions())}${this.renderPrItem()}${this.renderIssuesItem()}
 				</div>
 			</gl-card>
 		`;

--- a/src/webviews/home/protocol.ts
+++ b/src/webviews/home/protocol.ts
@@ -153,6 +153,12 @@ export interface GetOverviewBranch {
 		state: string;
 		hasIssue: boolean;
 	}[];
+	issues?: {
+		id: string;
+		title: string;
+		url: string;
+		state: string;
+	}[];
 	worktree?: {
 		name: string;
 		uri: string;


### PR DESCRIPTION
Closes #3870

In this PR:
- Adds models and util fns to get, add, remove or clear associated issues from branches in git config
- Plumbs git config associated issues through to the home view branch cards. Uses as primary source with autolinks as secondary source for associated branch issues
- Associates an issue with a branch when created through Start Work
- Deletes all issue associations in git config when a branch is deleted through our command

In the next PR:
- Split out issue list into its own command from Start Work
- Add a command to branches to "associate issue with branch"