### PR TITLE
Adds commands to Add Issue to Branch

### DIFF
--- a/contributions.json
+++ b/contributions.json
@@ -23,6 +23,10 @@
 				]
 			}
 		},
+		"gitlens.addIssueToBranch": {
+			"label": "Add Issue to Branch",
+			"commandPalette": "gitlens:enabled && !gitlens:readonly && !gitlens:untrusted && !gitlens:hasVirtualFolders"
+		},
 		"gitlens.annotations.nextChange": {
 			"label": "Next Change",
 			"icon": "$(arrow-down)"
@@ -1449,6 +1453,19 @@
 						"when": "webviewItem =~ /gitlens:contributor\\b(?!.*?\\b\\+current\\b)/ && !gitlens:hasVirtualFolders && !gitlens:readonly && !gitlens:untrusted",
 						"group": "1_gitlens_actions",
 						"order": 2
+					}
+				]
+			}
+		},
+		"gitlens.graph.addIssueToBranch": {
+			"label": "Add Issue to Branch...",
+			"enablement": "!operationInProgress",
+			"menus": {
+				"webview/context": [
+					{
+						"when": "webviewItem =~ /gitlens:branch\\b(?!.*?\\b\\+remote\\b)/ && !gitlens:hasVirtualFolders && !gitlens:readonly && !gitlens:untrusted",
+						"group": "1_gitlens_actions",
+						"order": 8
 					}
 				]
 			}
@@ -4735,6 +4752,19 @@
 						"when": "view == gitlens.views.contributors && !gitlens:hasVirtualFolders && !gitlens:readonly && !gitlens:untrusted",
 						"group": "navigation",
 						"order": 10
+					}
+				]
+			}
+		},
+		"gitlens.views.addIssueToBranch": {
+			"label": "Add Issue to Branch...",
+			"enablement": "!operationInProgress",
+			"menus": {
+				"view/item/context": [
+					{
+						"when": "viewItem =~ /gitlens:branch\\b(?!.*?\\b\\+remote\\b)/ && !listMultiSelection  && !gitlens:hasVirtualFolders && !gitlens:readonly && !gitlens:untrusted",
+						"group": "1_gitlens_actions",
+						"order": 8
 					}
 				]
 			}

--- a/contributions.json
+++ b/contributions.json
@@ -24,7 +24,7 @@
 			}
 		},
 		"gitlens.associateIssueWithBranch": {
-			"label": "Associate Issue with Branch",
+			"label": "Associate Issue with Branch...",
 			"commandPalette": "gitlens:enabled && !gitlens:readonly && !gitlens:untrusted && !gitlens:hasVirtualFolders"
 		},
 		"gitlens.annotations.nextChange": {

--- a/contributions.json
+++ b/contributions.json
@@ -23,8 +23,8 @@
 				]
 			}
 		},
-		"gitlens.addIssueToBranch": {
-			"label": "Add Issue to Branch",
+		"gitlens.associateIssueWithBranch": {
+			"label": "Associate Issue with Branch",
 			"commandPalette": "gitlens:enabled && !gitlens:readonly && !gitlens:untrusted && !gitlens:hasVirtualFolders"
 		},
 		"gitlens.annotations.nextChange": {
@@ -1457,8 +1457,8 @@
 				]
 			}
 		},
-		"gitlens.graph.addIssueToBranch": {
-			"label": "Add Issue to Branch...",
+		"gitlens.graph.associateIssueWithBranch": {
+			"label": "Associate Issue with Branch...",
 			"enablement": "!operationInProgress",
 			"menus": {
 				"webview/context": [
@@ -4756,8 +4756,8 @@
 				]
 			}
 		},
-		"gitlens.views.addIssueToBranch": {
-			"label": "Add Issue to Branch...",
+		"gitlens.views.associateIssueWithBranch": {
+			"label": "Associate Issue with Branch...",
 			"enablement": "!operationInProgress",
 			"menus": {
 				"view/item/context": [

--- a/docs/telemetry-events.md
+++ b/docs/telemetry-events.md
@@ -103,6 +103,105 @@
 }
 ```
 
+### addIssueToBranch/action
+
+> Sent when the user chooses to manage integrations
+
+```typescript
+{
+  'instance': number,
+  'action': 'manage' | 'connect',
+  'connected': boolean,
+  'items.count': number
+}
+```
+
+### addIssueToBranch/issue/action
+
+> Sent when the user takes an action on an issue
+
+```typescript
+{
+  'instance': number,
+  'action': 'soft-open',
+  'connected': boolean,
+  [`item.${string}`]: string | number | boolean,
+  'items.count': number
+}
+```
+
+### addIssueToBranch/issue/chosen
+
+> Sent when the user chooses an issue to associate with the branch in the second step
+
+```typescript
+{
+  'instance': number,
+  'connected': boolean,
+  [`item.${string}`]: string | number | boolean,
+  'items.count': number
+}
+```
+
+### addIssueToBranch/open
+
+> Sent when the user opens Start Work; use `instance` to correlate an Add Issue to Branch "session"
+
+```typescript
+{
+  'instance': number
+}
+```
+
+### addIssueToBranch/opened
+
+> Sent when the launchpad is opened; use `instance` to correlate an Add Issue to Branch "session"
+
+```typescript
+{
+  'instance': number,
+  'connected': boolean,
+  'items.count': number
+}
+```
+
+### addIssueToBranch/steps/connect
+
+> Sent when the user reaches the "connect an integration" step of Add Issue to Branch
+
+```typescript
+{
+  'instance': number,
+  'connected': boolean,
+  'items.count': number
+}
+```
+
+### addIssueToBranch/steps/issue
+
+> Sent when the user reaches the "choose an issue" step of Add Issue to Branch
+
+```typescript
+{
+  'instance': number,
+  'connected': boolean,
+  'items.count': number
+}
+```
+
+### addIssueToBranch/title/action
+
+> Sent when the user chooses to connect an integration
+
+```typescript
+{
+  'instance': number,
+  'action': 'connect',
+  'connected': boolean,
+  'items.count': number
+}
+```
+
 ### ai/explain
 
 > Sent when explaining changes from wip, commits, stashes, patches,etc.
@@ -960,7 +1059,7 @@ void
 {
   'instance': number,
   'items.error': string,
-  'action': 'open' | 'code-suggest' | 'merge' | 'soft-open' | 'switch' | 'open-worktree' | 'switch-and-code-suggest' | 'show-overview' | 'open-changes' | 'open-in-graph' | 'pin' | 'unpin' | 'snooze' | 'unsnooze' | 'open-suggestion' | 'open-suggestion-browser',
+  'action': 'soft-open' | 'open' | 'code-suggest' | 'merge' | 'switch' | 'open-worktree' | 'switch-and-code-suggest' | 'show-overview' | 'open-changes' | 'open-in-graph' | 'pin' | 'unpin' | 'snooze' | 'unsnooze' | 'open-suggestion' | 'open-suggestion-browser',
   'groups.blocked.collapsed': boolean,
   'groups.blocked.count': number,
   'groups.count': number,
@@ -1257,7 +1356,7 @@ void
 {
   'instance': number,
   'items.error': string,
-  'action': 'settings' | 'feedback' | 'open-on-gkdev' | 'refresh' | 'connect',
+  'action': 'settings' | 'connect' | 'feedback' | 'open-on-gkdev' | 'refresh',
   'groups.blocked.collapsed': boolean,
   'groups.blocked.count': number,
   'groups.count': number,
@@ -1298,7 +1397,7 @@ void
   'provider': string,
   'repoPrivacy': 'private' | 'public' | 'local',
   'repository.visibility': 'private' | 'public' | 'local',
-  'source': 'account' | 'subscription' | 'graph' | 'patchDetails' | 'settings' | 'timeline' | 'home' | 'code-suggest' | 'cloud-patches' | 'commandPalette' | 'deeplink' | 'inspect' | 'inspect-overview' | 'integrations' | 'launchpad' | 'launchpad-indicator' | 'launchpad-view' | 'notification' | 'prompt' | 'quick-wizard' | 'remoteProvider' | 'startWork' | 'trial-indicator' | 'scm-input' | 'walkthrough' | 'whatsnew' | 'worktrees'
+  'source': 'account' | 'subscription' | 'graph' | 'patchDetails' | 'settings' | 'timeline' | 'home' | 'view' | 'code-suggest' | 'addIssueToBranch' | 'cloud-patches' | 'commandPalette' | 'deeplink' | 'inspect' | 'inspect-overview' | 'integrations' | 'launchpad' | 'launchpad-indicator' | 'launchpad-view' | 'notification' | 'prompt' | 'quick-wizard' | 'remoteProvider' | 'startWork' | 'trial-indicator' | 'scm-input' | 'walkthrough' | 'whatsnew' | 'worktrees'
 }
 ```
 
@@ -1468,7 +1567,7 @@ void
 ```typescript
 {
   'instance': number,
-  'action': 'connect' | 'manage',
+  'action': 'manage' | 'connect',
   'connected': boolean,
   'items.count': number
 }

--- a/docs/telemetry-events.md
+++ b/docs/telemetry-events.md
@@ -103,105 +103,6 @@
 }
 ```
 
-### addIssueToBranch/action
-
-> Sent when the user chooses to manage integrations
-
-```typescript
-{
-  'instance': number,
-  'action': 'manage' | 'connect',
-  'connected': boolean,
-  'items.count': number
-}
-```
-
-### addIssueToBranch/issue/action
-
-> Sent when the user takes an action on an issue
-
-```typescript
-{
-  'instance': number,
-  'action': 'soft-open',
-  'connected': boolean,
-  [`item.${string}`]: string | number | boolean,
-  'items.count': number
-}
-```
-
-### addIssueToBranch/issue/chosen
-
-> Sent when the user chooses an issue to associate with the branch in the second step
-
-```typescript
-{
-  'instance': number,
-  'connected': boolean,
-  [`item.${string}`]: string | number | boolean,
-  'items.count': number
-}
-```
-
-### addIssueToBranch/open
-
-> Sent when the user opens Start Work; use `instance` to correlate an Add Issue to Branch "session"
-
-```typescript
-{
-  'instance': number
-}
-```
-
-### addIssueToBranch/opened
-
-> Sent when the launchpad is opened; use `instance` to correlate an Add Issue to Branch "session"
-
-```typescript
-{
-  'instance': number,
-  'connected': boolean,
-  'items.count': number
-}
-```
-
-### addIssueToBranch/steps/connect
-
-> Sent when the user reaches the "connect an integration" step of Add Issue to Branch
-
-```typescript
-{
-  'instance': number,
-  'connected': boolean,
-  'items.count': number
-}
-```
-
-### addIssueToBranch/steps/issue
-
-> Sent when the user reaches the "choose an issue" step of Add Issue to Branch
-
-```typescript
-{
-  'instance': number,
-  'connected': boolean,
-  'items.count': number
-}
-```
-
-### addIssueToBranch/title/action
-
-> Sent when the user chooses to connect an integration
-
-```typescript
-{
-  'instance': number,
-  'action': 'connect',
-  'connected': boolean,
-  'items.count': number
-}
-```
-
 ### ai/explain
 
 > Sent when explaining changes from wip, commits, stashes, patches,etc.
@@ -256,6 +157,105 @@ or
   'output.length': number,
   'retry.count': number,
   'type': 'draftMessage'
+}
+```
+
+### associateIssueWithBranch/action
+
+> Sent when the user chooses to manage integrations
+
+```typescript
+{
+  'instance': number,
+  'action': 'manage' | 'connect',
+  'connected': boolean,
+  'items.count': number
+}
+```
+
+### associateIssueWithBranch/issue/action
+
+> Sent when the user takes an action on an issue
+
+```typescript
+{
+  'instance': number,
+  'action': 'soft-open',
+  'connected': boolean,
+  [`item.${string}`]: string | number | boolean,
+  'items.count': number
+}
+```
+
+### associateIssueWithBranch/issue/chosen
+
+> Sent when the user chooses an issue to associate with the branch in the second step
+
+```typescript
+{
+  'instance': number,
+  'connected': boolean,
+  [`item.${string}`]: string | number | boolean,
+  'items.count': number
+}
+```
+
+### associateIssueWithBranch/open
+
+> Sent when the user opens Start Work; use `instance` to correlate an Associate Issue with Branch "session"
+
+```typescript
+{
+  'instance': number
+}
+```
+
+### associateIssueWithBranch/opened
+
+> Sent when the launchpad is opened; use `instance` to correlate an Associate Issue with Branch "session"
+
+```typescript
+{
+  'instance': number,
+  'connected': boolean,
+  'items.count': number
+}
+```
+
+### associateIssueWithBranch/steps/connect
+
+> Sent when the user reaches the "connect an integration" step of Associate Issue with Branch
+
+```typescript
+{
+  'instance': number,
+  'connected': boolean,
+  'items.count': number
+}
+```
+
+### associateIssueWithBranch/steps/issue
+
+> Sent when the user reaches the "choose an issue" step of Associate Issue with Branch
+
+```typescript
+{
+  'instance': number,
+  'connected': boolean,
+  'items.count': number
+}
+```
+
+### associateIssueWithBranch/title/action
+
+> Sent when the user chooses to connect an integration
+
+```typescript
+{
+  'instance': number,
+  'action': 'connect',
+  'connected': boolean,
+  'items.count': number
 }
 ```
 
@@ -1397,7 +1397,7 @@ void
   'provider': string,
   'repoPrivacy': 'private' | 'public' | 'local',
   'repository.visibility': 'private' | 'public' | 'local',
-  'source': 'account' | 'subscription' | 'graph' | 'patchDetails' | 'settings' | 'timeline' | 'home' | 'view' | 'code-suggest' | 'addIssueToBranch' | 'cloud-patches' | 'commandPalette' | 'deeplink' | 'inspect' | 'inspect-overview' | 'integrations' | 'launchpad' | 'launchpad-indicator' | 'launchpad-view' | 'notification' | 'prompt' | 'quick-wizard' | 'remoteProvider' | 'startWork' | 'trial-indicator' | 'scm-input' | 'walkthrough' | 'whatsnew' | 'worktrees'
+  'source': 'account' | 'subscription' | 'graph' | 'patchDetails' | 'settings' | 'timeline' | 'home' | 'view' | 'code-suggest' | 'associateIssueWithBranch' | 'cloud-patches' | 'commandPalette' | 'deeplink' | 'inspect' | 'inspect-overview' | 'integrations' | 'launchpad' | 'launchpad-indicator' | 'launchpad-view' | 'notification' | 'prompt' | 'quick-wizard' | 'remoteProvider' | 'startWork' | 'trial-indicator' | 'scm-input' | 'walkthrough' | 'whatsnew' | 'worktrees'
 }
 ```
 

--- a/package.json
+++ b/package.json
@@ -5748,7 +5748,7 @@
 			},
 			{
 				"command": "gitlens.associateIssueWithBranch",
-				"title": "Associate Issue with Branch",
+				"title": "Associate Issue with Branch...",
 				"category": "GitLens"
 			},
 			{

--- a/package.json
+++ b/package.json
@@ -5747,6 +5747,11 @@
 				"icon": "$(person-add)"
 			},
 			{
+				"command": "gitlens.addIssueToBranch",
+				"title": "Add Issue to Branch",
+				"category": "GitLens"
+			},
+			{
 				"command": "gitlens.annotations.nextChange",
 				"title": "Next Change",
 				"icon": "$(arrow-down)"
@@ -6301,6 +6306,11 @@
 				"command": "gitlens.graph.addAuthor",
 				"title": "Add as Co-author",
 				"icon": "$(person-add)"
+			},
+			{
+				"command": "gitlens.graph.addIssueToBranch",
+				"title": "Add Issue to Branch...",
+				"enablement": "!operationInProgress"
 			},
 			{
 				"command": "gitlens.graph.cherryPick",
@@ -7552,6 +7562,11 @@
 				"command": "gitlens.views.addAuthors",
 				"title": "Add Co-authors...",
 				"icon": "$(person-add)"
+			},
+			{
+				"command": "gitlens.views.addIssueToBranch",
+				"title": "Add Issue to Branch...",
+				"enablement": "!operationInProgress"
 			},
 			{
 				"command": "gitlens.views.addRemote",
@@ -9839,6 +9854,10 @@
 					"when": "gitlens:enabled && !gitlens:readonly && !gitlens:untrusted && !gitlens:hasVirtualFolders"
 				},
 				{
+					"command": "gitlens.addIssueToBranch",
+					"when": "gitlens:enabled && !gitlens:readonly && !gitlens:untrusted && !gitlens:hasVirtualFolders"
+				},
+				{
 					"command": "gitlens.annotations.nextChange",
 					"when": "false"
 				},
@@ -10248,6 +10267,10 @@
 				},
 				{
 					"command": "gitlens.graph.addAuthor",
+					"when": "false"
+				},
+				{
+					"command": "gitlens.graph.addIssueToBranch",
 					"when": "false"
 				},
 				{
@@ -11196,6 +11219,10 @@
 				},
 				{
 					"command": "gitlens.views.addAuthors",
+					"when": "false"
+				},
+				{
+					"command": "gitlens.views.addIssueToBranch",
 					"when": "false"
 				},
 				{
@@ -15206,6 +15233,11 @@
 					"group": "1_gitlens_actions@7"
 				},
 				{
+					"command": "gitlens.views.addIssueToBranch",
+					"when": "viewItem =~ /gitlens:branch\\b(?!.*?\\b\\+remote\\b)/ && !listMultiSelection && !gitlens:hasVirtualFolders && !gitlens:readonly && !gitlens:untrusted",
+					"group": "1_gitlens_actions@8"
+				},
+				{
 					"command": "gitlens.views.createBranch",
 					"when": "viewItem =~ /gitlens:branch\\b(?!.*?\\b\\+closed\\b)/ && !listMultiSelection && !gitlens:hasVirtualFolders && !gitlens:readonly && !gitlens:untrusted",
 					"group": "1_gitlens_actions_@7"
@@ -18090,6 +18122,11 @@
 					"command": "gitlens.graph.deleteBranch",
 					"when": "webviewItem =~ /gitlens:branch\\b(?!.*?\\b\\+(current|checkedout)\\b)/ && !gitlens:hasVirtualFolders && !gitlens:readonly && !gitlens:untrusted",
 					"group": "1_gitlens_actions@7"
+				},
+				{
+					"command": "gitlens.graph.addIssueToBranch",
+					"when": "webviewItem =~ /gitlens:branch\\b(?!.*?\\b\\+remote\\b)/ && !gitlens:hasVirtualFolders && !gitlens:readonly && !gitlens:untrusted",
+					"group": "1_gitlens_actions@8"
 				},
 				{
 					"command": "gitlens.graph.createBranch",

--- a/package.json
+++ b/package.json
@@ -5747,8 +5747,8 @@
 				"icon": "$(person-add)"
 			},
 			{
-				"command": "gitlens.addIssueToBranch",
-				"title": "Add Issue to Branch",
+				"command": "gitlens.associateIssueWithBranch",
+				"title": "Associate Issue with Branch",
 				"category": "GitLens"
 			},
 			{
@@ -6308,8 +6308,8 @@
 				"icon": "$(person-add)"
 			},
 			{
-				"command": "gitlens.graph.addIssueToBranch",
-				"title": "Add Issue to Branch...",
+				"command": "gitlens.graph.associateIssueWithBranch",
+				"title": "Associate Issue with Branch...",
 				"enablement": "!operationInProgress"
 			},
 			{
@@ -7564,8 +7564,8 @@
 				"icon": "$(person-add)"
 			},
 			{
-				"command": "gitlens.views.addIssueToBranch",
-				"title": "Add Issue to Branch...",
+				"command": "gitlens.views.associateIssueWithBranch",
+				"title": "Associate Issue with Branch...",
 				"enablement": "!operationInProgress"
 			},
 			{
@@ -9854,10 +9854,6 @@
 					"when": "gitlens:enabled && !gitlens:readonly && !gitlens:untrusted && !gitlens:hasVirtualFolders"
 				},
 				{
-					"command": "gitlens.addIssueToBranch",
-					"when": "gitlens:enabled && !gitlens:readonly && !gitlens:untrusted && !gitlens:hasVirtualFolders"
-				},
-				{
 					"command": "gitlens.annotations.nextChange",
 					"when": "false"
 				},
@@ -9868,6 +9864,10 @@
 				{
 					"command": "gitlens.applyPatchFromClipboard",
 					"when": "gitlens:enabled && !gitlens:untrusted && !gitlens:hasVirtualFolders"
+				},
+				{
+					"command": "gitlens.associateIssueWithBranch",
+					"when": "gitlens:enabled && !gitlens:readonly && !gitlens:untrusted && !gitlens:hasVirtualFolders"
 				},
 				{
 					"command": "gitlens.browseRepoAtRevision",
@@ -10270,7 +10270,7 @@
 					"when": "false"
 				},
 				{
-					"command": "gitlens.graph.addIssueToBranch",
+					"command": "gitlens.graph.associateIssueWithBranch",
 					"when": "false"
 				},
 				{
@@ -11222,15 +11222,15 @@
 					"when": "false"
 				},
 				{
-					"command": "gitlens.views.addIssueToBranch",
-					"when": "false"
-				},
-				{
 					"command": "gitlens.views.addRemote",
 					"when": "false"
 				},
 				{
 					"command": "gitlens.views.applyChanges",
+					"when": "false"
+				},
+				{
+					"command": "gitlens.views.associateIssueWithBranch",
 					"when": "false"
 				},
 				{
@@ -15233,7 +15233,7 @@
 					"group": "1_gitlens_actions@7"
 				},
 				{
-					"command": "gitlens.views.addIssueToBranch",
+					"command": "gitlens.views.associateIssueWithBranch",
 					"when": "viewItem =~ /gitlens:branch\\b(?!.*?\\b\\+remote\\b)/ && !listMultiSelection && !gitlens:hasVirtualFolders && !gitlens:readonly && !gitlens:untrusted",
 					"group": "1_gitlens_actions@8"
 				},
@@ -18124,7 +18124,7 @@
 					"group": "1_gitlens_actions@7"
 				},
 				{
-					"command": "gitlens.graph.addIssueToBranch",
+					"command": "gitlens.graph.associateIssueWithBranch",
 					"when": "webviewItem =~ /gitlens:branch\\b(?!.*?\\b\\+remote\\b)/ && !gitlens:hasVirtualFolders && !gitlens:readonly && !gitlens:untrusted",
 					"group": "1_gitlens_actions@8"
 				},

--- a/src/commands/quickWizard.ts
+++ b/src/commands/quickWizard.ts
@@ -1,18 +1,18 @@
 import { GlCommand } from '../constants.commands';
 import type { Container } from '../container';
 import type { LaunchpadCommandArgs } from '../plus/launchpad/launchpad';
-import type { AddIssueToBranchCommandArgs, StartWorkCommandArgs } from '../plus/startWork/startWork';
+import type { AssociateIssueWithBranchCommandArgs, StartWorkCommandArgs } from '../plus/startWork/startWork';
 import { command } from '../system/vscode/command';
 import type { CommandContext } from './base';
 import type { QuickWizardCommandArgsWithCompletion } from './quickWizard.base';
 import { QuickWizardCommandBase } from './quickWizard.base';
 
-export type QuickWizardCommandArgs = LaunchpadCommandArgs | StartWorkCommandArgs | AddIssueToBranchCommandArgs;
+export type QuickWizardCommandArgs = LaunchpadCommandArgs | StartWorkCommandArgs | AssociateIssueWithBranchCommandArgs;
 
 @command()
 export class QuickWizardCommand extends QuickWizardCommandBase {
 	constructor(container: Container) {
-		super(container, [GlCommand.ShowLaunchpad, GlCommand.StartWork, GlCommand.AddIssueToBranch]);
+		super(container, [GlCommand.ShowLaunchpad, GlCommand.StartWork, GlCommand.AssociateIssueWithBranch]);
 	}
 
 	protected override preExecute(
@@ -26,8 +26,8 @@ export class QuickWizardCommand extends QuickWizardCommandBase {
 			case GlCommand.StartWork:
 				return this.execute({ command: 'startWork', ...args });
 
-			case GlCommand.AddIssueToBranch:
-				return this.execute({ command: 'addIssueToBranch', ...args });
+			case GlCommand.AssociateIssueWithBranch:
+				return this.execute({ command: 'associateIssueWithBranch', ...args });
 
 			default:
 				return this.execute(args);

--- a/src/commands/quickWizard.ts
+++ b/src/commands/quickWizard.ts
@@ -1,18 +1,18 @@
 import { GlCommand } from '../constants.commands';
 import type { Container } from '../container';
 import type { LaunchpadCommandArgs } from '../plus/launchpad/launchpad';
-import type { StartWorkCommandArgs } from '../plus/startWork/startWork';
+import type { AddIssueToBranchCommandArgs, StartWorkCommandArgs } from '../plus/startWork/startWork';
 import { command } from '../system/vscode/command';
 import type { CommandContext } from './base';
 import type { QuickWizardCommandArgsWithCompletion } from './quickWizard.base';
 import { QuickWizardCommandBase } from './quickWizard.base';
 
-export type QuickWizardCommandArgs = LaunchpadCommandArgs | StartWorkCommandArgs;
+export type QuickWizardCommandArgs = LaunchpadCommandArgs | StartWorkCommandArgs | AddIssueToBranchCommandArgs;
 
 @command()
 export class QuickWizardCommand extends QuickWizardCommandBase {
 	constructor(container: Container) {
-		super(container, [GlCommand.ShowLaunchpad, GlCommand.StartWork]);
+		super(container, [GlCommand.ShowLaunchpad, GlCommand.StartWork, GlCommand.AddIssueToBranch]);
 	}
 
 	protected override preExecute(
@@ -25,6 +25,9 @@ export class QuickWizardCommand extends QuickWizardCommandBase {
 
 			case GlCommand.StartWork:
 				return this.execute({ command: 'startWork', ...args });
+
+			case GlCommand.AddIssueToBranch:
+				return this.execute({ command: 'addIssueToBranch', ...args });
 
 			default:
 				return this.execute(args);

--- a/src/commands/quickWizard.utils.ts
+++ b/src/commands/quickWizard.utils.ts
@@ -1,7 +1,7 @@
 import type { StoredRecentUsage } from '../constants.storage';
 import type { Container } from '../container';
 import { LaunchpadCommand } from '../plus/launchpad/launchpad';
-import { AddIssueToBranchCommand, StartWorkCommand } from '../plus/startWork/startWork';
+import { AssociateIssueWithBranchCommand, StartWorkCommand } from '../plus/startWork/startWork';
 import { configuration } from '../system/vscode/configuration';
 import { getContext } from '../system/vscode/context';
 import { BranchGitCommand } from './git/branch';
@@ -118,8 +118,8 @@ export class QuickWizardRootStep implements QuickPickStep<QuickCommand> {
 			this.hiddenItems.push(new StartWorkCommand(container, args));
 		}
 
-		if (args?.command === 'addIssueToBranch') {
-			this.hiddenItems.push(new AddIssueToBranchCommand(container, args));
+		if (args?.command === 'associateIssueWithBranch') {
+			this.hiddenItems.push(new AssociateIssueWithBranchCommand(container, args));
 		}
 	}
 

--- a/src/commands/quickWizard.utils.ts
+++ b/src/commands/quickWizard.utils.ts
@@ -1,7 +1,7 @@
 import type { StoredRecentUsage } from '../constants.storage';
 import type { Container } from '../container';
 import { LaunchpadCommand } from '../plus/launchpad/launchpad';
-import { StartWorkCommand } from '../plus/startWork/startWork';
+import { AddIssueToBranchCommand, StartWorkCommand } from '../plus/startWork/startWork';
 import { configuration } from '../system/vscode/configuration';
 import { getContext } from '../system/vscode/context';
 import { BranchGitCommand } from './git/branch';
@@ -116,6 +116,10 @@ export class QuickWizardRootStep implements QuickPickStep<QuickCommand> {
 
 		if (args?.command === 'startWork') {
 			this.hiddenItems.push(new StartWorkCommand(container, args));
+		}
+
+		if (args?.command === 'addIssueToBranch') {
+			this.hiddenItems.push(new AddIssueToBranchCommand(container, args));
 		}
 	}
 

--- a/src/constants.commands.ts
+++ b/src/constants.commands.ts
@@ -5,7 +5,7 @@ export const actionCommandPrefix = 'gitlens.action.';
 
 export const enum GlCommand {
 	AddAuthors = 'gitlens.addAuthors',
-	AddIssueToBranch = 'gitlens.addIssueToBranch',
+	AssociateIssueWithBranch = 'gitlens.associateIssueWithBranch',
 	BrowseRepoAtRevision = 'gitlens.browseRepoAtRevision',
 	BrowseRepoAtRevisionInNewWindow = 'gitlens.browseRepoAtRevisionInNewWindow',
 	BrowseRepoBeforeRevision = 'gitlens.browseRepoBeforeRevision',
@@ -573,7 +573,7 @@ export type TreeViewCommands = `gitlens.views.${
 	| 'addAuthors'
 	| 'addAuthor'
 	| 'addAuthor.multi'
-	| 'addIssueToBranch'
+	| 'associateIssueWithBranch'
 	| 'openBranchOnRemote'
 	| 'openBranchOnRemote.multi'
 	| 'copyRemoteCommitUrl'
@@ -699,7 +699,7 @@ type GraphWebviewCommands = `graph.${
 	| 'pull'
 	| 'fetch'
 	| 'pushWithForce'
-	| 'addIssueToBranch'
+	| 'associateIssueWithBranch'
 	| 'publishBranch'
 	| 'switchToAnotherBranch'
 	| 'createBranch'

--- a/src/constants.commands.ts
+++ b/src/constants.commands.ts
@@ -5,6 +5,7 @@ export const actionCommandPrefix = 'gitlens.action.';
 
 export const enum GlCommand {
 	AddAuthors = 'gitlens.addAuthors',
+	AddIssueToBranch = 'gitlens.addIssueToBranch',
 	BrowseRepoAtRevision = 'gitlens.browseRepoAtRevision',
 	BrowseRepoAtRevisionInNewWindow = 'gitlens.browseRepoAtRevisionInNewWindow',
 	BrowseRepoBeforeRevision = 'gitlens.browseRepoBeforeRevision',
@@ -572,6 +573,7 @@ export type TreeViewCommands = `gitlens.views.${
 	| 'addAuthors'
 	| 'addAuthor'
 	| 'addAuthor.multi'
+	| 'addIssueToBranch'
 	| 'openBranchOnRemote'
 	| 'openBranchOnRemote.multi'
 	| 'copyRemoteCommitUrl'
@@ -697,6 +699,7 @@ type GraphWebviewCommands = `graph.${
 	| 'pull'
 	| 'fetch'
 	| 'pushWithForce'
+	| 'addIssueToBranch'
 	| 'publishBranch'
 	| 'switchToAnotherBranch'
 	| 'createBranch'

--- a/src/constants.telemetry.ts
+++ b/src/constants.telemetry.ts
@@ -218,22 +218,22 @@ export interface TelemetryEvents extends WebviewShowAbortedEvents, WebviewShownE
 	/** Sent when the user chooses to manage integrations */
 	'startWork/action': StartWorkActionEvent;
 
-	/** Sent when the user opens Start Work; use `instance` to correlate an Add Issue to Branch "session" */
-	'addIssueToBranch/open': StartWorkEventDataBase;
-	/** Sent when the launchpad is opened; use `instance` to correlate an Add Issue to Branch "session" */
-	'addIssueToBranch/opened': StartWorkConnectedEventData;
+	/** Sent when the user opens Start Work; use `instance` to correlate an Associate Issue with Branch "session" */
+	'associateIssueWithBranch/open': StartWorkEventDataBase;
+	/** Sent when the launchpad is opened; use `instance` to correlate an Associate Issue with Branch "session" */
+	'associateIssueWithBranch/opened': StartWorkConnectedEventData;
 	/** Sent when the user takes an action on an issue */
-	'addIssueToBranch/issue/action': StartWorkIssueActionEvent;
+	'associateIssueWithBranch/issue/action': StartWorkIssueActionEvent;
 	/** Sent when the user chooses an issue to associate with the branch in the second step */
-	'addIssueToBranch/issue/chosen': StartWorkIssueChosenEvent;
-	/** Sent when the user reaches the "connect an integration" step of Add Issue to Branch */
-	'addIssueToBranch/steps/connect': StartWorkConnectedEventData;
-	/** Sent when the user reaches the "choose an issue" step of Add Issue to Branch */
-	'addIssueToBranch/steps/issue': StartWorkConnectedEventData;
+	'associateIssueWithBranch/issue/chosen': StartWorkIssueChosenEvent;
+	/** Sent when the user reaches the "connect an integration" step of Associate Issue with Branch */
+	'associateIssueWithBranch/steps/connect': StartWorkConnectedEventData;
+	/** Sent when the user reaches the "choose an issue" step of Associate Issue with Branch */
+	'associateIssueWithBranch/steps/issue': StartWorkConnectedEventData;
 	/** Sent when the user chooses to connect an integration */
-	'addIssueToBranch/title/action': StartWorkTitleActionEvent;
+	'associateIssueWithBranch/title/action': StartWorkTitleActionEvent;
 	/** Sent when the user chooses to manage integrations */
-	'addIssueToBranch/action': StartWorkActionEvent;
+	'associateIssueWithBranch/action': StartWorkActionEvent;
 
 	/** Sent when the subscription is loaded */
 	subscription: SubscriptionEventData;
@@ -878,7 +878,7 @@ export type TrackingContext = 'graph' | 'launchpad' | 'visual_file_history' | 'w
 
 export type Sources =
 	| 'account'
-	| 'addIssueToBranch'
+	| 'associateIssueWithBranch'
 	| 'code-suggest'
 	| 'cloud-patches'
 	| 'commandPalette'

--- a/src/constants.telemetry.ts
+++ b/src/constants.telemetry.ts
@@ -218,6 +218,23 @@ export interface TelemetryEvents extends WebviewShowAbortedEvents, WebviewShownE
 	/** Sent when the user chooses to manage integrations */
 	'startWork/action': StartWorkActionEvent;
 
+	/** Sent when the user opens Start Work; use `instance` to correlate an Add Issue to Branch "session" */
+	'addIssueToBranch/open': StartWorkEventDataBase;
+	/** Sent when the launchpad is opened; use `instance` to correlate an Add Issue to Branch "session" */
+	'addIssueToBranch/opened': StartWorkConnectedEventData;
+	/** Sent when the user takes an action on an issue */
+	'addIssueToBranch/issue/action': StartWorkIssueActionEvent;
+	/** Sent when the user chooses an issue to associate with the branch in the second step */
+	'addIssueToBranch/issue/chosen': StartWorkIssueChosenEvent;
+	/** Sent when the user reaches the "connect an integration" step of Add Issue to Branch */
+	'addIssueToBranch/steps/connect': StartWorkConnectedEventData;
+	/** Sent when the user reaches the "choose an issue" step of Add Issue to Branch */
+	'addIssueToBranch/steps/issue': StartWorkConnectedEventData;
+	/** Sent when the user chooses to connect an integration */
+	'addIssueToBranch/title/action': StartWorkTitleActionEvent;
+	/** Sent when the user chooses to manage integrations */
+	'addIssueToBranch/action': StartWorkActionEvent;
+
 	/** Sent when the subscription is loaded */
 	subscription: SubscriptionEventData;
 
@@ -861,6 +878,7 @@ export type TrackingContext = 'graph' | 'launchpad' | 'visual_file_history' | 'w
 
 export type Sources =
 	| 'account'
+	| 'addIssueToBranch'
 	| 'code-suggest'
 	| 'cloud-patches'
 	| 'commandPalette'
@@ -884,6 +902,7 @@ export type Sources =
 	| 'trial-indicator'
 	| 'scm-input'
 	| 'subscription'
+	| 'view'
 	| 'walkthrough'
 	| 'whatsnew'
 	| 'worktrees';

--- a/src/plus/startWork/startWork.ts
+++ b/src/plus/startWork/startWork.ts
@@ -30,9 +30,12 @@ import type { IntegrationId } from '../../constants.integrations';
 import { HostingIntegrationId, IssueIntegrationId } from '../../constants.integrations';
 import type { Source, Sources, StartWorkTelemetryContext, TelemetryEvents } from '../../constants.telemetry';
 import type { Container } from '../../container';
+import { addAssociatedIssueToBranch } from '../../git/models/branch.utils';
 import type { Issue, IssueShape, SearchedIssue } from '../../git/models/issue';
 import { getOrOpenIssueRepository } from '../../git/models/issue';
+import type { GitBranchReference } from '../../git/models/reference';
 import type { Repository } from '../../git/models/repository';
+import { showBranchPicker } from '../../quickpicks/branchPicker';
 import type { QuickPickItemOfT } from '../../quickpicks/items/common';
 import { createQuickPickItemOfT } from '../../quickpicks/items/common';
 import type { DirectiveQuickPickItem } from '../../quickpicks/items/directive';
@@ -43,6 +46,7 @@ import { some } from '../../system/iterable';
 import { executeCommand } from '../../system/vscode/command';
 import { configuration } from '../../system/vscode/configuration';
 import { openUrl } from '../../system/vscode/utils';
+import { getIssueOwner } from '../integrations/providers/utils';
 
 export type StartWorkItem = {
 	item: SearchedIssue;
@@ -70,9 +74,19 @@ function assertsStartWorkStepState(state: StepState<State>): asserts state is St
 	throw new Error('Missing item');
 }
 
-export interface StartWorkCommandArgs {
-	readonly command: 'startWork';
+export interface StartWorkBaseCommandArgs {
+	readonly command: 'startWork' | 'addIssueToBranch';
 	source?: Sources;
+}
+
+export interface StartWorkOverrides {
+	ownSource?: 'startWork' | 'addIssueToBranch';
+	placeholders?: {
+		localIntegrationConnect?: string;
+		cloudIntegrationConnectHasConnected?: string;
+		cloudIntegrationConnectNoConnected?: string;
+		issueSelection?: string;
+	};
 }
 
 export const supportedStartWorkIntegrations = [
@@ -111,20 +125,35 @@ function isManageIntegrationsItem(item: unknown): item is ManageIntegrationsItem
 	return item === manageIntegrationsItem;
 }
 
-export class StartWorkCommand extends QuickCommand<State> {
+export abstract class StartWorkBaseCommand extends QuickCommand<State> {
 	private readonly source: Source;
 	private readonly telemetryContext: StartWorkTelemetryContext | undefined;
+	private readonly telemetryEventKey: 'startWork' | 'addIssueToBranch';
+	protected abstract overrides?: StartWorkOverrides;
 
-	constructor(container: Container, args?: StartWorkCommandArgs) {
-		super(container, 'startWork', 'startWork', `Start Work\u00a0\u00a0${proBadge}`, {
-			description: 'Start work on an issue',
+	constructor(
+		container: Container,
+		args?: StartWorkBaseCommandArgs,
+		key: string = 'startWork',
+		label: string = 'startWork',
+		title: string = `Start Work\u00a0\u00a0${proBadge}`,
+		description: string = 'Start work on an issue',
+		telemetryEventKey: 'startWork' | 'addIssueToBranch' = 'startWork',
+	) {
+		super(container, key, label, title, {
+			description: description,
 		});
 
+		this.telemetryEventKey = telemetryEventKey;
 		this.source = { source: args?.source ?? 'commandPalette' };
 
 		if (this.container.telemetry.enabled) {
 			this.telemetryContext = { instance: instanceCounter.next() };
-			this.container.telemetry.sendEvent('startWork/open', { ...this.telemetryContext }, this.source);
+			this.container.telemetry.sendEvent(
+				`${this.telemetryEventKey}/open`,
+				{ ...this.telemetryContext },
+				this.source,
+			);
 		}
 
 		this.initialState = {
@@ -152,7 +181,7 @@ export class StartWorkCommand extends QuickCommand<State> {
 			if (!hasConnectedIntegrations) {
 				if (this.container.telemetry.enabled) {
 					this.container.telemetry.sendEvent(
-						opened ? 'startWork/steps/connect' : 'startWork/opened',
+						opened ? `${this.telemetryEventKey}/steps/connect` : `${this.telemetryEventKey}/opened`,
 						{
 							...context.telemetryContext!,
 							connected: false,
@@ -182,7 +211,7 @@ export class StartWorkCommand extends QuickCommand<State> {
 			if (state.counter < 1 || state.item == null) {
 				if (this.container.telemetry.enabled) {
 					this.container.telemetry.sendEvent(
-						opened ? 'startWork/steps/issue' : 'startWork/opened',
+						opened ? `${this.telemetryEventKey}/steps/issue` : `${this.telemetryEventKey}/opened`,
 						{
 							...context.telemetryContext!,
 							connected: true,
@@ -198,7 +227,7 @@ export class StartWorkCommand extends QuickCommand<State> {
 				state.item = result;
 				if (this.container.telemetry.enabled) {
 					this.container.telemetry.sendEvent(
-						'startWork/issue/chosen',
+						`${this.telemetryEventKey}/issue/chosen`,
 						{
 							...context.telemetryContext!,
 							...buildItemTelemetryData(result),
@@ -211,28 +240,8 @@ export class StartWorkCommand extends QuickCommand<State> {
 
 			assertsStartWorkStepState(state);
 
-			const issue = state.item.item.issue;
-			const repo = issue && (await this.getIssueRepositoryIfExists(issue));
-
-			const result = yield* getSteps(
-				this.container,
-				{
-					command: 'branch',
-					state: {
-						subcommand: 'create',
-						repo: repo,
-						name: issue ? `${slug(issue.id, { lower: false })}-${slug(issue.title)}` : undefined,
-						suggestNameOnly: true,
-						suggestRepoOnly: true,
-						confirmOptions: ['--switch', '--worktree'],
-						associateWithIssue: issue,
-					},
-				},
-				this.pickedVia,
-			);
-			if (result !== StepResultBreak) {
-				state.counter = 0;
-				continue;
+			if (this.continuation) {
+				yield* this.continuation(state, context);
 			}
 
 			endSteps(state);
@@ -241,7 +250,9 @@ export class StartWorkCommand extends QuickCommand<State> {
 		return state.counter < 0 ? StepResultBreak : undefined;
 	}
 
-	private async getIssueRepositoryIfExists(issue: IssueShape | Issue): Promise<Repository | undefined> {
+	protected abstract continuation?(state: StartWorkStepState, context: Context): StepGenerator;
+
+	protected async getIssueRepositoryIfExists(issue: IssueShape | Issue): Promise<Repository | undefined> {
 		try {
 			return await getOrOpenIssueRepository(this.container, issue);
 		} catch {
@@ -266,7 +277,7 @@ export class StartWorkCommand extends QuickCommand<State> {
 						createQuickPickItemOfT(
 							{
 								label: 'Connect to GitHub...',
-								detail: 'Will connect to GitHub to provide access your pull requests and issues',
+								detail: 'Will connect to GitHub to provide access to your pull requests and issues',
 							},
 							integration,
 						),
@@ -282,7 +293,9 @@ export class StartWorkCommand extends QuickCommand<State> {
 			confirmations,
 			createDirectiveQuickPickItem(Directive.Cancel, false, { label: 'Cancel' }),
 			{
-				placeholder: 'Connect an integration to view their issues in Start Work',
+				placeholder:
+					this.overrides?.placeholders?.localIntegrationConnect ??
+					'Connect an integration to view its issues in Start Work',
 				buttons: [],
 				ignoreFocusOut: false,
 			},
@@ -303,7 +316,7 @@ export class StartWorkCommand extends QuickCommand<State> {
 		const integration = await this.container.integrations.get(id);
 		let connected = integration.maybeConnected ?? (await integration.isConnected());
 		if (!connected) {
-			connected = await integration.connect('startWork');
+			connected = await integration.connect(this.overrides?.ownSource ?? 'startWork');
 		}
 
 		return connected;
@@ -329,7 +342,7 @@ export class StartWorkCommand extends QuickCommand<State> {
 						{
 							label: `Connect an ${hasConnectedIntegration ? 'Additional ' : ''}Integration...`,
 							detail: hasConnectedIntegration
-								? 'Connect additional integrations to view their issues in Start Work'
+								? 'Connect additional integrations to view their issues'
 								: 'Connect an integration to accelerate your work',
 							picked: true,
 						},
@@ -339,8 +352,10 @@ export class StartWorkCommand extends QuickCommand<State> {
 				createDirectiveQuickPickItem(Directive.Cancel, false, { label: 'Cancel' }),
 				{
 					placeholder: hasConnectedIntegration
-						? 'Connect additional integrations to Start Work'
-						: 'Connect an integration to get started with Start Work',
+						? this.overrides?.placeholders?.cloudIntegrationConnectHasConnected ??
+						  'Connect additional integrations to Start Work'
+						: this.overrides?.placeholders?.cloudIntegrationConnectNoConnected ??
+						  'Connect an integration to get started with Start Work',
 					buttons: [],
 					ignoreFocusOut: true,
 				},
@@ -362,7 +377,7 @@ export class StartWorkCommand extends QuickCommand<State> {
 			const connected = await this.container.integrations.connectCloudIntegrations(
 				{ integrationIds: supportedStartWorkIntegrations },
 				{
-					source: 'startWork',
+					source: this.overrides?.ownSource ?? 'startWork',
 				},
 			);
 			if (step.quickpick) {
@@ -409,7 +424,7 @@ export class StartWorkCommand extends QuickCommand<State> {
 			return items;
 		};
 
-		function getItemsAndPlaceholder(): {
+		function getItemsAndPlaceholder(placeholderOverride?: string): {
 			placeholder: string;
 			items: (DirectiveQuickPickItem | QuickPickItemOfT<StartWorkItem | undefined>)[];
 		} {
@@ -424,7 +439,7 @@ export class StartWorkCommand extends QuickCommand<State> {
 			}
 
 			return {
-				placeholder: 'Choose an issue to start working on',
+				placeholder: placeholderOverride ?? 'Choose an issue to start working on',
 				items: [...getItems(context.result), createDirectiveQuickPickItem(Directive.Cancel)],
 			};
 		}
@@ -433,7 +448,7 @@ export class StartWorkCommand extends QuickCommand<State> {
 			quickpick.busy = true;
 			try {
 				await updateContextItems(this.container, context);
-				const { items, placeholder } = getItemsAndPlaceholder();
+				const { items, placeholder } = getItemsAndPlaceholder(this.overrides?.placeholders?.issueSelection);
 				quickpick.placeholder = placeholder;
 				quickpick.items = items;
 			} catch {
@@ -492,7 +507,7 @@ export class StartWorkCommand extends QuickCommand<State> {
 			return StepResultBreak;
 		} else if (isManageIntegrationsItem(element)) {
 			this.sendActionTelemetry('manage', context);
-			executeCommand(GlCommand.PlusManageCloudIntegrations, { source: 'startWork' });
+			executeCommand(GlCommand.PlusManageCloudIntegrations, { source: this.overrides?.ownSource ?? 'startWork' });
 			endSteps(state);
 			return StepResultBreak;
 		}
@@ -506,7 +521,7 @@ export class StartWorkCommand extends QuickCommand<State> {
 	}
 
 	private sendItemActionTelemetry(action: 'soft-open', item: StartWorkItem, context: Context) {
-		this.container.telemetry.sendEvent('startWork/issue/action', {
+		this.container.telemetry.sendEvent(`${this.telemetryEventKey}/issue/action`, {
 			...context.telemetryContext!,
 			...buildItemTelemetryData(item),
 			action: action,
@@ -518,7 +533,7 @@ export class StartWorkCommand extends QuickCommand<State> {
 		if (!this.container.telemetry.enabled) return;
 
 		this.container.telemetry.sendEvent(
-			'startWork/title/action',
+			`${this.telemetryEventKey}/title/action`,
 			{ ...context.telemetryContext!, connected: true, action: action },
 			this.source,
 		);
@@ -528,10 +543,114 @@ export class StartWorkCommand extends QuickCommand<State> {
 		if (!this.container.telemetry.enabled) return;
 
 		this.container.telemetry.sendEvent(
-			'startWork/action',
+			`${this.telemetryEventKey}/action`,
 			{ ...context.telemetryContext!, connected: true, action: action },
 			this.source,
 		);
+	}
+}
+
+export interface StartWorkCommandArgs {
+	readonly command: 'startWork';
+	source?: Sources;
+}
+
+export class StartWorkCommand extends StartWorkBaseCommand {
+	overrides?: undefined;
+
+	protected override async *continuation(
+		state: StartWorkStepState,
+		_context: Context,
+	): AsyncStepResultGenerator<void> {
+		const issue = state.item.item.issue;
+		const repo = issue && (await this.getIssueRepositoryIfExists(issue));
+
+		const result = yield* getSteps(
+			this.container,
+			{
+				command: 'branch',
+				state: {
+					subcommand: 'create',
+					repo: repo,
+					name: issue ? `${slug(issue.id, { lower: false })}-${slug(issue.title)}` : undefined,
+					suggestNameOnly: true,
+					suggestRepoOnly: true,
+					confirmOptions: ['--switch', '--worktree'],
+					associateWithIssue: issue,
+				},
+			},
+			this.pickedVia,
+		);
+		if (result !== StepResultBreak) {
+			state.counter = 0;
+		} else {
+			endSteps(state);
+		}
+	}
+}
+
+export interface AddIssueToBranchCommandArgs {
+	readonly command: 'addIssueToBranch';
+	branch?: GitBranchReference;
+	source?: Sources;
+}
+
+export class AddIssueToBranchCommand extends StartWorkBaseCommand {
+	private branch: GitBranchReference | undefined;
+	protected override overrides: StartWorkOverrides = {
+		ownSource: 'addIssueToBranch',
+		placeholders: {
+			cloudIntegrationConnectHasConnected: 'Connect additional integrations to add their issues to your branches',
+			cloudIntegrationConnectNoConnected: 'Connect an integration to add its issues to your branches',
+			localIntegrationConnect: 'Connect an integration to add its issues to your branches',
+			issueSelection: 'Choose an issue to add to your branch',
+		},
+	};
+
+	constructor(container: Container, args?: AddIssueToBranchCommandArgs) {
+		super(
+			container,
+			{ command: 'addIssueToBranch', source: args?.source ?? 'commandPalette' },
+			'addIssueToBranch',
+			'addIssueToBranch',
+			`Add Issue to Branch\u00a0\u00a0${proBadge}`,
+			'Add an issue to your branch',
+			'addIssueToBranch',
+		);
+		this.branch = args?.branch;
+	}
+
+	// eslint-disable-next-line require-yield
+	protected override async *continuation(
+		state: StartWorkStepState,
+		_context: Context,
+	): AsyncStepResultGenerator<void> {
+		if (!this.container.git.openRepositories.length) {
+			return;
+		}
+
+		const issue = state.item.item.issue;
+
+		if (this.branch == null) {
+			this.branch = await showBranchPicker(
+				`Add Issue to Branch\u00a0\u00a0${proBadge}`,
+				'Choose a branch to add the issue to',
+				this.container.git.openRepositories,
+				{ filter: b => !b.remote },
+			);
+		}
+
+		if (this.branch == null) {
+			return;
+		}
+
+		const owner = getIssueOwner(issue);
+		if (owner == null) {
+			return;
+		}
+
+		await addAssociatedIssueToBranch(this.container, this.branch, { ...issue, type: 'issue' }, owner);
+		endSteps(state);
 	}
 }
 

--- a/src/plus/startWork/startWork.ts
+++ b/src/plus/startWork/startWork.ts
@@ -75,12 +75,12 @@ function assertsStartWorkStepState(state: StepState<State>): asserts state is St
 }
 
 export interface StartWorkBaseCommandArgs {
-	readonly command: 'startWork' | 'addIssueToBranch';
+	readonly command: 'startWork' | 'associateIssueWithBranch';
 	source?: Sources;
 }
 
 export interface StartWorkOverrides {
-	ownSource?: 'startWork' | 'addIssueToBranch';
+	ownSource?: 'startWork' | 'associateIssueWithBranch';
 	placeholders?: {
 		localIntegrationConnect?: string;
 		cloudIntegrationConnectHasConnected?: string;
@@ -128,7 +128,7 @@ function isManageIntegrationsItem(item: unknown): item is ManageIntegrationsItem
 export abstract class StartWorkBaseCommand extends QuickCommand<State> {
 	private readonly source: Source;
 	private readonly telemetryContext: StartWorkTelemetryContext | undefined;
-	private readonly telemetryEventKey: 'startWork' | 'addIssueToBranch';
+	private readonly telemetryEventKey: 'startWork' | 'associateIssueWithBranch';
 	protected abstract overrides?: StartWorkOverrides;
 
 	constructor(
@@ -138,7 +138,7 @@ export abstract class StartWorkBaseCommand extends QuickCommand<State> {
 		label: string = 'startWork',
 		title: string = `Start Work\u00a0\u00a0${proBadge}`,
 		description: string = 'Start work on an issue',
-		telemetryEventKey: 'startWork' | 'addIssueToBranch' = 'startWork',
+		telemetryEventKey: 'startWork' | 'associateIssueWithBranch' = 'startWork',
 	) {
 		super(container, key, label, title, {
 			description: description,
@@ -589,33 +589,34 @@ export class StartWorkCommand extends StartWorkBaseCommand {
 	}
 }
 
-export interface AddIssueToBranchCommandArgs {
-	readonly command: 'addIssueToBranch';
+export interface AssociateIssueWithBranchCommandArgs {
+	readonly command: 'associateIssueWithBranch';
 	branch?: GitBranchReference;
 	source?: Sources;
 }
 
-export class AddIssueToBranchCommand extends StartWorkBaseCommand {
+export class AssociateIssueWithBranchCommand extends StartWorkBaseCommand {
 	private branch: GitBranchReference | undefined;
 	protected override overrides: StartWorkOverrides = {
-		ownSource: 'addIssueToBranch',
+		ownSource: 'associateIssueWithBranch',
 		placeholders: {
-			cloudIntegrationConnectHasConnected: 'Connect additional integrations to add their issues to your branches',
-			cloudIntegrationConnectNoConnected: 'Connect an integration to add its issues to your branches',
-			localIntegrationConnect: 'Connect an integration to add its issues to your branches',
-			issueSelection: 'Choose an issue to add to your branch',
+			cloudIntegrationConnectHasConnected:
+				'Connect additional integrations to associate their issues with your branches',
+			cloudIntegrationConnectNoConnected: 'Connect an integration to associate its issues with your branches',
+			localIntegrationConnect: 'Connect an integration to associate its issues with your branches',
+			issueSelection: 'Choose an issue to associate with your branch',
 		},
 	};
 
-	constructor(container: Container, args?: AddIssueToBranchCommandArgs) {
+	constructor(container: Container, args?: AssociateIssueWithBranchCommandArgs) {
 		super(
 			container,
-			{ command: 'addIssueToBranch', source: args?.source ?? 'commandPalette' },
-			'addIssueToBranch',
-			'addIssueToBranch',
-			`Add Issue to Branch\u00a0\u00a0${proBadge}`,
-			'Add an issue to your branch',
-			'addIssueToBranch',
+			{ command: 'associateIssueWithBranch', source: args?.source ?? 'commandPalette' },
+			'associateIssueWithBranch',
+			'associateIssueWithBranch',
+			`Associate Issue with Branch\u00a0\u00a0${proBadge}`,
+			'Associate an issue with your branch',
+			'associateIssueWithBranch',
 		);
 		this.branch = args?.branch;
 	}
@@ -633,8 +634,8 @@ export class AddIssueToBranchCommand extends StartWorkBaseCommand {
 
 		if (this.branch == null) {
 			this.branch = await showBranchPicker(
-				`Add Issue to Branch\u00a0\u00a0${proBadge}`,
-				'Choose a branch to add the issue to',
+				`Associate Issue with Branch\u00a0\u00a0${proBadge}`,
+				'Choose a branch to associate the issue with',
 				this.container.git.openRepositories,
 				{ filter: b => !b.remote },
 			);

--- a/src/plus/webviews/graph/graphWebview.ts
+++ b/src/plus/webviews/graph/graphWebview.ts
@@ -125,6 +125,7 @@ import type { FeaturePreviewChangeEvent, SubscriptionChangeEvent } from '../../g
 import type { ConnectionStateChangeEvent } from '../../integrations/integrationService';
 import { remoteProviderIdToIntegrationId } from '../../integrations/integrationService';
 import { getPullRequestBranchDeepLink } from '../../launchpad/launchpadProvider';
+import type { AddIssueToBranchCommandArgs } from '../../startWork/startWork';
 import type {
 	BranchState,
 	DidChangeRefsVisibilityParams,
@@ -511,6 +512,7 @@ export class GraphWebviewProvider implements WebviewProvider<State, State, Graph
 			this.host.registerWebviewCommand('gitlens.graph.rebaseOntoBranch', this.rebase),
 			this.host.registerWebviewCommand('gitlens.graph.rebaseOntoUpstream', this.rebaseToRemote),
 			this.host.registerWebviewCommand('gitlens.graph.renameBranch', this.renameBranch),
+			this.host.registerWebviewCommand('gitlens.graph.addIssueToBranch', this.addIssueToBranch),
 
 			this.host.registerWebviewCommand('gitlens.graph.switchToBranch', this.switchTo),
 
@@ -3105,6 +3107,20 @@ export class GraphWebviewProvider implements WebviewProvider<State, State, Graph
 		if (isGraphItemRefContext(item, 'branch')) {
 			const { ref } = item.webviewItemValue;
 			return BranchActions.rename(ref.repoPath, ref);
+		}
+
+		return Promise.resolve();
+	}
+
+	@log()
+	private addIssueToBranch(item?: GraphItemContext) {
+		if (isGraphItemRefContext(item, 'branch')) {
+			const { ref } = item.webviewItemValue;
+			return executeCommand<AddIssueToBranchCommandArgs>(GlCommand.AddIssueToBranch, {
+				command: 'addIssueToBranch',
+				branch: ref,
+				source: 'graph',
+			});
 		}
 
 		return Promise.resolve();

--- a/src/plus/webviews/graph/graphWebview.ts
+++ b/src/plus/webviews/graph/graphWebview.ts
@@ -125,7 +125,7 @@ import type { FeaturePreviewChangeEvent, SubscriptionChangeEvent } from '../../g
 import type { ConnectionStateChangeEvent } from '../../integrations/integrationService';
 import { remoteProviderIdToIntegrationId } from '../../integrations/integrationService';
 import { getPullRequestBranchDeepLink } from '../../launchpad/launchpadProvider';
-import type { AddIssueToBranchCommandArgs } from '../../startWork/startWork';
+import type { AssociateIssueWithBranchCommandArgs } from '../../startWork/startWork';
 import type {
 	BranchState,
 	DidChangeRefsVisibilityParams,
@@ -512,7 +512,7 @@ export class GraphWebviewProvider implements WebviewProvider<State, State, Graph
 			this.host.registerWebviewCommand('gitlens.graph.rebaseOntoBranch', this.rebase),
 			this.host.registerWebviewCommand('gitlens.graph.rebaseOntoUpstream', this.rebaseToRemote),
 			this.host.registerWebviewCommand('gitlens.graph.renameBranch', this.renameBranch),
-			this.host.registerWebviewCommand('gitlens.graph.addIssueToBranch', this.addIssueToBranch),
+			this.host.registerWebviewCommand('gitlens.graph.associateIssueWithBranch', this.associateIssueWithBranch),
 
 			this.host.registerWebviewCommand('gitlens.graph.switchToBranch', this.switchTo),
 
@@ -3113,11 +3113,11 @@ export class GraphWebviewProvider implements WebviewProvider<State, State, Graph
 	}
 
 	@log()
-	private addIssueToBranch(item?: GraphItemContext) {
+	private associateIssueWithBranch(item?: GraphItemContext) {
 		if (isGraphItemRefContext(item, 'branch')) {
 			const { ref } = item.webviewItemValue;
-			return executeCommand<AddIssueToBranchCommandArgs>(GlCommand.AddIssueToBranch, {
-				command: 'addIssueToBranch',
+			return executeCommand<AssociateIssueWithBranchCommandArgs>(GlCommand.AssociateIssueWithBranch, {
+				command: 'associateIssueWithBranch',
 				branch: ref,
 				source: 'graph',
 			});

--- a/src/quickpicks/branchPicker.ts
+++ b/src/quickpicks/branchPicker.ts
@@ -9,13 +9,16 @@ import type { BranchQuickPickItem } from './items/gitWizard';
 export async function showBranchPicker(
 	title: string | undefined,
 	placeholder?: string,
-	repository?: Repository,
+	repository?: Repository | Repository[],
+	options?: {
+		filter?: (b: GitBranch) => boolean;
+	},
 ): Promise<GitBranch | undefined> {
 	if (repository == null) {
 		return undefined;
 	}
 
-	const items: BranchQuickPickItem[] = await getBranches(repository, {});
+	const items: BranchQuickPickItem[] = await getBranches(repository, options ?? {});
 	if (items.length === 0) return undefined;
 
 	const quickpick = window.createQuickPick<BranchQuickPickItem>();

--- a/src/views/viewCommands.ts
+++ b/src/views/viewCommands.ts
@@ -36,7 +36,7 @@ import { deletedOrMissing } from '../git/models/revision';
 import { shortenRevision } from '../git/models/revision.utils';
 import { showPatchesView } from '../plus/drafts/actions';
 import { getPullRequestBranchDeepLink } from '../plus/launchpad/launchpadProvider';
-import type { AddIssueToBranchCommandArgs } from '../plus/startWork/startWork';
+import type { AssociateIssueWithBranchCommandArgs } from '../plus/startWork/startWork';
 import { showContributorsPicker } from '../quickpicks/contributorsPicker';
 import { filterMap } from '../system/array';
 import { log } from '../system/decorators/log';
@@ -247,7 +247,7 @@ export class ViewCommands implements Disposable {
 				'sequential',
 			),
 
-			registerViewCommand('gitlens.views.addIssueToBranch', n => this.addIssueToBranch(n), this),
+			registerViewCommand('gitlens.views.associateIssueWithBranch', n => this.associateIssueWithBranch(n), this),
 
 			registerViewCommand(
 				'gitlens.views.copyRemoteCommitUrl',
@@ -1630,11 +1630,11 @@ export class ViewCommands implements Disposable {
 	}
 
 	@log()
-	private async addIssueToBranch(node: BranchNode) {
+	private async associateIssueWithBranch(node: BranchNode) {
 		if (!node.is('branch')) return Promise.resolve();
 
-		executeCommand<AddIssueToBranchCommandArgs>(GlCommand.AddIssueToBranch, {
-			command: 'addIssueToBranch',
+		executeCommand<AssociateIssueWithBranchCommandArgs>(GlCommand.AssociateIssueWithBranch, {
+			command: 'associateIssueWithBranch',
 			branch: node.ref,
 			source: 'view',
 		});

--- a/src/views/viewCommands.ts
+++ b/src/views/viewCommands.ts
@@ -36,6 +36,7 @@ import { deletedOrMissing } from '../git/models/revision';
 import { shortenRevision } from '../git/models/revision.utils';
 import { showPatchesView } from '../plus/drafts/actions';
 import { getPullRequestBranchDeepLink } from '../plus/launchpad/launchpadProvider';
+import type { AddIssueToBranchCommandArgs } from '../plus/startWork/startWork';
 import { showContributorsPicker } from '../quickpicks/contributorsPicker';
 import { filterMap } from '../system/array';
 import { log } from '../system/decorators/log';
@@ -245,6 +246,8 @@ export class ViewCommands implements Disposable {
 				this,
 				'sequential',
 			),
+
+			registerViewCommand('gitlens.views.addIssueToBranch', n => this.addIssueToBranch(n), this),
 
 			registerViewCommand(
 				'gitlens.views.copyRemoteCommitUrl',
@@ -1624,6 +1627,17 @@ export class ViewCommands implements Disposable {
 		}
 
 		void node.triggerChange(true);
+	}
+
+	@log()
+	private async addIssueToBranch(node: BranchNode) {
+		if (!node.is('branch')) return Promise.resolve();
+
+		executeCommand<AddIssueToBranchCommandArgs>(GlCommand.AddIssueToBranch, {
+			command: 'addIssueToBranch',
+			branch: node.ref,
+			source: 'view',
+		});
 	}
 }
 


### PR DESCRIPTION
Closes #3884 

-Adds support for three commands:
 - Command palette: Add Issue to Branch (you choose the branch after choosing the issue)
 - Branch view items: Add Issue to Branch (associates the chosen issue with the existing branch)
 - Graph branch items: Add Issue to Branch (associates the chosen issue with the existing branch)