### PR TITLE
Flushes old Jira global storage entries on connect

### DIFF
--- a/src/plus/integrations/providers/jira.ts
+++ b/src/plus/integrations/providers/jira.ts
@@ -304,6 +304,8 @@ export class JiraIntegration extends IssueIntegration<IssueIntegrationId.Jira> {
 
 		if (storedOrganizations == null) {
 			organizations = await this.getProviderResourcesForUser(this._session, true);
+			// Clear all other stored organizations and projects when our session changes
+			await this.container.storage.deleteWithPrefix('jira');
 			await this.container.storage.store(`jira:${this._session.accessToken}:organizations`, {
 				v: 1,
 				timestamp: Date.now(),


### PR DESCRIPTION
Closes #3886

When we are about to store new Jira orgs with a session (and don't detect anything with that session with storage), we flush all existing global storage entries prefixed with `jira` to stop them from accummulating.