### PR TITLE
Improves branch autolinks experiments

### DIFF
--- a/.npmrc
+++ b/.npmrc
@@ -1,0 +1,1 @@
+save-prefix = ''

--- a/ThirdPartyNotices.txt
+++ b/ThirdPartyNotices.txt
@@ -32,7 +32,8 @@ This project incorporates components from the projects listed below.
 27. react version 16.8.4 (https://github.com/facebook/react)
 28. signal-utils version 0.21.1 (https://github.com/proposal-signals/signal-utils)
 29. slug version 10.0.0 (https://github.com/Trott/slug)
-30. sortablejs version 1.15.0 (https://github.com/SortableJS/Sortable)
+30. slugify version 1.6.6 (https://github.com/simov/slugify)
+31. sortablejs version 1.15.0 (https://github.com/SortableJS/Sortable)
 
 %% @gk-nzaytsev/fast-string-truncated-width NOTICES AND INFORMATION BEGIN HERE
 =========================================
@@ -2218,6 +2219,33 @@ THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLI
 
 =========================================
 END OF  slug NOTICES AND INFORMATION
+
+%% slugify NOTICES AND INFORMATION BEGIN HERE
+=========================================
+The MIT License (MIT)
+
+Copyright (c) Simeon Velichkov <simeonvelichkov@gmail.com>
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.
+
+=========================================
+END OF  slugify NOTICES AND INFORMATION
 
 %% sortablejs NOTICES AND INFORMATION BEGIN HERE
 =========================================

--- a/package.json
+++ b/package.json
@@ -20165,7 +20165,7 @@
 		"@types/sortablejs": "1.15.8",
 		"@types/vscode": "1.82.0",
 		"@typescript-eslint/parser": "8.21.0",
-		"@vscode/test-cli": "^0.0.10",
+		"@vscode/test-cli": "0.0.10",
 		"@vscode/test-electron": "2.4.1",
 		"@vscode/test-web": "0.0.65",
 		"@vscode/vsce": "3.2.1",

--- a/package.json
+++ b/package.json
@@ -20147,6 +20147,7 @@
 		"react-dom": "16.8.4",
 		"signal-utils": "0.21.1",
 		"slug": "10.0.0",
+		"slugify": "1.6.6",
 		"sortablejs": "1.15.0"
 	},
 	"devDependencies": {

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -157,7 +157,7 @@ importers:
         specifier: 8.21.0
         version: 8.21.0(eslint@9.19.0(jiti@2.4.0))(typescript@5.7.3)
       '@vscode/test-cli':
-        specifier: ^0.0.10
+        specifier: 0.0.10
         version: 0.0.10
       '@vscode/test-electron':
         specifier: 2.4.1

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -107,6 +107,9 @@ importers:
       slug:
         specifier: 10.0.0
         version: 10.0.0
+      slugify:
+        specifier: 1.6.6
+        version: 1.6.6
       sortablejs:
         specifier: 1.15.0
         version: 1.15.0

--- a/src/autolinks/__tests__/autolinks.test.ts
+++ b/src/autolinks/__tests__/autolinks.test.ts
@@ -13,7 +13,7 @@ const mockRefSets = (prefixes: string[] = ['']): RefSet[] =>
 				ignoreCase: false,
 				prefix: prefix,
 				title: 'test',
-				url: 'test/<num>',
+				url: '<num>',
 				description: 'test',
 			},
 		],
@@ -25,27 +25,65 @@ function assertAutolinks(actual: Map<string, Autolink>, expected: Array<string>)
 
 suite('Autolinks Test Suite', () => {
 	test('Branch name autolinks', () => {
-		assertAutolinks(getBranchAutolinks('123', mockRefSets()), ['test/123']);
-		assertAutolinks(getBranchAutolinks('feature/123', mockRefSets()), ['test/123']);
-		assertAutolinks(getBranchAutolinks('feature/PRE-123', mockRefSets()), ['test/123']);
-		assertAutolinks(getBranchAutolinks('123.2', mockRefSets()), ['test/123', 'test/2']);
+		assertAutolinks(getBranchAutolinks('123', mockRefSets()), ['123']);
+		assertAutolinks(getBranchAutolinks('feature/123', mockRefSets()), ['123']);
+		assertAutolinks(getBranchAutolinks('feature/PRE-123', mockRefSets()), ['123']);
+		assertAutolinks(getBranchAutolinks('123.2', mockRefSets()), ['123']);
 		assertAutolinks(getBranchAutolinks('123', mockRefSets(['PRE-'])), []);
 		assertAutolinks(getBranchAutolinks('feature/123', mockRefSets(['PRE-'])), []);
-		assertAutolinks(getBranchAutolinks('feature/2-fa/123', mockRefSets([''])), ['test/123', 'test/2']);
-		assertAutolinks(getBranchAutolinks('feature/2-fa/123', mockRefSets([''])), ['test/123', 'test/2']);
-		// incorrectly solved cat worths to compare the blocks length so that the less block size (without possible link) is more likely a link
-		assertAutolinks(getBranchAutolinks('feature/2-fa/3', mockRefSets([''])), ['test/2', 'test/3']);
-		assertAutolinks(getBranchAutolinks('feature/PRE-123', mockRefSets(['PRE-'])), ['test/123']);
-		assertAutolinks(getBranchAutolinks('feature/PRE-123.2', mockRefSets(['PRE-'])), ['test/123']);
-		assertAutolinks(getBranchAutolinks('feature/3-123-PRE-123', mockRefSets(['PRE-'])), ['test/123']);
+		assertAutolinks(getBranchAutolinks('feature/2-fa/123', mockRefSets([''])), ['123', '2']);
+		assertAutolinks(getBranchAutolinks('feature/2-fa/123', mockRefSets([''])), ['123', '2']);
+		assertAutolinks(getBranchAutolinks('feature/2-fa/3', mockRefSets([''])), ['3', '2']);
+		assertAutolinks(getBranchAutolinks('feature/PRE-123', mockRefSets(['PRE-'])), ['123']);
+		assertAutolinks(getBranchAutolinks('feature/PRE-123.2', mockRefSets(['PRE-'])), ['123']);
+		assertAutolinks(getBranchAutolinks('feature/3-123-PRE-123', mockRefSets(['PRE-'])), ['123']);
 		assertAutolinks(
 			getBranchAutolinks('feature/3-123-PRE-123', mockRefSets(['', 'PRE-'])),
 
-			['test/123', 'test/3'],
+			['123', '3'],
 		);
 	});
 
 	test('Commit message autolinks', () => {
-		assertAutolinks(getAutolinks('test message 123 sd', mockRefSets()), ['test/123']);
+		assertAutolinks(getAutolinks('test message 123 sd', mockRefSets()), ['123']);
+	});
+
+	/**
+	 * 16.1.1^ - improved branch name autolinks matching
+	 */
+	test('Improved branch name autolinks matching', () => {
+		// skip branch names chunks matching '^release(?=(-(?<number-chunk>))$` or other release-like values
+		// skip pair in case of double chunk
+		assertAutolinks(getBranchAutolinks('folder/release/16/issue-1', mockRefSets([''])), ['1']);
+		assertAutolinks(getBranchAutolinks('folder/release/16.1/issue-1', mockRefSets([''])), ['1']);
+		assertAutolinks(getBranchAutolinks('folder/release/16.1.1/1', mockRefSets([''])), ['1']);
+		// skip one in case of single chunk
+		assertAutolinks(getBranchAutolinks('folder/release-16/1', mockRefSets([''])), ['1']);
+		assertAutolinks(getBranchAutolinks('folder/release-16.1/1', mockRefSets([''])), ['1']);
+		assertAutolinks(getBranchAutolinks('folder/release-16.1.2/1', mockRefSets([''])), ['1']);
+
+		/**
+		 * Added chunk matching logic for non-prefixed numbers:
+		 * 		- XX - is more likely issue number
+		 * 		- XX.XX - is less likely issue number, but still possible
+		 * 		- XX.XX.XX - is more likely not issue number
+		 */
+		assertAutolinks(getBranchAutolinks('some-issue-in-release-2024', mockRefSets([''])), ['2024']);
+		assertAutolinks(getBranchAutolinks('some-issue-in-release-2024.1', mockRefSets([''])), ['2024']);
+		assertAutolinks(getBranchAutolinks('some-issue-in-release-2024.1.1', mockRefSets([''])), []);
+
+		assertAutolinks(getBranchAutolinks('folder/release-notes-16-1', mockRefSets([''])), ['16']);
+		assertAutolinks(getBranchAutolinks('folder/16-1-release-notes', mockRefSets([''])), ['16']);
+
+		// considered the distance from the edges of the chunk as a priority sign
+		assertAutolinks(getBranchAutolinks('folder/16-content-1-content', mockRefSets([''])), ['16', '1']);
+		assertAutolinks(getBranchAutolinks('folder/content-1-content-16', mockRefSets([''])), ['16', '1']);
+
+		// the chunk that is more close to the end is more likely actual issue number
+		assertAutolinks(getBranchAutolinks('1-epic-folder/10-issue/100-subissue', mockRefSets([''])), [
+			'100',
+			'10',
+			'1',
+		]);
 	});
 });

--- a/src/autolinks/__tests__/autolinks.test.ts
+++ b/src/autolinks/__tests__/autolinks.test.ts
@@ -2,9 +2,9 @@ import * as assert from 'assert';
 import { suite, test } from 'mocha';
 import { map } from '../../system/iterable';
 import type { Autolink, RefSet } from '../autolinks.utils';
-import { getAutolinks, getBranchAutolinks } from '../autolinks.utils';
+import { calculatePriority, getAutolinks, getBranchAutolinks } from '../autolinks.utils';
 
-const mockRefSets = (prefixes: string[] = ['']): RefSet[] =>
+const mockRefSets = (prefixes: string[] = [''], title = 'test'): RefSet[] =>
 	prefixes.map(prefix => [
 		{ domain: 'test', icon: '1', id: '1', name: 'test' },
 		[
@@ -12,78 +12,121 @@ const mockRefSets = (prefixes: string[] = ['']): RefSet[] =>
 				alphanumeric: false,
 				ignoreCase: false,
 				prefix: prefix,
-				title: 'test',
+				title: title,
 				url: '<num>',
 				description: 'test',
 			},
 		],
 	]);
 
-function assertAutolinks(actual: Map<string, Autolink>, expected: Array<string>): void {
-	assert.deepEqual([...map(actual.values(), x => x.url)], expected);
+function assertAutolinks(actual: Map<string, Autolink>, expected: Array<string>, message: string): void {
+	assert.deepEqual([...map(actual.values(), x => x.url)], expected, message);
 }
 
 suite('Autolinks Test Suite', () => {
 	test('Branch name autolinks', () => {
-		assertAutolinks(getBranchAutolinks('123', mockRefSets()), ['123']);
-		assertAutolinks(getBranchAutolinks('feature/123', mockRefSets()), ['123']);
-		assertAutolinks(getBranchAutolinks('feature/PRE-123', mockRefSets()), ['123']);
-		assertAutolinks(getBranchAutolinks('123.2', mockRefSets()), ['123']);
-		assertAutolinks(getBranchAutolinks('123', mockRefSets(['PRE-'])), []);
-		assertAutolinks(getBranchAutolinks('feature/123', mockRefSets(['PRE-'])), []);
-		assertAutolinks(getBranchAutolinks('feature/2-fa/123', mockRefSets([''])), ['123', '2']);
-		assertAutolinks(getBranchAutolinks('feature/2-fa/123', mockRefSets([''])), ['123', '2']);
-		assertAutolinks(getBranchAutolinks('feature/2-fa/3', mockRefSets([''])), ['3', '2']);
-		assertAutolinks(getBranchAutolinks('feature/PRE-123', mockRefSets(['PRE-'])), ['123']);
-		assertAutolinks(getBranchAutolinks('feature/PRE-123.2', mockRefSets(['PRE-'])), ['123']);
-		assertAutolinks(getBranchAutolinks('feature/3-123-PRE-123', mockRefSets(['PRE-'])), ['123']);
+		assertAutolinks(getBranchAutolinks('123', mockRefSets()), ['123'], 'test-1');
+		assertAutolinks(getBranchAutolinks('feature/123', mockRefSets()), ['123'], 'test-2');
+		assertAutolinks(getBranchAutolinks('feature/PRE-123', mockRefSets()), ['123'], 'test-3');
+		assertAutolinks(getBranchAutolinks('123.2', mockRefSets()), ['123'], 'test-4');
+		assertAutolinks(getBranchAutolinks('123', mockRefSets(['PRE-'])), [], 'test-5');
+		assertAutolinks(getBranchAutolinks('feature/123', mockRefSets(['PRE-'])), [], 'test-6');
+		assertAutolinks(getBranchAutolinks('feature/2-fa/123', mockRefSets([''])), ['123', '2'], 'test-7');
+		assertAutolinks(getBranchAutolinks('feature/2-fa/123', mockRefSets([''])), ['123', '2'], 'test-8');
+		assertAutolinks(getBranchAutolinks('feature/2-fa/3', mockRefSets([''])), ['3', '2'], 'test-9');
+		assertAutolinks(getBranchAutolinks('feature/PRE-123', mockRefSets(['PRE-'])), ['123'], 'test-10');
+		assertAutolinks(getBranchAutolinks('feature/PRE-123.2', mockRefSets(['PRE-'])), ['123'], 'test-11');
+		assertAutolinks(getBranchAutolinks('feature/3-123-PRE-123', mockRefSets(['PRE-'])), ['123'], 'test-12');
 		assertAutolinks(
 			getBranchAutolinks('feature/3-123-PRE-123', mockRefSets(['', 'PRE-'])),
 
 			['123', '3'],
+			'test-13',
 		);
 	});
 
 	test('Commit message autolinks', () => {
-		assertAutolinks(getAutolinks('test message 123 sd', mockRefSets()), ['123']);
+		assertAutolinks(getAutolinks('test message 123 sd', mockRefSets()), ['123'], 'test-14');
 	});
 
+	test('Test autolink priority comparation', () => {
+		assert.equal(calculatePriority('1', 0, '1', 1) > calculatePriority('1', 0, '1', 0), true, 'test-15');
+		assert.equal(calculatePriority('1', 0, '1', 2) > calculatePriority('1', 1, '1', 0), true, 'test-16');
+		assert.equal(calculatePriority('1', 0, '1', 2) > calculatePriority('1', 0, '1.1', 2), true, 'test-17');
+		assert.equal(calculatePriority('2', 0, '2', 2) > calculatePriority('1', 0, '1', 2), true, 'test-19');
+	});
 	/**
 	 * 16.1.1^ - improved branch name autolinks matching
 	 */
 	test('Improved branch name autolinks matching', () => {
 		// skip branch names chunks matching '^release(?=(-(?<number-chunk>))$` or other release-like values
 		// skip pair in case of double chunk
-		assertAutolinks(getBranchAutolinks('folder/release/16/issue-1', mockRefSets([''])), ['1']);
-		assertAutolinks(getBranchAutolinks('folder/release/16.1/issue-1', mockRefSets([''])), ['1']);
-		assertAutolinks(getBranchAutolinks('folder/release/16.1.1/1', mockRefSets([''])), ['1']);
-		// skip one in case of single chunk
-		assertAutolinks(getBranchAutolinks('folder/release-16/1', mockRefSets([''])), ['1']);
-		assertAutolinks(getBranchAutolinks('folder/release-16.1/1', mockRefSets([''])), ['1']);
-		assertAutolinks(getBranchAutolinks('folder/release-16.1.2/1', mockRefSets([''])), ['1']);
+		assertAutolinks(getBranchAutolinks('folder/release/16/issue-1', mockRefSets([''])), ['1'], 'test-20');
+		assertAutolinks(getBranchAutolinks('folder/release/16.1/issue-1', mockRefSets([''])), ['1'], 'test-21');
+		assertAutolinks(getBranchAutolinks('folder/release/16.1.1/1', mockRefSets([''])), ['1'], 'test-22');
+		assertAutolinks(getBranchAutolinks('release-2024', mockRefSets([''])), [], 'test-23');
+		assertAutolinks(getBranchAutolinks('v-2024', mockRefSets([''])), [], 'test-24');
+		assertAutolinks(getBranchAutolinks('v2024', mockRefSets([''])), [], 'test-25');
+		// cannot be definitely handled
+		assertAutolinks(getBranchAutolinks('some-issue-in-release-2024', mockRefSets([''])), ['2024'], 'test-26');
+		assertAutolinks(getBranchAutolinks('folder/release-notes-16-1', mockRefSets([''])), ['16'], 'test-27');
+		assertAutolinks(getBranchAutolinks('folder/16-1-release-notes', mockRefSets([''])), ['16'], 'test-28');
+		// skip next in case of single chunk
+		assertAutolinks(getBranchAutolinks('folder/release-16/1', mockRefSets([''])), ['1'], 'test-29');
+		assertAutolinks(getBranchAutolinks('folder/release-16.1/1', mockRefSets([''])), ['1'], 'test-30');
+		assertAutolinks(getBranchAutolinks('folder/release-16.1.2/1', mockRefSets([''])), ['1'], 'test-31');
 
 		/**
 		 * Added chunk matching logic for non-prefixed numbers:
 		 * 		- XX - is more likely issue number
 		 * 		- XX.XX - is less likely issue number, but still possible
-		 * 		- XX.XX.XX - is more likely not issue number
+		 * 		- XX.XX.XX - is more likely not issue number: seems like a date or version number
 		 */
-		assertAutolinks(getBranchAutolinks('some-issue-in-release-2024', mockRefSets([''])), ['2024']);
-		assertAutolinks(getBranchAutolinks('some-issue-in-release-2024.1', mockRefSets([''])), ['2024']);
-		assertAutolinks(getBranchAutolinks('some-issue-in-release-2024.1.1', mockRefSets([''])), []);
-
-		assertAutolinks(getBranchAutolinks('folder/release-notes-16-1', mockRefSets([''])), ['16']);
-		assertAutolinks(getBranchAutolinks('folder/16-1-release-notes', mockRefSets([''])), ['16']);
-
-		// considered the distance from the edges of the chunk as a priority sign
-		assertAutolinks(getBranchAutolinks('folder/16-content-1-content', mockRefSets([''])), ['16', '1']);
-		assertAutolinks(getBranchAutolinks('folder/content-1-content-16', mockRefSets([''])), ['16', '1']);
+		assertAutolinks(getBranchAutolinks('issue-2024', mockRefSets([''])), ['2024'], 'test-32');
+		assertAutolinks(getBranchAutolinks('issue-2024.1', mockRefSets([''])), ['2024'], 'test-33');
+		assertAutolinks(getBranchAutolinks('issue-2024.1.1', mockRefSets([''])), [], 'test-34');
 
 		// the chunk that is more close to the end is more likely actual issue number
-		assertAutolinks(getBranchAutolinks('1-epic-folder/10-issue/100-subissue', mockRefSets([''])), [
-			'100',
-			'10',
-			'1',
-		]);
+		assertAutolinks(
+			getBranchAutolinks('1-epic-folder/10-issue/100-subissue', mockRefSets([''])),
+			['100', '10', '1'],
+			'test-35',
+		);
+
+		// ignore numbers from title
+		assertAutolinks(
+			getBranchAutolinks('folder/100-content-content-16', mockRefSets([''], '100-content-content')),
+			['16'],
+			'test-36',
+		);
+		assertAutolinks(
+			getBranchAutolinks('folder/100-content-content-16', mockRefSets([''], 'content-content-16')),
+			['100'],
+			'test-37',
+		);
+
+		// consider edge distance and issue key length to sort
+		assertAutolinks(
+			getBranchAutolinks('2-some-issue-in-release-2024', mockRefSets([''])),
+			['2024', '2'],
+			'test-38',
+		);
+		assertAutolinks(
+			getBranchAutolinks('2024-some-issue-in-release-2', mockRefSets([''])),
+			['2024', '2'],
+			'test-39',
+		);
+		assertAutolinks(
+			getBranchAutolinks('some-2-issue-in-release-2024', mockRefSets([''])),
+			['2024', '2'],
+			'test-40',
+		);
+		assertAutolinks(
+			getBranchAutolinks('4048-issue-in-release-2024.1', mockRefSets([''])),
+			['4048', '2024'],
+			'test-41',
+		);
+		// less numbers - more likely issue key
+		assertAutolinks(getBranchAutolinks('1-issue-in-release-2024.1', mockRefSets([''])), ['1', '2024'], 'test-42');
 	});
 });


### PR DESCRIPTION
# Description

Added chunk matching logic for non-prefixed numbers:
- XX - is more likely issue number
- XX.XX - is less likely issue number, but still possible
- XX.XX.XX - is more likely not issue number

considered the distance from the edges of the chunk as a priority sign

the chunk that is more close to the end is more likely actual issue number

# Checklist

<!-- Please check off the following -->

- [ ] I have followed the guidelines in the Contributing document
- [ ] My changes follow the coding style of this project
- [ ] My changes build without any errors or warnings
- [ ] My changes have been formatted and linted
- [ ] My changes include any required corresponding changes to the documentation (including CHANGELOG.md and README.md)
- [ ] My changes have been rebased and squashed to the minimal number (typically 1) of relevant commits
- [ ] My changes have a descriptive commit message with a short title, including a `Fixes $XXX -` or `Closes #XXX -` prefix to auto-close the issue that your PR addresses
