### PR TITLE
Adds a new control for graph branches visibility

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/) and this p
 - Adds new ability to search for a GitLab MR in the _Launchpad_ &mdash; closes [#3788](https://github.com/gitkraken/vscode-gitlens/issues/3788)
 - Adds go to home view button to the commit graph title section &mdash; closes [#3873](https://github.com/gitkraken/vscode-gitlens/issues/3873)
 - Adds a _Contributors_ section to comparison results in the views
+- Adds a new control for graph branches visibility &mdash; closes [#3101](https://github.com/gitkraken/vscode-gitlens/issues/3101)
 
 ### Changed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,7 +11,7 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/) and this p
 - Adds new ability to search for a GitLab MR in the _Launchpad_ &mdash; closes [#3788](https://github.com/gitkraken/vscode-gitlens/issues/3788)
 - Adds go to home view button to the commit graph title section &mdash; closes [#3873](https://github.com/gitkraken/vscode-gitlens/issues/3873)
 - Adds a _Contributors_ section to comparison results in the views
-- Adds a new control for graph branches visibility &mdash; closes [#3101](https://github.com/gitkraken/vscode-gitlens/issues/3101)
+- Adds a new Hidden Branches dropdown next to the Branch Visibility dropdown in the graph toolbar &mdash; closes [#3101](https://github.com/gitkraken/vscode-gitlens/issues/3101)
 
 ### Changed
 

--- a/src/webviews/apps/plus/graph/GraphWrapper.tsx
+++ b/src/webviews/apps/plus/graph/GraphWrapper.tsx
@@ -890,7 +890,7 @@ export function GraphWrapper({
 	const fixedExcludeRefsById = useMemo(() => ({ ...excludeRefsById }), [excludeRefsById]);
 	const handleOnToggleRefsVisibilityClick = (_event: any, refs: GraphRefOptData[], visible: boolean) => {
 		if (!visible) {
-			document.getElementById('test')?.animate(
+			document.getElementById('hiddenRefs')?.animate(
 				[
 					{ offset: 0, background: 'transparent' },
 					{
@@ -1059,8 +1059,6 @@ export function GraphWrapper({
 
 		onChangeSelection?.(rows);
 	};
-
-	const hasExcludedRefs = excludeRefsById && Object.keys(excludeRefsById).length;
 
 	return (
 		<>
@@ -1389,8 +1387,8 @@ export function GraphWrapper({
 									distance={0}
 								>
 									<GlTooltip placement="top" slot="anchor">
-										<button type="button" id="test" className="action-button">
-											<CodeIcon icon={`eye`} />
+										<button type="button" id="hiddenRefs" className="action-button">
+											<CodeIcon icon={`eye-closed`} />
 											{Object.values(excludeRefsById ?? {}).length}
 											<CodeIcon
 												className="action-button__more"
@@ -1398,11 +1396,12 @@ export function GraphWrapper({
 												aria-hidden="true"
 											/>
 										</button>
-										<span slot="content">Hidden branches</span>
+										<span slot="content">Hidden Branches / Tags</span>
 									</GlTooltip>
 									<div slot="content">
-										<MenuLabel>Hidden branches</MenuLabel>
-										{hasExcludedRefs &&
+										<MenuLabel>Hidden Branches / Tags</MenuLabel>
+										{excludeRefsById &&
+											Object.keys(excludeRefsById).length &&
 											[...Object.values(excludeRefsById), null].map(ref =>
 												ref ? (
 													<MenuItem
@@ -1426,7 +1425,7 @@ export function GraphWrapper({
 															);
 														}}
 													>
-														Show all
+														Show All
 													</MenuItem>
 												),
 											)}

--- a/src/webviews/apps/plus/graph/graph.scss
+++ b/src/webviews/apps/plus/graph/graph.scss
@@ -250,6 +250,20 @@ button:not([disabled]),
 	--button-foreground: var(--color-foreground);
 }
 
+.shrink {
+	max-width: fit-content;
+	transition: all .2s;
+
+	&.hidden {
+		max-width: 0;
+		overflow: hidden;
+		.titlebar__group &:not(:first-child) {
+			// compensate the parent gap
+			margin-left: -0.5rem;
+		}
+	}
+}
+
 .action-button {
 	position: relative;
 	appearance: none;
@@ -473,6 +487,12 @@ button:not([disabled]),
 
 .gk-graph.bs-tooltip {
 	z-index: 1040;
+}
+
+.flex-gap {
+	display: flex;
+	gap: 0.5em;
+	align-items: center;
 }
 
 .alert {


### PR DESCRIPTION
# Description

The additional dropdown is appeared only when not there are some branches hidden. It blinks twice after the first branch hiding, then it blinks one time per hidden branch. The dropdown is closed when the list is ended

https://github.com/user-attachments/assets/7937148e-c33c-494b-b84b-abdd1fd39590

# Checklist

<!-- Please check off the following -->

- [ ] I have followed the guidelines in the Contributing document
- [ ] My changes follow the coding style of this project
- [ ] My changes build without any errors or warnings
- [ ] My changes have been formatted and linted
- [ ] My changes include any required corresponding changes to the documentation (including CHANGELOG.md and README.md)
- [ ] My changes have been rebased and squashed to the minimal number (typically 1) of relevant commits
- [ ] My changes have a descriptive commit message with a short title, including a `Fixes $XXX -` or `Closes #XXX -` prefix to auto-close the issue that your PR addresses
