### PR TITLE
Prevents caching a Cloud GitHub Enterprise integration without domain

### DIFF
--- a/src/plus/integrations/integrationService.ts
+++ b/src/plus/integrations/integrationService.ts
@@ -479,17 +479,19 @@ export class IntegrationService implements Disposable {
 							SelfHostedIntegrationId.CloudGitHubEnterprise,
 						);
 						if (existingConfigured?.length) {
-							const { domain } = existingConfigured[0];
-							if (domain == null) throw new Error(`Domain is required for '${id}' integration`);
+							const { domain: configuredDomain } = existingConfigured[0];
+							if (configuredDomain == null) throw new Error(`Domain is required for '${id}' integration`);
 							integration = new (
 								await import(/* webpackChunkName: "integrations" */ './providers/github')
 							).GitHubEnterpriseIntegration(
 								this.container,
 								this.authenticationService,
 								this.getProvidersApi.bind(this),
-								domain,
+								configuredDomain,
 								id,
 							);
+							// assign domain because it's part of caching key:
+							domain = configuredDomain;
 							break;
 						}
 


### PR DESCRIPTION
(#3901)

This situation happens because an integration is cached twice with a real domain and with `undefined`:
![image](https://github.com/user-attachments/assets/6c5b559e-14d5-4499-8ba2-43302937307f)

# Checklist

<!-- Please check off the following -->

- [x] I have followed the guidelines in the Contributing document
- [x] My changes follow the coding style of this project
- [x] My changes build without any errors or warnings
- [x] My changes have been formatted and linted
- [ ] My changes include any required corresponding changes to the documentation (including CHANGELOG.md and README.md)
- [x] My changes have been rebased and squashed to the minimal number (typically 1) of relevant commits
- [x] My changes have a descriptive commit message with a short title, including a `Fixes $XXX -` or `Closes #XXX -` prefix to auto-close the issue that your PR addresses
