### PR TITLE
Adds avatarUrl handling to the hidden refs popover

### DIFF
--- a/src/webviews/apps/plus/graph/GraphWrapper.tsx
+++ b/src/webviews/apps/plus/graph/GraphWrapper.tsx
@@ -98,20 +98,9 @@ import { GitActionsButtons } from './actions/gitActionsButtons';
 import { GlGraphHover } from './hover/graphHover.react';
 import type { GraphMinimapDaySelectedEventDetail } from './minimap/minimap';
 import { GlGraphMinimapContainer } from './minimap/minimap-container.react';
+import { compareGraphRefOpts } from './refHelpers/compareGraphRefOpts';
+import { RemoteIcon } from './refHelpers/RemoteIcon';
 import { GlGraphSideBar } from './sidebar/sidebar.react';
-
-function getRemoteIcon(type: string | number) {
-	switch (type) {
-		case 'head':
-			return 'vm';
-		case 'remote':
-			return 'cloud';
-		case 'tag':
-			return 'tag';
-		default:
-			return '';
-	}
-}
 
 export interface GraphWrapperProps {
 	nonce?: string;
@@ -1406,33 +1395,39 @@ export function GraphWrapper({
 										<MenuLabel>Hidden Branches / Tags</MenuLabel>
 										{excludeRefsById &&
 											Object.keys(excludeRefsById).length &&
-											[...Object.values(excludeRefsById), null].map(ref =>
-												ref ? (
-													<MenuItem
-														// key prop is skipped intentionally. It allows me to not hide the dropdown after click (I don't know why)
-														onClick={event => {
-															handleOnToggleRefsVisibilityClick(event, [ref], true);
-														}}
-														className="flex-gap"
-													>
-														<CodeIcon icon={getRemoteIcon(ref.type)}></CodeIcon>
-														<span>{ref.name}</span>
-													</MenuItem>
-												) : (
-													// One more weird case. If I render it outside the listed items, the dropdown is hidden after click on the last item
-													<MenuItem
-														onClick={event => {
-															handleOnToggleRefsVisibilityClick(
-																event,
-																Object.values(excludeRefsById ?? {}),
-																true,
-															);
-														}}
-													>
-														Show All
-													</MenuItem>
-												),
-											)}
+											(
+												Object.values(excludeRefsById)
+													.slice()
+													.sort(compareGraphRefOpts) as Array<GraphRefOptData | null>
+											)
+												.concat(null)
+												.map(ref =>
+													ref ? (
+														<MenuItem
+															// key prop is skipped intentionally. It allows me to not hide the dropdown after click (I don't know why)
+															onClick={event => {
+																handleOnToggleRefsVisibilityClick(event, [ref], true);
+															}}
+															className="flex-gap"
+														>
+															<RemoteIcon refOptData={ref} />
+															<span>{ref.name}</span>
+														</MenuItem>
+													) : (
+														// One more weird case. If I render it outside the listed items, the dropdown is hidden after click on the last item
+														<MenuItem
+															onClick={event => {
+																handleOnToggleRefsVisibilityClick(
+																	event,
+																	Object.values(excludeRefsById ?? {}),
+																	true,
+																);
+															}}
+														>
+															Show All
+														</MenuItem>
+													),
+												)}
 									</div>
 								</GlPopover>
 							</div>

--- a/src/webviews/apps/plus/graph/refHelpers/RemoteIcon.tsx
+++ b/src/webviews/apps/plus/graph/refHelpers/RemoteIcon.tsx
@@ -1,0 +1,25 @@
+import type { GraphRefOptData } from '@gitkraken/gitkraken-components';
+import React from 'react';
+import { CodeIcon } from '../../../shared/components/code-icon.react';
+
+// eslint-disable-next-line @typescript-eslint/naming-convention
+export function RemoteIcon({ refOptData }: Readonly<{ refOptData: GraphRefOptData }>) {
+	if (refOptData.avatarUrl) {
+		return <img alt={refOptData.name} style={{ width: 14, aspectRatio: 1 }} src={refOptData.avatarUrl} />;
+	}
+	let icon = '';
+	switch (refOptData.type) {
+		case 'head':
+			icon = 'vm';
+			break;
+		case 'remote':
+			icon = 'cloud';
+			break;
+		case 'tag':
+			icon = 'tag';
+			break;
+		default:
+			break;
+	}
+	return <CodeIcon size={14} icon={icon} />;
+}

--- a/src/webviews/apps/plus/graph/refHelpers/compareGraphRefOpts.ts
+++ b/src/webviews/apps/plus/graph/refHelpers/compareGraphRefOpts.ts
@@ -1,0 +1,13 @@
+import type { GraphRefOptData } from '@gitkraken/gitkraken-components';
+
+// copied from GitkrakenComponents to keep refs order the same as in the graph
+export function compareGraphRefOpts(a: GraphRefOptData, b: GraphRefOptData): number {
+	const comparationResult = a.name.localeCompare(b.name);
+	if (comparationResult === 0) {
+		// If names are equals
+		if (a.type === 'remote') {
+			return -1;
+		}
+	}
+	return comparationResult;
+}


### PR DESCRIPTION
# Description

Tried to reuse methods and components from the GraphComponents module, but it cannot be imported. Implemented very simplified copies of required functions to show avatarUrl and sort the list

![Screenshot 2025-01-16 at 11 50 54](https://github.com/user-attachments/assets/396100a8-4923-427b-a343-e934fedec3c2)
![Screenshot 2025-01-16 at 11 51 07](https://github.com/user-attachments/assets/a5d4d32a-2db7-447e-8992-31a9d1983418)


# Checklist

<!-- Please check off the following -->

- [ ] I have followed the guidelines in the Contributing document
- [ ] My changes follow the coding style of this project
- [ ] My changes build without any errors or warnings
- [ ] My changes have been formatted and linted
- [ ] My changes include any required corresponding changes to the documentation (including CHANGELOG.md and README.md)
- [ ] My changes have been rebased and squashed to the minimal number (typically 1) of relevant commits
- [ ] My changes have a descriptive commit message with a short title, including a `Fixes $XXX -` or `Closes #XXX -` prefix to auto-close the issue that your PR addresses
