### PR TITLE
Searches by URL for self hosted GitHub and GitLab on Launchpad

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/) and this p
 
 ### Added
 
+- Adds the ability to search for GitHub Enterprise and GitLab Self-Managed pull requests by URL in the main step of Launchpad
 - Adds OpenRouter support for GitLens' AI features ([#3906](https://github.com/gitkraken/vscode-gitlens/issues/3906))
 - Adds OpenAI GPT-4.1, GPT-4.1 mini, GPT-4.1 nano, o4 mini, and o3 models for GitLens' AI features ([#4235](https://github.com/gitkraken/vscode-gitlens/issues/4235))
 - Adds _Open File at Revision from Remote_ command to open the specific file revision from a remote file URL

--- a/src/git/utils/pullRequest.utils.ts
+++ b/src/git/utils/pullRequest.utils.ts
@@ -1,4 +1,4 @@
-import type { HostingIntegrationId } from '../../constants.integrations';
+import type { HostingIntegrationId, SelfHostedIntegrationId } from '../../constants.integrations';
 import type {
 	PullRequest,
 	PullRequestComparisonRefs,
@@ -9,7 +9,7 @@ import type {
 import { shortenRevision } from './revision.utils';
 
 export interface PullRequestUrlIdentity {
-	provider?: HostingIntegrationId;
+	provider?: SelfHostedIntegrationId | HostingIntegrationId;
 
 	ownerAndRepo?: string;
 	prNumber: string;

--- a/src/plus/integrations/providers/github.ts
+++ b/src/plus/integrations/providers/github.ts
@@ -13,8 +13,9 @@ import { log } from '../../../system/decorators/log';
 import { ensurePaidPlan } from '../../gk/utils/-webview/plus.utils';
 import type { IntegrationAuthenticationProviderDescriptor } from '../authentication/integrationAuthenticationProvider';
 import type { IntegrationAuthenticationService } from '../authentication/integrationAuthenticationService';
-import type { RepositoryDescriptor, SupportedIntegrationIds } from '../integration';
+import type { RepositoryDescriptor } from '../integration';
 import { HostingIntegration } from '../integration';
+import type { GitHubRelatedIntegrationIds } from './github/github.utils';
 import { getGitHubPullRequestIdentityFromMaybeUrl } from './github/github.utils';
 import { providersMetadata } from './models';
 import type { ProvidersApi } from './providersApi';
@@ -38,7 +39,7 @@ const cloudEnterpriseAuthProvider: IntegrationAuthenticationProviderDescriptor =
 
 export type GitHubRepositoryDescriptor = RepositoryDescriptor;
 
-abstract class GitHubIntegrationBase<ID extends SupportedIntegrationIds> extends HostingIntegration<
+abstract class GitHubIntegrationBase<ID extends GitHubRelatedIntegrationIds> extends HostingIntegration<
 	ID,
 	GitHubRepositoryDescriptor
 > {
@@ -260,6 +261,10 @@ abstract class GitHubIntegrationBase<ID extends SupportedIntegrationIds> extends
 			baseUrl: this.apiBaseUrl,
 		});
 	}
+
+	protected override getProviderPullRequestIdentityFromMaybeUrl(search: string): PullRequestUrlIdentity | undefined {
+		return getGitHubPullRequestIdentityFromMaybeUrl(search, this.id);
+	}
 }
 
 export class GitHubIntegration extends GitHubIntegrationBase<HostingIntegrationId.GitHub> {
@@ -293,10 +298,6 @@ export class GitHubIntegration extends GitHubIntegrationBase<HostingIntegrationI
 			}
 			super.refresh();
 		}
-	}
-
-	protected override getProviderPullRequestIdentityFromMaybeUrl(search: string): PullRequestUrlIdentity | undefined {
-		return getGitHubPullRequestIdentityFromMaybeUrl(search);
 	}
 }
 

--- a/src/plus/integrations/providers/github/__tests__/github.utils.test.ts
+++ b/src/plus/integrations/providers/github/__tests__/github.utils.test.ts
@@ -11,7 +11,7 @@ suite('Test GitHub PR URL parsing to identity: getPullRequestIdentityFromMaybeUr
 				: {
 						ownerAndRepo: ownerAndRepo,
 						prNumber: prNumber,
-						provider: 'github',
+						provider: undefined,
 				  },
 			`Parse: ${message} (${JSON.stringify(query)})`,
 		);

--- a/src/plus/integrations/providers/github/github.utils.ts
+++ b/src/plus/integrations/providers/github/github.utils.ts
@@ -2,18 +2,30 @@
 // That's why this file has been created that can collect more simple functions which
 // don't require Container and can be tested.
 
-import { HostingIntegrationId } from '../../../../constants.integrations';
+import type { HostingIntegrationId, SelfHostedIntegrationId } from '../../../../constants.integrations';
 import type { PullRequestUrlIdentity } from '../../../../git/utils/pullRequest.utils';
+
+export type GitHubRelatedIntegrationIds =
+	| HostingIntegrationId.GitHub
+	| SelfHostedIntegrationId.GitHubEnterprise
+	| SelfHostedIntegrationId.CloudGitHubEnterprise;
 
 export function isMaybeGitHubPullRequestUrl(url: string): boolean {
 	if (url == null) return false;
-
 	return getGitHubPullRequestIdentityFromMaybeUrl(url) != null;
 }
 
 export function getGitHubPullRequestIdentityFromMaybeUrl(
 	search: string,
-): (PullRequestUrlIdentity & { provider: HostingIntegrationId.GitHub }) | undefined {
+): (PullRequestUrlIdentity & { provider: undefined }) | undefined;
+export function getGitHubPullRequestIdentityFromMaybeUrl(
+	search: string,
+	id: GitHubRelatedIntegrationIds,
+): (PullRequestUrlIdentity & { provider: GitHubRelatedIntegrationIds }) | undefined;
+export function getGitHubPullRequestIdentityFromMaybeUrl(
+	search: string,
+	id?: GitHubRelatedIntegrationIds,
+): (PullRequestUrlIdentity & { provider: GitHubRelatedIntegrationIds | undefined }) | undefined {
 	let ownerAndRepo: string | undefined = undefined;
 	let prNumber: string | undefined = undefined;
 
@@ -30,7 +42,5 @@ export function getGitHubPullRequestIdentityFromMaybeUrl(
 		}
 	}
 
-	return prNumber != null
-		? { ownerAndRepo: ownerAndRepo, prNumber: prNumber, provider: HostingIntegrationId.GitHub }
-		: undefined;
+	return prNumber != null ? { ownerAndRepo: ownerAndRepo, prNumber: prNumber, provider: id } : undefined;
 }

--- a/src/plus/integrations/providers/gitlab.ts
+++ b/src/plus/integrations/providers/gitlab.ts
@@ -17,6 +17,7 @@ import type { IntegrationAuthenticationProviderDescriptor } from '../authenticat
 import type { IntegrationAuthenticationService } from '../authentication/integrationAuthenticationService';
 import type { RepositoryDescriptor } from '../integration';
 import { HostingIntegration } from '../integration';
+import type { GitLabRelatedIntegrationIds } from './gitlab/gitlab.utils';
 import { getGitLabPullRequestIdentityFromMaybeUrl } from './gitlab/gitlab.utils';
 import { fromGitLabMergeRequestProvidersApi } from './gitlab/models';
 import type { ProviderRepository } from './models';
@@ -42,12 +43,10 @@ const cloudEnterpriseAuthProvider: IntegrationAuthenticationProviderDescriptor =
 
 export type GitLabRepositoryDescriptor = RepositoryDescriptor;
 
-abstract class GitLabIntegrationBase<
-	ID extends
-		| HostingIntegrationId.GitLab
-		| SelfHostedIntegrationId.GitLabSelfHosted
-		| SelfHostedIntegrationId.CloudGitLabSelfHosted,
-> extends HostingIntegration<ID, GitLabRepositoryDescriptor> {
+abstract class GitLabIntegrationBase<ID extends GitLabRelatedIntegrationIds> extends HostingIntegration<
+	ID,
+	GitLabRepositoryDescriptor
+> {
 	protected abstract get apiBaseUrl(): string;
 
 	protected override async getProviderAccountForCommit(
@@ -409,7 +408,7 @@ abstract class GitLabIntegrationBase<
 	}
 
 	protected override getProviderPullRequestIdentityFromMaybeUrl(search: string): PullRequestUrlIdentity | undefined {
-		return getGitLabPullRequestIdentityFromMaybeUrl(search);
+		return getGitLabPullRequestIdentityFromMaybeUrl(search, this.id);
 	}
 }
 

--- a/src/plus/integrations/providers/gitlab/__tests__/gitlab.utils.test.ts
+++ b/src/plus/integrations/providers/gitlab/__tests__/gitlab.utils.test.ts
@@ -10,7 +10,7 @@ suite('Test GitLab PR URL parsing to identity: getPullRequestIdentityFromMaybeUr
 				: {
 						ownerAndRepo: ownerAndRepo,
 						prNumber: prNumber,
-						provider: 'gitlab',
+						provider: undefined,
 				  },
 			`Parse: ${message} (${JSON.stringify(query)})`,
 		);

--- a/src/plus/integrations/providers/gitlab/gitlab.utils.ts
+++ b/src/plus/integrations/providers/gitlab/gitlab.utils.ts
@@ -2,8 +2,13 @@
 // That's why this file has been created that can collect more simple functions which
 // don't require Container and can be tested.
 
-import { HostingIntegrationId } from '../../../../constants.integrations';
+import type { HostingIntegrationId, SelfHostedIntegrationId } from '../../../../constants.integrations';
 import type { PullRequestUrlIdentity } from '../../../../git/utils/pullRequest.utils';
+
+export type GitLabRelatedIntegrationIds =
+	| HostingIntegrationId.GitLab
+	| SelfHostedIntegrationId.GitLabSelfHosted
+	| SelfHostedIntegrationId.CloudGitLabSelfHosted;
 
 export function isMaybeGitLabPullRequestUrl(url: string): boolean {
 	return getGitLabPullRequestIdentityFromMaybeUrl(url) != null;
@@ -11,7 +16,15 @@ export function isMaybeGitLabPullRequestUrl(url: string): boolean {
 
 export function getGitLabPullRequestIdentityFromMaybeUrl(
 	search: string,
-): (PullRequestUrlIdentity & { provider: HostingIntegrationId.GitLab }) | undefined {
+): (PullRequestUrlIdentity & { provider: undefined }) | undefined;
+export function getGitLabPullRequestIdentityFromMaybeUrl(
+	search: string,
+	id: GitLabRelatedIntegrationIds,
+): (PullRequestUrlIdentity & { provider: GitLabRelatedIntegrationIds }) | undefined;
+export function getGitLabPullRequestIdentityFromMaybeUrl(
+	search: string,
+	id?: GitLabRelatedIntegrationIds,
+): (PullRequestUrlIdentity & { provider: GitLabRelatedIntegrationIds | undefined }) | undefined {
 	let ownerAndRepo: string | undefined = undefined;
 	let prNumber: string | undefined = undefined;
 
@@ -28,7 +41,5 @@ export function getGitLabPullRequestIdentityFromMaybeUrl(
 		}
 	}
 
-	return prNumber != null
-		? { ownerAndRepo: ownerAndRepo, prNumber: prNumber, provider: HostingIntegrationId.GitLab }
-		: undefined;
+	return prNumber != null ? { ownerAndRepo: ownerAndRepo, prNumber: prNumber, provider: id } : undefined;
 }


### PR DESCRIPTION
follow up of #3923  and #3934

# Description

- Adds search by URL for GitLab Self Managed to the Launchpad
- Adds search by URL for GitHub Enterprise to the Launchpad


# Checklist

<!-- Please check off the following -->

- [x] I have followed the guidelines in the Contributing document
- [x] My changes follow the coding style of this project
- [x] My changes build without any errors or warnings
- [x] My changes have been formatted and linted
- [x] My changes include any required corresponding changes to the documentation (including CHANGELOG.md and README.md)
- [x] My changes have been rebased and squashed to the minimal number (typically 1) of relevant commits
- [x] My changes have a descriptive commit message with a short title, including a `Fixes $XXX -` or `Closes #XXX -` prefix to auto-close the issue that your PR addresses
