### PR TITLE
Provides webviewId to merge conflicts wrapper

### DIFF
--- a/src/webviews/apps/plus/graph/GraphWrapper.tsx
+++ b/src/webviews/apps/plus/graph/GraphWrapper.tsx
@@ -1344,6 +1344,7 @@ export function GraphWrapper({
 								continueCommand="gitlens.graph.continuePausedOperation"
 								abortCommand="gitlens.graph.abortPausedOperation"
 								openEditorCommand="gitlens.graph.openRebaseEditor"
+								webviewId="gitlens.views.graph"
 							></GlMergeConflictWarning>
 						</div>
 					)}

--- a/src/webviews/apps/plus/shared/components/merge-rebase-status.ts
+++ b/src/webviews/apps/plus/shared/components/merge-rebase-status.ts
@@ -5,6 +5,7 @@ import type { Commands } from '../../../../../constants.commands';
 import type { GitPausedOperationStatus } from '../../../../../git/models/pausedOperationStatus';
 import { pausedOperationStatusStringsByType } from '../../../../../git/utils/pausedOperationStatus.utils';
 import { createCommandLink } from '../../../../../system/commands';
+import { createWebviewCommandLink } from '../../../../../system/webview';
 import { getReferenceLabel } from '../../../shared/git-utils';
 import '../../../shared/components/actions/action-item';
 import '../../../shared/components/actions/action-nav';
@@ -74,20 +75,35 @@ export class GlMergeConflictWarning extends LitElement {
 	@property()
 	openEditorCommand = 'gitlens.home.openRebaseEditor';
 
+	@property({ type: String })
+	webviewId?: Parameters<typeof createWebviewCommandLink>[1];
+
+	private createWebviewCommandLink<T>(command: string, props: T) {
+		if (this.webviewId) {
+			return createWebviewCommandLink(
+				command as Parameters<typeof createWebviewCommandLink>[0],
+				this.webviewId,
+				'',
+				props,
+			);
+		}
+		return createCommandLink(command as Commands, props);
+	}
+
 	private get onSkipUrl() {
-		return createCommandLink(this.skipCommand as Commands, this.pausedOpStatus);
+		return this.createWebviewCommandLink(this.skipCommand, this.pausedOpStatus);
 	}
 
 	private get onContinueUrl() {
-		return createCommandLink(this.continueCommand as Commands, this.pausedOpStatus);
+		return this.createWebviewCommandLink(this.continueCommand, this.pausedOpStatus);
 	}
 
 	private get onAbortUrl() {
-		return createCommandLink(this.abortCommand as Commands, this.pausedOpStatus);
+		return this.createWebviewCommandLink(this.abortCommand, this.pausedOpStatus);
 	}
 
 	private get onOpenEditorUrl() {
-		return createCommandLink(this.openEditorCommand as Commands, this.pausedOpStatus);
+		return this.createWebviewCommandLink(this.openEditorCommand, this.pausedOpStatus);
 	}
 
 	override render() {

--- a/src/webviews/plus/graph/graphWebview.ts
+++ b/src/webviews/plus/graph/graphWebview.ts
@@ -692,11 +692,10 @@ export class GraphWebviewProvider implements WebviewProvider<State, State, Graph
 			this.host.registerWebviewCommand('gitlens.graph.generateCommitMessage', this.generateCommitMessage),
 
 			this.host.registerWebviewCommand('gitlens.graph.compareSelectedCommits.multi', this.compareSelectedCommits),
-			// TODO@d13: convert to this.host.registerWebviewCommand
-			registerCommand('gitlens.graph.abortPausedOperation', this.abortPausedOperation, this),
-			registerCommand('gitlens.graph.continuePausedOperation', this.continuePausedOperation, this),
-			registerCommand('gitlens.graph.openRebaseEditor', this.openRebaseEditor, this),
-			registerCommand('gitlens.graph.skipPausedOperation', this.skipPausedOperation, this),
+			this.host.registerWebviewCommand('gitlens.graph.abortPausedOperation', this.abortPausedOperation),
+			this.host.registerWebviewCommand('gitlens.graph.continuePausedOperation', this.continuePausedOperation),
+			this.host.registerWebviewCommand('gitlens.graph.openRebaseEditor', this.openRebaseEditor),
+			this.host.registerWebviewCommand('gitlens.graph.skipPausedOperation', this.skipPausedOperation),
 		);
 
 		return commands;


### PR DESCRIPTION
# Description

Wanted to provide webviewId as context (and implemented, but then reverted), but the command registration on graphWebview side is a bit incorrect, it always handles events of `gitlens.views.graph`

So, I provide webviewId from graphWrapper and check inside the MergeConflictWarning, then pick between createWebviewCommandLink and createCommandLink. It's bad that there are several types for commands and webviewIds, it's not easy to unify it now

# Checklist

<!-- Please check off the following -->

- [ ] I have followed the guidelines in the Contributing document
- [ ] My changes follow the coding style of this project
- [ ] My changes build without any errors or warnings
- [ ] My changes have been formatted and linted
- [ ] My changes include any required corresponding changes to the documentation (including CHANGELOG.md and README.md)
- [ ] My changes have been rebased and squashed to the minimal number (typically 1) of relevant commits
- [ ] My changes have a descriptive commit message with a short title, including a `Fixes $XXX -` or `Closes #XXX -` prefix to auto-close the issue that your PR addresses
