### PR TITLE
Improves overview branch autolinks

### DIFF
--- a/src/autolinks/autolinks.ts
+++ b/src/autolinks/autolinks.ts
@@ -223,7 +223,7 @@ export class Autolinks implements Disposable {
 					linkIntegration = undefined;
 				}
 			}
-			const issueOrPullRequestPromise =
+			let issueOrPullRequestPromise =
 				remote?.provider != null &&
 				integration != null &&
 				link.provider?.id === integration.id &&
@@ -235,6 +235,13 @@ export class Autolinks implements Disposable {
 					: link.descriptor != null
 					  ? linkIntegration?.getIssueOrPullRequest(link.descriptor, this.getAutolinkEnrichableId(link))
 					  : undefined;
+			// we consider that all non-prefixed links are came from branch names and linked to issues
+			// skip if it's a PR link
+			if (!link.prefix) {
+				issueOrPullRequestPromise = issueOrPullRequestPromise?.then(x =>
+					x?.type === 'pullrequest' ? undefined : x,
+				);
+			}
 			enrichedAutolinks.set(id, [issueOrPullRequestPromise, link]);
 		}
 

--- a/src/constants.commands.ts
+++ b/src/constants.commands.ts
@@ -688,6 +688,7 @@ export type TreeViewCommandSuffixesByViewType<T extends TreeViewTypes> = Extract
 >;
 
 type HomeWebviewCommands = `home.${
+	| 'unlinkIssue'
 	| 'openMergeTargetComparison'
 	| 'openPullRequestChanges'
 	| 'openPullRequestComparison'

--- a/src/constants.storage.ts
+++ b/src/constants.storage.ts
@@ -79,6 +79,8 @@ export type GlobalStorage = {
 	'graph:searchMode': StoredGraphSearchMode;
 	'views:scm:grouped:welcome:dismissed': boolean;
 	'integrations:configured': StoredIntegrationConfigurations;
+	'autolinks:branches:ignore': IgnoredBranchesAutolinks;
+	'autolinks:branches:ignore:skipPrompt': boolean | undefined;
 } & { [key in `plus:preview:${FeaturePreviews}:usages`]: StoredFeaturePreviewUsagePeriod[] } & {
 	[key in `confirm:ai:tos:${AIProviders}`]: boolean;
 } & {
@@ -94,6 +96,8 @@ export type GlobalStorage = {
 };
 
 export type StoredIntegrationConfigurations = Record<string, StoredConfiguredIntegrationDescriptor[] | undefined>;
+
+export type IgnoredBranchesAutolinks = Record<string, string[] | undefined>;
 
 export interface StoredConfiguredIntegrationDescriptor {
 	cloud: boolean;

--- a/src/webviews/home/protocol.ts
+++ b/src/webviews/home/protocol.ts
@@ -2,6 +2,7 @@ import type { IntegrationDescriptor } from '../../constants.integrations';
 import type { GitBranchMergedStatus } from '../../git/gitProvider';
 import type { GitBranchStatus, GitTrackingState } from '../../git/models/branch';
 import type { Issue } from '../../git/models/issue';
+import type { IssueOrPullRequestType } from '../../git/models/issueOrPullRequest';
 import type { MergeConflict } from '../../git/models/mergeConflict';
 import type { GitPausedOperationStatus } from '../../git/models/pausedOperationStatus';
 import type { GitBranchReference } from '../../git/models/reference';
@@ -61,6 +62,14 @@ export const GetLaunchpadSummary = new IpcRequest<GetLaunchpadSummaryRequest, Ge
 	scope,
 	'launchpad/summary',
 );
+
+export interface BranchIssueLink {
+	id: string;
+	title: string;
+	url: string;
+	state: Omit<Issue['state'], 'merged'>;
+	isAutolink?: boolean;
+}
 
 export interface GetOverviewBranch {
 	reference: GitBranchReference;
@@ -161,23 +170,9 @@ export interface GetOverviewBranch {
 		| undefined
 	>;
 
-	autolinks?: Promise<
-		{
-			id: string;
-			title: string;
-			url: string;
-			state: Omit<Issue['state'], 'merged'>;
-		}[]
-	>;
+	autolinks?: Promise<(BranchIssueLink & { type: IssueOrPullRequestType })[]>;
 
-	issues?: Promise<
-		{
-			id: string;
-			title: string;
-			url: string;
-			state: Omit<Issue['state'], 'merged'>;
-		}[]
-	>;
+	issues?: Promise<BranchIssueLink[]>;
 
 	worktree?: {
 		name: string;


### PR DESCRIPTION
# Description


https://github.com/user-attachments/assets/71103275-6672-4f2b-89ad-10cb9898328b

- skip redirected PR autolinks if the refset is non-prefixed
- filter autolinks by type=issue before render in the issues section
- add unlink feature

# Checklist

<!-- Please check off the following -->

- [ ] I have followed the guidelines in the Contributing document
- [ ] My changes follow the coding style of this project
- [ ] My changes build without any errors or warnings
- [ ] My changes have been formatted and linted
- [ ] My changes include any required corresponding changes to the documentation (including CHANGELOG.md and README.md)
- [ ] My changes have been rebased and squashed to the minimal number (typically 1) of relevant commits
- [ ] My changes have a descriptive commit message with a short title, including a `Fixes $XXX -` or `Closes #XXX -` prefix to auto-close the issue that your PR addresses
