### PR TITLE
Moves configured integrations and session storage to new service

### DIFF
--- a/src/container.ts
+++ b/src/container.ts
@@ -32,6 +32,7 @@ import { ServerConnection } from './plus/gk/serverConnection';
 import { SubscriptionService } from './plus/gk/subscriptionService';
 import { GraphStatusBarController } from './plus/graph/statusbar';
 import type { CloudIntegrationService } from './plus/integrations/authentication/cloudIntegrationService';
+import { ConfiguredIntegrationService } from './plus/integrations/authentication/configuredIntegrationService';
 import { IntegrationAuthenticationService } from './plus/integrations/authentication/integrationAuthenticationService';
 import { IntegrationService } from './plus/integrations/integrationService';
 import type { GitHubApi } from './plus/integrations/providers/github/github';
@@ -532,8 +533,12 @@ export class Container {
 	private _integrations: IntegrationService | undefined;
 	get integrations(): IntegrationService {
 		if (this._integrations == null) {
-			const authService = new IntegrationAuthenticationService(this);
-			this._disposables.push(authService, (this._integrations = new IntegrationService(this, authService)));
+			const configuredIntegrationService = new ConfiguredIntegrationService(this);
+			const authService = new IntegrationAuthenticationService(this, configuredIntegrationService);
+			this._disposables.push(
+				authService,
+				(this._integrations = new IntegrationService(this, authService, configuredIntegrationService)),
+			);
 		}
 		return this._integrations;
 	}

--- a/src/env/node/git/sub-providers/remotes.ts
+++ b/src/env/node/git/sub-providers/remotes.ts
@@ -40,7 +40,7 @@ export class RemotesGitSubProvider extends RemotesGitProviderBase implements Git
 			async function load(this: RemotesGitSubProvider): Promise<GitRemote[]> {
 				const providers = loadRemoteProviders(
 					configuration.get('remotes', this.container.git.getRepository(repoPath!)?.folder?.uri ?? null),
-					this.container.integrations.getConfiguredIntegrationDescriptors(),
+					await this.container.integrations.getConfigured(),
 				);
 
 				try {
@@ -49,7 +49,7 @@ export class RemotesGitSubProvider extends RemotesGitProviderBase implements Git
 						this.container,
 						data,
 						repoPath!,
-						getRemoteProviderMatcher(this.container, providers),
+						await getRemoteProviderMatcher(this.container, providers),
 					);
 					return remotes;
 				} catch (ex) {

--- a/src/git/parsers/remoteParser.ts
+++ b/src/git/parsers/remoteParser.ts
@@ -10,7 +10,7 @@ export function parseGitRemotes(
 	container: Container,
 	data: string,
 	repoPath: string,
-	remoteProviderMatcher: ReturnType<typeof getRemoteProviderMatcher>,
+	remoteProviderMatcher: Awaited<ReturnType<typeof getRemoteProviderMatcher>>,
 ): GitRemote[] {
 	using sw = maybeStopWatch(`Git.parseRemotes(${repoPath})`, { log: false, logLevel: 'debug' });
 	if (!data) return [];

--- a/src/git/remotes/remoteProviders.ts
+++ b/src/git/remotes/remoteProviders.ts
@@ -167,14 +167,14 @@ function getCustomProviderCreator(cfg: RemotesConfig) {
 	}
 }
 
-export function getRemoteProviderMatcher(
+export async function getRemoteProviderMatcher(
 	container: Container,
 	providers?: RemoteProviders,
-): (url: string, domain: string, path: string) => RemoteProvider | undefined {
+): Promise<(url: string, domain: string, path: string) => RemoteProvider | undefined> {
 	if (providers == null) {
 		providers = loadRemoteProviders(
 			configuration.get('remotes', null),
-			container.integrations.getConfiguredIntegrationDescriptors(),
+			await container.integrations.getConfigured(),
 		);
 	}
 

--- a/src/plus/drafts/draftsService.ts
+++ b/src/plus/drafts/draftsService.ts
@@ -729,7 +729,7 @@ export class DraftService implements Disposable {
 		} else if (data.provider?.repoName != null) {
 			name = data.provider.repoName;
 		} else if (data.remote?.url != null && data.remote?.domain != null && data.remote?.path != null) {
-			const matcher = getRemoteProviderMatcher(this.container);
+			const matcher = await getRemoteProviderMatcher(this.container);
 			const provider = matcher(data.remote.url, data.remote.domain, data.remote.path);
 			name = provider?.repoName ?? data.remote.path;
 		} else {

--- a/src/plus/gk/utils/-webview/integrationAuthentication.utils.ts
+++ b/src/plus/gk/utils/-webview/integrationAuthentication.utils.ts
@@ -29,6 +29,7 @@ export const getBuiltInIntegrationSession = sequentialize(
 				return {
 					...session,
 					cloud: false,
+					domain: descriptor.domain,
 				};
 			},
 		),

--- a/src/plus/integrations/authentication/azureDevOps.ts
+++ b/src/plus/integrations/authentication/azureDevOps.ts
@@ -12,9 +12,9 @@ export class AzureDevOpsAuthenticationProvider extends LocalIntegrationAuthentic
 	}
 
 	override async createSession(
-		descriptor?: IntegrationAuthenticationSessionDescriptor,
+		descriptor: IntegrationAuthenticationSessionDescriptor,
 	): Promise<ProviderAuthenticationSession | undefined> {
-		let azureOrganization: string | undefined = descriptor?.organization as string | undefined;
+		let azureOrganization: string | undefined = descriptor.organization as string | undefined;
 		if (!azureOrganization) {
 			const orgInput = window.createInputBox();
 			orgInput.ignoreFocusOut = true;
@@ -35,9 +35,7 @@ export class AzureDevOpsAuthenticationProvider extends LocalIntegrationAuthentic
 						}),
 					);
 
-					orgInput.title = `Azure DevOps Authentication${
-						descriptor?.domain ? `  \u2022 ${descriptor.domain}` : ''
-					}`;
+					orgInput.title = `Azure DevOps Authentication  \u2022 ${descriptor.domain}`;
 					orgInput.placeholder = 'Organization';
 					orgInput.prompt = 'Enter your Azure DevOps organization';
 					orgInput.show();
@@ -78,24 +76,16 @@ export class AzureDevOpsAuthenticationProvider extends LocalIntegrationAuthentic
 					tokenInput.onDidTriggerButton(e => {
 						if (e === infoButton) {
 							void env.openExternal(
-								Uri.parse(
-									`https://${
-										descriptor?.domain ?? 'dev.azure.com'
-									}/${azureOrganization}/_usersSettings/tokens`,
-								),
+								Uri.parse(`https://${descriptor.domain}/${azureOrganization}/_usersSettings/tokens`),
 							);
 						}
 					}),
 				);
 
 				tokenInput.password = true;
-				tokenInput.title = `Azure DevOps Authentication${
-					descriptor?.domain ? `  \u2022 ${descriptor.domain}` : ''
-				}`;
-				tokenInput.placeholder = `Requires ${descriptor?.scopes.join(', ') ?? 'all'} scopes`;
-				tokenInput.prompt = `Paste your [Azure DevOps Personal Access Token](https://${
-					descriptor?.domain ?? 'dev.azure.com'
-				}/${azureOrganization}/_usersSettings/tokens "Get your Azure DevOps Access Token")`;
+				tokenInput.title = `Azure DevOps Authentication  \u2022 ${descriptor.domain}`;
+				tokenInput.placeholder = `Requires ${descriptor.scopes.join(', ') ?? 'all'} scopes`;
+				tokenInput.prompt = `Paste your [Azure DevOps Personal Access Token](https://${descriptor.domain}/${azureOrganization}/_usersSettings/tokens "Get your Azure DevOps Access Token")`;
 				tokenInput.buttons = [infoButton];
 
 				tokenInput.show();
@@ -108,14 +98,15 @@ export class AzureDevOpsAuthenticationProvider extends LocalIntegrationAuthentic
 		if (!token) return undefined;
 
 		return {
-			id: this.getSessionId(descriptor),
+			id: this.configuredIntegrationService.getSessionId(descriptor),
 			accessToken: base64(`:${token}`),
-			scopes: descriptor?.scopes ?? [],
+			scopes: descriptor.scopes,
 			account: {
 				id: '',
 				label: '',
 			},
 			cloud: false,
+			domain: descriptor.domain,
 		};
 	}
 }

--- a/src/plus/integrations/authentication/bitbucket.ts
+++ b/src/plus/integrations/authentication/bitbucket.ts
@@ -12,9 +12,9 @@ export class BitbucketAuthenticationProvider extends LocalIntegrationAuthenticat
 	}
 
 	override async createSession(
-		descriptor?: IntegrationAuthenticationSessionDescriptor,
+		descriptor: IntegrationAuthenticationSessionDescriptor,
 	): Promise<ProviderAuthenticationSession | undefined> {
-		let bitbucketUsername: string | undefined = descriptor?.username as string | undefined;
+		let bitbucketUsername: string | undefined = descriptor.username as string | undefined;
 		if (!bitbucketUsername) {
 			const infoButton: QuickInputButton = {
 				iconPath: new ThemeIcon(`link-external`),
@@ -40,20 +40,14 @@ export class BitbucketAuthenticationProvider extends LocalIntegrationAuthenticat
 						}),
 						usernameInput.onDidTriggerButton(e => {
 							if (e === infoButton) {
-								void env.openExternal(
-									Uri.parse(`https://${descriptor?.domain ?? 'bitbucket.org'}/account/settings/`),
-								);
+								void env.openExternal(Uri.parse(`https://${descriptor.domain}/account/settings/`));
 							}
 						}),
 					);
 
-					usernameInput.title = `Bitbucket Authentication${
-						descriptor?.domain ? `  \u2022 ${descriptor.domain}` : ''
-					}`;
+					usernameInput.title = `Bitbucket Authentication  \u2022 ${descriptor.domain}`;
 					usernameInput.placeholder = 'Username';
-					usernameInput.prompt = `Enter your [Bitbucket Username](https://${
-						descriptor?.domain ?? 'bitbucket.org'
-					}/account/settings/ "Get your Bitbucket App Password")`;
+					usernameInput.prompt = `Enter your [Bitbucket Username](https://${descriptor.domain}/account/settings/ "Get your Bitbucket App Password")`;
 					usernameInput.show();
 				});
 			} finally {
@@ -92,22 +86,16 @@ export class BitbucketAuthenticationProvider extends LocalIntegrationAuthenticat
 					appPasswordInput.onDidTriggerButton(e => {
 						if (e === infoButton) {
 							void env.openExternal(
-								Uri.parse(
-									`https://${descriptor?.domain ?? 'bitbucket.org'}/account/settings/app-passwords/`,
-								),
+								Uri.parse(`https://${descriptor.domain}/account/settings/app-passwords/`),
 							);
 						}
 					}),
 				);
 
 				appPasswordInput.password = true;
-				appPasswordInput.title = `Bitbucket Authentication${
-					descriptor?.domain ? `  \u2022 ${descriptor.domain}` : ''
-				}`;
-				appPasswordInput.placeholder = `Requires ${descriptor?.scopes.join(', ') ?? 'all'} scopes`;
-				appPasswordInput.prompt = `Paste your [Bitbucket App Password](https://${
-					descriptor?.domain ?? 'bitbucket.org'
-				}/account/settings/app-passwords/ "Get your Bitbucket App Password")`;
+				appPasswordInput.title = `Bitbucket Authentication  \u2022 ${descriptor.domain}`;
+				appPasswordInput.placeholder = `Requires ${descriptor.scopes.join(', ')} scopes`;
+				appPasswordInput.prompt = `Paste your [Bitbucket App Password](https://${descriptor.domain}/account/settings/app-passwords/ "Get your Bitbucket App Password")`;
 				appPasswordInput.buttons = [infoButton];
 
 				appPasswordInput.show();
@@ -120,14 +108,15 @@ export class BitbucketAuthenticationProvider extends LocalIntegrationAuthenticat
 		if (!appPassword) return undefined;
 
 		return {
-			id: this.getSessionId(descriptor),
+			id: this.configuredIntegrationService.getSessionId(descriptor),
 			accessToken: base64(`${bitbucketUsername}:${appPassword}`),
-			scopes: descriptor?.scopes ?? [],
+			scopes: descriptor.scopes,
 			account: {
 				id: '',
 				label: '',
 			},
 			cloud: false,
+			domain: descriptor.domain,
 		};
 	}
 }

--- a/src/plus/integrations/authentication/configuredIntegrationService.ts
+++ b/src/plus/integrations/authentication/configuredIntegrationService.ts
@@ -1,0 +1,370 @@
+import type { IntegrationId } from '../../../constants.integrations';
+import { HostingIntegrationId } from '../../../constants.integrations';
+import type { StoredConfiguredIntegrationDescriptor } from '../../../constants.storage';
+import type { Container } from '../../../container';
+import { flatten } from '../../../system/iterable';
+import { getBuiltInIntegrationSession } from '../../gk/utils/-webview/integrationAuthentication.utils';
+import { isSelfHostedIntegrationId, providersMetadata } from '../providers/models';
+import type { IntegrationAuthenticationSessionDescriptor } from './integrationAuthenticationProvider';
+import type { ConfiguredIntegrationDescriptor, ProviderAuthenticationSession } from './models';
+
+interface StoredSession {
+	id: string;
+	accessToken: string;
+	account?: {
+		label?: string;
+		displayName?: string;
+		id: string;
+	};
+	scopes: string[];
+	cloud?: boolean;
+	expiresAt?: string;
+	domain?: string;
+}
+
+export type ConfiguredIntegrationType = 'cloud' | 'local';
+
+export class ConfiguredIntegrationService {
+	private _configured?: Map<IntegrationId, ConfiguredIntegrationDescriptor[]>;
+
+	constructor(private readonly container: Container) {}
+
+	private get configured(): Map<IntegrationId, ConfiguredIntegrationDescriptor[]> {
+		if (this._configured == null) {
+			this._configured = new Map();
+			const storedConfigured = this.container.storage.get('integrations:configured');
+			for (const [id, configured] of Object.entries(storedConfigured ?? {})) {
+				if (configured == null) continue;
+				const descriptors = configured.map(d => ({
+					...d,
+					expiresAt: d.expiresAt ? new Date(d.expiresAt) : undefined,
+				}));
+				this._configured.set(id as IntegrationId, descriptors);
+			}
+		}
+
+		return this._configured;
+	}
+
+	// async because we do the heavy work of checking authentication api for your vscode GitHub session
+	async getConfigured(options?: {
+		id?: IntegrationId;
+		domain?: string;
+		type?: ConfiguredIntegrationType;
+	}): Promise<ConfiguredIntegrationDescriptor[]> {
+		const descriptors: ConfiguredIntegrationDescriptor[] = [];
+		const configured =
+			options?.id != null
+				? this.configured.get(options.id)
+				: [...flatten<ConfiguredIntegrationDescriptor>(this.configured.values())];
+
+		if (configured != null && (options?.domain != null || options?.type != null)) {
+			for (const descriptor of configured) {
+				if (options?.domain != null && descriptor.domain !== options.domain) continue;
+				if (options?.type === 'cloud' && !descriptor.cloud) continue;
+				if (options?.type === 'local' && descriptor.cloud) continue;
+				descriptors.push(descriptor);
+			}
+		} else {
+			descriptors.push(...(configured ?? []));
+		}
+
+		// If we don't have a cloud config for GitHub, include a descriptor for the built-in VS Code session of GitHub even though we don't store it
+		if (
+			(options?.id == null || options.id === HostingIntegrationId.GitHub) &&
+			options?.type !== 'cloud' &&
+			!this.configured.get(HostingIntegrationId.GitHub)
+		) {
+			const vscodeSession = await getBuiltInIntegrationSession(
+				this.container,
+				HostingIntegrationId.GitHub,
+				{
+					domain: providersMetadata[HostingIntegrationId.GitHub].domain,
+					scopes: providersMetadata[HostingIntegrationId.GitHub].scopes,
+				},
+				{ silent: true },
+			);
+
+			if (vscodeSession != null) {
+				descriptors.push({
+					integrationId: HostingIntegrationId.GitHub,
+					domain: undefined,
+					expiresAt: vscodeSession.expiresAt,
+					scopes: providersMetadata[HostingIntegrationId.GitHub].scopes.join(','),
+					cloud: false,
+				});
+			}
+		}
+
+		return descriptors;
+	}
+
+	// getConfigured without the async check for the GitHub vscode session (which forces async and is a db hit)
+	getConfiguredLite(options?: {
+		id?: IntegrationId;
+		domain?: string;
+		type?: ConfiguredIntegrationType;
+	}): ConfiguredIntegrationDescriptor[] {
+		const descriptors: ConfiguredIntegrationDescriptor[] = [];
+
+		const configured =
+			options?.id != null
+				? this.configured.get(options.id)
+				: [...flatten<ConfiguredIntegrationDescriptor>(this.configured.values())];
+		if (configured == null) return descriptors;
+
+		if (options?.domain != null || options?.type != null) {
+			for (const descriptor of configured) {
+				if (options?.domain != null && descriptor.domain !== options.domain) continue;
+				if (options?.type === 'cloud' && !descriptor.cloud) continue;
+				if (options?.type === 'local' && descriptor.cloud) continue;
+				descriptors.push(descriptor);
+			}
+		} else {
+			descriptors.push(...configured);
+		}
+
+		return descriptors;
+	}
+
+	private async storeConfigured(): Promise<void> {
+		// We need to convert the map to a record to store
+		const configured: Record<string, StoredConfiguredIntegrationDescriptor[]> = {};
+		for (const [id, descriptors] of this.configured) {
+			configured[id] = descriptors.map(d => ({
+				...d,
+				expiresAt: d.expiresAt
+					? d.expiresAt instanceof Date
+						? d.expiresAt.toISOString()
+						: d.expiresAt
+					: undefined,
+			}));
+		}
+
+		await this.container.storage.store('integrations:configured', configured);
+	}
+
+	private async addConfigured(descriptor: ConfiguredIntegrationDescriptor): Promise<void> {
+		const descriptors = this.configured.get(descriptor.integrationId) ?? [];
+		const existing = descriptors.find(
+			d =>
+				d.domain === descriptor.domain &&
+				d.integrationId === descriptor.integrationId &&
+				d.cloud === descriptor.cloud,
+		);
+
+		if (existing != null) {
+			if (existing.expiresAt === descriptor.expiresAt && existing.scopes === descriptor.scopes) {
+				return;
+			}
+
+			//remove the existing descriptor from the array
+			const index = descriptors.indexOf(existing);
+			descriptors.splice(index, 1);
+		}
+
+		descriptors.push(descriptor);
+		this.configured.set(descriptor.integrationId, descriptors);
+		await this.storeConfigured();
+	}
+
+	private async removeConfigured(
+		id: IntegrationId,
+		options?: { domain?: string; type?: ConfiguredIntegrationType },
+	): Promise<void> {
+		const descriptors = this.configured
+			.get(id)
+			?.filter(d =>
+				options?.type === 'cloud'
+					? !(d.cloud === true && d.domain === options?.domain)
+					: options?.type === 'local'
+					  ? !(d.cloud === false && d.domain === options?.domain)
+					  : d.domain !== options?.domain,
+			);
+
+		if (descriptors != null && descriptors.length === 0) {
+			this.configured.delete(id);
+		}
+
+		this.configured.set(id, descriptors ?? []);
+		await this.storeConfigured();
+	}
+
+	async storeSession(id: IntegrationId, session: ProviderAuthenticationSession): Promise<void> {
+		await this.writeSecret(id, session);
+	}
+
+	async getStoredSession(
+		id: IntegrationId,
+		descriptor: IntegrationAuthenticationSessionDescriptor,
+		type: ConfiguredIntegrationType = 'local',
+	): Promise<ProviderAuthenticationSession | undefined> {
+		const sessionId = this.getSessionId(descriptor);
+		let session = await this.readSecret(id, sessionId, 'local');
+		if (type !== 'cloud') return convertStoredSessionToSession(session, descriptor, false);
+
+		let cloudIfMissing = false;
+		if (session != null) {
+			// Check the `expiresAt` field
+			// If it has an expiresAt property and the key is the old type, then it's a cloud session,
+			// so delete it from the local key and
+			// store with the "cloud" type key, and then use that one.
+			// Otherwise it's a local session under the local key, so just return it.
+			if (session.expiresAt != null) {
+				cloudIfMissing = true;
+				await Promise.allSettled([this.deleteSecrets(id, session.id), this.writeSecret(id, session)]);
+			}
+		}
+
+		// If no local session we try to restore a session with the cloud key
+		if (session == null) {
+			cloudIfMissing = true;
+			session = await this.readSecret(id, sessionId, 'cloud');
+		}
+
+		return convertStoredSessionToSession(session, descriptor, cloudIfMissing);
+	}
+
+	async deleteStoredSessions(
+		id: IntegrationId,
+		descriptor: IntegrationAuthenticationSessionDescriptor,
+		type?: ConfiguredIntegrationType,
+	): Promise<void> {
+		await this.deleteSecrets(id, this.getSessionId(descriptor), type);
+	}
+
+	async deleteAllStoredSessions(id: IntegrationId, type?: ConfiguredIntegrationType): Promise<void> {
+		await this.deleteAllSecrets(id, type);
+	}
+
+	async deleteSecrets(id: IntegrationId, sessionId: string, type?: ConfiguredIntegrationType): Promise<void> {
+		if (type == null || type === 'local') {
+			await this.container.storage.deleteSecret(this.getLocalSecretKey(id, sessionId));
+		}
+
+		if (type == null || type === 'cloud') {
+			await this.container.storage.deleteSecret(this.getCloudSecretKey(id, sessionId));
+		}
+
+		await this.removeConfigured(id, {
+			domain: isSelfHostedIntegrationId(id) ? sessionId : undefined,
+			type: type,
+		});
+	}
+
+	async deleteAllSecrets(id: IntegrationId, type?: ConfiguredIntegrationType): Promise<void> {
+		if (isSelfHostedIntegrationId(id)) {
+			// Hack because session IDs are tied to domain. Update this when session ids are different
+			const configuredDomains = this.configured.get(id)?.map(c => c.domain);
+			if (configuredDomains != null) {
+				for (const domain of configuredDomains) {
+					await this.deleteSecrets(id, domain!, type);
+				}
+			}
+
+			return;
+		}
+
+		await this.deleteSecrets(id, providersMetadata[id].domain, type);
+	}
+
+	async writeSecret(id: IntegrationId, session: ProviderAuthenticationSession | StoredSession): Promise<void> {
+		await this.container.storage.storeSecret(
+			this.getSecretKey(id, session.id, session.cloud ? 'cloud' : 'local'),
+			JSON.stringify(session),
+		);
+
+		await this.addConfigured({
+			integrationId: id,
+			domain: isSelfHostedIntegrationId(id) ? session.domain : undefined,
+			expiresAt: session.expiresAt,
+			scopes: session.scopes.join(','),
+			cloud: session.cloud ?? false,
+		});
+	}
+
+	async readSecret(
+		id: IntegrationId,
+		sessionId: string,
+		type: ConfiguredIntegrationType = 'local',
+	): Promise<StoredSession | undefined> {
+		let storedSession: StoredSession | undefined;
+		try {
+			const sessionJSON = await this.container.storage.getSecret(this.getSecretKey(id, sessionId, type));
+			if (sessionJSON) {
+				storedSession = JSON.parse(sessionJSON);
+				if (storedSession != null) {
+					const configured = this.configured.get(id);
+					const domain = isSelfHostedIntegrationId(id) ? storedSession.id : undefined;
+					if (
+						configured == null ||
+						configured.length === 0 ||
+						!configured.some(c => c.domain === domain && c.integrationId === id)
+					) {
+						await this.addConfigured({
+							integrationId: id,
+							domain: domain,
+							expiresAt: storedSession.expiresAt,
+							scopes: storedSession.scopes.join(','),
+							cloud: storedSession.cloud ?? false,
+						});
+					}
+				}
+			}
+		} catch (_ex) {
+			try {
+				await this.deleteSecrets(id, sessionId, type);
+			} catch {}
+		}
+		return storedSession;
+	}
+
+	private getSecretKey(
+		id: IntegrationId,
+		sessionId: string,
+		type: ConfiguredIntegrationType = 'local',
+	):
+		| `gitlens.integration.auth:${IntegrationId}|${string}`
+		| `gitlens.integration.auth.cloud:${IntegrationId}|${string}` {
+		return type === 'cloud' ? this.getCloudSecretKey(id, sessionId) : this.getLocalSecretKey(id, sessionId);
+	}
+
+	private getLocalSecretKey(
+		id: IntegrationId,
+		sessionId: string,
+	): `gitlens.integration.auth:${IntegrationId}|${string}` {
+		return `gitlens.integration.auth:${id}|${sessionId}`;
+	}
+
+	private getCloudSecretKey(
+		id: IntegrationId,
+		sessionId: string,
+	): `gitlens.integration.auth.cloud:${IntegrationId}|${string}` {
+		return `gitlens.integration.auth.cloud:${id}|${sessionId}`;
+	}
+
+	getSessionId(descriptor: IntegrationAuthenticationSessionDescriptor): string {
+		return descriptor.domain;
+	}
+}
+
+function convertStoredSessionToSession(
+	storedSession: StoredSession | undefined,
+	descriptor: IntegrationAuthenticationSessionDescriptor,
+	cloudIfMissing: boolean,
+): ProviderAuthenticationSession | undefined {
+	if (storedSession == null) return undefined;
+
+	return {
+		id: storedSession.id,
+		accessToken: storedSession.accessToken,
+		account: {
+			id: storedSession.account?.id ?? '',
+			label: storedSession.account?.label ?? '',
+		},
+		scopes: storedSession.scopes,
+		cloud: storedSession.cloud ?? cloudIfMissing,
+		expiresAt: storedSession.expiresAt ? new Date(storedSession.expiresAt) : undefined,
+		domain: storedSession.domain ?? descriptor.domain,
+	};
+}

--- a/src/plus/integrations/authentication/integrationAuthenticationService.ts
+++ b/src/plus/integrations/authentication/integrationAuthenticationService.ts
@@ -1,86 +1,26 @@
 import type { Disposable } from 'vscode';
 import type { IntegrationId } from '../../../constants.integrations';
 import { HostingIntegrationId, IssueIntegrationId, SelfHostedIntegrationId } from '../../../constants.integrations';
-import type { StoredConfiguredIntegrationDescriptor } from '../../../constants.storage';
 import type { Container } from '../../../container';
 import { gate } from '../../../system/decorators/-webview/gate';
 import { log } from '../../../system/decorators/log';
 import { supportedIntegrationIds } from '../providers/models';
+import type { ConfiguredIntegrationService } from './configuredIntegrationService';
 import type { IntegrationAuthenticationProvider } from './integrationAuthenticationProvider';
 import { BuiltInAuthenticationProvider } from './integrationAuthenticationProvider';
-import type { ConfiguredIntegrationDescriptor } from './models';
 import { isSupportedCloudIntegrationId } from './models';
 
 export class IntegrationAuthenticationService implements Disposable {
 	private readonly providers = new Map<IntegrationId, IntegrationAuthenticationProvider>();
-	private _configured?: Map<IntegrationId, ConfiguredIntegrationDescriptor[]>;
 
-	constructor(private readonly container: Container) {}
+	constructor(
+		private readonly container: Container,
+		private readonly configuredIntegrationService: ConfiguredIntegrationService,
+	) {}
 
 	dispose(): void {
 		this.providers.forEach(p => void p.dispose());
 		this.providers.clear();
-	}
-
-	get configured(): Map<IntegrationId, ConfiguredIntegrationDescriptor[]> {
-		if (this._configured == null) {
-			this._configured = new Map();
-			const storedConfigured = this.container.storage.get('integrations:configured');
-			for (const [id, configured] of Object.entries(storedConfigured ?? {})) {
-				if (configured == null) continue;
-				const descriptors = configured.map(d => ({
-					...d,
-					expiresAt: d.expiresAt ? new Date(d.expiresAt) : undefined,
-				}));
-				this._configured.set(id as IntegrationId, descriptors);
-			}
-		}
-
-		return this._configured;
-	}
-
-	private async storeConfigured() {
-		// We need to convert the map to a record to store
-		const configured: Record<string, StoredConfiguredIntegrationDescriptor[]> = {};
-		for (const [id, descriptors] of this.configured) {
-			configured[id] = descriptors.map(d => ({
-				...d,
-				expiresAt: d.expiresAt
-					? d.expiresAt instanceof Date
-						? d.expiresAt.toISOString()
-						: d.expiresAt
-					: undefined,
-			}));
-		}
-
-		await this.container.storage.store('integrations:configured', configured);
-	}
-
-	async addConfigured(descriptor: ConfiguredIntegrationDescriptor): Promise<void> {
-		const descriptors = this.configured.get(descriptor.integrationId) ?? [];
-		// Only add if one does not exist
-		if (descriptors.some(d => d.domain === descriptor.domain && d.integrationId === descriptor.integrationId)) {
-			return;
-		}
-		descriptors.push(descriptor);
-		this.configured.set(descriptor.integrationId, descriptors);
-		await this.storeConfigured();
-	}
-
-	async removeConfigured(
-		descriptor: Pick<ConfiguredIntegrationDescriptor, 'integrationId' | 'domain'>,
-	): Promise<void> {
-		const descriptors = this.configured.get(descriptor.integrationId);
-		if (descriptors == null) return;
-		const index = descriptors.findIndex(
-			d => d.domain === descriptor.domain && d.integrationId === descriptor.integrationId,
-		);
-		if (index === -1) return;
-
-		descriptors.splice(index, 1);
-		this.configured.set(descriptor.integrationId, descriptors);
-
-		await this.storeConfigured();
 	}
 
 	async get(providerId: IntegrationId): Promise<IntegrationAuthenticationProvider> {
@@ -91,7 +31,9 @@ export class IntegrationAuthenticationService implements Disposable {
 	async reset(): Promise<void> {
 		// TODO: This really isn't ideal, since it will only work for "cloud" providers as we won't have any more specific descriptors
 		await Promise.allSettled(
-			supportedIntegrationIds.map(async providerId => (await this.ensureProvider(providerId)).deleteSession()),
+			supportedIntegrationIds.map(async providerId =>
+				(await this.ensureProvider(providerId)).deleteAllSessions(),
+			),
 		);
 	}
 
@@ -119,57 +61,85 @@ export class IntegrationAuthenticationService implements Disposable {
 				case HostingIntegrationId.AzureDevOps:
 					provider = new (
 						await import(/* webpackChunkName: "integrations" */ './azureDevOps')
-					).AzureDevOpsAuthenticationProvider(this.container, this);
+					).AzureDevOpsAuthenticationProvider(this.container, this, this.configuredIntegrationService);
 					break;
 				case HostingIntegrationId.Bitbucket:
 					provider = new (
 						await import(/* webpackChunkName: "integrations" */ './bitbucket')
-					).BitbucketAuthenticationProvider(this.container, this);
+					).BitbucketAuthenticationProvider(this.container, this, this.configuredIntegrationService);
 					break;
 				case HostingIntegrationId.GitHub:
 					provider = isSupportedCloudIntegrationId(HostingIntegrationId.GitHub)
 						? new (
 								await import(/* webpackChunkName: "integrations" */ './github')
-						  ).GitHubAuthenticationProvider(this.container, this)
-						: new BuiltInAuthenticationProvider(this.container, this, providerId);
+						  ).GitHubAuthenticationProvider(this.container, this, this.configuredIntegrationService)
+						: new BuiltInAuthenticationProvider(
+								this.container,
+								this,
+								this.configuredIntegrationService,
+								providerId,
+						  );
 
 					break;
 				case SelfHostedIntegrationId.CloudGitHubEnterprise:
 					provider = new (
 						await import(/* webpackChunkName: "integrations" */ './github')
-					).GitHubEnterpriseCloudAuthenticationProvider(this.container, this);
+					).GitHubEnterpriseCloudAuthenticationProvider(
+						this.container,
+						this,
+						this.configuredIntegrationService,
+					);
 					break;
 				case SelfHostedIntegrationId.GitHubEnterprise:
 					provider = new (
 						await import(/* webpackChunkName: "integrations" */ './github')
-					).GitHubEnterpriseAuthenticationProvider(this.container, this);
+					).GitHubEnterpriseAuthenticationProvider(this.container, this, this.configuredIntegrationService);
 					break;
 				case HostingIntegrationId.GitLab:
 					provider = isSupportedCloudIntegrationId(HostingIntegrationId.GitLab)
 						? new (
 								await import(/* webpackChunkName: "integrations" */ './gitlab')
-						  ).GitLabCloudAuthenticationProvider(this.container, this)
+						  ).GitLabCloudAuthenticationProvider(this.container, this, this.configuredIntegrationService)
 						: new (
 								await import(/* webpackChunkName: "integrations" */ './gitlab')
-						  ).GitLabLocalAuthenticationProvider(this.container, this, HostingIntegrationId.GitLab);
+						  ).GitLabLocalAuthenticationProvider(
+								this.container,
+								this,
+								this.configuredIntegrationService,
+								HostingIntegrationId.GitLab,
+						  );
 					break;
 				case SelfHostedIntegrationId.CloudGitLabSelfHosted:
 					provider = new (
 						await import(/* webpackChunkName: "integrations" */ './gitlab')
-					).GitLabSelfHostedCloudAuthenticationProvider(this.container, this);
+					).GitLabSelfHostedCloudAuthenticationProvider(
+						this.container,
+						this,
+						this.configuredIntegrationService,
+					);
 					break;
 				case SelfHostedIntegrationId.GitLabSelfHosted:
 					provider = new (
 						await import(/* webpackChunkName: "integrations" */ './gitlab')
-					).GitLabLocalAuthenticationProvider(this.container, this, SelfHostedIntegrationId.GitLabSelfHosted);
+					).GitLabLocalAuthenticationProvider(
+						this.container,
+						this,
+						this.configuredIntegrationService,
+						SelfHostedIntegrationId.GitLabSelfHosted,
+					);
 					break;
 				case IssueIntegrationId.Jira:
 					provider = new (
 						await import(/* webpackChunkName: "integrations" */ './jira')
-					).JiraAuthenticationProvider(this.container, this);
+					).JiraAuthenticationProvider(this.container, this, this.configuredIntegrationService);
 					break;
 				default:
-					provider = new BuiltInAuthenticationProvider(this.container, this, providerId);
+					provider = new BuiltInAuthenticationProvider(
+						this.container,
+						this,
+						this.configuredIntegrationService,
+						providerId,
+					);
 			}
 			this.providers.set(providerId, provider);
 		}

--- a/src/plus/integrations/authentication/jira.ts
+++ b/src/plus/integrations/authentication/jira.ts
@@ -5,8 +5,4 @@ export class JiraAuthenticationProvider extends CloudIntegrationAuthenticationPr
 	protected override get authProviderId(): IssueIntegrationId.Jira {
 		return IssueIntegrationId.Jira;
 	}
-
-	protected override getCompletionInputTitle(): string {
-		return 'Connect to Jira';
-	}
 }

--- a/src/plus/integrations/authentication/models.ts
+++ b/src/plus/integrations/authentication/models.ts
@@ -12,14 +12,15 @@ import { configuration } from '../../../system/-webview/configuration';
 export interface ProviderAuthenticationSession extends AuthenticationSession {
 	readonly cloud: boolean;
 	readonly expiresAt?: Date;
+	readonly domain: string;
 }
 
 export interface ConfiguredIntegrationDescriptor {
 	readonly cloud: boolean;
 	readonly integrationId: IntegrationId;
+	readonly scopes: string;
 	readonly domain?: string;
 	readonly expiresAt?: string | Date;
-	readonly scopes: string;
 }
 
 export interface CloudIntegrationAuthenticationSession {

--- a/src/plus/integrations/providers/github/sub-providers/remotes.ts
+++ b/src/plus/integrations/providers/github/sub-providers/remotes.ts
@@ -7,7 +7,6 @@ import { log } from '../../../../../system/decorators/log';
 
 export class RemotesGitSubProvider extends RemotesGitProviderBase {
 	@log({ args: { 1: false } })
-	// eslint-disable-next-line @typescript-eslint/require-await
 	async getRemotes(
 		repoPath: string | undefined,
 		_options?: { filter?: (remote: GitRemote) => boolean; sort?: boolean },
@@ -31,7 +30,7 @@ export class RemotesGitSubProvider extends RemotesGitProviderBase {
 				'https',
 				domain,
 				path,
-				getRemoteProviderMatcher(this.container, providers)(url, domain, path),
+				(await getRemoteProviderMatcher(this.container, providers))(url, domain, path),
 				[
 					{ type: 'fetch', url: url },
 					{ type: 'push', url: url },

--- a/src/plus/integrations/providers/models.ts
+++ b/src/plus/integrations/providers/models.ts
@@ -53,7 +53,7 @@ import {
 } from '../../../git/models/pullRequest';
 import type { ProviderReference } from '../../../git/models/remoteProvider';
 import type { EnrichableItem } from '../../launchpad/models/enrichedItem';
-import type { Integration } from '../integration';
+import type { Integration, IntegrationType } from '../integration';
 import { getEntityIdentifierInput } from './utils';
 
 export type ProviderAccount = Account;
@@ -351,6 +351,9 @@ export interface ProviderInfo extends ProviderMetadata {
 export interface ProviderMetadata {
 	domain: string;
 	id: IntegrationId;
+	name: string;
+	type: IntegrationType;
+	iconKey: string;
 	issuesPagingMode?: PagingMode;
 	pullRequestsPagingMode?: PagingMode;
 	scopes: string[];
@@ -365,6 +368,9 @@ export const providersMetadata: ProvidersMetadata = {
 	[HostingIntegrationId.GitHub]: {
 		domain: 'github.com',
 		id: HostingIntegrationId.GitHub,
+		name: 'GitHub',
+		type: 'hosting',
+		iconKey: HostingIntegrationId.GitHub,
 		issuesPagingMode: PagingMode.Repos,
 		pullRequestsPagingMode: PagingMode.Repos,
 		// Use 'username' property on account for PR filters
@@ -381,6 +387,9 @@ export const providersMetadata: ProvidersMetadata = {
 	[SelfHostedIntegrationId.CloudGitHubEnterprise]: {
 		domain: '',
 		id: SelfHostedIntegrationId.CloudGitHubEnterprise,
+		name: 'GitHub Enterprise',
+		type: 'hosting',
+		iconKey: SelfHostedIntegrationId.GitHubEnterprise,
 		issuesPagingMode: PagingMode.Repos,
 		pullRequestsPagingMode: PagingMode.Repos,
 		// Use 'username' property on account for PR filters
@@ -397,6 +406,9 @@ export const providersMetadata: ProvidersMetadata = {
 	[SelfHostedIntegrationId.GitHubEnterprise]: {
 		domain: '',
 		id: SelfHostedIntegrationId.GitHubEnterprise,
+		name: 'GitHub Enterprise',
+		type: 'hosting',
+		iconKey: SelfHostedIntegrationId.GitHubEnterprise,
 		issuesPagingMode: PagingMode.Repos,
 		pullRequestsPagingMode: PagingMode.Repos,
 		// Use 'username' property on account for PR filters
@@ -413,6 +425,9 @@ export const providersMetadata: ProvidersMetadata = {
 	[HostingIntegrationId.GitLab]: {
 		domain: 'gitlab.com',
 		id: HostingIntegrationId.GitLab,
+		name: 'GitLab',
+		type: 'hosting',
+		iconKey: HostingIntegrationId.GitLab,
 		issuesPagingMode: PagingMode.Repo,
 		pullRequestsPagingMode: PagingMode.Repo,
 		// Use 'username' property on account for PR filters
@@ -428,6 +443,9 @@ export const providersMetadata: ProvidersMetadata = {
 	[SelfHostedIntegrationId.CloudGitLabSelfHosted]: {
 		domain: '',
 		id: SelfHostedIntegrationId.CloudGitLabSelfHosted,
+		name: 'Self-Hosted',
+		type: 'hosting',
+		iconKey: SelfHostedIntegrationId.GitLabSelfHosted,
 		issuesPagingMode: PagingMode.Repo,
 		pullRequestsPagingMode: PagingMode.Repo,
 		// Use 'username' property on account for PR filters
@@ -443,6 +461,9 @@ export const providersMetadata: ProvidersMetadata = {
 	[SelfHostedIntegrationId.GitLabSelfHosted]: {
 		domain: '',
 		id: SelfHostedIntegrationId.GitLabSelfHosted,
+		name: 'Self-Hosted',
+		type: 'hosting',
+		iconKey: SelfHostedIntegrationId.GitLabSelfHosted,
 		issuesPagingMode: PagingMode.Repo,
 		pullRequestsPagingMode: PagingMode.Repo,
 		// Use 'username' property on account for PR filters
@@ -458,6 +479,9 @@ export const providersMetadata: ProvidersMetadata = {
 	[HostingIntegrationId.Bitbucket]: {
 		domain: 'bitbucket.org',
 		id: HostingIntegrationId.Bitbucket,
+		name: 'Bitbucket',
+		type: 'hosting',
+		iconKey: HostingIntegrationId.Bitbucket,
 		pullRequestsPagingMode: PagingMode.Repo,
 		// Use 'id' property on account for PR filters
 		supportedPullRequestFilters: [PullRequestFilter.Author],
@@ -466,6 +490,9 @@ export const providersMetadata: ProvidersMetadata = {
 	[HostingIntegrationId.AzureDevOps]: {
 		domain: 'dev.azure.com',
 		id: HostingIntegrationId.AzureDevOps,
+		name: 'Azure DevOps',
+		type: 'hosting',
+		iconKey: HostingIntegrationId.AzureDevOps,
 		issuesPagingMode: PagingMode.Project,
 		pullRequestsPagingMode: PagingMode.Repo,
 		// Use 'id' property on account for PR filters
@@ -477,6 +504,9 @@ export const providersMetadata: ProvidersMetadata = {
 	[IssueIntegrationId.Jira]: {
 		domain: 'atlassian.net',
 		id: IssueIntegrationId.Jira,
+		name: 'Jira',
+		type: 'issues',
+		iconKey: IssueIntegrationId.Jira,
 		scopes: [
 			'read:status:jira',
 			'read:application-role:jira',
@@ -518,6 +548,9 @@ export const providersMetadata: ProvidersMetadata = {
 	[IssueIntegrationId.Trello]: {
 		domain: 'trello.com',
 		id: IssueIntegrationId.Trello,
+		name: 'Trello',
+		type: 'issues',
+		iconKey: IssueIntegrationId.Trello,
 		scopes: [],
 	},
 };

--- a/src/plus/integrations/providers/providersApi.ts
+++ b/src/plus/integrations/providers/providersApi.ts
@@ -300,10 +300,7 @@ export class ProvidersApi {
 		provider: ProviderInfo,
 		options?: { createSessionIfNeeded?: boolean },
 	): Promise<string | undefined> {
-		const providerDescriptor =
-			provider.domain == null || provider.scopes == null
-				? undefined
-				: { domain: provider.domain, scopes: provider.scopes };
+		const providerDescriptor = { domain: provider.domain, scopes: provider.scopes };
 		try {
 			const authProvider = await this.authenticationService.get(provider.id);
 			return (


### PR DESCRIPTION
Major refactor (and fix to Home View integration states) that does the following:
 - Creates a new configuredIntegrationService
 - Moves all management of stored integration configurations as well as stored integration authentication sessions to the new service
 - Renames functions across auth providers and the new service to be clearer, and simplifies logic on the integration authentication providers where possible
 - Adds domain property to integration auth sessions
 - Removes redundant code that isn't used, and makes a session descriptor required when interacting with an auth provider
- Updates home view to use the new service to get configured integrations

We will want this in before adding other cloud integrations into the mix, like Azure.
