### PR TITLE
Uses actual exec path as editor command

### DIFF
--- a/src/env/browser/execPath.ts
+++ b/src/env/browser/execPath.ts
@@ -1,0 +1,3 @@
+export function getExecPath(): string {
+	throw new Error('Cannot get exec path from webview context');
+}

--- a/src/env/node/execPath.ts
+++ b/src/env/node/execPath.ts
@@ -1,0 +1,32 @@
+import { resolve } from 'path';
+import { env } from 'vscode';
+import { getPlatform } from './platform';
+
+export function getExecPath(): string {
+	if (env.appHost !== 'desktop') {
+		throw new Error('Cannot get exec path for not desktop runtime');
+	}
+	switch (getPlatform()) {
+		case 'windows':
+			// tested with vscode portable (from zip) https://code.visualstudio.com/docs/editor/portable#_enable-portable-mode
+			return resolve(env.appRoot, '../../bin/code').replace(/\\/g, '/');
+		case 'linux':
+			return resolve(env.appRoot, '../../bin/code');
+		case 'macOS':
+			return resolve(env.appRoot, 'bin/code');
+		default:
+			break;
+	}
+	switch (env.appName) {
+		case 'Visual Studio Code - Insiders':
+			return 'code-insiders';
+		case 'Visual Studio Code - Exploration':
+			return 'code-exploration';
+		case 'VSCodium':
+			return 'codium';
+		case 'Cursor':
+			return 'cursor';
+		default:
+			return 'code';
+	}
+}

--- a/src/env/node/platform.ts
+++ b/src/env/node/platform.ts
@@ -9,7 +9,7 @@ export const isLinux = platform === 'linux';
 export const isMac = platform === 'darwin';
 export const isWindows = platform === 'win32';
 
-export function getPlatform(): string {
+export function getPlatform(): 'windows' | 'macOS' | 'linux' | 'web' | 'unknown' {
 	if (isWindows) return 'windows';
 	if (isMac) return 'macOS';
 	if (isLinux) return 'linux';

--- a/src/system/-webview/vscode.ts
+++ b/src/system/-webview/vscode.ts
@@ -8,6 +8,7 @@ import type {
 	WorkspaceFolder,
 } from 'vscode';
 import { version as codeVersion, ColorThemeKind, env, Uri, ViewColumn, window, workspace } from 'vscode';
+import { getExecPath } from '@env/execPath';
 import type { IconPath } from '../../@types/vscode.iconpath';
 import { imageMimetypes, Schemes, trackableSchemes } from '../../constants';
 import type { Container } from '../../container';
@@ -71,25 +72,8 @@ export function findOrOpenEditors(uris: Uri[], options?: TextDocumentShowOptions
 }
 
 export function getEditorCommand(): string {
-	let editor;
-	switch (env.appName) {
-		case 'Visual Studio Code - Insiders':
-			editor = 'code-insiders --wait --reuse-window';
-			break;
-		case 'Visual Studio Code - Exploration':
-			editor = 'code-exploration --wait --reuse-window';
-			break;
-		case 'VSCodium':
-			editor = 'codium --wait --reuse-window';
-			break;
-		case 'Cursor':
-			editor = 'cursor --wait --reuse-window';
-			break;
-		default:
-			editor = 'code --wait --reuse-window';
-			break;
-	}
-	return editor;
+	const escapedExecPath = getExecPath().replace(/([ ()])/gm, '\\$1');
+	return `${escapedExecPath} --wait --reuse-window`;
 }
 
 export function getEditorIfActive(document: TextDocument): TextEditor | undefined {


### PR DESCRIPTION
# Description

The interactive rebase is a native git feature that uses code or another similar target as an editor. If the editor is portable or there is no env path to the editor for some other reason, then git can not open it. To fix it we can use direct app path that can be resolved from `vscode.env.appRoot` and some minor redirection to `bin/code`.

For windows and linux it's solved by `../../bin/code`
For MacOS - `./bin/code`

# Checklist

<!-- Please check off the following -->

- [x] I have followed the guidelines in the Contributing document
- [x] My changes follow the coding style of this project
- [x] My changes build without any errors or warnings
- [x] My changes have been formatted and linted
- [x] My changes include any required corresponding changes to the documentation (including CHANGELOG.md and README.md)
- [x] My changes have been rebased and squashed to the minimal number (typically 1) of relevant commits
- [x] My changes have a descriptive commit message with a short title, including a `Fixes $XXX -` or `Closes #XXX -` prefix to auto-close the issue that your PR addresses
