### PR TITLE
4039 Launchpad view can cause an unwanted "add remote" prompt on load

### DIFF
--- a/contributions.json
+++ b/contributions.json
@@ -4804,6 +4804,11 @@
 				]
 			}
 		},
+		"gitlens.views.addPullRequestRemote": {
+			"label": "Add Pull Request Remote",
+			"icon": "$(add)",
+			"enablement": "!operationInProgress"
+		},
 		"gitlens.views.addRemote": {
 			"label": "Add Remote...",
 			"icon": "$(add)",

--- a/package.json
+++ b/package.json
@@ -7630,6 +7630,12 @@
 				"icon": "$(person-add)"
 			},
 			{
+				"command": "gitlens.views.addPullRequestRemote",
+				"title": "Add Pull Request Remote",
+				"icon": "$(add)",
+				"enablement": "!operationInProgress"
+			},
+			{
 				"command": "gitlens.views.addRemote",
 				"title": "Add Remote...",
 				"icon": "$(add)",
@@ -11328,6 +11334,10 @@
 				},
 				{
 					"command": "gitlens.views.addAuthors",
+					"when": "false"
+				},
+				{
+					"command": "gitlens.views.addPullRequestRemote",
 					"when": "false"
 				},
 				{

--- a/src/constants.commands.generated.ts
+++ b/src/constants.commands.generated.ts
@@ -176,6 +176,7 @@ export type ContributedCommands =
 	| 'gitlens.views.addAuthor'
 	| 'gitlens.views.addAuthor.multi'
 	| 'gitlens.views.addAuthors'
+	| 'gitlens.views.addPullRequestRemote'
 	| 'gitlens.views.addRemote'
 	| 'gitlens.views.applyChanges'
 	| 'gitlens.views.associateIssueWithBranch'

--- a/src/constants.commands.ts
+++ b/src/constants.commands.ts
@@ -182,6 +182,8 @@ type InternalPlusCommands =
 	| 'gitlens.plus.showPlans'
 	| 'gitlens.plus.validate';
 
+type InternalPullRequestViewCommands = 'gitlens.views.addPullRequestRemote';
+
 type InternalScmGroupedViewCommands =
 	| 'gitlens.views.scm.grouped.welcome.dismiss'
 	| 'gitlens.views.scm.grouped.welcome.restore';
@@ -221,6 +223,7 @@ type InternalGlCommands =
 	| InternalHomeWebviewViewCommands
 	| InternalLaunchPadCommands
 	| InternalPlusCommands
+	| InternalPullRequestViewCommands
 	| InternalScmGroupedViewCommands
 	| InternalSearchAndCompareViewCommands
 	| InternalTimelineWebviewViewCommands

--- a/src/views/nodes/common.ts
+++ b/src/views/nodes/common.ts
@@ -51,8 +51,10 @@ export class CommandMessageNode extends MessageNode {
 		description?: string,
 		tooltip?: string,
 		iconPath?: TreeItem['iconPath'],
+		contextValue?: string,
+		resourceUri?: Uri,
 	) {
-		super(view, parent, message, description, tooltip, iconPath);
+		super(view, parent, message, description, tooltip, iconPath, contextValue, resourceUri);
 	}
 
 	override getTreeItem(): TreeItem | Promise<TreeItem> {

--- a/src/views/nodes/pullRequestNode.ts
+++ b/src/views/nodes/pullRequestNode.ts
@@ -1,4 +1,5 @@
-import { MarkdownString, TreeItem, TreeItemCollapsibleState } from 'vscode';
+import { MarkdownString, ThemeColor, ThemeIcon, TreeItem, TreeItemCollapsibleState } from 'vscode';
+import type { Colors } from '../../constants.colors';
 import { GitUri } from '../../git/gitUri';
 import { GitBranch } from '../../git/models/branch';
 import type { GitCommit } from '../../git/models/commit';
@@ -20,6 +21,7 @@ import { createRevisionRange } from '../../git/utils/revision.utils';
 import { createCommand } from '../../system/-webview/command';
 import { pluralize } from '../../system/string';
 import type { ViewsWithCommits } from '../viewBase';
+import { createViewDecorationUri } from '../viewDecorationProvider';
 import { CacheableChildrenViewNode } from './abstract/cacheableChildrenViewNode';
 import type { ClipboardType, ViewNode } from './abstract/viewNode';
 import { ContextValues, getViewNodeId } from './abstract/viewNode';
@@ -180,7 +182,15 @@ export async function getPullRequestChildren(
 					pullRequest,
 					repo,
 				),
-				`Missing remote '${identity.provider.repoDomain}'. Click to add.`,
+				`Unable to find a remote for '${identity.provider.repoDomain}'`,
+				undefined,
+				`Click to add a remote for '${identity.provider.repoDomain}'`,
+				new ThemeIcon(
+					'question',
+					new ThemeColor('gitlens.decorations.workspaceRepoMissingForegroundColor' satisfies Colors),
+				),
+				undefined,
+				createViewDecorationUri('remote', { state: 'missing' }),
 			),
 		];
 	}

--- a/src/views/nodes/remoteNode.ts
+++ b/src/views/nodes/remoteNode.ts
@@ -130,7 +130,7 @@ export class RemoteNode extends ViewNode<'remote', ViewsWithRemotes> {
 		if (this.remote.default) {
 			item.contextValue += '+default';
 		}
-		item.resourceUri = createViewDecorationUri('remote', { default: this.remote.default });
+		item.resourceUri = createViewDecorationUri('remote', { state: this.remote.default ? 'default' : undefined });
 
 		for (const { type, url } of this.remote.urls) {
 			tooltip += `\\\n${url} (${type})`;

--- a/src/views/viewCommands.ts
+++ b/src/views/viewCommands.ts
@@ -22,7 +22,9 @@ import * as StashActions from '../git/actions/stash';
 import * as TagActions from '../git/actions/tag';
 import * as WorktreeActions from '../git/actions/worktree';
 import { GitUri } from '../git/gitUri';
+import type { PullRequest } from '../git/models/pullRequest';
 import { RemoteResourceType } from '../git/models/remoteResource';
+import type { Repository } from '../git/models/repository';
 import { deletedOrMissing } from '../git/models/revision';
 import {
 	ensurePullRequestRefs,
@@ -237,6 +239,8 @@ export class ViewCommands implements Disposable {
 			registerViewCommand('gitlens.views.addAuthors', this.addAuthors, this),
 			registerViewCommand('gitlens.views.addAuthor', this.addAuthor, this),
 			registerViewCommand('gitlens.views.addAuthor.multi', this.addAuthor, this, true),
+
+			registerViewCommand('gitlens.views.addPullRequestRemote', this.addPullRequestRemote, this),
 
 			registerViewCommand(
 				'gitlens.views.openBranchOnRemote',
@@ -479,6 +483,16 @@ export class ViewCommands implements Disposable {
 	@log()
 	private addRemote(node?: ViewNode) {
 		return RemoteActions.add(getNodeRepoPath(node));
+	}
+
+	@log()
+	private async addPullRequestRemote(node: ViewNode, pr: PullRequest, repo: Repository) {
+		const identity = getRepositoryIdentityForPullRequest(pr);
+		if (identity.remote?.url == null) return;
+		await repo.git
+			.remotes()
+			.addRemoteWithResult?.(identity.provider.repoDomain, identity.remote.url, { fetch: true });
+		return node.view.refreshNode(node, true);
 	}
 
 	@log()

--- a/src/views/viewCommands.ts
+++ b/src/views/viewCommands.ts
@@ -489,10 +489,9 @@ export class ViewCommands implements Disposable {
 	private async addPullRequestRemote(node: ViewNode, pr: PullRequest, repo: Repository) {
 		const identity = getRepositoryIdentityForPullRequest(pr);
 		if (identity.remote?.url == null) return;
-		await repo.git
-			.remotes()
-			.addRemoteWithResult?.(identity.provider.repoDomain, identity.remote.url, { fetch: true });
-		return node.view.refreshNode(node, true);
+
+		await repo.git.remotes().addRemote?.(identity.provider.repoDomain, identity.remote.url, { fetch: true });
+		return node.triggerChange(true);
 	}
 
 	@log()

--- a/src/views/viewDecorationProvider.ts
+++ b/src/views/viewDecorationProvider.ts
@@ -207,17 +207,25 @@ function getCommitFileStatusDecoration(uri: Uri, _token: CancellationToken): Fil
 }
 
 interface RemoteViewDecoration {
-	default?: boolean;
+	state?: 'default' | 'missing';
 }
 
 function getRemoteDecoration(uri: Uri, _token: CancellationToken): FileDecoration | undefined {
 	const state = getViewDecoration<'remote'>(uri);
 
-	if (state?.default) {
-		return {
-			badge: GlyphChars.Check,
-			tooltip: 'Default Remote',
-		};
+	switch (state?.state) {
+		case 'default':
+			return {
+				badge: GlyphChars.Check,
+				tooltip: 'Default Remote',
+			};
+
+		case 'missing':
+			return {
+				badge: '?',
+				color: new ThemeColor('gitlens.decorations.workspaceRepoMissingForegroundColor' satisfies Colors),
+				tooltip: '',
+			};
 	}
 
 	return undefined;


### PR DESCRIPTION
Closes [#4039](https://github.com/gitkraken/vscode-gitlens/issues/4039)

Two fixes, each one commit:
- Fixes false "current branch" detection using the base repository ("current branch" and "remote" must use the head repository, but "open repo" can still use either)
- Instead of prompting, returns a command message node which can be clicked to add the missing remote.
