### PR TITLE
Fix Markdown parenthesis escape

### DIFF
--- a/src/system/markdown.ts
+++ b/src/system/markdown.ts
@@ -1,4 +1,4 @@
-const escapeMarkdownRegex = /[\\*_{}[\]()#+\-.!]/g;
+const escapeMarkdownRegex = /[\\*_{}[\](#+\-.!]/g;
 const unescapeMarkdownRegex = /\\([\\`*_{}[\]()#+\-.!])/g;
 
 const escapeMarkdownHeaderRegex = /^===/gm;


### PR DESCRIPTION
# Description
This partially addresses #3246 by not escaping closing parentheses in Markdown commit messages.

| Before  | After  |
|---------|--------|
| <img src="https://github.com/user-attachments/assets/406c787f-723e-4be6-87a9-3fee81427922"> | <img src="https://github.com/user-attachments/assets/719262b4-b25a-4110-b227-cd9bd4e9b68f"> |

<!--
Please include a summary of the changes and which issue will be addressed. Please also include relevant motivation and context.
-->

# Checklist

<!-- Please check off the following -->

- [x] I have followed the guidelines in the Contributing document
- [x] My changes follow the coding style of this project
- [x] My changes build without any errors or warnings
- [x] My changes have been formatted and linted
- [ ] My changes include any required corresponding changes to the documentation (including CHANGELOG.md and README.md)
- [x] My changes have been rebased and squashed to the minimal number (typically 1) of relevant commits
- [ ] My changes have a descriptive commit message with a short title, including a `Fixes $XXX -` or `Closes #XXX -` prefix to auto-close the issue that your PR addresses
