### PR TITLE
Closes #2959 autosquash commits in interactive rebases

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/) and this p
 
 ### Added
 
+- Adds auto-squashing of fixup commits to interactive rebases ([#2949](https://github.com/gitkraken/vscode-gitlens/issues/2959)) — thanks to [PR #4109](https://github.com/gitkraken/vscode-gitlens/pull/4109) by Gabriel Seltzer [@gabeseltzer](https://github.com/gabeseltzer)
 - Adds AI model status and model switcher to the _Home_ view ([#4064](https://github.com/gitkraken/vscode-gitlens/issues/4064))
 - Adds Anthropic Claude 3.7 Sonnet model for GitLens' AI features ([#4101](https://github.com/gitkraken/vscode-gitlens/issues/4101))
 - Adds Google Gemini 2.0 Flash-Lite model for GitLens' AI features ([#4104](https://github.com/gitkraken/vscode-gitlens/issues/4104))

--- a/README.md
+++ b/README.md
@@ -435,6 +435,7 @@ A big thanks to the people that have contributed to this project 🙏❤️:
 - Jean Pierre ([@jeanp413](https://github.com/jeanp413)) &mdash; [contributions](https://github.com/gitkraken/vscode-gitlens/commits?author=jeanp413)
 - Dawn Hwang ([@hwangh95](https://github.com/hwangh95)) &mdash; [contributions](https://github.com/gitkraken/vscode-gitlens/commits?author=hwangh95)
 - Emmanuel Ferdman ([@emmanuel-ferdman](https://github.com/emmanuel-ferdman)) &mdash; [contributions](https://github.com/gitkraken/vscode-gitlens/commits?author=emmanuel-ferdman)
+- Gabriel Seltzer ([@gabeseltzer](https://github.com/gabeseltzer)) &mdash; [contributions](https://github.com/gitkraken/vscode-gitlens/commits?author=gabeseltzer)
 
 Also special thanks to the people that have provided support, testing, brainstorming, etc:
 

--- a/src/commands/git/rebase.ts
+++ b/src/commands/git/rebase.ts
@@ -40,7 +40,7 @@ interface Context {
 	title: string;
 }
 
-type Flags = '--interactive';
+type Flags = '--interactive' | '--autosquash';
 
 interface State {
 	repo: string | Repository;
@@ -253,14 +253,14 @@ export class RebaseGitCommand extends QuickCommand<State> {
 		}
 
 		const items: FlagsQuickPickItem<Flags>[] = [
-			createFlagsQuickPickItem<Flags>(state.flags, ['--interactive'], {
+			createFlagsQuickPickItem<Flags>(state.flags, ['--interactive', '--autosquash'], {
 				label: `Interactive ${this.title}`,
 				description: '--interactive',
 				detail: `Will interactively update ${getReferenceLabel(context.branch, {
 					label: false,
 				})} by applying ${pluralize('commit', ahead)} on top of ${getReferenceLabel(state.destination, {
 					label: false,
-				})}`,
+				})} and auto-squash any fixup commits`,
 				picked: behind === 0,
 			}),
 		];


### PR DESCRIPTION
# Description

Closes #2959 

Adds the `--autosquash` flag to interactive rebases.

Note, I wasn't 100% sure if this is the right solution, but it works and was easy. As far as I know, there's no real downside to always using the autosquash feature. I had some other ideas but they were harder so I thought I'd PR and see what people thought. Here's the other options:

1. Simply add `--autosquash` to the arguments for the existing `--interactive` line item for everyone. <<< This is what I did
2. Simply add `--autosquash` to the arguments for the existing `--interactive` line item **if users enable it with a vscode extension setting**
3. Add a new option that does both `--interactive --autosquash`, and show it all the time
4. Add a new option that does both `--interactive --autosquash`, and **only show it if there are fixup commits in your rebase range**

# Checklist

<!-- Please check off the following -->

- [x] I have followed the guidelines in the Contributing document
- [x] My changes follow the coding style of this project
- [x] My changes build without any errors or warnings
- [x] My changes have been formatted and linted
- [x] My changes include any required corresponding changes to the documentation (including CHANGELOG.md and README.md)
- [x] My changes have been rebased and squashed to the minimal number (typically 1) of relevant commits
- [x] My changes have a descriptive commit message with a short title, including a `Fixes $XXX -` or `Closes #XXX -` prefix to auto-close the issue that your PR addresses
