### PR TITLE
Bitbucket cloud: add Start Work support

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/) and this p
 - Adds integration with Bitbucket Cloud ([#3916](https://github.com/gitkraken/vscode-gitlens/issues/3916))
   - shows enriched links to PRs and issues [#4045](https://github.com/gitkraken/vscode-gitlens/issues/4045)
   - shows Bitbucket PRs in Launchpad [#4046](https://github.com/gitkraken/vscode-gitlens/issues/4046)
+  - supports Bitbucket issues in Start Work and lets associate issues with branches [#4047](https://github.com/gitkraken/vscode-gitlens/issues/4047)
 - Adds ability to control how worktrees are displayed in the views
   - Adds a `gitlens.views.worktrees.worktrees.viewAs` setting to specify whether to show worktrees by name, path, or relative path
   - Adds a `gitlens.views.worktrees.branches.layout` setting to specify whether to show branch worktrees as a list or tree, similar to branches

--- a/src/plus/integrations/providers/bitbucket.ts
+++ b/src/plus/integrations/providers/bitbucket.ts
@@ -97,11 +97,18 @@ export class BitbucketIntegration extends HostingIntegration<
 	}
 
 	protected override async getProviderIssue(
-		_session: AuthenticationSession,
-		_repo: BitbucketRepositoryDescriptor,
-		_id: string,
+		{ accessToken }: AuthenticationSession,
+		repo: BitbucketRepositoryDescriptor,
+		id: string,
 	): Promise<Issue | undefined> {
-		return Promise.resolve(undefined);
+		return (await this.container.bitbucket)?.getIssue(
+			this,
+			accessToken,
+			repo.owner,
+			repo.name,
+			id,
+			this.apiBaseUrl,
+		);
 	}
 
 	protected override async getProviderPullRequestForBranch(

--- a/src/plus/integrations/providers/utils.ts
+++ b/src/plus/integrations/providers/utils.ts
@@ -105,6 +105,8 @@ export function getProviderIdFromEntityIdentifier(
 			return IssueIntegrationId.Jira;
 		case EntityIdentifierProviderType.Azure:
 			return HostingIntegrationId.AzureDevOps;
+		case EntityIdentifierProviderType.Bitbucket:
+			return HostingIntegrationId.Bitbucket;
 		default:
 			return undefined;
 	}
@@ -228,6 +230,7 @@ export async function getIssueFromGitConfigEntityIdentifier(
 		identifier.provider !== EntityIdentifierProviderType.Gitlab &&
 		identifier.provider !== EntityIdentifierProviderType.GithubEnterprise &&
 		identifier.provider !== EntityIdentifierProviderType.GitlabSelfHosted &&
+		identifier.provider !== EntityIdentifierProviderType.Bitbucket &&
 		identifier.provider !== EntityIdentifierProviderType.Azure
 	) {
 		return undefined;

--- a/src/plus/startWork/startWork.ts
+++ b/src/plus/startWork/startWork.ts
@@ -21,6 +21,7 @@ import {
 import {
 	ConnectIntegrationButton,
 	OpenOnAzureDevOpsQuickInputButton,
+	OpenOnBitbucketQuickInputButton,
 	OpenOnGitHubQuickInputButton,
 	OpenOnGitLabQuickInputButton,
 	OpenOnJiraQuickInputButton,
@@ -96,6 +97,7 @@ export const supportedStartWorkIntegrations = [
 	HostingIntegrationId.GitLab,
 	SelfHostedIntegrationId.CloudGitLabSelfHosted,
 	HostingIntegrationId.AzureDevOps,
+	HostingIntegrationId.Bitbucket,
 	IssueIntegrationId.Jira,
 ];
 export type SupportedStartWorkIntegrationIds = (typeof supportedStartWorkIntegrations)[number];
@@ -483,6 +485,7 @@ export abstract class StartWorkBaseCommand extends QuickCommand<State> {
 			onDidClickItemButton: (_quickpick, button, { item }) => {
 				switch (button) {
 					case OpenOnAzureDevOpsQuickInputButton:
+					case OpenOnBitbucketQuickInputButton:
 					case OpenOnGitHubQuickInputButton:
 					case OpenOnGitLabQuickInputButton:
 					case OpenOnJiraQuickInputButton:
@@ -716,6 +719,8 @@ function getOpenOnWebQuickInputButton(integrationId: string): QuickInputButton |
 	switch (integrationId) {
 		case HostingIntegrationId.AzureDevOps:
 			return OpenOnAzureDevOpsQuickInputButton;
+		case HostingIntegrationId.Bitbucket:
+			return OpenOnBitbucketQuickInputButton;
 		case HostingIntegrationId.GitHub:
 		case SelfHostedIntegrationId.CloudGitHubEnterprise:
 			return OpenOnGitHubQuickInputButton;

--- a/src/webviews/apps/plus/graph/GraphWrapper.tsx
+++ b/src/webviews/apps/plus/graph/GraphWrapper.tsx
@@ -184,6 +184,7 @@ const createIconElements = (): Record<string, ReactElement> => {
 		'issue-gitlab',
 		'issue-jiraCloud',
 		'issue-azureDevops',
+		'issue-bitbucket',
 	];
 
 	const miniIconList = ['upstream-ahead', 'upstream-behind'];

--- a/src/webviews/apps/plus/graph/graph.scss
+++ b/src/webviews/apps/plus/graph/graph.scss
@@ -871,6 +871,13 @@ button:not([disabled]),
 			@include iconUtils.codicon('issues');
 		}
 	}
+
+	&--issue-bitbucket {
+		&::before {
+			font-family: codicon;
+			@include iconUtils.codicon('issues');
+		}
+	}
 }
 
 .titlebar {

--- a/src/webviews/plus/graph/graphWebview.ts
+++ b/src/webviews/plus/graph/graphWebview.ts
@@ -4225,6 +4225,9 @@ function toGraphIssueTrackerType(id: string): GraphIssueTrackerType | undefined 
 		case 'azure-devops':
 			// TODO: Remove the casting once this is officially recognized by the component
 			return 'azureDevops' as GraphIssueTrackerType;
+		case 'bitbucket':
+			// TODO: Remove the casting once this is officially recognized by the component
+			return HostingIntegrationId.Bitbucket as GraphIssueTrackerType;
 		default:
 			return undefined;
 	}


### PR DESCRIPTION
# Description
solves #4047 

- Adds support for seeing Bitbucket issues in Start Work.
- Also makes sure Bitbucket issues can be associated to branches using the "associate issue to branch" command in branch context menus.
- Makes sure that the associated issue is displayed on Home
- Makes sure the associated issue is displayed on Graph

# Checklist
- [x] I have followed the guidelines in the Contributing document
- [x] My changes follow the coding style of this project
- [x] My changes build without any errors or warnings
- [x] My changes have been formatted and linted
- [x] My changes include any required corresponding changes to the documentation (including CHANGELOG.md and README.md)
- [x] My changes have been rebased and squashed to the minimal number (typically 1) of relevant commits
- [x] My changes have a descriptive commit message with a short title, including a `Fixes $XXX -` or `Closes #XXX -` prefix to auto-close the issue that your PR addresses
