### PR TITLE
Adds squash merge detection and merge target actions

### DIFF
--- a/src/commands/git/worktree.ts
+++ b/src/commands/git/worktree.ts
@@ -103,7 +103,7 @@ interface CreateState {
 	};
 
 	onWorkspaceChanging?: ((isNewWorktree?: boolean) => Promise<void>) | ((isNewWorktree?: boolean) => void);
-	skipWorktreeConfirmations?: boolean;
+	worktreeDefaultOpen?: 'new' | 'current';
 }
 
 type DeleteFlags = '--force' | '--delete-branches';
@@ -141,7 +141,7 @@ interface OpenState {
 
 	onWorkspaceChanging?: ((isNewWorktree?: boolean) => Promise<void>) | ((isNewWorktree?: boolean) => void);
 	isNewWorktree?: boolean;
-	skipWorktreeConfirmations?: boolean;
+	worktreeDefaultOpen?: 'new' | 'current';
 }
 
 interface CopyChangesState {
@@ -632,7 +632,7 @@ export class WorktreeGitCommand extends QuickCommand<State> {
 						openOnly: true,
 						overrides: { disallowBack: true },
 						isNewWorktree: true,
-						skipWorktreeConfirmations: state.skipWorktreeConfirmations,
+						worktreeDefaultOpen: state.worktreeDefaultOpen,
 						onWorkspaceChanging: state.onWorkspaceChanging,
 					} satisfies OpenStepState,
 					context,
@@ -739,7 +739,7 @@ export class WorktreeGitCommand extends QuickCommand<State> {
 
 		const confirmations: StepType[] = [];
 		if (!createDirectlyInFolder) {
-			if (state.skipWorktreeConfirmations) {
+			if (state.worktreeDefaultOpen) {
 				return [defaultOption.context, defaultOption.item];
 			}
 
@@ -1101,15 +1101,21 @@ export class WorktreeGitCommand extends QuickCommand<State> {
 			detail: 'Will open the worktree in a new window',
 		});
 
-		if (state.skipWorktreeConfirmations) {
+		const currentWindowItem = createFlagsQuickPickItem<OpenFlags>(state.flags, [], {
+			label: 'Open Worktree',
+			detail: 'Will open the worktree in the current window',
+		});
+
+		if (state.worktreeDefaultOpen === 'new') {
 			return newWindowItem.item;
 		}
 
+		if (state.worktreeDefaultOpen === 'current') {
+			return currentWindowItem.item;
+		}
+
 		const confirmations: StepType[] = [
-			createFlagsQuickPickItem<OpenFlags>(state.flags, [], {
-				label: 'Open Worktree',
-				detail: 'Will open the worktree in the current window',
-			}),
+			currentWindowItem,
 			newWindowItem,
 			createFlagsQuickPickItem<OpenFlags>(state.flags, ['--add-to-workspace'], {
 				label: `Add Worktree to Workspace`,

--- a/src/constants.commands.ts
+++ b/src/constants.commands.ts
@@ -148,6 +148,8 @@ type InternalGraphWebviewCommands =
 	| 'gitlens.graph.skipPausedOperation';
 
 type InternalHomeWebviewCommands =
+	| 'gitlens.home.deleteBranchOrWorktree'
+	| 'gitlens.home.pushBranch'
 	| 'gitlens.home.openMergeTargetComparison'
 	| 'gitlens.home.openPullRequestChanges'
 	| 'gitlens.home.openPullRequestComparison'

--- a/src/env/node/git/sub-providers/branches.ts
+++ b/src/env/node/git/sub-providers/branches.ts
@@ -433,7 +433,7 @@ export class BranchesGitSubProvider implements GitBranchesSubProvider {
 			}
 
 			// Attempt to detect squash merges by checking if the diff of the branch can be cleanly removed from the target
-			const mergeBase = await this.getMergeBase(repoPath, into.name, branch.name);
+			const mergeBase = await this.provider.refs.getMergeBase(repoPath, into.name, branch.name);
 			data = await this.git.exec<string>({ cwd: repoPath }, 'diff', mergeBase, branch.name);
 			if (data?.length) {
 				// Create a temporary index file

--- a/src/plus/launchpad/launchpad.ts
+++ b/src/plus/launchpad/launchpad.ts
@@ -391,7 +391,7 @@ export class LaunchpadCommand extends QuickCommand<State> {
 						void this.container.launchpad.switchTo(state.item);
 						break;
 					case 'open-worktree':
-						void this.container.launchpad.switchTo(state.item, { skipWorktreeConfirmations: true });
+						void this.container.launchpad.switchTo(state.item, { openInWorktree: true });
 						break;
 					case 'switch-and-code-suggest':
 					case 'code-suggest':
@@ -900,7 +900,7 @@ export class LaunchpadCommand extends QuickCommand<State> {
 
 					case OpenWorktreeInNewWindowQuickInputButton:
 						this.sendItemActionTelemetry('open-worktree', item, group, context);
-						await this.container.launchpad.switchTo(item, { skipWorktreeConfirmations: true });
+						await this.container.launchpad.switchTo(item, { openInWorktree: true });
 						break;
 				}
 

--- a/src/plus/launchpad/launchpadProvider.ts
+++ b/src/plus/launchpad/launchpadProvider.ts
@@ -467,7 +467,7 @@ export class LaunchpadProvider implements Disposable {
 	@log<LaunchpadProvider['switchTo']>({ args: { 0: i => `${i.id} (${i.provider.name} ${i.type})` } })
 	async switchTo(
 		item: LaunchpadItem,
-		options?: { skipWorktreeConfirmations?: boolean; startCodeSuggestion?: boolean },
+		options?: { openInWorktree?: boolean; startCodeSuggestion?: boolean },
 	): Promise<void> {
 		if (item.openRepository?.localBranch?.current) {
 			void showInspectView({
@@ -483,7 +483,7 @@ export class LaunchpadProvider implements Disposable {
 			item,
 			options?.startCodeSuggestion
 				? DeepLinkActionType.SwitchToAndSuggestPullRequest
-				: options?.skipWorktreeConfirmations
+				: options?.openInWorktree
 				  ? DeepLinkActionType.SwitchToPullRequestWorktree
 				  : DeepLinkActionType.SwitchToPullRequest,
 		);

--- a/src/uris/deepLinks/deepLink.ts
+++ b/src/uris/deepLinks/deepLink.ts
@@ -45,6 +45,7 @@ export const DeepLinkCommandTypeToCommand = new Map<DeepLinkCommandType, GlComma
 ]);
 
 export enum DeepLinkActionType {
+	DeleteBranch = 'delete-branch',
 	Switch = 'switch',
 	SwitchToPullRequest = 'switch-to-pr',
 	SwitchToPullRequestWorktree = 'switch-to-pr-worktree',
@@ -245,6 +246,7 @@ export const enum DeepLinkServiceState {
 	SwitchToRef,
 	RunCommand,
 	OpenAllPrChanges,
+	DeleteBranch,
 }
 
 export const enum DeepLinkServiceAction {
@@ -278,6 +280,7 @@ export const enum DeepLinkServiceAction {
 	OpenInspect,
 	OpenSwitch,
 	OpenAllPrChanges,
+	DeleteBranch,
 }
 
 export type DeepLinkRepoOpenType = 'clone' | 'folder' | 'workspace' | 'current';
@@ -396,6 +399,7 @@ export const deepLinkStateTransitionTable: Record<string, Record<string, DeepLin
 		[DeepLinkServiceAction.OpenFile]: DeepLinkServiceState.OpenFile,
 		[DeepLinkServiceAction.OpenSwitch]: DeepLinkServiceState.SwitchToRef,
 		[DeepLinkServiceAction.OpenComparison]: DeepLinkServiceState.OpenComparison,
+		[DeepLinkServiceAction.DeleteBranch]: DeepLinkServiceState.DeleteBranch,
 		[DeepLinkServiceAction.DeepLinkErrored]: DeepLinkServiceState.Idle,
 		[DeepLinkServiceAction.DeepLinkCancelled]: DeepLinkServiceState.Idle,
 	},
@@ -442,6 +446,11 @@ export const deepLinkStateTransitionTable: Record<string, Record<string, DeepLin
 		[DeepLinkServiceAction.DeepLinkCancelled]: DeepLinkServiceState.Idle,
 	},
 	[DeepLinkServiceState.RunCommand]: {
+		[DeepLinkServiceAction.DeepLinkResolved]: DeepLinkServiceState.Idle,
+		[DeepLinkServiceAction.DeepLinkErrored]: DeepLinkServiceState.Idle,
+		[DeepLinkServiceAction.DeepLinkCancelled]: DeepLinkServiceState.Idle,
+	},
+	[DeepLinkServiceState.DeleteBranch]: {
 		[DeepLinkServiceAction.DeepLinkResolved]: DeepLinkServiceState.Idle,
 		[DeepLinkServiceAction.DeepLinkErrored]: DeepLinkServiceState.Idle,
 		[DeepLinkServiceAction.DeepLinkCancelled]: DeepLinkServiceState.Idle,

--- a/src/views/viewCommands.ts
+++ b/src/views/viewCommands.ts
@@ -949,7 +949,7 @@ export class ViewCommands implements Disposable {
 				state: {
 					repos: node.repo,
 					reference: node.branch,
-					skipWorktreeConfirmations: true,
+					worktreeDefaultOpen: 'new',
 				},
 			});
 		}

--- a/src/webviews/apps/plus/home/components/branch-card.ts
+++ b/src/webviews/apps/plus/home/components/branch-card.ts
@@ -416,6 +416,9 @@ export abstract class GlBranchCardBase extends GlElement {
 			repoPath: this.repo,
 			branchId: this.branch.id,
 			branchName: this.branch.name,
+			worktree: this.branch.worktree
+				? { name: this.branch.worktree.name, isDefault: this.branch.worktree.isDefault }
+				: undefined,
 		};
 	}
 

--- a/src/webviews/apps/plus/home/components/merge-target-status.ts
+++ b/src/webviews/apps/plus/home/components/merge-target-status.ts
@@ -240,6 +240,9 @@ export class GlMergeTargetStatus extends LitElement {
 			repoPath: this.branch.repoPath,
 			branchId: this.branch.id,
 			branchName: this.branch.name,
+			worktree: this.branch.worktree
+				? { name: this.branch.worktree.name, isDefault: this.branch.worktree.isDefault }
+				: undefined,
 		};
 	}
 

--- a/src/webviews/apps/plus/home/components/merge-target-status.ts
+++ b/src/webviews/apps/plus/home/components/merge-target-status.ts
@@ -285,6 +285,23 @@ export class GlMergeTargetStatus extends LitElement {
 	private renderContent() {
 		const target = renderBranchName(this.target?.name);
 
+		const mergeTargetRef =
+			this.mergedStatus?.merged && this.mergedStatus.localBranchOnly
+				? {
+						repoPath: this.branch.repoPath,
+						branchId: this.mergedStatus.localBranchOnly.id!,
+						branchName: this.mergedStatus.localBranchOnly.name,
+						branchUpstreamName: this.mergedStatus.localBranchOnly.upstream?.name,
+				  }
+				: this.target
+				  ? {
+							repoPath: this.target.repoPath,
+							branchId: this.target.id,
+							branchName: this.target.name,
+							branchUpstreamName: undefined,
+				    }
+				  : undefined;
+
 		if (this.mergedStatus?.merged) {
 			if (this.mergedStatus.localBranchOnly) {
 				return html`<div class="header">
@@ -301,6 +318,29 @@ export class GlMergeTargetStatus extends LitElement {
 							${this.mergedStatus.confidence !== 'highest' ? 'likely ' : ''}been merged into its merge
 							target's local branch ${renderBranchName(this.mergedStatus.localBranchOnly.name)}.
 						</p>
+						<div class="button-container">
+							<gl-button
+								full
+								href="${createCommandLink(
+									'gitlens.home.pushBranch',
+									mergeTargetRef! satisfies BranchRef,
+								)}"
+								>Push ${renderBranchName(this.mergedStatus.localBranchOnly.name)}</gl-button
+							>
+							<gl-button
+								full
+								appearance="secondary"
+								href="${createCommandLink('gitlens.home.deleteBranchOrWorktree', [
+									this.branchRef,
+									mergeTargetRef,
+								])}"
+								>Delete
+								${this.branch.worktree != null && !this.branch.worktree.isDefault
+									? 'Worktree'
+									: 'Branch'}
+								${renderBranchName(this.branch.name, this.branch.worktree != null)}</gl-button
+							>
+						</div>
 					</div>`;
 			}
 
@@ -318,6 +358,18 @@ export class GlMergeTargetStatus extends LitElement {
 						${this.mergedStatus.confidence !== 'highest' ? 'likely ' : ''}been merged into its merge target
 						${target}.
 					</p>
+					<div class="button-container">
+						<gl-button
+							full
+							href="${createCommandLink('gitlens.home.deleteBranchOrWorktree', [
+								this.branchRef,
+								mergeTargetRef,
+							])}"
+							>Delete
+							${this.branch.worktree != null && !this.branch.worktree.isDefault ? 'Worktree' : 'Branch'}
+							${renderBranchName(this.branch.name, this.branch.worktree != null)}</gl-button
+						>
+					</div>
 				</div>`;
 		}
 

--- a/src/webviews/home/homeWebview.ts
+++ b/src/webviews/home/homeWebview.ts
@@ -1,5 +1,5 @@
 import type { ConfigurationChangeEvent } from 'vscode';
-import { Disposable, Uri, window, workspace } from 'vscode';
+import { Disposable, env, Uri, window, workspace } from 'vscode';
 import type { CreatePullRequestActionContext } from '../../api/gitlens';
 import type { EnrichedAutolink } from '../../autolinks/models/autolinks';
 import { getAvatarUriFromGravatarEmail } from '../../avatars';
@@ -65,6 +65,8 @@ import { debounce } from '../../system/function/debounce';
 import { filterMap } from '../../system/iterable';
 import { getSettledValue } from '../../system/promise';
 import { SubscriptionManager } from '../../system/subscriptionManager';
+import type { UriTypes } from '../../uris/deepLinks/deepLink';
+import { DeepLinkServiceState, DeepLinkType } from '../../uris/deepLinks/deepLink';
 import type { ShowInCommitGraphCommandArgs } from '../plus/graph/protocol';
 import type { Change } from '../plus/patchDetails/protocol';
 import type { IpcMessage } from '../protocol';
@@ -1173,22 +1175,63 @@ export class HomeWebviewProvider implements WebviewProvider<State, State, HomeWe
 	private async deleteBranchOrWorktree(ref: BranchRef, mergeTarget?: BranchRef) {
 		const repo = this._repositoryBranches.get(ref.repoPath);
 		const branch = repo?.branches.find(b => b.id === ref.branchId);
+		const worktree = branch ? repo?.worktreesByBranch.get(branch.id) : undefined;
 		if (branch == null) return;
-		if (branch.current && mergeTarget != null) {
-			if (mergeTarget != null) {
-				const mergeTargetLocalBranch = getBranchNameWithoutRemote(mergeTarget.branchName);
-				await this.container.git.checkout(ref.repoPath, mergeTargetLocalBranch);
-			}
-		}
+		if (branch.current && mergeTarget != null && (!worktree || worktree.isDefault)) {
+			const mergeTargetLocalBranchName = getBranchNameWithoutRemote(mergeTarget.branchName);
+			const confirm = await window.showWarningMessage(
+				`The merge target branch ${mergeTargetLocalBranchName} will be checked out before deleting the current branch ${branch.name}.`,
+				{ title: 'Proceed' },
+				{ title: 'Cancel' },
+			);
 
-		void executeGitCommand({
-			command: 'branch',
-			state: {
-				subcommand: 'delete',
-				repo: ref.repoPath,
-				references: branch,
-			},
-		});
+			if (confirm == null || confirm.title !== 'Proceed') return;
+			await this.container.git.checkout(ref.repoPath, mergeTargetLocalBranchName);
+
+			void executeGitCommand({
+				command: 'branch',
+				state: {
+					subcommand: 'delete',
+					repo: ref.repoPath,
+					references: branch,
+				},
+			});
+		} else if (repo != null && branch != null && worktree != null && !worktree.isDefault) {
+			const defaultWorktree = [...repo.worktreesByBranch.values()].find(w => w.isDefault);
+			if (defaultWorktree == null) return;
+
+			const confirm = await window.showWarningMessage(
+				`You will be returned to the default worktree before deleting the worktree for ${branch.name}.`,
+				{ title: 'Proceed' },
+				{ title: 'Cancel' },
+			);
+
+			if (confirm == null || confirm.title !== 'Proceed') return;
+			const schemeOverride = configuration.get('deepLinks.schemeOverride');
+			const scheme = typeof schemeOverride === 'string' ? schemeOverride : env.uriScheme;
+			const deleteBranchDeepLink = {
+				url: `${scheme}://${this.container.context.extension.id}/${'link' satisfies UriTypes}/${
+					DeepLinkType.Repository
+				}/-/${DeepLinkType.Branch}/${encodeURIComponent(branch.name)}?path=${encodeURIComponent(
+					branch.repoPath,
+				)}&action=delete-branch`,
+				repoPath: branch.repoPath,
+				useProgress: false,
+				state: DeepLinkServiceState.GoToTarget,
+			};
+
+			void executeGitCommand({
+				command: 'worktree',
+				state: {
+					subcommand: 'open',
+					repo: defaultWorktree.repoPath,
+					worktree: defaultWorktree,
+					onWorkspaceChanging: async (_isNewWorktree?: boolean) =>
+						this.container.storage.store('deepLinks:pending', deleteBranchDeepLink),
+					worktreeDefaultOpen: 'current',
+				},
+			});
+		}
 	}
 
 	private pushBranch(ref: BranchRef) {

--- a/src/webviews/home/homeWebview.ts
+++ b/src/webviews/home/homeWebview.ts
@@ -1181,8 +1181,8 @@ export class HomeWebviewProvider implements WebviewProvider<State, State, HomeWe
 			const mergeTargetLocalBranchName = getBranchNameWithoutRemote(mergeTarget.branchName);
 			const confirm = await window.showWarningMessage(
 				`The merge target branch ${mergeTargetLocalBranchName} will be checked out before deleting the current branch ${branch.name}.`,
+				{ modal: true },
 				{ title: 'Proceed' },
-				{ title: 'Cancel' },
 			);
 
 			if (confirm == null || confirm.title !== 'Proceed') return;
@@ -1197,13 +1197,14 @@ export class HomeWebviewProvider implements WebviewProvider<State, State, HomeWe
 				},
 			});
 		} else if (repo != null && branch != null && worktree != null && !worktree.isDefault) {
+			const commonRepo = await repo.repo.getCommonRepository();
 			const defaultWorktree = [...repo.worktreesByBranch.values()].find(w => w.isDefault);
-			if (defaultWorktree == null) return;
+			if (defaultWorktree == null || commonRepo == null) return;
 
 			const confirm = await window.showWarningMessage(
 				`You will be returned to the default worktree before deleting the worktree for ${branch.name}.`,
+				{ modal: true },
 				{ title: 'Proceed' },
-				{ title: 'Cancel' },
 			);
 
 			if (confirm == null || confirm.title !== 'Proceed') return;
@@ -1213,9 +1214,9 @@ export class HomeWebviewProvider implements WebviewProvider<State, State, HomeWe
 				url: `${scheme}://${this.container.context.extension.id}/${'link' satisfies UriTypes}/${
 					DeepLinkType.Repository
 				}/-/${DeepLinkType.Branch}/${encodeURIComponent(branch.name)}?path=${encodeURIComponent(
-					branch.repoPath,
+					commonRepo.path,
 				)}&action=delete-branch`,
-				repoPath: branch.repoPath,
+				repoPath: commonRepo.path,
 				useProgress: false,
 				state: DeepLinkServiceState.GoToTarget,
 			};

--- a/src/webviews/home/protocol.ts
+++ b/src/webviews/home/protocol.ts
@@ -181,6 +181,7 @@ export interface GetOverviewBranch {
 	worktree?: {
 		name: string;
 		uri: string;
+		isDefault: boolean;
 	};
 }
 
@@ -320,6 +321,7 @@ export interface BranchRef {
 	repoPath: string;
 	branchId: string;
 	branchName: string;
+	branchUpstreamName?: string;
 }
 
 export interface BranchAndTargetRefs extends BranchRef {

--- a/src/webviews/home/protocol.ts
+++ b/src/webviews/home/protocol.ts
@@ -322,6 +322,10 @@ export interface BranchRef {
 	branchId: string;
 	branchName: string;
 	branchUpstreamName?: string;
+	worktree?: {
+		name: string;
+		isDefault: boolean;
+	};
 }
 
 export interface BranchAndTargetRefs extends BranchRef {

--- a/src/webviews/plus/graph/graphWebview.ts
+++ b/src/webviews/plus/graph/graphWebview.ts
@@ -3891,7 +3891,7 @@ export class GraphWebviewProvider implements WebviewProvider<State, State, Graph
 				state: {
 					repos: ref.repoPath,
 					reference: ref,
-					skipWorktreeConfirmations: true,
+					worktreeDefaultOpen: 'new',
 				},
 			});
 		}


### PR DESCRIPTION
Closes #4124

Note: there are known issues with the "delete worktree" case where when the worktree is deleted before deleting the branch, the "delete branch" portion of the commands fail to proceed because the commands are using a worktree path that no longer exists. These should be addressed in follow-up.