### PR TITLE
Fixes isMaybeConnected to let it return undefined when the value is unknown

### DIFF
--- a/src/plus/integrations/integrationService.ts
+++ b/src/plus/integrations/integrationService.ts
@@ -964,9 +964,9 @@ export class IntegrationService implements Disposable {
 		return this.getMyPullRequestsCore(integrations);
 	}
 
-	isMaybeConnected(remote: GitRemote): boolean {
+	isMaybeConnected(remote: GitRemote): boolean | undefined {
 		if (remote.provider?.id != null && this.supports(remote.provider.id)) {
-			return this.getByRemoteCached(remote)?.maybeConnected ?? false;
+			return this.getByRemoteCached(remote)?.maybeConnected;
 		}
 		return false;
 	}


### PR DESCRIPTION
# Description

### The problem
I've noticed that here the `connected` variable is always boolean and can never be equal to `null`, so we always skip the `if` body here: https://github.com/gitkraken/vscode-gitlens/blob/fef314b19051be1fd8890996e13091ef15c367da/src/git/gitProviderService.ts#L1143-L1149

Therefore, integrations with `unknown` connection status never get saved here: https://github.com/gitkraken/vscode-gitlens/blob/fef314b19051be1fd8890996e13091ef15c367da/src/git/gitProviderService.ts#L1191-L1194

As a result we don't see them on reading. For example in the List of Remotes it didn't see a connected Bitbucket integration and didn't request for PRs: https://github.com/gitkraken/vscode-gitlens/blob/fef314b19051be1fd8890996e13091ef15c367da/src/views/nodes/branchNode.ts#L178-L184

### Investigation
I've noticed that the related code [only changed once](https://github.com/gitkraken/vscode-gitlens/commit/33e092a587cc9697b13c2cbfbe74d8ff7388a5b7#diff-7e47c1b1c97e15648dbdffe854cbbf16570122454726420d8e5c830907b9f7d6) and the "always boolean effect" might appear occasionally.


### Suggested solution
I suggest we should let it be `undefined` again.


# Checklist

<!-- Please check off the following -->

- [x] I have followed the guidelines in the Contributing document
- [x] My changes follow the coding style of this project
- [x] My changes build without any errors or warnings
- [x] My changes have been formatted and linted
- [ ] My changes include any required corresponding changes to the documentation (including CHANGELOG.md and README.md)
- [x] My changes have been rebased and squashed to the minimal number (typically 1) of relevant commits
- [x] My changes have a descriptive commit message with a short title, including a `Fixes $XXX -` or `Closes #XXX -` prefix to auto-close the issue that your PR addresses
