### PR TITLE
Fixes #4207 - Incorrect PR Link Across Azure DevOps Projects

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,7 +12,11 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/) and this p
 
 ### Changed
 
-- Improves editor revision navigation ([#4200](https://github.com/gitkraken/vscode-gitlens/issues/4200))
+- Improves editor revision navigation ([#4207](https://github.com/gitkraken/vscode-gitlens/issues/4207))
+
+### Fixed
+
+- Fixes Incorrect PR Link Across Azure DevOps Projects ([#3218](https://github.com/gitkraken/vscode-gitlens/issues/3218))
 
 ## [17.0.1] - 2025-04-03
 

--- a/README.md
+++ b/README.md
@@ -444,6 +444,7 @@ A big thanks to the people that have contributed to this project 🙏❤️:
 - Jean Pierre ([@jeanp413](https://github.com/jeanp413)) &mdash; [contributions](https://github.com/gitkraken/vscode-gitlens/commits?author=jeanp413)
 - Dawn Hwang ([@hwangh95](https://github.com/hwangh95)) &mdash; [contributions](https://github.com/gitkraken/vscode-gitlens/commits?author=hwangh95)
 - Emmanuel Ferdman ([@emmanuel-ferdman](https://github.com/emmanuel-ferdman)) &mdash; [contributions](https://github.com/gitkraken/vscode-gitlens/commits?author=emmanuel-ferdman)
+- Jordon Kashanchi ([@jordonkash](https://github.com/JordonKash)) &mdash; [contributions](https://github.com/gitkraken/vscode-gitlens/commits?author=jordonkash)
 
 Also special thanks to the people that have provided support, testing, brainstorming, etc:
 

--- a/src/plus/integrations/providers/azure/azure.ts
+++ b/src/plus/integrations/providers/azure/azure.ts
@@ -105,7 +105,7 @@ export class AzureDevOpsApi implements Disposable {
 			const pr = prResult?.value.find(pr => pr.sourceRefName.endsWith(branch));
 			if (pr == null) return undefined;
 
-			return fromAzurePullRequest(pr, provider, owner, projectName);
+			return fromAzurePullRequest(pr, provider, owner);
 		} catch (ex) {
 			Logger.error(ex, scope);
 			return undefined;

--- a/src/plus/integrations/providers/azure/models.ts
+++ b/src/plus/integrations/providers/azure/models.ts
@@ -476,7 +476,6 @@ export function fromAzurePullRequest(
 	pr: AzurePullRequest,
 	provider: Provider,
 	orgName: string,
-	projectName: string,
 ): PullRequest {
 	const url = new URL(pr.url);
 	return new PullRequest(
@@ -531,7 +530,7 @@ export function fromAzurePullRequest(
 		undefined,
 		{
 			id: pr.repository?.project?.id,
-			name: projectName,
+			name: pr.repository.project.name,
 			resourceId: '', // TODO: This is a workaround until we can get the org id here.
 			resourceName: orgName,
 		},


### PR DESCRIPTION
# Description

This pull request resolves an issue where GitLens incorrectly links pull requests when a commit originates from a different Azure DevOps project, despite the commit tree being visible in the current project.

When a commit from a pull request (PR) in one Azure DevOps project (e.g., Project B) is reflected in another project (e.g., Project A) due to shared repositories or mirrored refs, GitLens correctly displays the commit in Project A. However, it incorrectly assumes the associated PR also exists in Project A, resulting in a broken or invalid PR link. Since PRs are scoped to their respective projects, this leads to a mismatch between the commit’s origin and the generated PR URL.

Fix includes using `pr.repository.project.name` when fetching the repository name, rather than just the current `projectName`.

# Checklist

<!-- Please check off the following -->

- [x] I have followed the guidelines in the Contributing document
- [x] My changes follow the coding style of this project
- [x] My changes build without any errors or warnings
- [x] My changes have been formatted and linted
- [x] My changes include any required corresponding changes to the documentation (including CHANGELOG.md and README.md)
- [x] My changes have been rebased and squashed to the minimal number (typically 1) of relevant commits
- [x] My changes have a descriptive commit message with a short title, including a `Fixes $XXX -` or `Closes #XXX -` prefix to auto-close the issue that your PR addresses
