### PR TITLE
Adds `IssueOrPullRequestType ` to cache keys for issue/PR retrieval

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,6 +22,7 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/) and this p
 
 ### Fixed
 
+- Fixes cache collision between issues and PRs in autolinks ([#4193](https://github.com/gitkraken/vscode-gitlens/issues/4193))
 - Fixes incorrect PR Link Across Azure DevOps Projects ([#4207](https://github.com/gitkraken/vscode-gitlens/issues/4207))
 - Fixes detail view incorrectly parses GitHub account in commit message ([#3246](https://github.com/gitkraken/vscode-gitlens/issues/3246))
 - Fixes `undefined` sometimes showing for search results in the _Search Commits_ command and _Search & Compare_ view

--- a/src/cache.ts
+++ b/src/cache.ts
@@ -4,7 +4,7 @@ import type { Container } from './container';
 import type { Account } from './git/models/author';
 import type { DefaultBranch } from './git/models/defaultBranch';
 import type { Issue } from './git/models/issue';
-import type { IssueOrPullRequest } from './git/models/issueOrPullRequest';
+import type { IssueOrPullRequest, IssueOrPullRequestType } from './git/models/issueOrPullRequest';
 import type { PullRequest } from './git/models/pullRequest';
 import type { RepositoryMetadata } from './git/models/repositoryMetadata';
 import type { HostingIntegration, IntegrationBase, ResourceDescriptor } from './plus/integrations/integration';
@@ -111,6 +111,7 @@ export class CacheProvider implements Disposable {
 
 	getIssueOrPullRequest(
 		id: string,
+		type: IssueOrPullRequestType | undefined,
 		resource: ResourceDescriptor,
 		integration: IntegrationBase | undefined,
 		cacheable: Cacheable<IssueOrPullRequest>,
@@ -119,11 +120,11 @@ export class CacheProvider implements Disposable {
 		const { key, etag } = getResourceKeyAndEtag(resource, integration);
 
 		if (resource == null) {
-			return this.get('issuesOrPrsById', `id:${id}:${key}`, etag, cacheable, options);
+			return this.get('issuesOrPrsById', `id:${id}:${key}:${type ?? 'unknown'}`, etag, cacheable, options);
 		}
 		return this.get(
 			'issuesOrPrsByIdAndRepo',
-			`id:${id}:${key}:${JSON.stringify(resource)}}`,
+			`id:${id}:${key}:${type ?? 'unknown'}:${JSON.stringify(resource)}}`,
 			etag,
 			cacheable,
 			options,
@@ -140,11 +141,17 @@ export class CacheProvider implements Disposable {
 		const { key, etag } = getResourceKeyAndEtag(resource, integration);
 
 		if (resource == null) {
-			return this.get('issuesById', `id:${id}:${key}`, etag, cacheable, options);
+			return this.get(
+				'issuesById',
+				`id:${id}:${key}:${'issue' satisfies IssueOrPullRequestType}`,
+				etag,
+				cacheable,
+				options,
+			);
 		}
 		return this.get(
 			'issuesByIdAndResource',
-			`id:${id}:${key}:${JSON.stringify(resource)}}`,
+			`id:${id}:${key}:${'issue' satisfies IssueOrPullRequestType}:${JSON.stringify(resource)}}`,
 			etag,
 			cacheable,
 			options,
@@ -161,9 +168,21 @@ export class CacheProvider implements Disposable {
 		const { key, etag } = getResourceKeyAndEtag(resource, integration);
 
 		if (resource == null) {
-			return this.get('prsById', `id:${id}:${key}`, etag, cacheable, options);
+			return this.get(
+				'prsById',
+				`id:${id}:${key}:${'pullrequest' satisfies IssueOrPullRequestType}`,
+				etag,
+				cacheable,
+				options,
+			);
 		}
-		return this.get('prsById', `id:${id}:${key}:${JSON.stringify(resource)}}`, etag, cacheable, options);
+		return this.get(
+			'prsById',
+			`id:${id}:${key}:${'pullrequest' satisfies IssueOrPullRequestType}:${JSON.stringify(resource)}}`,
+			etag,
+			cacheable,
+			options,
+		);
 	}
 
 	getPullRequestForBranch(
@@ -264,7 +283,12 @@ export class CacheProvider implements Disposable {
 			if (isPromise(item.value)) {
 				void item.value.then(v => {
 					if (v != null) {
-						this.set('issuesOrPrsById', `id:${v.id}:${key}`, v, etag);
+						this.set(
+							'issuesOrPrsById',
+							`id:${v.id}:${key}:${'pullrequest' satisfies IssueOrPullRequestType}`,
+							v,
+							etag,
+						);
 					}
 				});
 			}

--- a/src/plus/integrations/integration.ts
+++ b/src/plus/integrations/integration.ts
@@ -465,6 +465,7 @@ export abstract class IntegrationBase<
 
 		const issueOrPR = this.container.cache.getIssueOrPullRequest(
 			id,
+			options?.type,
 			resource,
 			this,
 			() => ({


### PR DESCRIPTION
solves #4193

# Description

Adds `IssueOrPullRequestType` to cache keys for issue/PR retrieval preventing potential cache collisions.

# Checklist

<!-- Please check off the following -->

- [x] I have followed the guidelines in the Contributing document
- [x] My changes follow the coding style of this project
- [x] My changes build without any errors or warnings
- [x] My changes have been formatted and linted
- [x] My changes include any required corresponding changes to the documentation (including CHANGELOG.md and README.md)
- [x] My changes have been rebased and squashed to the minimal number (typically 1) of relevant commits
- [x] My changes have a descriptive commit message with a short title, including a `Fixes $XXX -` or `Closes #XXX -` prefix to auto-close the issue that your PR addresses
