### PR TITLE
Improves branch name autolink matching logic

### DIFF
--- a/src/autolinks/__tests__/autolinks.test.ts
+++ b/src/autolinks/__tests__/autolinks.test.ts
@@ -24,24 +24,34 @@ function assertAutolinks(actual: Map<string, Autolink>, expected: Array<string>)
 
 suite('Autolinks Test Suite', () => {
 	test('Branch name autolinks', () => {
-		assertAutolinks(getBranchAutolinks('123', mockRefSets()), ['test/123']);
-		assertAutolinks(getBranchAutolinks('feature/123', mockRefSets()), ['test/123']);
+		// Matches under rule 1 (prefixed 2+ digit number followed by end of string)
+		assertAutolinks(getBranchAutolinks('feature/PRE-12', mockRefSets(['PRE-'])), ['test/12']);
+		// Matches under rule 1 (prefixed 2+ digit number followed by a separator)
+		assertAutolinks(getBranchAutolinks('feature/PRE-12.2', mockRefSets(['PRE-'])), ['test/12']);
+		// Matches under rule 2 (feature/ followed by a 2+ digit number and nothing after it)
+		assertAutolinks(getBranchAutolinks('feature/12', mockRefSets()), ['test/12']);
+		// Matches under rule 2 (feature/ followed by a 2+ digit number and a separator after it)
+		assertAutolinks(getBranchAutolinks('feature/12.test-bug', mockRefSets()), ['test/12']);
+		// Matches under rule 3 (3+ digit issue number preceded by at least two non-slash, non-digit characters)
 		assertAutolinks(getBranchAutolinks('feature/PRE-123', mockRefSets()), ['test/123']);
-		assertAutolinks(getBranchAutolinks('123.2', mockRefSets()), ['test/123', 'test/2']);
+		// Matches under rule 3 (3+ digit issue number followed by at least two non-slash, non-digit characters)
+		assertAutolinks(getBranchAutolinks('123abc', mockRefSets()), ['test/123']);
+		// Matches under rule 3 (3+ digit issue number is the entire branch name)
+		assertAutolinks(getBranchAutolinks('123', mockRefSets()), ['test/123']);
+		// Fails all rules because it is a 1 digit number.
+		assertAutolinks(getBranchAutolinks('feature/3', mockRefSets([''])), []);
+		// Fails all rules because it is a 1 digit number.
+		assertAutolinks(getBranchAutolinks('feature/3', mockRefSets(['PRE-'])), []);
+		// Fails all rules. In rule 3, fails because one of the two following characters is a number.
+		assertAutolinks(getBranchAutolinks('123.2', mockRefSets()), []);
+		// Fails all rules. In rule 3, fails because the issue is a full section (a slash before and after it).
+		assertAutolinks(getBranchAutolinks('improvement/123/ui-fix', mockRefSets()), []);
+		// Fails all rules. 2&3 because the ref is prefixed, and 1 because the branch name doesn't have the ref's prefix.
 		assertAutolinks(getBranchAutolinks('123', mockRefSets(['PRE-'])), []);
-		assertAutolinks(getBranchAutolinks('feature/123', mockRefSets(['PRE-'])), []);
-		assertAutolinks(getBranchAutolinks('feature/2-fa/123', mockRefSets([''])), ['test/123', 'test/2']);
-		assertAutolinks(getBranchAutolinks('feature/2-fa/123', mockRefSets([''])), ['test/123', 'test/2']);
-		// incorrectly solved cat worths to compare the blocks length so that the less block size (without possible link) is more likely a link
-		assertAutolinks(getBranchAutolinks('feature/2-fa/3', mockRefSets([''])), ['test/2', 'test/3']);
-		assertAutolinks(getBranchAutolinks('feature/PRE-123', mockRefSets(['PRE-'])), ['test/123']);
-		assertAutolinks(getBranchAutolinks('feature/PRE-123.2', mockRefSets(['PRE-'])), ['test/123']);
-		assertAutolinks(getBranchAutolinks('feature/3-123-PRE-123', mockRefSets(['PRE-'])), ['test/123']);
-		assertAutolinks(
-			getBranchAutolinks('feature/3-123-PRE-123', mockRefSets(['', 'PRE-'])),
-
-			['test/123', 'test/3'],
-		);
+		// Fails all rules. 2 because the issue is not immediately following the feature/ section, and 3 because it is a full section.
+		assertAutolinks(getBranchAutolinks('feature/2-fa/123', mockRefSets([''])), []);
+		// Fails all rules. 2 because of non-separator character after issue number, and 3 because it has end-of-string two character after.
+		assertAutolinks(getBranchAutolinks('feature/123a', mockRefSets(['PRE-'])), []);
 	});
 
 	test('Commit message autolinks', () => {

--- a/src/autolinks/models/autolinks.ts
+++ b/src/autolinks/models/autolinks.ts
@@ -26,7 +26,6 @@ export interface AutolinkReference {
 export interface Autolink extends Omit<CacheableAutolinkReference, 'id'> {
 	provider?: ProviderReference;
 	id: string;
-	index?: number;
 }
 
 export type EnrichedAutolink = [
@@ -56,7 +55,7 @@ export interface CacheableAutolinkReference extends AutolinkReference {
 	messageHtmlRegex?: RegExp;
 	messageMarkdownRegex?: RegExp;
 	messageRegex?: RegExp;
-	branchNameRegex?: RegExp;
+	branchNameRegexes?: RegExp[];
 }
 
 export interface DynamicAutolinkReference {

--- a/src/plus/integrations/providers/jira.ts
+++ b/src/plus/integrations/providers/jira.ts
@@ -57,16 +57,29 @@ export class JiraIntegration extends IssueIntegration<IssueIntegrationId.Jira> {
 				const projects = this._projects.get(`${this._session.accessToken}:${organization.id}`);
 				if (projects != null) {
 					for (const project of projects) {
-						const prefix = `${project.key}-`;
+						const dashedPrefix = `${project.key}-`;
+						const underscoredPrefix = `${project.key}_`;
 						autolinks.push({
-							prefix: prefix,
-							url: `${organization.url}/browse/${prefix}<num>`,
+							prefix: dashedPrefix,
+							url: `${organization.url}/browse/${dashedPrefix}<num>`,
 							alphanumeric: false,
 							ignoreCase: false,
-							title: `Open Issue ${prefix}<num> on ${organization.name}`,
+							title: `Open Issue ${dashedPrefix}<num> on ${organization.name}`,
 
 							type: 'issue',
-							description: `${organization.name} Issue ${prefix}<num>`,
+							description: `${organization.name} Issue ${dashedPrefix}<num>`,
+							descriptor: { ...organization },
+						});
+						autolinks.push({
+							prefix: underscoredPrefix,
+							url: `${organization.url}/browse/${dashedPrefix}<num>`,
+							alphanumeric: false,
+							ignoreCase: false,
+							referenceType: 'branch',
+							title: `Open Issue ${dashedPrefix}<num> on ${organization.name}`,
+
+							type: 'issue',
+							description: `${organization.name} Issue ${dashedPrefix}<num>`,
 							descriptor: { ...organization },
 						});
 					}


### PR DESCRIPTION
Refactors the branch name autolink matching logic to improve accuracy and reduce false positives.

- Introduces new regex matching rules/heuristics for branch name matching based on prefix and issue number patterns:

1. If a ref is prefixed, match to a 2+ digit number with the prefix followed by a connector `(/|-|_|.)` or end-of-string and take the first match encountered..
2. If ref is not prefixed, match to a 2+ digit number in the pattern of `(feature|feat|fix|bug|bugfix|hotfix|issue|ticket)(/|-|_|#|/#|-#|_#)<num>` followed by a connector `(/|-|_|.)` or end-of-string and take the first match.
3. If ref is not prefixed and no matches from rule 2, match to a 3+ digit number that is either the full branch name, or is preceded or followed by at least two non-slash (`/`), non-numeric characters. Note: this is to rule out numbers that are full sections like `<num>/...`, `.../<num>/...`, or `.../<num>` and to rule out date-formats like `<num.<num2>` or `<num>-<num2>`.

- Filters remote autolinks for branch names to only include non-dynamic autolinks of type 'branch'.
- Fixes issue where integration autolinks were incorrectly collected for branch autolinking.
- Sorts refsets so that issue integrations are checked first for matches.
- Limits branch autolink matches to 1 maximum per branch name.

Closes #3894