### PR TITLE
Improves handling of 'delete worktree' action on merge target when the default worktree is already open

### DIFF
--- a/src/constants.commands.ts
+++ b/src/constants.commands.ts
@@ -147,6 +147,7 @@ export type CoreCommands =
 	| 'workbench.action.closeActiveEditor'
 	| 'workbench.action.closeAllEditors'
 	| 'workbench.action.closePanel'
+	| 'workbench.action.closeWindow'
 	| 'workbench.action.focusRightGroup'
 	| 'workbench.action.nextEditor'
 	| 'workbench.action.newGroupRight'

--- a/src/constants.storage.ts
+++ b/src/constants.storage.ts
@@ -14,7 +14,8 @@ import type { DeepLinkServiceState } from './uris/deepLinks/deepLink';
 export type SecretKeys =
 	| IntegrationAuthenticationKeys
 	| `gitlens.${AIProviders}.key`
-	| `gitlens.plus.auth:${Environment}`;
+	| `gitlens.plus.auth:${Environment}`
+	| 'deepLinks:pending';
 
 export type IntegrationAuthenticationKeys =
 	| `gitlens.integration.auth:${IntegrationId}|${string}`
@@ -64,7 +65,6 @@ export type GlobalStorage = {
 	avatars: [string, StoredAvatar][];
 	'confirm:ai:tos': boolean;
 	repoVisibility: [string, StoredRepoVisibilityInfo][];
-	'deepLinks:pending': StoredDeepLinkContext;
 	pendingWhatsNewOnFocus: boolean;
 	// Don't change this key name ('premium`) as its the stored subscription
 	'premium:subscription': Stored<Subscription & { lastValidatedAt: number | undefined }>;

--- a/src/git/models/repository.ts
+++ b/src/git/models/repository.ts
@@ -625,11 +625,11 @@ export class Repository implements Disposable {
 	@gate()
 	@log({ exit: true })
 	async getCommonRepository(): Promise<Repository | undefined> {
-		const gitDir = await this.git.config().getGitDir?.();
-		if (gitDir?.commonUri == null) return this;
+		const uri = await this.getCommonRepositoryUri();
+		if (uri == null) return this;
 
 		// If the repository isn't already opened, then open it as a "closed" repo (won't show up in the UI)
-		return this.container.git.getOrOpenRepository(gitDir.commonUri, {
+		return this.container.git.getOrOpenRepository(uri, {
 			detectNested: false,
 			force: true,
 			closeOnOpen: true,

--- a/src/webviews/home/homeWebview.ts
+++ b/src/webviews/home/homeWebview.ts
@@ -1236,8 +1236,12 @@ export class HomeWebviewProvider implements WebviewProvider<State, State, HomeWe
 					subcommand: 'open',
 					repo: defaultWorktree.repoPath,
 					worktree: defaultWorktree,
-					onWorkspaceChanging: async (_isNewWorktree?: boolean) =>
-						this.container.storage.store('deepLinks:pending', deleteBranchDeepLink),
+					onWorkspaceChanging: async (_isNewWorktree?: boolean) => {
+						await this.container.storage.storeSecret(
+							'deepLinks:pending',
+							JSON.stringify(deleteBranchDeepLink),
+						);
+					},
 					worktreeDefaultOpen: 'current',
 				},
 			});

--- a/src/webviews/home/homeWebview.ts
+++ b/src/webviews/home/homeWebview.ts
@@ -1241,6 +1241,11 @@ export class HomeWebviewProvider implements WebviewProvider<State, State, HomeWe
 							'deepLinks:pending',
 							JSON.stringify(deleteBranchDeepLink),
 						);
+						// Close the current window. This should only occur if there was already a different
+						// window open for the default worktree.
+						setTimeout(() => {
+							void executeCoreCommand('workbench.action.closeWindow');
+						}, 2000);
 					},
 					worktreeDefaultOpen: 'current',
 				},


### PR DESCRIPTION
https://github.com/gitkraken/vscode-gitlens/issues/4232

When using the "delete worktree" action on the merge target hover, closes the current window and hands the rest of the flow over to the existing window with the default worktree, whenever it exists already.

To make this happen:
1. Fixes a bug in `findCommonRepository` where we are passing a '.git' folder path into the lower-level rev-parse git ops, which ultimately results in an error from git (to repro in any terminal, navigate to the .git directory of a repo and try `git rev-parse --show-toplevel`. You will see a `fatal: this operation must be run in a work tree` error.)
2. Pending deep links are moved to secret storage so that GitLens in other windows can detect when they are stored externally.
3. A listener is added to the deep link service to respond to pending deep links in storage whenever they match a repo open in the current window, and for the time being, only for pending deep links with the "delete worktree" action, to minimize possible regression risk.
4. A delayed command is triggered to close the window that initiated the handoff.

This carries a great deal of regression risk with deep links, so we should check for regressions where we can.

Closes #4232