### PR TITLE
Adds Ollama support

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,7 +9,7 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/) and this p
 ### Added
 
 - Adds the ability to search for GitHub Enterprise and GitLab Self-Managed pull requests by URL in the main step of Launchpad
-- Adds OpenRouter support for GitLens' AI features ([#3906](https://github.com/gitkraken/vscode-gitlens/issues/3906))
+- Adds Ollama and OpenRouter support for GitLens' AI features ([#3311](https://github.com/gitkraken/vscode-gitlens/issues/3311), [#3906](https://github.com/gitkraken/vscode-gitlens/issues/3906))
 - Adds Google Gemini 2.5 Flash (Preview) model, and OpenAI GPT-4.1, GPT-4.1 mini, GPT-4.1 nano, o4 mini, and o3 models for GitLens' AI features ([#4235](https://github.com/gitkraken/vscode-gitlens/issues/4235))
 - Adds _Open File at Revision from Remote_ command to open the specific file revision from a remote file URL
 

--- a/docs/telemetry-events.md
+++ b/docs/telemetry-events.md
@@ -124,7 +124,7 @@
   'failed.reason': 'user-declined' | 'user-cancelled' | 'error',
   'input.length': number,
   'model.id': string,
-  'model.provider.id': 'anthropic' | 'deepseek' | 'gemini' | 'github' | 'gitkraken' | 'huggingface' | 'openai' | 'openrouter' | 'vscode' | 'xai',
+  'model.provider.id': 'anthropic' | 'deepseek' | 'gemini' | 'github' | 'gitkraken' | 'huggingface' | 'ollama' | 'openai' | 'openrouter' | 'vscode' | 'xai',
   'model.provider.name': string,
   'output.length': number,
   'retry.count': number,
@@ -155,7 +155,7 @@
   'failed.reason': 'user-declined' | 'user-cancelled' | 'error',
   'input.length': number,
   'model.id': string,
-  'model.provider.id': 'anthropic' | 'deepseek' | 'gemini' | 'github' | 'gitkraken' | 'huggingface' | 'openai' | 'openrouter' | 'vscode' | 'xai',
+  'model.provider.id': 'anthropic' | 'deepseek' | 'gemini' | 'github' | 'gitkraken' | 'huggingface' | 'ollama' | 'openai' | 'openrouter' | 'vscode' | 'xai',
   'model.provider.name': string,
   'output.length': number,
   'retry.count': number,
@@ -185,7 +185,7 @@ or
   'failed.reason': 'user-declined' | 'user-cancelled' | 'error',
   'input.length': number,
   'model.id': string,
-  'model.provider.id': 'anthropic' | 'deepseek' | 'gemini' | 'github' | 'gitkraken' | 'huggingface' | 'openai' | 'openrouter' | 'vscode' | 'xai',
+  'model.provider.id': 'anthropic' | 'deepseek' | 'gemini' | 'github' | 'gitkraken' | 'huggingface' | 'ollama' | 'openai' | 'openrouter' | 'vscode' | 'xai',
   'model.provider.name': string,
   'output.length': number,
   'retry.count': number,
@@ -214,7 +214,7 @@ or
   'failed.reason': 'user-declined' | 'user-cancelled' | 'error',
   'input.length': number,
   'model.id': string,
-  'model.provider.id': 'anthropic' | 'deepseek' | 'gemini' | 'github' | 'gitkraken' | 'huggingface' | 'openai' | 'openrouter' | 'vscode' | 'xai',
+  'model.provider.id': 'anthropic' | 'deepseek' | 'gemini' | 'github' | 'gitkraken' | 'huggingface' | 'ollama' | 'openai' | 'openrouter' | 'vscode' | 'xai',
   'model.provider.name': string,
   'output.length': number,
   'retry.count': number,
@@ -243,7 +243,7 @@ or
   'failed.reason': 'user-declined' | 'user-cancelled' | 'error',
   'input.length': number,
   'model.id': string,
-  'model.provider.id': 'anthropic' | 'deepseek' | 'gemini' | 'github' | 'gitkraken' | 'huggingface' | 'openai' | 'openrouter' | 'vscode' | 'xai',
+  'model.provider.id': 'anthropic' | 'deepseek' | 'gemini' | 'github' | 'gitkraken' | 'huggingface' | 'ollama' | 'openai' | 'openrouter' | 'vscode' | 'xai',
   'model.provider.name': string,
   'output.length': number,
   'retry.count': number,
@@ -272,7 +272,7 @@ or
   'failed.reason': 'user-declined' | 'user-cancelled' | 'error',
   'input.length': number,
   'model.id': string,
-  'model.provider.id': 'anthropic' | 'deepseek' | 'gemini' | 'github' | 'gitkraken' | 'huggingface' | 'openai' | 'openrouter' | 'vscode' | 'xai',
+  'model.provider.id': 'anthropic' | 'deepseek' | 'gemini' | 'github' | 'gitkraken' | 'huggingface' | 'ollama' | 'openai' | 'openrouter' | 'vscode' | 'xai',
   'model.provider.name': string,
   'output.length': number,
   'retry.count': number,
@@ -295,7 +295,7 @@ or
 ```typescript
 {
   'model.id': string,
-  'model.provider.id': 'anthropic' | 'deepseek' | 'gemini' | 'github' | 'gitkraken' | 'huggingface' | 'openai' | 'openrouter' | 'vscode' | 'xai',
+  'model.provider.id': 'anthropic' | 'deepseek' | 'gemini' | 'github' | 'gitkraken' | 'huggingface' | 'ollama' | 'openai' | 'openrouter' | 'vscode' | 'xai',
   'model.provider.name': string
 }
 ```

--- a/package.json
+++ b/package.json
@@ -4047,7 +4047,7 @@
 							"null"
 						],
 						"default": null,
-						"pattern": "^((anthropic|deepseek|gemini|github|huggingface|openai|xai):([\\w.-]+)|gitkraken|vscode)$",
+						"pattern": "^((anthropic|deepseek|gemini|github|huggingface|ollama|openai|openrouter|xai):([\\w.-:]+)|gitkraken|vscode)$",
 						"markdownDescription": "Specifies the AI provider and model to use for GitLens' AI features. Should be formatted as `provider:model` (e.g. `openai:gpt-4o` or `anthropic:claude-3-5-sonnet-latest`), `gitkraken` for GitKraken AI provided models, or `vscode` for models provided by the VS Code extension API (e.g. Copilot)",
 						"scope": "window",
 						"order": 10,
@@ -4083,6 +4083,19 @@
 							"preview"
 						]
 					},
+					"gitlens.ai.ollama.url": {
+						"type": [
+							"string",
+							"null"
+						],
+						"default": null,
+						"markdownDescription": "Specifies the Ollama URL to use for access",
+						"scope": "window",
+						"order": 30,
+						"tags": [
+							"preview"
+						]
+					},
 					"gitlens.ai.openai.url": {
 						"type": [
 							"string",
@@ -4091,7 +4104,7 @@
 						"default": null,
 						"markdownDescription": "Specifies a custom URL to use for access to an OpenAI model via Azure. Azure URLs should be in the following format: https://{your-resource-name}.openai.azure.com/openai/deployments/{deployment-id}/chat/completions?api-version={api-version}",
 						"scope": "window",
-						"order": 30,
+						"order": 31,
 						"tags": [
 							"preview"
 						]

--- a/src/config.ts
+++ b/src/config.ts
@@ -243,6 +243,9 @@ interface AIConfig {
 	readonly modelOptions: {
 		readonly temperature: number;
 	};
+	readonly ollama: {
+		readonly url: string | null;
+	};
 	readonly openai: {
 		readonly url: string | null;
 	};

--- a/src/constants.ai.ts
+++ b/src/constants.ai.ts
@@ -7,6 +7,7 @@ export type AIProviders =
 	| 'github'
 	| 'gitkraken'
 	| 'huggingface'
+	| 'ollama'
 	| 'openai'
 	| 'openrouter'
 	| 'vscode'
@@ -85,4 +86,11 @@ export const openRouterProviderDescriptor: AIProviderDescriptor<'openrouter'> = 
 	primary: false,
 	requiresAccount: true,
 	requiresUserKey: true,
+} as const;
+export const ollamaProviderDescriptor: AIProviderDescriptor<'ollama'> = {
+	id: 'ollama',
+	name: 'Ollama',
+	primary: false,
+	requiresAccount: false,
+	requiresUserKey: false,
 } as const;

--- a/src/plus/ai/aiProviderService.ts
+++ b/src/plus/ai/aiProviderService.ts
@@ -8,6 +8,7 @@ import {
 	githubProviderDescriptor,
 	gitKrakenProviderDescriptor,
 	huggingFaceProviderDescriptor,
+	ollamaProviderDescriptor,
 	openAIProviderDescriptor,
 	openRouterProviderDescriptor,
 	vscodeProviderDescriptor,
@@ -181,6 +182,13 @@ const supportedAIProviders = new Map<AIProviders, AIProviderDescriptorWithType>(
 			type: lazy(
 				async () => (await import(/* webpackChunkName: "ai" */ './huggingFaceProvider')).HuggingFaceProvider,
 			),
+		},
+	],
+	[
+		'ollama',
+		{
+			...ollamaProviderDescriptor,
+			type: lazy(async () => (await import(/* webpackChunkName: "ai" */ './ollamaProvider')).OllamaProvider),
 		},
 	],
 ]);

--- a/src/plus/ai/ollamaProvider.ts
+++ b/src/plus/ai/ollamaProvider.ts
@@ -1,0 +1,288 @@
+import type { CancellationToken, Disposable } from 'vscode';
+import { window } from 'vscode';
+import { ollamaProviderDescriptor as provider } from '../../constants.ai';
+import { configuration } from '../../system/-webview/configuration';
+import type { AIActionType, AIModel } from './models/model';
+import type { AIChatMessage, AIRequestResult } from './models/provider';
+import { OpenAICompatibleProvider } from './openAICompatibleProvider';
+
+type OllamaModel = AIModel<typeof provider.id>;
+
+const defaultBaseUrl = 'http://localhost:11434';
+
+export class OllamaProvider extends OpenAICompatibleProvider<typeof provider.id> {
+	readonly id = provider.id;
+	readonly name = provider.name;
+	protected readonly descriptor = provider;
+	protected readonly config = {
+		keyUrl: 'https://ollama.com/download',
+	};
+
+	override async configured(silent: boolean): Promise<boolean> {
+		// Ollama doesn't require an API key, but we'll check if the base URL is reachable
+		return this.validateUrl(await this.getOrPromptBaseUrl(silent), silent);
+	}
+
+	override getApiKey(_silent: boolean): Promise<string | undefined> {
+		// Ollama doesn't require an API key
+		return Promise.resolve('<not applicable>');
+	}
+
+	async getModels(): Promise<readonly AIModel<typeof provider.id>[]> {
+		try {
+			const url = this.getBaseUrl();
+			const rsp = await fetch(`${url}/api/tags`, {
+				headers: {
+					Accept: 'application/json',
+					'Content-Type': 'application/json',
+				},
+				method: 'GET',
+			});
+
+			if (!rsp.ok) {
+				throw new Error(`Getting models failed: ${rsp.status} (${rsp.statusText})`);
+			}
+
+			interface OllamaModelsResponse {
+				models: {
+					name: string;
+					model: string;
+					modified_at: string;
+					size: number;
+					details?: {
+						parameter_size?: string;
+						quantization_level?: string;
+					};
+				}[];
+			}
+
+			const result: OllamaModelsResponse = (await rsp.json()) as OllamaModelsResponse;
+
+			// If there are models installed on the user's Ollama instance, use those
+			if (result.models?.length) {
+				return result.models.map<OllamaModel>(m => ({
+					id: m.name,
+					name: m.name,
+					maxTokens: { input: 8192, output: 8192 },
+					provider: provider,
+					default: m.name === 'llama3',
+				}));
+			}
+		} catch {}
+
+		return [];
+	}
+
+	private async getOrPromptBaseUrl(silent: boolean): Promise<string> {
+		let url = configuration.get('ai.ollama.url') ?? undefined;
+		if (url) {
+			if (silent) return url;
+
+			const valid = await this.validateUrl(url, true);
+			if (valid) return url;
+		}
+
+		if (silent) return defaultBaseUrl;
+
+		const input = window.createInputBox();
+		input.ignoreFocusOut = true;
+
+		const disposables: Disposable[] = [];
+
+		try {
+			url = await new Promise<string | undefined>(resolve => {
+				disposables.push(
+					input.onDidHide(() => resolve(undefined)),
+					input.onDidChangeValue(value => {
+						if (value) {
+							try {
+								new URL(value);
+							} catch {
+								input.validationMessage = `Please enter a valid URL`;
+								return;
+							}
+						}
+						input.validationMessage = undefined;
+					}),
+					input.onDidAccept(async () => {
+						const value = input.value.trim();
+						if (!value) {
+							input.validationMessage = `Please enter a valid URL`;
+							return;
+						}
+
+						try {
+							new URL(value);
+						} catch {
+							input.validationMessage = `Please enter a valid URL`;
+							return;
+						}
+
+						const configured = await this.validateUrl(value, true);
+						if (!configured) {
+							input.validationMessage = `Could not connect to Ollama server. Make sure Ollama is installed and running locally.`;
+							return;
+						}
+
+						resolve(value);
+					}),
+				);
+
+				input.title = `Connect to Ollama`;
+				input.placeholder = `Please enter your Ollama server URL to use this feature`;
+				input.prompt = `Enter your Ollama server URL (default: ${defaultBaseUrl})`;
+				input.value = defaultBaseUrl;
+
+				input.show();
+			});
+		} finally {
+			input.dispose();
+			disposables.forEach(d => void d.dispose());
+		}
+
+		if (!url) return defaultBaseUrl;
+
+		void configuration.updateEffective('ai.ollama.url', url);
+
+		return url;
+	}
+
+	private async validateUrl(url: string, silent: boolean): Promise<boolean> {
+		try {
+			const rsp = await fetch(`${url}/api/tags`, {
+				headers: { Accept: 'application/json', 'Content-Type': 'application/json' },
+				method: 'GET',
+			});
+			return rsp.ok;
+		} catch {
+			// If we reach here, Ollama server is not accessible
+			if (!silent) {
+				await window.showErrorMessage(
+					`Could not connect to Ollama server. Make sure Ollama is installed and running locally.`,
+				);
+			}
+			return false;
+		}
+	}
+
+	private getBaseUrl(): string {
+		// Get base URL from configuration or use default
+		return configuration.get('ai.ollama.url') || defaultBaseUrl;
+	}
+
+	protected getUrl(_model: AIModel<typeof provider.id>): string {
+		return `${this.getBaseUrl()}/api/chat`;
+	}
+
+	protected override getHeaders<TAction extends AIActionType>(
+		_action: TAction,
+		_apiKey: string,
+		_model: AIModel<typeof provider.id>,
+		_url: string,
+	): Record<string, string> {
+		return {
+			Accept: 'application/json',
+			'Content-Type': 'application/json',
+		};
+	}
+
+	protected override async fetch<TAction extends AIActionType>(
+		action: TAction,
+		model: AIModel<typeof provider.id>,
+		apiKey: string,
+		messages: (maxInputTokens: number, retries: number) => Promise<AIChatMessage[]>,
+		modelOptions?: { outputTokens?: number; temperature?: number },
+		cancellation?: CancellationToken,
+	): Promise<AIRequestResult> {
+		let retries = 0;
+		let maxInputTokens = model.maxTokens.input;
+
+		while (true) {
+			// Get messages and prepare request payload for Ollama
+			const chatMessages = await messages(maxInputTokens, retries);
+
+			// Convert to the format expected by Ollama
+			const ollamaMessages = chatMessages.map(msg => ({
+				role: msg.role,
+				content: msg.content,
+			}));
+
+			// Ensure temperature is within valid range for Ollama (0.0-1.0)
+			const temperature = Math.min(Math.max(modelOptions?.temperature ?? 0.7, 0), 1);
+
+			const request: OllamaChatRequest = {
+				model: model.id,
+				messages: ollamaMessages,
+				stream: false,
+				options: {
+					temperature: temperature,
+					// Add num_predict if outputTokens is specified
+					...(modelOptions?.outputTokens ? { num_predict: modelOptions.outputTokens } : {}),
+				},
+			};
+
+			const rsp = await this.fetchCore(action, model, apiKey, request, cancellation);
+			if (!rsp.ok) {
+				const result = await this.handleFetchFailure(rsp, action, model, retries, maxInputTokens);
+				if (result.retry) {
+					maxInputTokens = result.maxInputTokens;
+					retries++;
+					continue;
+				}
+			}
+
+			try {
+				// Parse response from Ollama
+				const data = (await rsp.json()) as OllamaChatResponse;
+
+				if (!data.message?.content) {
+					throw new Error(`Empty response from Ollama model: ${model.id}`);
+				}
+
+				return {
+					content: data.message.content,
+					model: model,
+					usage: {
+						promptTokens: data.prompt_eval_count ?? 0,
+						completionTokens: data.eval_count ?? 0,
+						totalTokens: (data.prompt_eval_count ?? 0) + (data.eval_count ?? 0),
+					},
+				};
+			} catch (err) {
+				throw new Error(`Failed to parse Ollama response: ${err instanceof Error ? err.message : String(err)}`);
+			}
+		}
+	}
+}
+
+// Define Ollama API types
+interface OllamaChatRequest {
+	model: string;
+	messages: Array<{
+		role: string;
+		content: string;
+	}>;
+	stream: boolean;
+	options?: {
+		temperature?: number;
+		top_p?: number;
+		top_k?: number;
+		num_predict?: number;
+	};
+}
+
+interface OllamaChatResponse {
+	model: string;
+	created_at: string;
+	message: {
+		role: string;
+		content: string;
+	};
+	done: boolean;
+	total_duration?: number;
+	load_duration?: number;
+	prompt_eval_count?: number;
+	eval_count?: number;
+	prompt_eval_duration?: number;
+	eval_duration?: number;
+}


### PR DESCRIPTION
Adds support for Ollama as a provider (requires Ollama server to be configured and running).

Prompts for URL when chosen or used as a provider and one is not configured.

Shows messaging when no models are installed.

To use:

1. Download Ollama: https://ollama.com/download
2. Install a model from the library: https://ollama.com/library (note: you can use any terminal and write, for example, `ollama run llama3.3` if Ollama is installed and configured)
3. Be sure Ollama is running, then use the "switch AI model" flow and choose Ollama, then put in your server URL (default is `http://localhost:11434` if you're running it locally.
4. Your installed models should show up in a list. Choose one and you're good to go.

Closes #3311