### PR TITLE
Allow the merge target to be changed or ignored

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/) and this p
 
 - Adds the ability to search for GitHub Enterprise and GitLab Self-Managed pull requests by URL in the main step of Launchpad
 - Adds Ollama and OpenRouter support for GitLens' AI features ([#3311](https://github.com/gitkraken/vscode-gitlens/issues/3311), [#3906](https://github.com/gitkraken/vscode-gitlens/issues/3906))
+- Adds the ability to change a branch's merge target in Home view. ([#4224](https://github.com/gitkraken/vscode-gitlens/issues/4224))
 - Adds Google Gemini 2.5 Flash (Preview) model, and OpenAI GPT-4.1, GPT-4.1 mini, GPT-4.1 nano, o4 mini, and o3 models for GitLens' AI features ([#4235](https://github.com/gitkraken/vscode-gitlens/issues/4235))
 - Adds _Open File at Revision from Remote_ command to open the specific file revision from a remote file URL
 
@@ -22,6 +23,7 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/) and this p
 
 ### Fixed
 
+- Fixes an error that can occur when retrieving the active repository, such as when the current file is not part of a repository.
 - Fixes cache collision between issues and PRs in autolinks ([#4193](https://github.com/gitkraken/vscode-gitlens/issues/4193))
 - Fixes incorrect PR Link Across Azure DevOps Projects ([#4207](https://github.com/gitkraken/vscode-gitlens/issues/4207))
 - Fixes detail view incorrectly parses GitHub account in commit message ([#3246](https://github.com/gitkraken/vscode-gitlens/issues/3246))

--- a/contributions.json
+++ b/contributions.json
@@ -71,6 +71,10 @@
 			"enablement": "gitlens:enabled && resourceScheme =~ /^(gitlens|pr)$/",
 			"commandPalette": "!gitlens:hasVirtualFolders && gitlens:enabled && resourceScheme =~ /^(gitlens|git|pr)$/"
 		},
+		"gitlens.changeBranchMergeTarget": {
+			"label": "Change Branch Merge Target",
+			"commandPalette": "gitlens:enabled && !gitlens:readonly && !gitlens:untrusted && !gitlens:hasVirtualFolders"
+		},
 		"gitlens.clearFileAnnotations": {
 			"label": "Clear File Annotations",
 			"icon": "$(gitlens-gitlens-filled)",

--- a/docs/telemetry-events.md
+++ b/docs/telemetry-events.md
@@ -1160,6 +1160,14 @@ or
 }
 ```
 
+### home/changeBranchMergeTarget
+
+> Sent when the user starts defining a user-specific merge target branch
+
+```typescript
+void
+```
+
 ### home/command
 
 > Sent when a Home command is executed

--- a/package.json
+++ b/package.json
@@ -6099,6 +6099,11 @@
 				"enablement": "gitlens:enabled && resourceScheme =~ /^(gitlens|pr)$/"
 			},
 			{
+				"command": "gitlens.changeBranchMergeTarget",
+				"title": "Change Branch Merge Target",
+				"category": "GitLens"
+			},
+			{
 				"command": "gitlens.clearFileAnnotations",
 				"title": "Clear File Annotations",
 				"category": "GitLens",
@@ -10382,6 +10387,10 @@
 				{
 					"command": "gitlens.browseRepoBeforeRevisionInNewWindow",
 					"when": "!gitlens:hasVirtualFolders && gitlens:enabled && resourceScheme =~ /^(gitlens|git|pr)$/"
+				},
+				{
+					"command": "gitlens.changeBranchMergeTarget",
+					"when": "gitlens:enabled && !gitlens:readonly && !gitlens:untrusted && !gitlens:hasVirtualFolders"
 				},
 				{
 					"command": "gitlens.clearFileAnnotations",

--- a/src/commands/changeBranchMergeTarget.ts
+++ b/src/commands/changeBranchMergeTarget.ts
@@ -100,7 +100,7 @@ export class ChangeBranchMergeTargetCommand extends QuickCommand {
 				placeholder: 'Pick a merge target branch',
 				filter: (branch: GitBranch) => branch.remote && branch.name !== state.branch,
 				resetTitle: 'Reset Merge Target',
-				resetDescription: `Reset to "${detectedMergeTarget}"`,
+				resetDescription: detectedMergeTarget ? `Reset to "${detectedMergeTarget}"` : '',
 			});
 			if (result === StepResultBreak) {
 				continue;

--- a/src/commands/changeBranchMergeTarget.ts
+++ b/src/commands/changeBranchMergeTarget.ts
@@ -1,0 +1,64 @@
+import type { Container } from '../container';
+import type { GitBranch } from '../git/models/branch';
+import type { Repository } from '../git/models/repository';
+import type { PartialStepState, StepGenerator } from './quickCommand';
+import { QuickCommand, StepResultBreak } from './quickCommand';
+import { pickBranchOrTagStep } from './quickCommand.steps';
+
+interface Context {
+	repos: Repository[];
+	title: string;
+}
+
+type State = {
+	repo: string | Repository;
+	branch: string;
+	mergeBranch: string | undefined;
+};
+
+export interface ChangeBranchMergeTargetCommandArgs {
+	readonly command: 'changeBranchMergeTarget';
+	state?: Partial<State>;
+}
+
+export class ChangeBranchMergeTargetCommand extends QuickCommand {
+	constructor(container: Container, args?: ChangeBranchMergeTargetCommandArgs) {
+		super(container, 'changeBranchMergeTarget', 'changeBranchMergeTarget', 'Change Merge Target', {
+			description: 'Change Merge Target for a branch',
+		});
+		this.initialState = {
+			counter: 0,
+			...args?.state,
+		};
+	}
+
+	protected async *steps(state: PartialStepState<State>): StepGenerator {
+		const context: Context = {
+			repos: this.container.git.openRepositories,
+			title: this.title,
+		};
+		const repository = typeof state.repo === 'string' ? this.container.git.getRepository(state.repo) : state.repo;
+		if (repository) {
+			const result = yield* pickBranchOrTagStep({ counter: 0, repo: repository }, context, {
+				picked: state.mergeBranch,
+				placeholder: 'Pick a merge target branch',
+				value: undefined,
+				filter: {
+					branches: (branch: GitBranch) => branch.remote && branch.name !== state.branch,
+					tags: () => false,
+				},
+			});
+			if (result === StepResultBreak) {
+				return;
+			}
+			const ref = await this.container.git.branches(repository.path).getBranch(state.branch);
+			if (ref && result && state.branch) {
+				await this.container.git
+					.branches(repository.path)
+					.setUserMergeTargetBranchName?.(state.branch, result.name);
+			}
+		}
+
+		await Promise.resolve(true);
+	}
+}

--- a/src/commands/quickCommand.steps.ts
+++ b/src/commands/quickCommand.steps.ts
@@ -1616,7 +1616,16 @@ export async function* pickRepositoryStep<
 		state.repo = Container.instance.git.getRepository(state.repo);
 		if (state.repo != null) return state.repo;
 	}
-	const active = state.repo ?? (await Container.instance.git.getOrOpenRepositoryForEditor());
+	let active;
+	try {
+		active = state.repo ?? (await Container.instance.git.getOrOpenRepositoryForEditor());
+	} catch (ex) {
+		Logger.log(
+			'pickRepositoryStep: failed to get active repository. Normally it happens when the currently open file does not belong to a repository',
+			ex,
+		);
+		active = undefined;
+	}
 
 	const step = createPickStep<RepositoryQuickPickItem>({
 		title: context.title,

--- a/src/commands/quickCommand.steps.ts
+++ b/src/commands/quickCommand.steps.ts
@@ -823,7 +823,7 @@ export function* pickOrResetBranchStep<
 
 	const resetButton: QuickInputButton = {
 		iconPath: new ThemeIcon('notebook-revert'),
-		tooltip: resetDescription,
+		tooltip: resetDescription || resetTitle,
 	};
 	let resetButtonClicked = false;
 	const step = createPickStep<BranchQuickPickItem>({

--- a/src/commands/quickWizard.ts
+++ b/src/commands/quickWizard.ts
@@ -2,16 +2,26 @@ import type { Container } from '../container';
 import type { LaunchpadCommandArgs } from '../plus/launchpad/launchpad';
 import type { AssociateIssueWithBranchCommandArgs, StartWorkCommandArgs } from '../plus/startWork/startWork';
 import { command } from '../system/-webview/command';
+import type { ChangeBranchMergeTargetCommandArgs } from './changeBranchMergeTarget';
 import type { CommandContext } from './commandContext';
 import type { QuickWizardCommandArgsWithCompletion } from './quickWizard.base';
 import { QuickWizardCommandBase } from './quickWizard.base';
 
-export type QuickWizardCommandArgs = LaunchpadCommandArgs | StartWorkCommandArgs | AssociateIssueWithBranchCommandArgs;
+export type QuickWizardCommandArgs =
+	| LaunchpadCommandArgs
+	| StartWorkCommandArgs
+	| AssociateIssueWithBranchCommandArgs
+	| ChangeBranchMergeTargetCommandArgs;
 
 @command()
 export class QuickWizardCommand extends QuickWizardCommandBase {
 	constructor(container: Container) {
-		super(container, ['gitlens.showLaunchpad', 'gitlens.startWork', 'gitlens.associateIssueWithBranch']);
+		super(container, [
+			'gitlens.showLaunchpad',
+			'gitlens.startWork',
+			'gitlens.associateIssueWithBranch',
+			'gitlens.changeBranchMergeTarget',
+		]);
 	}
 
 	protected override preExecute(context: CommandContext, args?: QuickWizardCommandArgsWithCompletion): Promise<void> {
@@ -24,6 +34,9 @@ export class QuickWizardCommand extends QuickWizardCommandBase {
 
 			case 'gitlens.associateIssueWithBranch':
 				return this.execute({ command: 'associateIssueWithBranch', ...args });
+
+			case 'gitlens.changeBranchMergeTarget':
+				return this.execute({ command: 'changeBranchMergeTarget', ...args });
 
 			default:
 				return this.execute(args);

--- a/src/commands/quickWizard.utils.ts
+++ b/src/commands/quickWizard.utils.ts
@@ -5,6 +5,7 @@ import { LaunchpadCommand } from '../plus/launchpad/launchpad';
 import { AssociateIssueWithBranchCommand, StartWorkCommand } from '../plus/startWork/startWork';
 import { configuration } from '../system/-webview/configuration';
 import { getContext } from '../system/-webview/context';
+import { ChangeBranchMergeTargetCommand } from './changeBranchMergeTarget';
 import { BranchGitCommand } from './git/branch';
 import { CherryPickGitCommand } from './git/cherry-pick';
 import { CoAuthorsGitCommand } from './git/coauthors';
@@ -121,6 +122,10 @@ export class QuickWizardRootStep implements QuickPickStep<QuickCommand> {
 
 		if (args?.command === 'associateIssueWithBranch') {
 			this.hiddenItems.push(new AssociateIssueWithBranchCommand(container, args));
+		}
+
+		if (args?.command === 'changeBranchMergeTarget') {
+			this.hiddenItems.push(new ChangeBranchMergeTargetCommand(container, args));
 		}
 	}
 

--- a/src/constants.commands.generated.ts
+++ b/src/constants.commands.generated.ts
@@ -619,6 +619,7 @@ export type ContributedPaletteCommands =
 	| 'gitlens.browseRepoAtRevisionInNewWindow'
 	| 'gitlens.browseRepoBeforeRevision'
 	| 'gitlens.browseRepoBeforeRevisionInNewWindow'
+	| 'gitlens.changeBranchMergeTarget'
 	| 'gitlens.clearFileAnnotations'
 	| 'gitlens.closeUnchangedFiles'
 	| 'gitlens.compareHeadWith'

--- a/src/constants.commands.ts
+++ b/src/constants.commands.ts
@@ -33,6 +33,7 @@ type InternalGraphWebviewCommands =
 	| 'gitlens.graph.skipPausedOperation';
 
 type InternalHomeWebviewCommands =
+	| 'gitlens.home.changeBranchMergeTarget'
 	| 'gitlens.home.deleteBranchOrWorktree'
 	| 'gitlens.home.pushBranch'
 	| 'gitlens.home.openMergeTargetComparison'
@@ -103,6 +104,7 @@ type InternalWalkthroughCommands =
 
 type InternalGlCommands =
 	| `gitlens.action.${string}`
+	| 'gitlens.changeBranchMergeTarget'
 	| 'gitlens.diffWith'
 	| 'gitlens.openOnRemote'
 	| 'gitlens.openWalkthrough'

--- a/src/constants.telemetry.ts
+++ b/src/constants.telemetry.ts
@@ -157,6 +157,8 @@ export interface TelemetryEvents extends WebviewShowAbortedEvents, WebviewShownE
 	'home/createBranch': void;
 	/** Sent when the user chooses to start work on an issue from the home view */
 	'home/startWork': void;
+	/** Sent when the user starts defining a user-specific merge target branch */
+	'home/changeBranchMergeTarget': void;
 
 	/** Sent when the user takes an action on the Launchpad title bar */
 	'launchpad/title/action': LaunchpadTitleActionEvent;

--- a/src/constants.ts
+++ b/src/constants.ts
@@ -49,6 +49,7 @@ export const enum CharCode {
 
 export type GitConfigKeys =
 	| `branch.${string}.${'gk' | 'vscode'}-merge-base`
+	| `branch.${string}.gk-user-merge-target`
 	| `branch.${string}.gk-target-base`
 	| `branch.${string}.gk-associated-issues`
 	| `branch.${string}.github-pr-owner-number`;

--- a/src/env/node/git/sub-providers/branches.ts
+++ b/src/env/node/git/sub-providers/branches.ts
@@ -627,6 +627,19 @@ export class BranchesGitSubProvider implements GitBranchesSubProvider {
 		await this.provider.config.setConfig(repoPath, mergeBaseConfigKey, base);
 	}
 
+	@log()
+	async getUserMergeTargetBranchName(repoPath: string, ref: string): Promise<string | undefined> {
+		const mergeTargetConfigKey: GitConfigKeys = `branch.${ref}.gk-user-merge-target`;
+		const target = await this.provider.config.getConfig(repoPath, mergeTargetConfigKey);
+		return target?.trim() || undefined;
+	}
+
+	@log()
+	async setUserMergeTargetBranchName(repoPath: string, ref: string, target: string | undefined): Promise<void> {
+		const mergeTargetConfigKey: GitConfigKeys = `branch.${ref}.gk-user-merge-target`;
+		await this.provider.config.setConfig(repoPath, mergeTargetConfigKey, target);
+	}
+
 	private async getBaseBranchFromReflog(
 		repoPath: string,
 		ref: string,

--- a/src/git/gitProvider.ts
+++ b/src/git/gitProvider.ts
@@ -259,7 +259,7 @@ export interface GitBranchesSubProvider {
 	getTargetBranchName?(repoPath: string, ref: string): Promise<string | undefined>;
 	setTargetBranchName?(repoPath: string, ref: string, target: string): Promise<void>;
 	getUserMergeTargetBranchName?(repoPath: string, ref: string): Promise<string | undefined>;
-	setUserMergeTargetBranchName?(repoPath: string, ref: string, target: string): Promise<void>;
+	setUserMergeTargetBranchName?(repoPath: string, ref: string, target: string | undefined): Promise<void>;
 	renameBranch?(repoPath: string, oldName: string, newName: string): Promise<void>;
 }
 

--- a/src/git/gitProvider.ts
+++ b/src/git/gitProvider.ts
@@ -258,6 +258,8 @@ export interface GitBranchesSubProvider {
 	setBaseBranchName?(repoPath: string, ref: string, base: string): Promise<void>;
 	getTargetBranchName?(repoPath: string, ref: string): Promise<string | undefined>;
 	setTargetBranchName?(repoPath: string, ref: string, target: string): Promise<void>;
+	getUserMergeTargetBranchName?(repoPath: string, ref: string): Promise<string | undefined>;
+	setUserMergeTargetBranchName?(repoPath: string, ref: string, target: string): Promise<void>;
 	renameBranch?(repoPath: string, oldName: string, newName: string): Promise<void>;
 }
 

--- a/src/git/models/branch.ts
+++ b/src/git/models/branch.ts
@@ -227,4 +227,5 @@ export interface BranchTargetInfo {
 	baseBranch: string | undefined;
 	defaultBranch: string | undefined;
 	targetBranch: MaybePausedResult<string | undefined>;
+	userTargetBranch: string | undefined;
 }

--- a/src/git/utils/-webview/branch.utils.ts
+++ b/src/git/utils/-webview/branch.utils.ts
@@ -14,23 +14,26 @@ export async function getBranchTargetInfo(
 		timeout?: number;
 	},
 ): Promise<BranchTargetInfo> {
-	const [baseResult, defaultResult, targetResult] = await Promise.allSettled([
+	const [baseResult, defaultResult, targetResult, userTargetResult] = await Promise.allSettled([
 		container.git.branches(branch.repoPath).getBaseBranchName?.(branch.name),
 		getDefaultBranchName(container, branch.repoPath, branch.getRemoteName()),
 		getTargetBranchName(container, branch, {
 			cancellation: options?.cancellation,
 			timeout: options?.timeout,
 		}),
+		container.git.branches(branch.repoPath).getUserMergeTargetBranchName?.(branch.name),
 	]);
 
 	const baseBranchName = getSettledValue(baseResult);
 	const defaultBranchName = getSettledValue(defaultResult);
 	const targetMaybeResult = getSettledValue(targetResult);
+	const userTargetBranchName = getSettledValue(userTargetResult);
 
 	return {
 		baseBranch: baseBranchName,
 		defaultBranch: defaultBranchName,
 		targetBranch: targetMaybeResult ?? { value: undefined, paused: false },
+		userTargetBranch: userTargetBranchName,
 	};
 }
 

--- a/src/quickpicks/comparisonPicker.ts
+++ b/src/quickpicks/comparisonPicker.ts
@@ -81,9 +81,14 @@ export async function showComparisonPicker(
 				const branch = await repo?.git.branches().getBranch(head.name);
 				if (branch != null) {
 					const info = await getBranchTargetInfo(container, branch);
-					const target = info.targetBranch.paused
-						? info.baseBranch
-						: info.targetBranch.value ?? info.defaultBranch;
+					let target;
+					if (info.userTargetBranch) {
+						target = info.userTargetBranch;
+					} else if (!info.targetBranch.paused && info.targetBranch.value) {
+						target = info.targetBranch.value;
+					} else {
+						target = info.baseBranch ?? info.defaultBranch;
+					}
 					if (target != null) {
 						base = createReference(target, repoPath, { refType: 'revision' });
 					}

--- a/src/quickpicks/items/directive.ts
+++ b/src/quickpicks/items/directive.ts
@@ -5,6 +5,7 @@ import { pluralize } from '../../system/string';
 export enum Directive {
 	Back,
 	Cancel,
+	Reset,
 	LoadMore,
 	Noop,
 	Reload,
@@ -56,6 +57,9 @@ export function createDirectiveQuickPickItem(
 				break;
 			case Directive.Reload:
 				label = 'Refresh';
+				break;
+			case Directive.Reset:
+				label = 'Reset';
 				break;
 			case Directive.SignIn:
 				label = 'Sign In';

--- a/src/webviews/apps/plus/home/components/merge-target-status.ts
+++ b/src/webviews/apps/plus/home/components/merge-target-status.ts
@@ -477,18 +477,30 @@ export class GlMergeTargetStatus extends LitElement {
 		return html`<span class="header__actions"
 			>${branchRef && targetRef
 				? html`<gl-button
-						href="${createCommandLink<BranchAndTargetRefs>('gitlens.home.openMergeTargetComparison', {
-							...branchRef,
-							mergeTargetId: targetRef.branchId,
-							mergeTargetName: targetRef.branchName,
-						})}"
-						appearance="toolbar"
-						><code-icon icon="git-compare"></code-icon>
-						<span slot="tooltip"
-							>Compare Branch with Merge Target<br />${renderBranchName(this.branch.name)}
-							&leftrightarrow; ${renderBranchName(this.target?.name)}</span
-						>
-				  </gl-button>`
+							href="${createCommandLink<BranchAndTargetRefs>('gitlens.home.changeBranchMergeTarget', {
+								...branchRef,
+								mergeTargetId: targetRef.branchId,
+								mergeTargetName: targetRef.branchName,
+							})}"
+							appearance="toolbar"
+							><code-icon icon="pencil"></code-icon
+							><span slot="tooltip"
+								>Edit Merge Target<br />${renderBranchName(this.branch.name)} &leftrightarrow;
+								${renderBranchName(this.target?.name)}</span
+							></gl-button
+						><gl-button
+							href="${createCommandLink<BranchAndTargetRefs>('gitlens.home.openMergeTargetComparison', {
+								...branchRef,
+								mergeTargetId: targetRef.branchId,
+								mergeTargetName: targetRef.branchName,
+							})}"
+							appearance="toolbar"
+							><code-icon icon="git-compare"></code-icon>
+							<span slot="tooltip"
+								>Compare Branch with Merge Target<br />${renderBranchName(this.branch.name)}
+								&leftrightarrow; ${renderBranchName(this.target?.name)}</span
+							>
+						</gl-button>`
 				: nothing}<gl-button
 				href="${createCommandLink('gitlens.home.fetch', this.targetBranchRef)}"
 				appearance="toolbar"


### PR DESCRIPTION
## Description
solves #4224 


Edit button and its tooltip:
<img width="400" src="https://github.com/user-attachments/assets/145c3bfa-e0ad-447a-be32-756c424a0642">

Branch selection, filtered by:
- it's branch
- it's remote (does it have to be remote?)
<img width="800" src="https://github.com/user-attachments/assets/66da9a35-4db1-4813-b297-50772b5bc7bc">


Consequences: a new command has been added:
<img width="600" src="https://github.com/user-attachments/assets/f20f424e-190a-4f74-941d-02414cd6fd6a">


## Checklist

<!-- Please check off the following -->

- [x] I have followed the guidelines in the Contributing document
- [x] My changes follow the coding style of this project
- [x] My changes build without any errors or warnings
- [x] My changes have been formatted and linted
- [x] My changes include any required corresponding changes to the documentation (including CHANGELOG.md and README.md)
- [x] My changes have been rebased and squashed to the minimal number (typically 1) of relevant commits
- [x] My changes have a descriptive commit message with a short title, including a `Fixes $XXX -` or `Closes #XXX -` prefix to auto-close the issue that your PR addresses
