### PR TITLE
Adds Open-AI compatible provider

### DIFF
--- a/docs/telemetry-events.md
+++ b/docs/telemetry-events.md
@@ -124,7 +124,7 @@
   'failed.reason': 'user-declined' | 'user-cancelled' | 'error',
   'input.length': number,
   'model.id': string,
-  'model.provider.id': 'anthropic' | 'deepseek' | 'gemini' | 'github' | 'gitkraken' | 'huggingface' | 'ollama' | 'openai' | 'openrouter' | 'vscode' | 'xai',
+  'model.provider.id': 'anthropic' | 'deepseek' | 'gemini' | 'github' | 'gitkraken' | 'huggingface' | 'ollama' | 'openai' | 'openaicompatible' | 'openrouter' | 'vscode' | 'xai',
   'model.provider.name': string,
   'output.length': number,
   'retry.count': number,
@@ -155,7 +155,7 @@
   'failed.reason': 'user-declined' | 'user-cancelled' | 'error',
   'input.length': number,
   'model.id': string,
-  'model.provider.id': 'anthropic' | 'deepseek' | 'gemini' | 'github' | 'gitkraken' | 'huggingface' | 'ollama' | 'openai' | 'openrouter' | 'vscode' | 'xai',
+  'model.provider.id': 'anthropic' | 'deepseek' | 'gemini' | 'github' | 'gitkraken' | 'huggingface' | 'ollama' | 'openai' | 'openaicompatible' | 'openrouter' | 'vscode' | 'xai',
   'model.provider.name': string,
   'output.length': number,
   'retry.count': number,
@@ -185,7 +185,7 @@ or
   'failed.reason': 'user-declined' | 'user-cancelled' | 'error',
   'input.length': number,
   'model.id': string,
-  'model.provider.id': 'anthropic' | 'deepseek' | 'gemini' | 'github' | 'gitkraken' | 'huggingface' | 'ollama' | 'openai' | 'openrouter' | 'vscode' | 'xai',
+  'model.provider.id': 'anthropic' | 'deepseek' | 'gemini' | 'github' | 'gitkraken' | 'huggingface' | 'ollama' | 'openai' | 'openaicompatible' | 'openrouter' | 'vscode' | 'xai',
   'model.provider.name': string,
   'output.length': number,
   'retry.count': number,
@@ -214,7 +214,7 @@ or
   'failed.reason': 'user-declined' | 'user-cancelled' | 'error',
   'input.length': number,
   'model.id': string,
-  'model.provider.id': 'anthropic' | 'deepseek' | 'gemini' | 'github' | 'gitkraken' | 'huggingface' | 'ollama' | 'openai' | 'openrouter' | 'vscode' | 'xai',
+  'model.provider.id': 'anthropic' | 'deepseek' | 'gemini' | 'github' | 'gitkraken' | 'huggingface' | 'ollama' | 'openai' | 'openaicompatible' | 'openrouter' | 'vscode' | 'xai',
   'model.provider.name': string,
   'output.length': number,
   'retry.count': number,
@@ -243,7 +243,7 @@ or
   'failed.reason': 'user-declined' | 'user-cancelled' | 'error',
   'input.length': number,
   'model.id': string,
-  'model.provider.id': 'anthropic' | 'deepseek' | 'gemini' | 'github' | 'gitkraken' | 'huggingface' | 'ollama' | 'openai' | 'openrouter' | 'vscode' | 'xai',
+  'model.provider.id': 'anthropic' | 'deepseek' | 'gemini' | 'github' | 'gitkraken' | 'huggingface' | 'ollama' | 'openai' | 'openaicompatible' | 'openrouter' | 'vscode' | 'xai',
   'model.provider.name': string,
   'output.length': number,
   'retry.count': number,
@@ -272,7 +272,7 @@ or
   'failed.reason': 'user-declined' | 'user-cancelled' | 'error',
   'input.length': number,
   'model.id': string,
-  'model.provider.id': 'anthropic' | 'deepseek' | 'gemini' | 'github' | 'gitkraken' | 'huggingface' | 'ollama' | 'openai' | 'openrouter' | 'vscode' | 'xai',
+  'model.provider.id': 'anthropic' | 'deepseek' | 'gemini' | 'github' | 'gitkraken' | 'huggingface' | 'ollama' | 'openai' | 'openaicompatible' | 'openrouter' | 'vscode' | 'xai',
   'model.provider.name': string,
   'output.length': number,
   'retry.count': number,
@@ -295,7 +295,7 @@ or
 ```typescript
 {
   'model.id': string,
-  'model.provider.id': 'anthropic' | 'deepseek' | 'gemini' | 'github' | 'gitkraken' | 'huggingface' | 'ollama' | 'openai' | 'openrouter' | 'vscode' | 'xai',
+  'model.provider.id': 'anthropic' | 'deepseek' | 'gemini' | 'github' | 'gitkraken' | 'huggingface' | 'ollama' | 'openai' | 'openaicompatible' | 'openrouter' | 'vscode' | 'xai',
   'model.provider.name': string
 }
 ```

--- a/package.json
+++ b/package.json
@@ -4047,7 +4047,7 @@
 							"null"
 						],
 						"default": null,
-						"pattern": "^((anthropic|deepseek|gemini|github|huggingface|ollama|openai|openrouter|xai):([\\w.-:]+)|gitkraken|vscode)$",
+						"pattern": "^((anthropic|deepseek|gemini|github|huggingface|ollama|openai|openaicompatible|openrouter|xai):([\\w.-:]+)|gitkraken|vscode)$",
 						"markdownDescription": "Specifies the AI provider and model to use for GitLens' AI features. Should be formatted as `provider:model` (e.g. `openai:gpt-4o` or `anthropic:claude-3-5-sonnet-latest`), `gitkraken` for GitKraken AI provided models, or `vscode` for models provided by the VS Code extension API (e.g. Copilot)",
 						"scope": "window",
 						"order": 10,
@@ -4103,6 +4103,19 @@
 						],
 						"default": null,
 						"markdownDescription": "Specifies a custom URL to use for access to an OpenAI model via Azure. Azure URLs should be in the following format: https://{your-resource-name}.openai.azure.com/openai/deployments/{deployment-id}/chat/completions?api-version={api-version}",
+						"scope": "window",
+						"order": 31,
+						"tags": [
+							"preview"
+						]
+					},
+					"gitlens.ai.openaicompatible.url": {
+						"type": [
+							"string",
+							"null"
+						],
+						"default": null,
+						"markdownDescription": "Specifies a custom URL to use for access to an OpenAI-compatible model. Azure URLs should be in the following format: https://{your-resource-name}.openai.azure.com/openai/deployments/{deployment-id}/chat/completions?api-version={api-version}",
 						"scope": "window",
 						"order": 31,
 						"tags": [

--- a/src/config.ts
+++ b/src/config.ts
@@ -249,6 +249,9 @@ interface AIConfig {
 	readonly openai: {
 		readonly url: string | null;
 	};
+	readonly openaicompatible: {
+		readonly url: string | null;
+	};
 	readonly vscode: {
 		readonly model: AIProviderAndModel | null;
 	};

--- a/src/constants.ai.ts
+++ b/src/constants.ai.ts
@@ -9,6 +9,7 @@ export type AIProviders =
 	| 'huggingface'
 	| 'ollama'
 	| 'openai'
+	| 'openaicompatible'
 	| 'openrouter'
 	| 'vscode'
 	| 'xai';
@@ -34,6 +35,13 @@ export const vscodeProviderDescriptor: AIProviderDescriptor<'vscode'> = {
 export const openAIProviderDescriptor: AIProviderDescriptor<'openai'> = {
 	id: 'openai',
 	name: 'OpenAI',
+	primary: false,
+	requiresAccount: true,
+	requiresUserKey: true,
+} as const;
+export const openAICompatibleProviderDescriptor: AIProviderDescriptor<'openaicompatible'> = {
+	id: 'openaicompatible',
+	name: 'OpenAI-Compatible Provider (Azure, etc.)',
 	primary: false,
 	requiresAccount: true,
 	requiresUserKey: true,

--- a/src/plus/ai/aiProviderService.ts
+++ b/src/plus/ai/aiProviderService.ts
@@ -9,6 +9,7 @@ import {
 	gitKrakenProviderDescriptor,
 	huggingFaceProviderDescriptor,
 	ollamaProviderDescriptor,
+	openAICompatibleProviderDescriptor,
 	openAIProviderDescriptor,
 	openRouterProviderDescriptor,
 	vscodeProviderDescriptor,
@@ -146,6 +147,16 @@ const supportedAIProviders = new Map<AIProviders, AIProviderDescriptorWithType>(
 		{
 			...openAIProviderDescriptor,
 			type: lazy(async () => (await import(/* webpackChunkName: "ai" */ './openaiProvider')).OpenAIProvider),
+		},
+	],
+	[
+		'openaicompatible',
+		{
+			...openAICompatibleProviderDescriptor,
+			type: lazy(
+				async () =>
+					(await import(/* webpackChunkName: "ai" */ './openAICompatibleProvider')).OpenAICompatibleProvider,
+			),
 		},
 	],
 	[

--- a/src/plus/ai/anthropicProvider.ts
+++ b/src/plus/ai/anthropicProvider.ts
@@ -3,7 +3,7 @@ import type { Response } from '@env/fetch';
 import { anthropicProviderDescriptor as provider } from '../../constants.ai';
 import { AIError, AIErrorReason } from '../../errors';
 import type { AIActionType, AIModel } from './models/model';
-import { OpenAICompatibleProvider } from './openAICompatibleProvider';
+import { OpenAICompatibleProviderBase } from './openAICompatibleProviderBase';
 
 type AnthropicModel = AIModel<typeof provider.id>;
 const models: AnthropicModel[] = [
@@ -103,7 +103,7 @@ const models: AnthropicModel[] = [
 	},
 ];
 
-export class AnthropicProvider extends OpenAICompatibleProvider<typeof provider.id> {
+export class AnthropicProvider extends OpenAICompatibleProviderBase<typeof provider.id> {
 	readonly id = provider.id;
 	readonly name = provider.name;
 	protected readonly descriptor = provider;

--- a/src/plus/ai/deepSeekProvider.ts
+++ b/src/plus/ai/deepSeekProvider.ts
@@ -1,6 +1,6 @@
 import { deepSeekProviderDescriptor as provider } from '../../constants.ai';
 import type { AIModel } from './models/model';
-import { OpenAICompatibleProvider } from './openAICompatibleProvider';
+import { OpenAICompatibleProviderBase } from './openAICompatibleProviderBase';
 
 type DeepSeekModel = AIModel<typeof provider.id>;
 const models: DeepSeekModel[] = [
@@ -21,7 +21,7 @@ const models: DeepSeekModel[] = [
 	},
 ];
 
-export class DeepSeekProvider extends OpenAICompatibleProvider<typeof provider.id> {
+export class DeepSeekProvider extends OpenAICompatibleProviderBase<typeof provider.id> {
 	readonly id = provider.id;
 	readonly name = provider.name;
 	protected readonly descriptor = provider;

--- a/src/plus/ai/geminiProvider.ts
+++ b/src/plus/ai/geminiProvider.ts
@@ -2,7 +2,7 @@ import type { CancellationToken } from 'vscode';
 import type { Response } from '@env/fetch';
 import { geminiProviderDescriptor as provider } from '../../constants.ai';
 import type { AIActionType, AIModel } from './models/model';
-import { OpenAICompatibleProvider } from './openAICompatibleProvider';
+import { OpenAICompatibleProviderBase } from './openAICompatibleProviderBase';
 
 type GeminiModel = AIModel<typeof provider.id>;
 const models: GeminiModel[] = [
@@ -111,7 +111,7 @@ const models: GeminiModel[] = [
 	},
 ];
 
-export class GeminiProvider extends OpenAICompatibleProvider<typeof provider.id> {
+export class GeminiProvider extends OpenAICompatibleProviderBase<typeof provider.id> {
 	readonly id = provider.id;
 	readonly name = provider.name;
 	protected readonly descriptor = provider;

--- a/src/plus/ai/githubModelsProvider.ts
+++ b/src/plus/ai/githubModelsProvider.ts
@@ -3,11 +3,11 @@ import { fetch } from '@env/fetch';
 import { githubProviderDescriptor as provider } from '../../constants.ai';
 import { AIError, AIErrorReason } from '../../errors';
 import type { AIActionType, AIModel } from './models/model';
-import { OpenAICompatibleProvider } from './openAICompatibleProvider';
+import { OpenAICompatibleProviderBase } from './openAICompatibleProviderBase';
 
 type GitHubModelsModel = AIModel<typeof provider.id>;
 
-export class GitHubModelsProvider extends OpenAICompatibleProvider<typeof provider.id> {
+export class GitHubModelsProvider extends OpenAICompatibleProviderBase<typeof provider.id> {
 	readonly id = provider.id;
 	readonly name = provider.name;
 	protected readonly descriptor = provider;

--- a/src/plus/ai/gitkrakenProvider.ts
+++ b/src/plus/ai/gitkrakenProvider.ts
@@ -6,12 +6,12 @@ import { debug } from '../../system/decorators/log';
 import { Logger } from '../../system/logger';
 import { getLogScope } from '../../system/logger.scope';
 import type { AIActionType, AIModel } from './models/model';
-import { OpenAICompatibleProvider } from './openAICompatibleProvider';
+import { OpenAICompatibleProviderBase } from './openAICompatibleProviderBase';
 import { ensureAccount } from './utils/-webview/ai.utils';
 
 type GitKrakenModel = AIModel<typeof provider.id>;
 
-export class GitKrakenProvider extends OpenAICompatibleProvider<typeof provider.id> {
+export class GitKrakenProvider extends OpenAICompatibleProviderBase<typeof provider.id> {
 	readonly id = provider.id;
 	readonly name = provider.name;
 	protected readonly descriptor = provider;

--- a/src/plus/ai/huggingFaceProvider.ts
+++ b/src/plus/ai/huggingFaceProvider.ts
@@ -1,11 +1,11 @@
 import { fetch } from '@env/fetch';
 import { huggingFaceProviderDescriptor as provider } from '../../constants.ai';
 import type { AIModel } from './models/model';
-import { OpenAICompatibleProvider } from './openAICompatibleProvider';
+import { OpenAICompatibleProviderBase } from './openAICompatibleProviderBase';
 
 type HuggingFaceModel = AIModel<typeof provider.id>;
 
-export class HuggingFaceProvider extends OpenAICompatibleProvider<typeof provider.id> {
+export class HuggingFaceProvider extends OpenAICompatibleProviderBase<typeof provider.id> {
 	readonly id = provider.id;
 	readonly name = provider.name;
 	protected readonly descriptor = provider;

--- a/src/plus/ai/ollamaProvider.ts
+++ b/src/plus/ai/ollamaProvider.ts
@@ -4,13 +4,13 @@ import { ollamaProviderDescriptor as provider } from '../../constants.ai';
 import { configuration } from '../../system/-webview/configuration';
 import type { AIActionType, AIModel } from './models/model';
 import type { AIChatMessage, AIRequestResult } from './models/provider';
-import { OpenAICompatibleProvider } from './openAICompatibleProvider';
+import { OpenAICompatibleProviderBase } from './openAICompatibleProviderBase';
 
 type OllamaModel = AIModel<typeof provider.id>;
 
 const defaultBaseUrl = 'http://localhost:11434';
 
-export class OllamaProvider extends OpenAICompatibleProvider<typeof provider.id> {
+export class OllamaProvider extends OpenAICompatibleProviderBase<typeof provider.id> {
 	readonly id = provider.id;
 	readonly name = provider.name;
 	protected readonly descriptor = provider;

--- a/src/plus/ai/openAICompatibleProviderBase.ts
+++ b/src/plus/ai/openAICompatibleProviderBase.ts
@@ -1,0 +1,281 @@
+import type { CancellationToken } from 'vscode';
+import type { Response } from '@env/fetch';
+import { fetch } from '@env/fetch';
+import type { Role } from '../../@types/vsls';
+import type { AIProviders } from '../../constants.ai';
+import type { Container } from '../../container';
+import { AIError, AIErrorReason, CancellationError } from '../../errors';
+import { getLoggableName, Logger } from '../../system/logger';
+import { startLogScope } from '../../system/logger.scope';
+import type { ServerConnection } from '../gk/serverConnection';
+import type { AIActionType, AIModel, AIProviderDescriptor } from './models/model';
+import type { AIChatMessage, AIChatMessageRole, AIProvider, AIRequestResult } from './models/provider';
+import { getActionName, getOrPromptApiKey, getValidatedTemperature } from './utils/-webview/ai.utils';
+
+export interface AIProviderConfig {
+	url: string;
+	keyUrl: string;
+	keyValidator?: RegExp;
+}
+
+export abstract class OpenAICompatibleProviderBase<T extends AIProviders> implements AIProvider<T> {
+	constructor(
+		protected readonly container: Container,
+		protected readonly connection: ServerConnection,
+	) {}
+
+	dispose(): void {}
+
+	abstract readonly id: T;
+	abstract readonly name: string;
+	protected abstract readonly descriptor: AIProviderDescriptor<T>;
+	protected abstract readonly config: { keyUrl?: string; keyValidator?: RegExp };
+
+	async configured(silent: boolean): Promise<boolean> {
+		return (await this.getApiKey(silent)) != null;
+	}
+
+	async getApiKey(silent: boolean): Promise<string | undefined> {
+		const { keyUrl, keyValidator } = this.config;
+
+		return getOrPromptApiKey(
+			this.container,
+			{
+				id: this.id,
+				name: this.name,
+				requiresAccount: this.descriptor.requiresAccount,
+				validator: keyValidator != null ? v => keyValidator.test(v) : () => true,
+				url: keyUrl,
+			},
+			silent,
+		);
+	}
+
+	abstract getModels(): Promise<readonly AIModel<T>[]>;
+
+	protected abstract getUrl(_model: AIModel<T>): string | undefined;
+
+	protected getHeaders<TAction extends AIActionType>(
+		_action: TAction,
+		apiKey: string,
+		_model: AIModel<T>,
+		_url: string,
+	): Record<string, string> | Promise<Record<string, string>> {
+		return {
+			Accept: 'application/json',
+			'Content-Type': 'application/json',
+			Authorization: `Bearer ${apiKey}`,
+		};
+	}
+
+	async sendRequest<TAction extends AIActionType>(
+		action: TAction,
+		model: AIModel<T>,
+		apiKey: string,
+		getMessages: (maxCodeCharacters: number, retries: number) => Promise<AIChatMessage[]>,
+		options: { cancellation: CancellationToken; modelOptions?: { outputTokens?: number; temperature?: number } },
+	): Promise<AIRequestResult | undefined> {
+		using scope = startLogScope(`${getLoggableName(this)}.sendRequest`, false);
+
+		try {
+			const result = await this.fetch(
+				action,
+				model,
+				apiKey,
+				getMessages,
+				options.modelOptions,
+				options.cancellation,
+			);
+			return result;
+		} catch (ex) {
+			if (ex instanceof CancellationError) {
+				Logger.error(ex, scope, `Cancelled request to ${getActionName(action)}: (${model.provider.name})`);
+				throw ex;
+			}
+
+			Logger.error(ex, scope, `Unable to ${getActionName(action)}: (${model.provider.name})`);
+			if (ex instanceof AIError) throw ex;
+
+			debugger;
+			throw new Error(`Unable to ${getActionName(action)}: (${model.provider.name}) ${ex.message}`);
+		}
+	}
+
+	protected async fetch<TAction extends AIActionType>(
+		action: TAction,
+		model: AIModel<T>,
+		apiKey: string,
+		messages: (maxInputTokens: number, retries: number) => Promise<AIChatMessage[]>,
+		modelOptions?: { outputTokens?: number; temperature?: number },
+		cancellation?: CancellationToken,
+	): Promise<AIRequestResult> {
+		let retries = 0;
+		let maxInputTokens = model.maxTokens.input;
+
+		while (true) {
+			const request: ChatCompletionRequest = {
+				model: model.id,
+				messages: await messages(maxInputTokens, retries),
+				stream: false,
+				max_completion_tokens: model.maxTokens.output
+					? Math.min(modelOptions?.outputTokens ?? Infinity, model.maxTokens.output)
+					: modelOptions?.outputTokens,
+				temperature: getValidatedTemperature(modelOptions?.temperature ?? model.temperature),
+			};
+
+			const rsp = await this.fetchCore(action, model, apiKey, request, cancellation);
+			if (!rsp.ok) {
+				const result = await this.handleFetchFailure(rsp, action, model, retries, maxInputTokens);
+				if (result.retry) {
+					maxInputTokens = result.maxInputTokens;
+					retries++;
+					continue;
+				}
+			}
+
+			const data: ChatCompletionResponse = await rsp.json();
+			const result: AIRequestResult = {
+				id: data.id,
+				content: data.choices?.[0].message.content?.trim() ?? data.content?.[0]?.text?.trim() ?? '',
+				model: model,
+				usage: {
+					promptTokens: data.usage?.prompt_tokens ?? data.usage?.input_tokens,
+					completionTokens: data.usage?.completion_tokens ?? data.usage?.output_tokens,
+					totalTokens: data.usage?.total_tokens,
+					limits:
+						data?.usage?.gk != null
+							? {
+									used: data.usage.gk.used,
+									limit: data.usage.gk.limit,
+									resetsOn: new Date(data.usage.gk.resets_on),
+							  }
+							: undefined,
+				},
+			};
+			return result;
+		}
+	}
+
+	protected async handleFetchFailure<TAction extends AIActionType>(
+		rsp: Response,
+		_action: TAction,
+		model: AIModel<T>,
+		retries: number,
+		maxInputTokens: number,
+	): Promise<{ retry: true; maxInputTokens: number }> {
+		if (rsp.status === 404) {
+			throw new AIError(
+				AIErrorReason.Unauthorized,
+				new Error(`Your API key doesn't seem to have access to the selected '${model.id}' model`),
+			);
+		}
+		if (rsp.status === 429) {
+			throw new AIError(
+				AIErrorReason.RateLimitOrFundsExceeded,
+				new Error(
+					`(${this.name}) ${rsp.status}: Too many requests (rate limit exceeded) or your account is out of funds`,
+				),
+			);
+		}
+
+		let json;
+		try {
+			json = (await rsp.json()) as { error?: { code: string; message: string } } | undefined;
+		} catch {}
+
+		if (json?.error?.code === 'context_length_exceeded') {
+			if (retries < 2) {
+				return { retry: true, maxInputTokens: maxInputTokens - 200 * (retries || 1) };
+			}
+
+			throw new AIError(
+				AIErrorReason.RequestTooLarge,
+				new Error(`(${this.name}) ${rsp.status}: ${json?.error?.message || rsp.statusText}`),
+			);
+		}
+
+		throw new Error(`(${this.name}) ${rsp.status}: ${json?.error?.message || rsp.statusText}`);
+	}
+
+	protected async fetchCore<TAction extends AIActionType>(
+		action: TAction,
+		model: AIModel<T>,
+		apiKey: string,
+		request: object,
+		cancellation: CancellationToken | undefined,
+	): Promise<Response> {
+		let aborter: AbortController | undefined;
+		if (cancellation != null) {
+			aborter = new AbortController();
+			cancellation.onCancellationRequested(() => aborter?.abort());
+		}
+
+		const url = this.getUrl(model);
+		if (!url) {
+			throw new Error(`(${this.name}) ${getActionName(action)}: No URL configured`);
+		}
+
+		try {
+			return await fetch(url, {
+				headers: await this.getHeaders(action, apiKey, model, url),
+				method: 'POST',
+				body: JSON.stringify(request),
+				signal: aborter?.signal,
+			});
+		} catch (ex) {
+			if (ex.name === 'AbortError') throw new CancellationError(ex);
+			throw ex;
+		}
+	}
+}
+
+interface ChatCompletionRequest {
+	model: string;
+	messages: AIChatMessage<AIChatMessageRole>[];
+
+	/** @deprecated but used by Anthropic & Gemini */
+	max_tokens?: number;
+	/** Currently can't be used for Anthropic & Gemini */
+	max_completion_tokens?: number;
+	metadata?: Record<string, string>;
+	stream?: boolean;
+	temperature?: number;
+	top_p?: number;
+
+	/** Not supported by many models/providers */
+	reasoning_effort?: 'low' | 'medium' | 'high';
+}
+
+interface ChatCompletionResponse {
+	id: string;
+	model: string;
+	/** OpenAI compatible output */
+	choices?: {
+		index: number;
+		message: {
+			role: Role;
+			content: string | null;
+			refusal: string | null;
+		};
+		finish_reason: string;
+	}[];
+	/** Anthropic output */
+	content?: { type: 'text'; text: string }[];
+	usage: {
+		/** OpenAI compatible */
+		prompt_tokens?: number;
+		completion_tokens?: number;
+		total_tokens?: number;
+
+		/** Anthropic */
+		input_tokens?: number;
+		output_tokens?: number;
+
+		/** GitKraken */
+		gk: {
+			used: number;
+			limit: number;
+			resets_on: string;
+		};
+	};
+}

--- a/src/plus/ai/openRouterProvider.ts
+++ b/src/plus/ai/openRouterProvider.ts
@@ -1,11 +1,11 @@
 import { fetch } from '@env/fetch';
 import { openRouterProviderDescriptor as provider } from '../../constants.ai';
 import type { AIActionType, AIModel } from './models/model';
-import { OpenAICompatibleProvider } from './openAICompatibleProvider';
+import { OpenAICompatibleProviderBase } from './openAICompatibleProviderBase';
 
 type OpenRouterModel = AIModel<typeof provider.id>;
 
-export class OpenRouterProvider extends OpenAICompatibleProvider<typeof provider.id> {
+export class OpenRouterProvider extends OpenAICompatibleProviderBase<typeof provider.id> {
 	readonly id = provider.id;
 	readonly name = provider.name;
 	protected readonly descriptor = provider;

--- a/src/plus/ai/openaiProvider.ts
+++ b/src/plus/ai/openaiProvider.ts
@@ -1,7 +1,7 @@
 import { openAIProviderDescriptor as provider } from '../../constants.ai';
 import { configuration } from '../../system/-webview/configuration';
 import type { AIActionType, AIModel } from './models/model';
-import { OpenAICompatibleProvider } from './openAICompatibleProvider';
+import { OpenAICompatibleProviderBase } from './openAICompatibleProviderBase';
 
 type OpenAIModel = AIModel<typeof provider.id>;
 const models: OpenAIModel[] = [
@@ -276,7 +276,7 @@ const models: OpenAIModel[] = [
 	},
 ];
 
-export class OpenAIProvider extends OpenAICompatibleProvider<typeof provider.id> {
+export class OpenAIProvider extends OpenAICompatibleProviderBase<typeof provider.id> {
 	readonly id = provider.id;
 	readonly name = provider.name;
 	protected readonly descriptor = provider;

--- a/src/plus/ai/utils/-webview/ai.utils.ts
+++ b/src/plus/ai/utils/-webview/ai.utils.ts
@@ -105,7 +105,11 @@ export async function getOrPromptApiKey(
 			input.password = true;
 			input.title = `Connect to ${provider.name}`;
 			input.placeholder = `Please enter your ${provider.name} API key to use this feature`;
-			input.prompt = `Enter your [${provider.name} API Key](${provider.url} "Get your ${provider.name} API key")`;
+			input.prompt = `Enter your ${
+				provider.url
+					? `[${provider.name} API Key](${provider.url} "Get your ${provider.name} API key")`
+					: `${provider.name} API Key`
+			}`;
 			if (provider.url) {
 				input.buttons = [infoButton];
 			}

--- a/src/plus/ai/xaiProvider.ts
+++ b/src/plus/ai/xaiProvider.ts
@@ -1,6 +1,6 @@
 import { xAIProviderDescriptor as provider } from '../../constants.ai';
 import type { AIModel } from './models/model';
-import { OpenAICompatibleProvider } from './openAICompatibleProvider';
+import { OpenAICompatibleProviderBase } from './openAICompatibleProviderBase';
 
 type XAIModel = AIModel<typeof provider.id>;
 const models: XAIModel[] = [
@@ -13,7 +13,7 @@ const models: XAIModel[] = [
 	},
 ];
 
-export class XAIProvider extends OpenAICompatibleProvider<typeof provider.id> {
+export class XAIProvider extends OpenAICompatibleProviderBase<typeof provider.id> {
 	readonly id = provider.id;
 	readonly name = provider.name;
 	protected readonly descriptor = provider;


### PR DESCRIPTION
Adds a new provider that mimics the OpenAI provider class with the difference being that a user-provider URL is required when configuring it.

Moves/renames the existing "OpenAICompatibleProvider" base class to "OpenAICompatibleProviderBase"

Closes #4263
