### PR TITLE
Fix broken URLs for old GitLab instances

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,7 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/) and this p
 - Adds the ability to change a branch's merge target in Home view. ([#4224](https://github.com/gitkraken/vscode-gitlens/issues/4224))
 - Adds Google Gemini 2.5 Flash (Preview) model, and OpenAI GPT-4.1, GPT-4.1 mini, GPT-4.1 nano, o4 mini, and o3 models for GitLens' AI features ([#4235](https://github.com/gitkraken/vscode-gitlens/issues/4235))
 - Adds _Open File at Revision from Remote_ command to open the specific file revision from a remote file URL
+- Adds a new `version` option to `gitlens.remotes` to support some providers where the version affects the URL format, such as GitLab.
 
 ### Changed
 

--- a/package.json
+++ b/package.json
@@ -3889,6 +3889,10 @@
 									"default": false,
 									"description": "Specifies whether to ignore invalid SSL certificate errors when connecting to the remote service"
 								},
+								"version": {
+									"type": "string",
+									"description": "Specifies the version of the remote service. Only used by some services such as GitLab."
+								},
 								"urls": {
 									"type": "object",
 									"required": [

--- a/src/config.ts
+++ b/src/config.ts
@@ -648,6 +648,7 @@ export type RemotesConfig =
 			readonly type: CustomRemoteType;
 			readonly urls?: RemotesUrlsConfig;
 			readonly ignoreSSLErrors?: boolean | 'force';
+			readonly version?: string;
 	  }
 	| {
 			readonly domain: null;
@@ -657,6 +658,7 @@ export type RemotesConfig =
 			readonly type: CustomRemoteType;
 			readonly urls?: RemotesUrlsConfig;
 			readonly ignoreSSLErrors?: boolean | 'force';
+			readonly version?: string;
 	  };
 
 export interface RemotesUrlsConfig {

--- a/src/git/remotes/remoteProviders.ts
+++ b/src/git/remotes/remoteProviders.ts
@@ -182,7 +182,7 @@ function getCustomProviderCreator(cfg: RemotesConfig) {
 				new GitHubRemote(container, domain, path, cfg.protocol, cfg.name, true);
 		case 'GitLab':
 			return (container: Container, domain: string, path: string) =>
-				new GitLabRemote(container, domain, path, cfg.protocol, cfg.name, true);
+				new GitLabRemote(container, domain, path, cfg.protocol, cfg.name, true, cfg.version);
 		default:
 			return undefined;
 	}


### PR DESCRIPTION
Closes #2162

---

# Description

Since #2022, anyone using an old installation of GitLab can no longer use the <kbd>View on Remote</kbd> feature; all URLs produce a 404 since gitlab [changed the URL format](https://gitlab.com/gitlab-org/gitlab/-/issues/29572), and GitLens only supports the new format as of #2022

This PR adds a new option to the `gitlens.remote` setting, called `version`. For example:
```jsonc
  "gitlens.remotes": [{ "domain": "example.intranet.net", "type": "GitLab", "version": "17" }],
```

This field could be reused by other providers in the future, if they need version-specific logic.

For gitlab, if the version is too old, the URLs will not include the `/-/` infix

# Checklist

- [x] I have followed the guidelines in the Contributing document
- [x] My changes follow the coding style of this project
- [x] My changes build without any errors or warnings
- [x] My changes have been formatted and linted
- [x] My changes include any required corresponding changes to the documentation (including CHANGELOG.md and README.md)
- [x] My changes have been rebased and squashed to the minimal number (typically 1) of relevant commits
- [x] My changes have a descriptive commit message with a short title, including a `Fixes $XXX -` or `Closes #XXX -` prefix to auto-close the issue that your PR addresses
