### PR TITLE
Send telemetry on unusual token refreshing

### DIFF
--- a/docs/telemetry-events.md
+++ b/docs/telemetry-events.md
@@ -521,6 +521,19 @@ or
 }
 ```
 
+### cloudIntegrations/refreshConnection/skippedUnusualToken
+
+> Sent when a connection session has a missing expiry date
+or when connection refresh is skipped due to being a non-cloud session
+
+```typescript
+{
+  'cloud': boolean,
+  'integration.id': string,
+  'reason': 'skip-non-cloud' | 'missing-expiry'
+}
+```
+
 ### cloudIntegrations/settingsOpened
 
 > Sent when a user chooses to manage the cloud integrations

--- a/src/constants.telemetry.ts
+++ b/src/constants.telemetry.ts
@@ -84,6 +84,10 @@ export interface TelemetryEvents extends WebviewShowAbortedEvents, WebviewShownE
 	/** Sent when refreshing a provider token from the api fails */
 	'cloudIntegrations/refreshConnection/failed': CloudIntegrationsRefreshConnectionFailedEvent;
 
+	/** Sent when a connection session has a missing expiry date
+	 * or when connection refresh is skipped due to being a non-cloud session */
+	'cloudIntegrations/refreshConnection/skippedUnusualToken': CloudIntegrationsRefreshConnectionSkipUnusualTokenEvent;
+
 	/** Sent when a cloud-based hosting provider is connected */
 	'cloudIntegrations/hosting/connected': CloudIntegrationsHostingConnectedEvent;
 	/** Sent when a cloud-based hosting provider is disconnected */
@@ -405,6 +409,12 @@ interface CloudIntegrationsGetConnectionFailedEvent {
 interface CloudIntegrationsRefreshConnectionFailedEvent {
 	code: number | undefined;
 	'integration.id': string | undefined;
+}
+
+interface CloudIntegrationsRefreshConnectionSkipUnusualTokenEvent {
+	'integration.id': string;
+	reason: 'skip-non-cloud' | 'missing-expiry';
+	cloud: boolean | undefined;
 }
 
 interface CloudIntegrationsHostingConnectedEvent {


### PR DESCRIPTION
## Description
It sends a telemetry events on on-usual token refreshing:

1. when we try to refresh a non-github token that does not have expiration date.
2. when we reject refreshing a token because we see that it's non-cloud token for a non-github integration

## Checklist

<!-- Please check off the following -->

- [x] I have followed the guidelines in the Contributing document
- [x] My changes follow the coding style of this project
- [x] My changes build without any errors or warnings
- [x] My changes have been formatted and linted
- [ ] My changes include any required corresponding changes to the documentation (including CHANGELOG.md and README.md)
- [x] My changes have been rebased and squashed to the minimal number (typically 1) of relevant commits
- [x] My changes have a descriptive commit message with a short title, including a `Fixes $XXX -` or `Closes #XXX -` prefix to auto-close the issue that your PR addresses
