### PR TITLE
Modify the "Create Pull Request" button

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/) and this p
 
 - Automatically stashes (and pops) uncommitted changes on Pull ([#4296](https://github.com/gitkraken/vscode-gitlens/issues/4296))
 - Removes the option to associate an issue from cards in the RECENT section of the _Home_ view ([#4333](https://github.com/gitkraken/vscode-gitlens/issues/4333))
+- Combines the "Create Pull Request" and "Create with AI" buttons into a split button ([#4330](https://github.com/gitkraken/vscode-gitlens/issues/4330))
 
 ### Fixed
 

--- a/src/webviews/apps/plus/home/components/branch-card.ts
+++ b/src/webviews/apps/plus/home/components/branch-card.ts
@@ -790,39 +790,44 @@ export abstract class GlBranchCardBase extends GlElement {
 		if (!this.pr) {
 			if (this.branch.upstream?.missing === false && this.expanded) {
 				return html`
-					<div class="branch-item__row">
-						<gl-button
-							class="branch-item__missing"
-							appearance="secondary"
-							full
-							href="${createCommandLink('gitlens.home.createPullRequest', {
-								ref: this.branchRef,
-								describeWithAI: false,
-								source: { source: 'home', detail: 'create-pr' },
-							})}"
-							>Create a Pull Request</gl-button
-						>
-						${this._homeState.orgSettings.ai &&
-						this._homeState.aiEnabled &&
-						this.remote?.provider?.supportedFeatures?.createPullRequestWithDetails
-							? html`<gl-button
-									class="branch-item__missing"
-									tooltip="Create a Pull Request with AI (Preview)"
-									appearance="secondary"
-									href="${createCommandLink<CreatePullRequestCommandArgs>(
-										'gitlens.home.createPullRequest',
-										{
-											ref: this.branchRef,
-											describeWithAI: true,
-											source: { source: 'home', detail: 'create-pr' },
-										},
-									)}"
-							  >
-									<code-icon class="branch-item__is-wide" icon="sparkle" slot="prefix"></code-icon>
-									<code-icon class="branch-item__is-narrow" icon="sparkle"></code-icon>
-									<span class="branch-item__is-wide">Create with AI</span>
-							  </gl-button>`
-							: nothing}
+					<div>
+						<button-container grouping="split" layout="full">
+							<gl-button
+								class="branch-item__missing"
+								appearance="secondary"
+								full
+								href="${createCommandLink('gitlens.home.createPullRequest', {
+									ref: this.branchRef,
+									describeWithAI: false,
+									source: { source: 'home', detail: 'create-pr' },
+								})}"
+								>Create a Pull Request</gl-button
+							>
+							${this._homeState.orgSettings.ai &&
+							this._homeState.aiEnabled &&
+							this.remote?.provider?.supportedFeatures?.createPullRequestWithDetails
+								? html`<gl-button
+										class="branch-item__missing"
+										tooltip="Create a Pull Request with AI (Preview)"
+										appearance="secondary"
+										href="${createCommandLink<CreatePullRequestCommandArgs>(
+											'gitlens.home.createPullRequest',
+											{
+												ref: this.branchRef,
+												describeWithAI: true,
+												source: { source: 'home', detail: 'create-pr' },
+											},
+										)}"
+								  >
+										<code-icon
+											class="branch-item__is-wide"
+											icon="sparkle"
+											slot="prefix"
+										></code-icon>
+										<code-icon class="branch-item__is-narrow" icon="sparkle"></code-icon>
+								  </gl-button>`
+								: nothing}
+						</button-container>
 					</div>
 				`;
 			}

--- a/src/webviews/apps/plus/home/components/branch-card.ts
+++ b/src/webviews/apps/plus/home/components/branch-card.ts
@@ -801,8 +801,10 @@ export abstract class GlBranchCardBase extends GlElement {
 									describeWithAI: false,
 									source: { source: 'home', detail: 'create-pr' },
 								})}"
-								>Create a Pull Request</gl-button
 							>
+								<code-icon icon="git-pull-request" slot="prefix"></code-icon>
+								<span>Create a Pull Request</span>
+							</gl-button>
 							${this._homeState.orgSettings.ai &&
 							this._homeState.aiEnabled &&
 							this.remote?.provider?.supportedFeatures?.createPullRequestWithDetails

--- a/src/webviews/apps/plus/home/components/branch-card.ts
+++ b/src/webviews/apps/plus/home/components/branch-card.ts
@@ -191,19 +191,6 @@ export const branchCardStyles = css`
 		--button-foreground: inherit;
 	}
 
-	.branch-item__is-narrow {
-		display: none;
-	}
-
-	@media (max-width: 330px) {
-		.branch-item__is-narrow {
-			display: block;
-		}
-		.branch-item__is-wide {
-			display: none;
-		}
-	}
-
 	:host-context(.vscode-dark) .branch-item__missing,
 	:host-context(.vscode-high-contrast) .branch-item__missing {
 		--button-background: color-mix(in lab, var(--vscode-sideBar-background) 100%, #fff 3%);
@@ -821,12 +808,7 @@ export abstract class GlBranchCardBase extends GlElement {
 											},
 										)}"
 								  >
-										<code-icon
-											class="branch-item__is-wide"
-											icon="sparkle"
-											slot="prefix"
-										></code-icon>
-										<code-icon class="branch-item__is-narrow" icon="sparkle"></code-icon>
+										<code-icon icon="sparkle"></code-icon>
 								  </gl-button>`
 								: nothing}
 						</button-container>


### PR DESCRIPTION

# Description
Resolves part of #4332.

- combines the "Create Pull Request" and "Create with AI" buttons into a split button
<img width="400" src="https://github.com/user-attachments/assets/3919d305-bd52-48d1-98ad-f078f5aa5773">


- adds the pull request icon to the primary button
<img width="400" src="https://github.com/user-attachments/assets/538499c5-f917-40a7-87b4-4184fb0695f0">


- when the ✨ button is hovered, display the current tooltip: "Create a Pull Request with AI (Preview)"
<img width="400" src="https://github.com/user-attachments/assets/368128e3-812d-419b-995e-058c62cfcf08">



# Checklist

<!-- Please check off the following -->

- [x] I have followed the guidelines in the Contributing document
- [x] My changes follow the coding style of this project
- [x] My changes build without any errors or warnings
- [x] My changes have been formatted and linted
- [x] My changes include any required corresponding changes to the documentation (including CHANGELOG.md and README.md)
- [x] My changes have been rebased and squashed to the minimal number (typically 1) of relevant commits
- [x] My changes have a descriptive commit message with a short title, including a `Fixes $XXX -` or `Closes #XXX -` prefix to auto-close the issue that your PR addresses
