### PR TITLE
Modify the issue association flow and Issue display

### DIFF
--- a/src/webviews/apps/plus/home/components/active-work.ts
+++ b/src/webviews/apps/plus/home/components/active-work.ts
@@ -243,9 +243,9 @@ export class GlActiveBranchCard extends GlBranchCardBase {
 
 	override render(): unknown {
 		return html`
-			${this.renderBranchIndicator()}${this.renderBranchItem(
+			${this.renderBranchIndicator()}${this.renderIssuesItem()}${this.renderBranchItem(
 				html`${this.renderBranchStateActions()}${this.renderBranchActions()}`,
-			)}${this.renderPrItem()}${this.renderIssuesItem()}
+			)}${this.renderPrItem()}
 		`;
 	}
 

--- a/src/webviews/apps/plus/home/components/active-work.ts
+++ b/src/webviews/apps/plus/home/components/active-work.ts
@@ -237,6 +237,10 @@ export class GlActiveBranchCard extends GlBranchCardBase {
 				color: var(--vscode-descriptionForeground);
 				font-style: italic;
 			}
+
+			gl-work-item {
+				--gl-card-vertical-padding: 0.4rem;
+			}
 		`,
 	];
 

--- a/src/webviews/apps/plus/home/components/active-work.ts
+++ b/src/webviews/apps/plus/home/components/active-work.ts
@@ -232,6 +232,11 @@ export class GlActiveBranchCard extends GlBranchCardBase {
 				flex-direction: column;
 				gap: 0.8rem;
 			}
+
+			span.branch-item__missing {
+				color: var(--vscode-descriptionForeground);
+				font-style: italic;
+			}
 		`,
 	];
 
@@ -518,16 +523,21 @@ export class GlActiveBranchCard extends GlBranchCardBase {
 		if (!issues.length) {
 			if (!this.expanded) return nothing;
 
-			return html`<gl-button
-				class="branch-item__missing"
-				appearance="secondary"
-				full
-				href=${this.createCommandLink<AssociateIssueWithBranchCommandArgs>('gitlens.associateIssueWithBranch', {
-					branch: this.branch.reference,
-					source: 'home',
-				})}
-				>Associate an Issue</gl-button
-			>`;
+			return html`<div class="branch-item__row" full>
+				<span class="branch-item__missing" full>Current work item</span>
+				<gl-tooltip hoist content="Associate an issue">
+					<a
+						href=${this.createCommandLink<AssociateIssueWithBranchCommandArgs>(
+							'gitlens.associateIssueWithBranch',
+							{
+								branch: this.branch.reference,
+								source: 'home',
+							},
+						)}
+						><span class="branch-item__icon"> <issue-icon></issue-icon> </span
+					></a>
+				</gl-tooltip>
+			</div>`;
 		}
 		return super.renderIssuesItem();
 	}

--- a/src/webviews/apps/plus/home/components/branch-card.ts
+++ b/src/webviews/apps/plus/home/components/branch-card.ts
@@ -1152,6 +1152,8 @@ export class GlWorkUnit extends LitElement {
 
 			gl-card::part(base) {
 				margin-block-end: 0;
+				padding-top: var(--gl-card-vertical-padding, 0.8rem);
+				padding-bottom: var(--gl-card-vertical-padding, 0.8rem);
 			}
 		`,
 	];


### PR DESCRIPTION
# Description
part of #4332

- move the issue card above the branch card
- when no issue is associated, display an element with "Current work item" on the left and the issue icon to the right.
- when the issue icon is hovered, display a tooltip with "Associate an issue"
- when the issue icon is clicked, open the issue association flow
<img width="400" src="https://github.com/user-attachments/assets/eb1f61ac-b301-45e0-9d28-903f52315ff8">


- when an issue is associated, display the issue card
- modify the current issue card to be shorter than the other cards (reduce the top/bottom padding to 4px from 8px)

<img width="400" src="https://github.com/user-attachments/assets/12324747-01cc-4039-afc5-d5c158082b19">


# Checklist

<!-- Please check off the following -->

- [x] I have followed the guidelines in the Contributing document
- [x] My changes follow the coding style of this project
- [x] My changes build without any errors or warnings
- [x] My changes have been formatted and linted
- [ ] My changes include any required corresponding changes to the documentation (including CHANGELOG.md and README.md)
- [x] My changes have been rebased and squashed to the minimal number (typically 1) of relevant commits
- [x] My changes have a descriptive commit message with a short title, including a `Fixes $XXX -` or `Closes #XXX -` prefix to auto-close the issue that your PR addresses
