### PR TITLE
Removes the option to associate an issue from cards in the RECENT section

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/) and this p
 ### Changed
 
 - Automatically stashes (and pops) uncommitted changes on Pull ([#4296](https://github.com/gitkraken/vscode-gitlens/issues/4296))
+- Removes the option to associate an issue from cards in the RECENT section of the _Home_ view ([#4333](https://github.com/gitkraken/vscode-gitlens/issues/4333))
 
 ### Fixed
 

--- a/src/webviews/apps/plus/home/components/active-work.ts
+++ b/src/webviews/apps/plus/home/components/active-work.ts
@@ -5,6 +5,7 @@ import { css, html, LitElement, nothing } from 'lit';
 import { customElement, state } from 'lit/decorators.js';
 import { ifDefined } from 'lit/directives/if-defined.js';
 import { isSubscriptionTrialOrPaidFromState } from '../../../../../plus/gk/utils/subscription.utils';
+import type { AssociateIssueWithBranchCommandArgs } from '../../../../../plus/startWork/startWork';
 import { createCommandLink } from '../../../../../system/commands';
 import { createWebviewCommandLink } from '../../../../../system/webview';
 import type {
@@ -511,4 +512,25 @@ export class GlActiveBranchCard extends GlBranchCardBase {
 	protected getCollapsedActions(): TemplateResult[] {
 		return [];
 	}
+
+	protected override renderIssuesItem(): TemplateResult | NothingType {
+		const issues = [...(this.issues ?? []), ...(this.autolinks ?? [])];
+		if (!issues.length) {
+			if (!this.expanded) return nothing;
+
+			return html`<gl-button
+				class="branch-item__missing"
+				appearance="secondary"
+				full
+				href=${this.createCommandLink<AssociateIssueWithBranchCommandArgs>('gitlens.associateIssueWithBranch', {
+					branch: this.branch.reference,
+					source: 'home',
+				})}
+				>Associate an Issue</gl-button
+			>`;
+		}
+		return super.renderIssuesItem();
+	}
 }
+
+type NothingType = typeof nothing;

--- a/src/webviews/apps/plus/home/components/branch-card.ts
+++ b/src/webviews/apps/plus/home/components/branch-card.ts
@@ -12,7 +12,6 @@ import {
 	launchpadGroupIconMap,
 	launchpadGroupLabelMap,
 } from '../../../../../plus/launchpad/models/launchpad';
-import type { AssociateIssueWithBranchCommandArgs } from '../../../../../plus/startWork/startWork';
 import { createCommandLink } from '../../../../../system/commands';
 import { fromNow } from '../../../../../system/date';
 import { interpolate, pluralize } from '../../../../../system/string';
@@ -916,18 +915,7 @@ export abstract class GlBranchCardBase extends GlElement {
 	protected renderIssuesItem(): TemplateResult | NothingType {
 		const issues = [...(this.issues ?? []), ...(this.autolinks ?? [])];
 		if (!issues.length) {
-			if (!this.expanded) return nothing;
-
-			return html`<gl-button
-				class="branch-item__missing"
-				appearance="secondary"
-				full
-				href=${this.createCommandLink<AssociateIssueWithBranchCommandArgs>('gitlens.associateIssueWithBranch', {
-					branch: this.branch.reference,
-					source: 'home',
-				})}
-				>Associate an Issue</gl-button
-			>`;
+			return nothing;
 		}
 
 		const indicator: GlCard['indicator'] = this.branch.opened ? 'base' : undefined;


### PR DESCRIPTION


# Description

solves #4333

<img width="400" src="https://github.com/user-attachments/assets/d5ffd373-00cc-4d79-aa0c-c1d0d75c7718">

# Checklist

<!-- Please check off the following -->

- [x] I have followed the guidelines in the Contributing document
- [x] My changes follow the coding style of this project
- [x] My changes build without any errors or warnings
- [x] My changes have been formatted and linted
- [x] My changes include any required corresponding changes to the documentation (including CHANGELOG.md and README.md)
- [x] My changes have been rebased and squashed to the minimal number (typically 1) of relevant commits
- [x] My changes have a descriptive commit message with a short title, including a `Fixes $XXX -` or `Closes #XXX -` prefix to auto-close the issue that your PR addresses
