### PR TITLE
Fix org sync cache on refresh and signout-signin

### DIFF
--- a/src/plus/gk/organizationService.ts
+++ b/src/plus/gk/organizationService.ts
@@ -34,6 +34,7 @@ export class OrganizationService implements Disposable {
 				const orgId = await this.getActiveOrganizationId();
 				void this.updateOrganizationPermissions(orgId);
 			}),
+			container.subscription.onDidCheckIn(this.onUserCheckedIn, this),
 			container.subscription.onDidChange(this.onSubscriptionChanged, this),
 		);
 	}
@@ -128,6 +129,13 @@ export class OrganizationService implements Disposable {
 		});
 	}
 
+	private async onUserCheckedIn(): Promise<void> {
+		const orgId = await this.getActiveOrganizationId();
+		if (orgId == null) return;
+
+		await this.updateOrganizationPermissions(orgId, { force: true });
+	}
+
 	private async onSubscriptionChanged(e: SubscriptionChangeEvent): Promise<void> {
 		if (e.current?.account?.id == null) {
 			this.updateOrganizations(undefined);
@@ -142,8 +150,11 @@ export class OrganizationService implements Disposable {
 		void setContext('gitlens:gk:hasOrganizations', (organizations ?? []).length > 1);
 	}
 
-	private async updateOrganizationPermissions(orgId: string | undefined): Promise<void> {
-		const settings = orgId != null ? await this.getOrganizationSettings(orgId) : undefined;
+	private async updateOrganizationPermissions(
+		orgId: string | undefined,
+		options?: { force?: boolean },
+	): Promise<void> {
+		const settings = orgId != null ? await this.getOrganizationSettings(orgId, options) : undefined;
 		let aiProviders;
 		try {
 			aiProviders = fromGKDevAIProviders(settings?.aiProviders);

--- a/src/plus/gk/organizationService.ts
+++ b/src/plus/gk/organizationService.ts
@@ -131,8 +131,9 @@ export class OrganizationService implements Disposable {
 	private async onSubscriptionChanged(e: SubscriptionChangeEvent): Promise<void> {
 		if (e.current?.account?.id == null) {
 			this.updateOrganizations(undefined);
+			this._organizationSettings = undefined;
+			await this.clearAllStoredOrganizationsSettings();
 		}
-		await this.clearAllStoredOrganizationsSettings();
 		await this.updateOrganizationPermissions(e.current?.activeOrganization?.id);
 	}
 
@@ -274,7 +275,7 @@ export class OrganizationService implements Disposable {
 	}
 
 	private async clearAllStoredOrganizationsSettings(): Promise<void> {
-		return this.container.storage.deleteWithPrefix(`plus:organization:`);
+		return this.container.storage.deleteWithPrefix(`plus:organization`);
 	}
 
 	private async deleteStoredOrganizationSettings(id: string): Promise<void> {


### PR DESCRIPTION
# Description
A follow-up on #4300 

- Fixes deleting of stored organization settings by _prefix_ on sign-out
- Deletes org settings from memory on sign-out, so when users signs in it takes fresh settings from GK.dev
- Refreshes org settings on manual refresh initialized by user (`onUserCheckedIn`).  

# Checklist

<!-- Please check off the following -->

- [x] I have followed the guidelines in the Contributing document
- [x] My changes follow the coding style of this project
- [x] My changes build without any errors or warnings
- [x] My changes have been formatted and linted
- [ ] My changes include any required corresponding changes to the documentation (including CHANGELOG.md and README.md)
- [x] My changes have been rebased and squashed to the minimal number (typically 1) of relevant commits
- [x] My changes have a descriptive commit message with a short title, including a `Fixes $XXX -` or `Closes #XXX -` prefix to auto-close the issue that your PR addresses
