### PR TITLE
Fix the update integration status of the current repository on Home

### DIFF
--- a/src/webviews/apps/plus/home/components/overviewState.ts
+++ b/src/webviews/apps/plus/home/components/overviewState.ts
@@ -7,6 +7,7 @@ import type {
 } from '../../../../home/protocol';
 import {
 	ChangeOverviewRepositoryCommand,
+	DidChangeIntegrationsConnections,
 	DidChangeOverviewFilter,
 	DidChangeOverviewRepository,
 	DidChangeRepositories,
@@ -39,6 +40,9 @@ export class ActiveOverviewState extends AsyncComputedState<ActiveOverview> {
 
 		this._disposable = this._ipc.onReceiveMessage(msg => {
 			switch (true) {
+				case DidChangeIntegrationsConnections.is(msg):
+					this.run(true);
+					break;
 				case DidChangeRepositories.is(msg):
 					this.run(true);
 					break;


### PR DESCRIPTION
# Description


This is a follow up of #4387 
It makes Home View to handle the event of changed integration status of the current repository, so when a disconnected integration gets connected, the active repo icon gets updated and the "plug" icon disappears:


![image](https://github.com/user-attachments/assets/0bfae248-e221-4b73-aa8d-5397ba123678)





<!--
Please include a summary of the changes and which issue will be addressed. Please also include relevant motivation and context.
-->

# Checklist

<!-- Please check off the following -->

- [x] I have followed the guidelines in the Contributing document
- [x] My changes follow the coding style of this project
- [x] My changes build without any errors or warnings
- [x] My changes have been formatted and linted
- [x] My changes include any required corresponding changes to the documentation (including CHANGELOG.md and README.md)
- [x] My changes have been rebased and squashed to the minimal number (typically 1) of relevant commits
- [x] My changes have a descriptive commit message with a short title, including a `Fixes $XXX -` or `Closes #XXX -` prefix to auto-close the issue that your PR addresses
