### PR TITLE
Enhances remote provider connection flow

### DIFF
--- a/src/git/models/repositoryShape.ts
+++ b/src/git/models/repositoryShape.ts
@@ -14,5 +14,6 @@ export interface RepositoryShape {
 		integration?: { id: SupportedCloudIntegrationIds; connected: boolean };
 		supportedFeatures: RemoteProviderSupportedFeatures;
 		url?: string;
+		bestRemoteName: string;
 	};
 }

--- a/src/git/utils/-webview/repository.utils.ts
+++ b/src/git/utils/-webview/repository.utils.ts
@@ -94,6 +94,7 @@ export async function toRepositoryShapeWithProvider(
 				: undefined,
 			supportedFeatures: remote.provider.supportedFeatures,
 			url: await remote.provider.url({ type: RemoteResourceType.Repo }),
+			bestRemoteName: remote.name,
 		};
 		if (provider.integration?.id == null) {
 			provider.integration = undefined;

--- a/src/webviews/apps/shared/components/repo-button-group.ts
+++ b/src/webviews/apps/shared/components/repo-button-group.ts
@@ -2,7 +2,7 @@ import { css, html, nothing } from 'lit';
 import { customElement, property } from 'lit/decorators.js';
 import { ifDefined } from 'lit/directives/if-defined.js';
 import { when } from 'lit/directives/when.js';
-import type { ConnectCloudIntegrationsCommandArgs } from '../../../../commands/cloudIntegrations';
+import type { ConnectRemoteProviderCommandArgs } from '../../../../commands/remoteProviders';
 import type { Source } from '../../../../constants.telemetry';
 import type { RepositoryShape } from '../../../../git/models/repositoryShape';
 import { createCommandLink } from '../../../../system/commands';
@@ -198,9 +198,9 @@ export class GlRepoButtonGroup extends GlElement {
 							return html`
 								<code-icon style="margin-top: -3px" icon="plug" aria-hidden="true"></code-icon>
 								<a
-									href=${createCommandLink<ConnectCloudIntegrationsCommandArgs>(
-										'gitlens.plus.cloudIntegrations.connect',
-										{ integrationIds: [provider.integration!.id], source: this.source },
+									href=${createCommandLink<ConnectRemoteProviderCommandArgs>(
+										'gitlens.connectRemoteProvider',
+										{ repoPath: repo.path, remote: provider.bestRemoteName },
 									)}
 								>
 									Connect to ${repo.provider!.name}
@@ -227,10 +227,10 @@ export class GlRepoButtonGroup extends GlElement {
 			<gl-button
 				part="connect-icon"
 				appearance="toolbar"
-				href=${createCommandLink<ConnectCloudIntegrationsCommandArgs>(
-					'gitlens.plus.cloudIntegrations.connect',
-					{ integrationIds: [provider.integration.id], source: this.source },
-				)}
+				href=${createCommandLink<ConnectRemoteProviderCommandArgs>('gitlens.connectRemoteProvider', {
+					repoPath: repo.path,
+					remote: provider.bestRemoteName,
+				})}
 			>
 				<code-icon icon="plug" style="color: var(--titlebar-fg)"></code-icon>
 				<span slot="tooltip">

--- a/src/webviews/home/homeWebview.ts
+++ b/src/webviews/home/homeWebview.ts
@@ -55,6 +55,7 @@ import { isMcpBannerEnabled, mcpExtensionRegistrationAllowed } from '../../plus/
 import { isAiAllAccessPromotionActive } from '../../plus/gk/utils/-webview/promo.utils';
 import { isSubscriptionTrialOrPaidFromState } from '../../plus/gk/utils/subscription.utils';
 import type { ConfiguredIntegrationsChangeEvent } from '../../plus/integrations/authentication/configuredIntegrationService';
+import type { ConnectionStateChangeEvent } from '../../plus/integrations/integrationService';
 import { providersMetadata } from '../../plus/integrations/providers/models';
 import type { LaunchpadCategorizedResult } from '../../plus/launchpad/launchpadProvider';
 import { getLaunchpadItemGroups } from '../../plus/launchpad/launchpadProvider';
@@ -179,6 +180,7 @@ export class HomeWebviewProvider implements WebviewProvider<State, State, HomeWe
 			this.container.subscription.onDidChange(this.onSubscriptionChanged, this),
 			onDidChangeContext(this.onContextChanged, this),
 			this.container.integrations.onDidChange(this.onIntegrationsChanged, this),
+			this.container.integrations.onDidChangeConnectionState(this.onIntegrationConnectionStateChanged, this),
 			this.container.walkthrough.onDidChangeProgress(this.onWalkthroughProgressChanged, this),
 			configuration.onDidChange(this.onDidChangeConfig, this),
 			this.container.launchpad.onDidChange(this.onLaunchpadChanged, this),
@@ -251,6 +253,10 @@ export class HomeWebviewProvider implements WebviewProvider<State, State, HomeWe
 	}
 
 	private onIntegrationsChanged(_e: ConfiguredIntegrationsChangeEvent) {
+		void this.notifyDidChangeIntegrations();
+	}
+
+	private onIntegrationConnectionStateChanged(_e: ConnectionStateChangeEvent) {
 		void this.notifyDidChangeIntegrations();
 	}
 


### PR DESCRIPTION
# Description

This is a follow-up on #4387

Originates from [this conversation](https://gitkraken-hq.slack.com/archives/C06QFFUSVUZ/p1750157934439699?thread_ts=1750096212.425849):

> And there is another thing that I think is worth fixing: handling of the "connect" click should be different. I'm attaching the example how it's handled in Remotes View and in Home. I think on Home it should work the same way as on Remotes View.

How it should work (without a web page, using existing connection):

https://github.com/user-attachments/assets/7fb47859-2025-4782-90cc-716606009293

How it works (it passes user through a web page) and what this pull request changes:

![image](https://github.com/user-attachments/assets/542b07c8-fb09-4328-8ea9-f99885ebf477)


# Verification steps

- [ ] basic change: open "remotes", disconnect, open "Home", connect: it should not go through the browser.
- [ ] right remote is selected
  - switch to a branch, that has an upstream from `origin`
    <img width="300" height="84" alt="image" src="https://github.com/user-attachments/assets/66816656-79a9-4e28-96a1-4e86f505c062" />

  - on remotes: disconnect, if there is a default remote then "Unset as default"
  - open "Home", connect.
  - [ ] on "remotes" check that the `origin` is selected as default
  - edit the branch, change its upstream to another remote
    <img width="300" height="86" alt="image" src="https://github.com/user-attachments/assets/37cddf3a-7712-4bd2-a169-e79c79d333bf" />
  - disconnect and "Unset the default" again
  - open "Home", connect
  - [ ] on "remotes" check that the `orther` is set as default
- [ ] prioritized remote is selected
  - switch to a branch without an upstream
    <img width="300" height="74" alt="image" src="https://github.com/user-attachments/assets/34e642b2-b974-4a5d-b72d-6dd5744850f3" />
  - Have a remote called as "upstream"
  - disconnect and "Unset the default"
  - open "Home", connect
  - [ ] on "remotes" check that no "upstream" is set as default
  - [ ] same steps but no "upstream" remote: "origin" is set as default


# Checklist

<!-- Please check off the following -->

- [x] I have followed the guidelines in the Contributing document
- [x] My changes follow the coding style of this project
- [x] My changes build without any errors or warnings
- [x] My changes have been formatted and linted
- [ ] My changes include any required corresponding changes to the documentation (including CHANGELOG.md and README.md)
- [x] My changes have been rebased and squashed to the minimal number (typically 1) of relevant commits
- [x] My changes have a descriptive commit message with a short title, including a `Fixes $XXX -` or `Closes #XXX -` prefix to auto-close the issue that your PR addresses
