### PR TITLE
Improves AI label in the Integrations dropdown on the Home View 

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,10 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/) and this p
 
 ## [Unreleased]
 
+### Changed
+
+- Improves AI status label in integrations popup to "Select AI model to enable AI features" and fixes text brightness ([#4400](https://github.com/gitkraken/vscode-gitlens/issues/4400))
+
 ## [17.2.0] - 2025-06-17
 
 ### Added

--- a/src/webviews/apps/plus/shared/components/integrations-chip.ts
+++ b/src/webviews/apps/plus/shared/components/integrations-chip.ts
@@ -356,16 +356,18 @@ export class GlIntegrationsChip extends LitElement {
 			<span class="integration__icon"><code-icon icon="${icon}"></code-icon></span>
 			${this.aiEnabled
 				? html`<span class="integration__content">
-							<span class="integration__title">
-								<span>${model?.provider.name ?? 'AI'}</span>
-								${showProBadge
-									? html` <gl-feature-badge
-											placement="right"
-											.source=${{ source: 'home', detail: 'integrations' } as const}
-											cloud
-									  ></gl-feature-badge>`
-									: nothing}
-							</span>
+							${model?.provider.name
+								? html`<span class="integration__title">
+										<span>${model.provider.name}</span>
+										${showProBadge
+											? html` <gl-feature-badge
+													placement="right"
+													.source=${{ source: 'home', detail: 'integrations' } as const}
+													cloud
+											  ></gl-feature-badge>`
+											: nothing}
+								  </span>`
+								: html`<span class="integration_details">AI</span>`}
 							${model?.name ? html`<span class="integration__details">${model.name}</span>` : nothing}
 						</span>
 						<span class="integration__actions">

--- a/src/webviews/apps/plus/shared/components/integrations-chip.ts
+++ b/src/webviews/apps/plus/shared/components/integrations-chip.ts
@@ -367,7 +367,7 @@ export class GlIntegrationsChip extends LitElement {
 											  ></gl-feature-badge>`
 											: nothing}
 								  </span>`
-								: html`<span class="integration_details">AI</span>`}
+								: html`<span class="integration_details">Select AI model to enable AI features</span>`}
 							${model?.name ? html`<span class="integration__details">${model.name}</span>` : nothing}
 						</span>
 						<span class="integration__actions">


### PR DESCRIPTION
# Description
Solves #4400 

- The label text is improved. It tells user to select AI provider and the model to start using AI feature
- The label text stopped being dimmed. It's shown with normal brightness

![image](https://github.com/user-attachments/assets/7462311e-1dec-452b-953f-e4a201a3debe)


# Checklist

<!-- Please check off the following -->

- [x] I have followed the guidelines in the Contributing document
- [x] My changes follow the coding style of this project
- [x] My changes build without any errors or warnings
- [x] My changes have been formatted and linted
- [x] My changes include any required corresponding changes to the documentation (including CHANGELOG.md and README.md)
- [x] My changes have been rebased and squashed to the minimal number (typically 1) of relevant commits
- [x] My changes have a descriptive commit message with a short title, including a `Fixes $XXX -` or `Closes #XXX -` prefix to auto-close the issue that your PR addresses
