### PR TITLE
Silences duplicate-case warnings in test builds

### DIFF
--- a/scripts/esbuild.tests.mjs
+++ b/scripts/esbuild.tests.mjs
@@ -24,6 +24,9 @@ async function buildTests(target) {
 		external: ['vscode'],
 		format: 'cjs',
 		logLevel: 'info',
+		logOverride: {
+			'duplicate-case': 'silent',
+		},
 		mainFields: target === 'webworker' ? ['browser', 'module', 'main'] : ['module', 'main'],
 		metafile: false,
 		minify: false,

--- a/src/commands/resets.ts
+++ b/src/commands/resets.ts
@@ -103,7 +103,7 @@ export class ResetCommand extends GlCommandBase {
 				{
 					label: 'Promo Opt-Ins...',
 					detail: 'Clears any locally stored promo opt-ins',
-					item: 'promoOptIns'
+					item: 'promoOptIns',
 				},
 			);
 		}

--- a/src/plus/gk/subscriptionService.ts
+++ b/src/plus/gk/subscriptionService.ts
@@ -1682,16 +1682,17 @@ export class SubscriptionService implements Disposable {
 		try {
 			if (hasAccount) {
 				try {
-					const token = await this.container.accountAuthentication.getExchangeToken(
-						AiAllAccessOptInPathPrefix,
-					);
+					const token =
+						await this.container.accountAuthentication.getExchangeToken(AiAllAccessOptInPathPrefix);
 					query.set('token', token);
 				} catch (ex) {
 					Logger.error(ex, scope);
 				}
 			} else {
 				const callbackUri = await env.asExternalUri(
-					Uri.parse(`${env.uriScheme}://${this.container.context.extension.id}/${AiAllAccessOptInPathPrefix}`),
+					Uri.parse(
+						`${env.uriScheme}://${this.container.context.extension.id}/${AiAllAccessOptInPathPrefix}`,
+					),
 				);
 				query.set('redirect_uri', callbackUri.toString(true));
 			}
@@ -1700,7 +1701,7 @@ export class SubscriptionService implements Disposable {
 				this.container.telemetry.sendEvent('aiAllAccess/opened', undefined, source);
 			}
 
-			if(!(await openUrl(this.container.urls.getGkDevUrl('all-access', query)))) {
+			if (!(await openUrl(this.container.urls.getGkDevUrl('all-access', query)))) {
 				return false;
 			}
 		} catch (ex) {
@@ -1710,14 +1711,20 @@ export class SubscriptionService implements Disposable {
 
 		const completionPromises = [
 			new Promise<string>(resolve => setTimeout(() => resolve('cancel'), 5 * 60 * 1000)),
-			new Promise<string>(resolve => once(this.container.uri.onDidReceiveAiAllAccessOptInUri)(() => resolve(hasAccount ? 'update' : 'login'))),
+			new Promise<string>(resolve =>
+				once(this.container.uri.onDidReceiveAiAllAccessOptInUri)(() =>
+					resolve(hasAccount ? 'update' : 'login'),
+				),
+			),
 		];
 
 		const action = await Promise.race(completionPromises);
 
 		if (action === 'update' && hasAccount) {
 			void this.checkUpdatedSubscription(source);
-			void this.container.storage.store(`gk:promo:${this._session?.account.id ?? '00000000'}:ai:allAccess:dismissed`, true).catch();
+			void this.container.storage
+				.store(`gk:promo:${this._session?.account.id ?? '00000000'}:ai:allAccess:dismissed`, true)
+				.catch();
 			void this.container.views.home.refresh();
 		}
 
@@ -1743,7 +1750,9 @@ export class SubscriptionService implements Disposable {
 			await this.loginWithCode({ code: code }, { source: 'subscription' });
 			const newSession = await this.getAuthenticationSession();
 			if (newSession?.account?.id != null) {
-				await this.container.storage.store(`gk:promo:${newSession.account.id}:ai:allAccess:dismissed`, true).catch();
+				await this.container.storage
+					.store(`gk:promo:${newSession.account.id}:ai:allAccess:dismissed`, true)
+					.catch();
 				void this.container.views.home.refresh();
 			}
 		}

--- a/src/webviews/apps/home/components/ai-all-access-banner.ts
+++ b/src/webviews/apps/home/components/ai-all-access-banner.ts
@@ -41,12 +41,13 @@ export class GlAiAllAccessBanner extends LitElement {
 
 	private get shouldShow(): boolean {
 		// Don't show if dismissed or closed
-		return !(this._state.aiAllAccessBannerCollapsed);
+		return !this._state.aiAllAccessBannerCollapsed;
 	}
 
 	private get bodyLabel(): string {
-		return this.hasAdvancedOrHigher ? 'Opt in now to get unlimited GitKraken AI until July 11th!' : 'Opt in now to try all Advanced GitLens features with unlimited GitKraken AI for FREE until July 11th!';
-
+		return this.hasAdvancedOrHigher
+			? 'Opt in now to get unlimited GitKraken AI until July 11th!'
+			: 'Opt in now to try all Advanced GitLens features with unlimited GitKraken AI for FREE until July 11th!';
 	}
 
 	private get primaryButtonLabel(): string {
@@ -54,7 +55,11 @@ export class GlAiAllAccessBanner extends LitElement {
 	}
 
 	private get hasAdvancedOrHigher(): boolean {
-		return this._state.subscription.plan && compareSubscriptionPlans(this._state.subscription.plan.actual.id, 'advanced') >= 0 || compareSubscriptionPlans(this._state.subscription.plan.effective.id, 'advanced') >= 0;
+		return (
+			(this._state.subscription.plan &&
+				compareSubscriptionPlans(this._state.subscription.plan.actual.id, 'advanced') >= 0) ||
+			compareSubscriptionPlans(this._state.subscription.plan.effective.id, 'advanced') >= 0
+		);
 	}
 
 	override render(): unknown {
@@ -68,10 +73,7 @@ export class GlAiAllAccessBanner extends LitElement {
 				banner-title="All Access Week - now until July 11th!"
 				body="${this.bodyLabel}"
 				primary-button="${this.primaryButtonLabel}"
-				primary-button-href="${createCommandLink(
-					'gitlens.plus.aiAllAccess.optIn',
-					{ source: 'home' },
-				)}"
+				primary-button-href="${createCommandLink('gitlens.plus.aiAllAccess.optIn', { source: 'home' })}"
 				secondary-button="Dismiss"
 				@gl-banner-secondary-click=${this.onSecondaryClick}
 			></gl-banner>

--- a/src/webviews/apps/shared/components/banner/banner.css.ts
+++ b/src/webviews/apps/shared/components/banner/banner.css.ts
@@ -51,21 +51,42 @@ export const bannerStyles = css`
 			var(--gl-banner-primary-emphasis-background) 0%,
 			var(--gl-banner-secondary-emphasis-background) 100%
 		);
-		border: 1px solid color-mix(in lab, var(--gl-banner-primary-emphasis-background) 50%, var(--gl-banner-secondary-emphasis-background) 50%);
+		border: 1px solid
+			color-mix(
+				in lab,
+				var(--gl-banner-primary-emphasis-background) 50%,
+				var(--gl-banner-secondary-emphasis-background) 50%
+			);
 	}
 
 	/* Gradient transparent display mode - same gradient but with transparency */
 	.banner--gradient-transparent {
 		background: linear-gradient(
 			to right,
-			color-mix(in lab, var(--gl-banner-primary-emphasis-background) calc(100% * (1 - var(--gl-banner-transparency))), transparent) 0%,
-			color-mix(in lab, var(--gl-banner-secondary-emphasis-background) calc(100% * (1 - var(--gl-banner-transparency))), transparent) 100%
+			color-mix(
+					in lab,
+					var(--gl-banner-primary-emphasis-background) calc(100% * (1 - var(--gl-banner-transparency))),
+					transparent
+				)
+				0%,
+			color-mix(
+					in lab,
+					var(--gl-banner-secondary-emphasis-background) calc(100% * (1 - var(--gl-banner-transparency))),
+					transparent
+				)
+				100%
 		);
-		border: 1px solid color-mix(
-			in lab,
-			color-mix(in lab, var(--gl-banner-primary-emphasis-background) 50%, var(--gl-banner-secondary-emphasis-background) 50%) calc(100% * (1 - var(--gl-banner-transparency))),
-			transparent
-		);
+		border: 1px solid
+			color-mix(
+				in lab,
+				color-mix(
+						in lab,
+						var(--gl-banner-primary-emphasis-background) 50%,
+						var(--gl-banner-secondary-emphasis-background) 50%
+					)
+					calc(100% * (1 - var(--gl-banner-transparency))),
+				transparent
+			);
 	}
 
 	.banner__content {
@@ -131,7 +152,11 @@ export const bannerStyles = css`
 	:host-context(.vscode-light),
 	:host-context(.vscode-high-contrast-light) {
 		--gl-banner-primary-emphasis-background: color-mix(in lab, var(--vscode-button-background) 40%, #fff 60%);
-		--gl-banner-secondary-emphasis-background: color-mix(in lab, var(--vscode-button-secondaryBackground) 40%, #fff 60%);
+		--gl-banner-secondary-emphasis-background: color-mix(
+			in lab,
+			var(--vscode-button-secondaryBackground) 40%,
+			#fff 60%
+		);
 	}
 
 	/* Override text color for high contrast light theme specifically */

--- a/src/webviews/apps/shared/components/banner/banner.ts
+++ b/src/webviews/apps/shared/components/banner/banner.ts
@@ -53,18 +53,13 @@ export class GlBanner extends LitElement {
 	}
 
 	override render(): unknown {
-		return html`
-			<div part="base" class=${classMap(this.classNames)}>
-				${this.renderContent()}
-			</div>
-		`;
+		return html` <div part="base" class=${classMap(this.classNames)}>${this.renderContent()}</div> `;
 	}
 
 	private renderContent() {
 		return html`
 			<div class="banner__content">
-				${this.bannerTitle ? this.renderTitle() : ''}
-				${this.body ? this.renderBody() : ''}
+				${this.bannerTitle ? this.renderTitle() : ''} ${this.body ? this.renderBody() : ''}
 				${this.renderButtons()}
 			</div>
 		`;
@@ -86,8 +81,7 @@ export class GlBanner extends LitElement {
 
 		return html`
 			<div class="banner__buttons">
-				${hasPrimary ? this.renderPrimaryButton() : ''}
-				${hasSecondary ? this.renderSecondaryButton() : ''}
+				${hasPrimary ? this.renderPrimaryButton() : ''} ${hasSecondary ? this.renderSecondaryButton() : ''}
 			</div>
 		`;
 	}


### PR DESCRIPTION
Fixes warnings like these:

```
▲ [WARNING] This case clause will never be evaluated because it duplicates an earlier case clause [duplicate-case]

    src/webviews/plus/graph/graphWebview.utils.ts:173:7:
      173 │     case 'github' satisfies Unbrand<GkProviderId>:
```

that started happening during `pnpm run test` here: f7faceae187a  (#4468)

Probably that started happening because `graphWebview.utils.ts` appeared in the test assembly for the first time, through a new chain of imports.

However, it does not appear on the main build task. Therefore I decided to modify building properties of tests, so the compiler become tolerant to these expressions as well as the main build.

---

Also fixes prettier that was broken in ff3858f191a9 (#4473)

