### PR TITLE
Opens summary before AI result

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,7 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/) and this p
 ### Changed
 
 - Changes branch favoriting to apply to both local and remote branch pairs ([#4497](https://github.com/gitkraken/vscode-gitlens/issues/4497))
+- Supports opening an explain summary document before summary content is generated ([#4328](https://github.com/gitkraken/vscode-gitlens/issues/4328))
 
 ## [17.3.3] - 2025-07-28
 

--- a/src/commands/aiFeedback.ts
+++ b/src/commands/aiFeedback.ts
@@ -1,5 +1,5 @@
-import type { TextEditor, Uri } from 'vscode';
-import { window } from 'vscode';
+import type { Disposable, TextEditor, Uri } from 'vscode';
+import { window, workspace } from 'vscode';
 import type { AIFeedbackEvent, AIFeedbackUnhelpfulReasons, Source } from '../constants.telemetry';
 import type { Container } from '../container';
 import type { AIResultContext } from '../plus/ai/aiProviderService';
@@ -12,6 +12,7 @@ import type { Deferrable } from '../system/function/debounce';
 import { debounce } from '../system/function/debounce';
 import { filterMap, map } from '../system/iterable';
 import { Logger } from '../system/logger';
+import { createDisposable } from '../system/unifiedDisposable';
 import { ActiveEditorCommand } from './commandBase';
 import { getCommandUri } from './commandBase.utils';
 
@@ -44,6 +45,31 @@ export class AIFeedbackUnhelpfulCommand extends ActiveEditorCommand {
 }
 
 type UnhelpfulResult = { reasons?: AIFeedbackUnhelpfulReasons[]; custom?: string };
+
+let _documentCloseTracker: Disposable | undefined;
+const _markdownDocuments = new Map<string, AIResultContext>();
+export function getMarkdownDocument(documentUri: string): AIResultContext | undefined {
+	return _markdownDocuments.get(documentUri);
+}
+export function setMarkdownDocument(documentUri: string, context: AIResultContext, container: Container): void {
+	_markdownDocuments.set(documentUri, context);
+
+	if (!_documentCloseTracker) {
+		_documentCloseTracker = workspace.onDidCloseTextDocument(document => {
+			deleteMarkdownDocument(document.uri.toString());
+		});
+		container.context.subscriptions.push(
+			createDisposable(() => {
+				_documentCloseTracker?.dispose();
+				_documentCloseTracker = undefined;
+				_markdownDocuments.clear();
+			}),
+		);
+	}
+}
+function deleteMarkdownDocument(documentUri: string): void {
+	_markdownDocuments.delete(documentUri);
+}
 
 const uriResponses = new UriMap<AIFeedbackEvent['sentiment']>();
 let _updateContextDebounced: Deferrable<() => void> | undefined;

--- a/src/commands/explainBase.ts
+++ b/src/commands/explainBase.ts
@@ -11,6 +11,7 @@ import type { AIModel } from '../plus/ai/models/model';
 import { getAIResultContext } from '../plus/ai/utils/-webview/ai.utils';
 import { getBestRepositoryOrShowPicker } from '../quickpicks/repositoryPicker';
 import { showMarkdownPreview } from '../system/-webview/markdown';
+import { setMarkdownDocument } from './aiFeedback';
 import { GlCommandBase } from './commandBase';
 import { getCommandUri } from './commandBase.utils';
 
@@ -135,9 +136,13 @@ export abstract class ExplainCommandBase extends GlCommandBase {
 		result: AISummarizeResult,
 		metadata: MarkdownContentMetadata,
 	): void {
-		const metadataWithContext: MarkdownContentMetadata = { ...metadata, context: getAIResultContext(result) };
+		const context = getAIResultContext(result);
+		const metadataWithContext: MarkdownContentMetadata = { ...metadata, context: context };
 		const headerContent = getMarkdownHeaderContent(metadataWithContext, this.container.telemetry.enabled);
 		const content = `${headerContent}\n\n${result.parsed.summary}\n\n${result.parsed.body}`;
+
+		// Store the AI result context in the feedback provider for documents that cannot store it in their URI
+		setMarkdownDocument(documentUri.toString(), context, this.container);
 
 		this.container.markdown.updateDocument(documentUri, content);
 	}

--- a/src/commands/explainBase.ts
+++ b/src/commands/explainBase.ts
@@ -78,7 +78,7 @@ export abstract class ExplainCommandBase extends GlCommandBase {
 
 		const metadataWithContext: MarkdownContentMetadata = { ...metadata, context: loadingContext };
 		const headerContent = getMarkdownHeaderContent(metadataWithContext, this.container.telemetry.enabled);
-		const loadingContent = `${headerContent}\n\n---\n\n🤖 **Generating explanation...**\n\nPlease wait while the AI analyzes the changes and generates an explanation. This document will update automatically when the content is ready.\n\n*This may take a few moments depending on the complexity of the changes.*`;
+		const loadingContent = `${headerContent}\n\n> 🤖 **Generating explanation...**\n> Please wait while the AI analyzes the changes and generates an explanation. This document will update automatically when the content is ready.\n>\n> *This may take a few moments depending on the complexity of the changes.*`;
 
 		// Open the document immediately with loading content
 		const documentUri = this.container.markdown.openDocument(

--- a/src/commands/explainBase.ts
+++ b/src/commands/explainBase.ts
@@ -1,11 +1,13 @@
 import type { TextEditor, Uri } from 'vscode';
+import { md5 } from '@env/crypto';
 import type { GlCommands } from '../constants.commands';
 import type { Container } from '../container';
 import type { MarkdownContentMetadata } from '../documents/markdown';
 import { getMarkdownHeaderContent } from '../documents/markdown';
 import type { GitRepositoryService } from '../git/gitRepositoryService';
 import { GitUri } from '../git/gitUri';
-import type { AIExplainSource, AISummarizeResult } from '../plus/ai/aiProviderService';
+import type { AIExplainSource, AIResultContext, AISummarizeResult } from '../plus/ai/aiProviderService';
+import type { AIModel } from '../plus/ai/models/model';
 import { getAIResultContext } from '../plus/ai/utils/-webview/ai.utils';
 import { getBestRepositoryOrShowPicker } from '../quickpicks/repositoryPicker';
 import { showMarkdownPreview } from '../system/-webview/markdown';
@@ -55,23 +57,104 @@ export abstract class ExplainCommandBase extends GlCommandBase {
 		return svc;
 	}
 
+	/**
+	 * Opens a document immediately with loading state, then updates it when AI content is ready
+	 */
 	protected openDocument(
-		result: AISummarizeResult,
+		aiPromise: Promise<AISummarizeResult | 'cancelled' | undefined>,
 		path: string,
+		model: AIModel,
+		feature: string,
 		metadata: Omit<MarkdownContentMetadata, 'context'>,
 	): void {
-		const metadataWithContext: MarkdownContentMetadata = { ...metadata, context: getAIResultContext(result) };
+		// Create a placeholder AI context for the loading state
+		const loadingContext: AIResultContext = {
+			id: `loading-${md5(path)}`,
+			type: 'explain-changes',
+			feature: feature,
+			model: model,
+		};
 
+		const metadataWithContext: MarkdownContentMetadata = { ...metadata, context: loadingContext };
 		const headerContent = getMarkdownHeaderContent(metadataWithContext, this.container.telemetry.enabled);
-		const content = `${headerContent}\n\n${result.parsed.summary}\n\n${result.parsed.body}`;
+		const loadingContent = `${headerContent}\n\n---\n\n🤖 **Generating explanation...**\n\nPlease wait while the AI analyzes the changes and generates an explanation. This document will update automatically when the content is ready.\n\n*This may take a few moments depending on the complexity of the changes.*`;
 
+		// Open the document immediately with loading content
 		const documentUri = this.container.markdown.openDocument(
-			content,
+			loadingContent,
 			path,
 			metadata.header.title,
 			metadataWithContext,
 		);
 
 		showMarkdownPreview(documentUri);
+
+		// Update the document when AI content is ready
+		void this.updateDocumentWhenReady(documentUri, aiPromise, metadataWithContext);
+	}
+
+	/**
+	 * Updates the document content when AI generation completes
+	 */
+	private async updateDocumentWhenReady(
+		documentUri: Uri,
+		aiPromise: Promise<AISummarizeResult | 'cancelled' | undefined>,
+		metadata: MarkdownContentMetadata,
+	): Promise<void> {
+		try {
+			const result = await aiPromise;
+
+			if (result === 'cancelled') {
+				// Update with cancellation message
+				const cancelledContent = this.createCancelledContent(metadata);
+				this.container.markdown.updateDocument(documentUri, cancelledContent);
+				return;
+			}
+
+			if (result == null) {
+				// Update with error message
+				const errorContent = this.createErrorContent(metadata);
+				this.container.markdown.updateDocument(documentUri, errorContent);
+				return;
+			}
+
+			// Update with successful AI content
+			this.updateDocumentWithResult(documentUri, result, metadata);
+		} catch (_error) {
+			// Update with error message
+			const errorContent = this.createErrorContent(metadata);
+			this.container.markdown.updateDocument(documentUri, errorContent);
+		}
+	}
+
+	/**
+	 * Updates the document with successful AI result
+	 */
+	private updateDocumentWithResult(
+		documentUri: Uri,
+		result: AISummarizeResult,
+		metadata: MarkdownContentMetadata,
+	): void {
+		const metadataWithContext: MarkdownContentMetadata = { ...metadata, context: getAIResultContext(result) };
+		const headerContent = getMarkdownHeaderContent(metadataWithContext, this.container.telemetry.enabled);
+		const content = `${headerContent}\n\n${result.parsed.summary}\n\n${result.parsed.body}`;
+
+		this.container.markdown.updateDocument(documentUri, content);
+	}
+
+	/**
+	 * Creates content for cancelled AI generation
+	 */
+	private createCancelledContent(metadata: MarkdownContentMetadata): string {
+		const headerContent = getMarkdownHeaderContent(metadata, this.container.telemetry.enabled);
+		return `${headerContent}\n\n---\n\n⚠️ **Generation Cancelled**\n\nThe AI explanation was cancelled before completion.`;
+	}
+
+	/**
+	 * Creates content for failed AI generation
+	 */
+	private createErrorContent(metadata: MarkdownContentMetadata): string {
+		const headerContent = getMarkdownHeaderContent(metadata, this.container.telemetry.enabled);
+		return `${headerContent}\n\n---\n\n❌ **Generation Failed**\n\nUnable to generate an explanation for the changes. Please try again.`;
 	}
 }

--- a/src/commands/explainBranch.ts
+++ b/src/commands/explainBranch.ts
@@ -121,7 +121,12 @@ export class ExplainBranchCommand extends ExplainCommandBase {
 				return;
 			}
 
-			this.openDocument(result, `/explain/branch/${branch.ref}/${result.model.id}`, {
+			const {
+				aiPromise,
+				info: { model },
+			} = result;
+
+			this.openDocument(aiPromise, `/explain/branch/${branch.ref}/${model.id}`, model, 'explain-branch', {
 				header: { title: 'Branch Summary', subtitle: branch.name },
 				command: {
 					label: 'Explain Branch Changes',

--- a/src/commands/explainCommit.ts
+++ b/src/commands/explainCommit.ts
@@ -97,7 +97,12 @@ export class ExplainCommitCommand extends ExplainCommandBase {
 				return;
 			}
 
-			this.openDocument(result, `/explain/commit/${commit.ref}/${result.model.id}`, {
+			const {
+				aiPromise,
+				info: { model },
+			} = result;
+
+			this.openDocument(aiPromise, `/explain/commit/${commit.ref}/${model.id}`, model, 'explain-commit', {
 				header: { title: 'Commit Summary', subtitle: `${commit.summary} (${commit.shortSha})` },
 				command: {
 					label: 'Explain Commit Summary',

--- a/src/commands/explainStash.ts
+++ b/src/commands/explainStash.ts
@@ -79,11 +79,16 @@ export class ExplainStashCommand extends ExplainCommandBase {
 			if (result === 'cancelled') return;
 
 			if (result == null) {
-				void showGenericErrorMessage('No changes found to explain for stash');
+				void showGenericErrorMessage('Unable to explain stash');
 				return;
 			}
 
-			this.openDocument(result, `/explain/stash/${commit.ref}/${result.model.id}`, {
+			const {
+				aiPromise,
+				info: { model },
+			} = result;
+
+			this.openDocument(aiPromise, `/explain/stash/${commit.ref}/${model.id}`, model, 'explain-stash', {
 				header: { title: 'Stash Summary', subtitle: commit.message || commit.ref },
 				command: {
 					label: 'Explain Stash Changes',

--- a/src/commands/explainWip.ts
+++ b/src/commands/explainWip.ts
@@ -119,7 +119,12 @@ export class ExplainWipCommand extends ExplainCommandBase {
 				return;
 			}
 
-			this.openDocument(result, `/explain/wip/${svc.path}/${result.model.id}`, {
+			const {
+				aiPromise,
+				info: { model },
+			} = result;
+
+			this.openDocument(aiPromise, `/explain/wip/${svc.path}/${model.id}`, model, 'explain-wip', {
 				header: {
 					title: `${capitalize(label)} Changes Summary`,
 					subtitle: `${capitalize(label)} Changes (${repoName})`,

--- a/src/documents/markdown.ts
+++ b/src/documents/markdown.ts
@@ -27,16 +27,11 @@ export class MarkdownContentProvider implements TextDocumentContentProvider {
 	constructor(private container: Container) {
 		this.registration = workspace.registerTextDocumentContentProvider(Schemes.GitLensAIMarkdown, this);
 
-		// Track document visibility to detect when content needs recovery
+		// Track tab changes to detect when content needs recovery
 		this.visibilityTracker = Disposable.from(
 			window.tabGroups.onDidChangeTabs((e: TabChangeEvent) => {
 				this.onTabsChanged(e);
 			}),
-			// // Also track when tabs change which might affect preview visibility
-			// window.onDidChangeActiveTextEditor(() => {
-			// 	// Delay to allow VS Code to finish tab switching
-			// 	setTimeout(() => this.forceRecoveryForAllOpenedDocuments(), 1000);
-			// }),
 		);
 
 		workspace.onDidCloseTextDocument(document => {
@@ -117,25 +112,6 @@ export class MarkdownContentProvider implements TextDocumentContentProvider {
 		this.registration.dispose();
 		this.visibilityTracker.dispose();
 	}
-
-	// /**
-	//  * Checks preview visibility by examining workspace documents
-	//  */
-	// private forceRecoveryForAllOpenedDocuments(): void {
-	// 	// Check all workspace documents for our markdown scheme
-	// 	for (const document of workspace.textDocuments) {
-	// 		if (document.uri.scheme === Schemes.GitLensAIMarkdown) {
-	// 			const uriString = document.uri.toString();
-	// 			if (this.contents.has(uriString)) {
-	// 				console.log(`[GitLens] Checking preview visibility for: ${document.uri.path}`);
-	// 				// Trigger recovery check for this document
-	// 				setTimeout(() => {
-	// 					this.forceContentRecovery(document.uri);
-	// 				}, 1000);
-	// 			}
-	// 		}
-	// 	}
-	// }
 
 	private onTabsChanged(e: TabChangeEvent) {
 		for (const tab of e.changed) {

--- a/src/documents/markdown.ts
+++ b/src/documents/markdown.ts
@@ -1,5 +1,5 @@
-import type { Disposable, Event, TextDocumentContentProvider } from 'vscode';
-import { EventEmitter, Uri, workspace } from 'vscode';
+import type { Event, TabChangeEvent, TextDocumentContentProvider } from 'vscode';
+import { Disposable, EventEmitter, TabInputCustom, Uri, window, workspace } from 'vscode';
 import { Schemes } from '../constants';
 import type { GlCommands } from '../constants.commands';
 import type { Container } from '../container';
@@ -17,6 +17,7 @@ export interface MarkdownContentMetadata {
 export class MarkdownContentProvider implements TextDocumentContentProvider {
 	private contents = new Map<string, string>();
 	private registration: Disposable;
+	private visibilityTracker: Disposable;
 
 	private _onDidChange = new EventEmitter<Uri>();
 	get onDidChange(): Event<Uri> {
@@ -25,6 +26,18 @@ export class MarkdownContentProvider implements TextDocumentContentProvider {
 
 	constructor(private container: Container) {
 		this.registration = workspace.registerTextDocumentContentProvider(Schemes.GitLensAIMarkdown, this);
+
+		// Track document visibility to detect when content needs recovery
+		this.visibilityTracker = Disposable.from(
+			window.tabGroups.onDidChangeTabs((e: TabChangeEvent) => {
+				this.onTabsChanged(e);
+			}),
+			// // Also track when tabs change which might affect preview visibility
+			// window.onDidChangeActiveTextEditor(() => {
+			// 	// Delay to allow VS Code to finish tab switching
+			// 	setTimeout(() => this.forceRecoveryForAllOpenedDocuments(), 1000);
+			// }),
+		);
 
 		workspace.onDidCloseTextDocument(document => {
 			if (document.uri.scheme === Schemes.GitLensAIMarkdown) {
@@ -71,6 +84,30 @@ export class MarkdownContentProvider implements TextDocumentContentProvider {
 		this._onDidChange.fire(uri);
 	}
 
+	/**
+	 * Forces content recovery for a document - useful when content gets corrupted
+	 */
+	forceContentRecovery(uri: Uri): void {
+		const uriString = uri.toString();
+		if (!this.contents.has(uriString)) return;
+
+		const storedContent = this.contents.get(uriString);
+		if (!storedContent) return;
+
+		// I'm deleting the content because if I just fire the change once to make VSCode
+		// reach our `provideTextDocumentContent` method
+		// and `provideTextDocumentContent` returns the unchanged conent,
+		// VSCode will not refresh the content, instead it keeps displaying the original conetnt
+		// that the view had when it was opened initially.
+		// That's why I need to blink the content.
+		if (storedContent.at(storedContent.length - 1) === '\n') {
+			this.contents.set(uriString, storedContent.substring(0, storedContent.length - 1));
+		} else {
+			this.contents.set(uriString, `${storedContent}\n`);
+		}
+		this._onDidChange.fire(uri);
+	}
+
 	closeDocument(uri: Uri): void {
 		this.contents.delete(uri.toString());
 	}
@@ -78,6 +115,35 @@ export class MarkdownContentProvider implements TextDocumentContentProvider {
 	dispose(): void {
 		this.contents.clear();
 		this.registration.dispose();
+		this.visibilityTracker.dispose();
+	}
+
+	// /**
+	//  * Checks preview visibility by examining workspace documents
+	//  */
+	// private forceRecoveryForAllOpenedDocuments(): void {
+	// 	// Check all workspace documents for our markdown scheme
+	// 	for (const document of workspace.textDocuments) {
+	// 		if (document.uri.scheme === Schemes.GitLensAIMarkdown) {
+	// 			const uriString = document.uri.toString();
+	// 			if (this.contents.has(uriString)) {
+	// 				console.log(`[GitLens] Checking preview visibility for: ${document.uri.path}`);
+	// 				// Trigger recovery check for this document
+	// 				setTimeout(() => {
+	// 					this.forceContentRecovery(document.uri);
+	// 				}, 1000);
+	// 			}
+	// 		}
+	// 	}
+	// }
+
+	private onTabsChanged(e: TabChangeEvent) {
+		for (const tab of e.changed) {
+			if (tab.input instanceof TabInputCustom && tab.input.uri.scheme === Schemes.GitLensAIMarkdown) {
+				const uri = tab.input.uri;
+				this.forceContentRecovery(uri);
+			}
+		}
 	}
 }
 

--- a/src/plus/ai/utils/-webview/ai.utils.ts
+++ b/src/plus/ai/utils/-webview/ai.utils.ts
@@ -1,5 +1,6 @@
 import type { Disposable, QuickInputButton } from 'vscode';
 import { env, ThemeIcon, Uri, window } from 'vscode';
+import { getMarkdownDocument } from '../../../../commands/aiFeedback';
 import { Schemes } from '../../../../constants';
 import type { AIProviders } from '../../../../constants.ai';
 import type { Container } from '../../../../container';
@@ -289,8 +290,9 @@ export function extractAIResultContext(uri: Uri | undefined): AIResultContext | 
 	if (!authority) return undefined;
 
 	try {
+		const context: AIResultContext | undefined = getMarkdownDocument(uri.toString());
 		const metadata = decodeGitLensRevisionUriAuthority<MarkdownContentMetadata>(authority);
-		return metadata.context;
+		return context ?? metadata.context;
 	} catch (ex) {
 		Logger.error(ex, 'extractResultContext');
 		return undefined;

--- a/src/webviews/plus/patchDetails/patchDetailsWebview.ts
+++ b/src/webviews/plus/patchDetails/patchDetailsWebview.ts
@@ -841,7 +841,14 @@ export class PatchDetailsWebviewProvider
 
 			if (result == null) throw new Error('Error retrieving content');
 
-			params = { result: result.parsed };
+			const { aiPromise } = result;
+
+			const aiResult = await aiPromise;
+			if (aiResult === 'cancelled') throw new Error('Operation was canceled');
+
+			if (aiResult == null) throw new Error('Error retrieving content');
+
+			params = { result: aiResult.parsed };
 		} catch (ex) {
 			debugger;
 			params = { error: { message: ex.message } };


### PR DESCRIPTION
# Description

Solves #4328

- Updates AI provider methods to return the used model before the request is finished. The model is used to form partial document context.
- Stores partial context in URI that is enough to identify the document and to re-generate the content if it's needed.
- Stores the usage part of the context in memory that is used for sending feedback.
- Introduces a blinking hack to the `markdown.ts` in order to fight VSCode's caching of views (rewriting using the FileSystemProvider didn't help, but it can be reviewed here: 8c365a8fa5505826f8bd0eb781b4135116018ca1 


# Checklist

<!-- Please check off the following -->

- [x] I have followed the guidelines in the Contributing document
- [x] My changes follow the coding style of this project
- [x] My changes build without any errors or warnings
- [x] My changes have been formatted and linted
- [x] My changes include any required corresponding changes to the documentation (including CHANGELOG.md and README.md)
- [x] My changes have been rebased and squashed to the minimal number (typically 1) of relevant commits
- [x] My changes have a descriptive commit message with a short title, including a `Fixes $XXX -` or `Closes #XXX -` prefix to auto-close the issue that your PR addresses
