### PR TITLE
Fills `type` and `feature` fields in AI feedback events

### DIFF
--- a/docs/telemetry-events.md
+++ b/docs/telemetry-events.md
@@ -146,6 +146,7 @@
 
 ```typescript
 {
+  'feature': string,
   'id': string,
   'model.id': string,
   'model.provider.id': 'anthropic' | 'azure' | 'deepseek' | 'gemini' | 'github' | 'gitkraken' | 'huggingface' | 'mistral' | 'ollama' | 'openai' | 'openaicompatible' | 'openrouter' | 'vscode' | 'xai',

--- a/src/commands/aiFeedback.ts
+++ b/src/commands/aiFeedback.ts
@@ -121,6 +121,7 @@ function sendFeedbackEvent(
 ): void {
 	const eventData: AIFeedbackEvent = {
 		type: context.type,
+		feature: context.feature,
 		sentiment: sentiment,
 		'unhelpful.reasons': unhelpful?.reasons?.length ? unhelpful.reasons.join(',') : undefined,
 		'unhelpful.custom': unhelpful?.custom?.trim() ?? undefined,

--- a/src/constants.telemetry.ts
+++ b/src/constants.telemetry.ts
@@ -419,6 +419,7 @@ export type AIFeedbackUnhelpfulReasons =
 export interface AIFeedbackEvent extends AIEventDataBase {
 	/** The AI feature that feedback was submitted for */
 	type: AIActionType;
+	feature: string;
 	sentiment: 'helpful' | 'unhelpful';
 	/** Unhelpful reasons selected (if any) - comma-separated list of AIFeedbackUnhelpfulReasons values */
 	'unhelpful.reasons'?: string;

--- a/src/plus/ai/aiProviderService.ts
+++ b/src/plus/ai/aiProviderService.ts
@@ -1064,6 +1064,7 @@ export class AIProviderService implements Disposable {
 		return {
 			...rq,
 			...result,
+			type: 'generate-rebase',
 		};
 	}
 

--- a/src/plus/ai/aiProviderService.ts
+++ b/src/plus/ai/aiProviderService.ts
@@ -120,6 +120,7 @@ function dedent(template: string): string {
 export interface AIResult {
 	readonly id: string;
 	readonly type: AIActionType;
+	readonly feature: string;
 	readonly content: string;
 	readonly model: AIModel;
 	readonly usage?: {
@@ -647,7 +648,12 @@ export class AIProviderService implements Disposable {
 		return result === 'cancelled'
 			? result
 			: result != null
-				? { ...result, type: 'explain-changes', parsed: parseSummarizeResult(result.content) }
+				? {
+						...result,
+						type: 'explain-changes',
+						feature: `explain-${type}`,
+						parsed: parseSummarizeResult(result.content),
+					}
 				: undefined;
 	}
 
@@ -703,7 +709,12 @@ export class AIProviderService implements Disposable {
 		return result === 'cancelled'
 			? result
 			: result != null
-				? { ...result, type: 'generate-commitMessage', parsed: parseSummarizeResult(result.content) }
+				? {
+						...result,
+						type: 'generate-commitMessage',
+						feature: 'generate-commitMessage',
+						parsed: parseSummarizeResult(result.content),
+					}
 				: undefined;
 	}
 
@@ -767,7 +778,12 @@ export class AIProviderService implements Disposable {
 		return result === 'cancelled'
 			? result
 			: result != null
-				? { ...result, type: 'generate-create-pullRequest', parsed: parseSummarizeResult(result.content) }
+				? {
+						...result,
+						type: 'generate-create-pullRequest',
+						feature: 'generate-create-pullRequest',
+						parsed: parseSummarizeResult(result.content),
+					}
 				: undefined;
 	}
 
@@ -839,6 +855,9 @@ export class AIProviderService implements Disposable {
 				? {
 						...result,
 						type: options?.codeSuggestion ? 'generate-create-codeSuggestion' : 'generate-create-cloudPatch',
+						feature: options?.codeSuggestion
+							? 'generate-create-codeSuggestion'
+							: 'generate-create-cloudPatch',
 						parsed: parseSummarizeResult(result.content),
 					}
 				: undefined;
@@ -896,7 +915,12 @@ export class AIProviderService implements Disposable {
 		return result === 'cancelled'
 			? result
 			: result != null
-				? { ...result, type: 'generate-stashMessage', parsed: parseSummarizeResult(result.content) }
+				? {
+						...result,
+						type: 'generate-stashMessage',
+						feature: 'generate-stashMessage',
+						parsed: parseSummarizeResult(result.content),
+					}
 				: undefined;
 	}
 
@@ -943,7 +967,11 @@ export class AIProviderService implements Disposable {
 			}),
 			options,
 		);
-		return result === 'cancelled' ? result : result != null ? { ...result, type: 'generate-changelog' } : undefined;
+		return result === 'cancelled'
+			? result
+			: result != null
+				? { ...result, type: 'generate-changelog', feature: 'generate-changelog' }
+				: undefined;
 	}
 
 	async generateSearchQuery(
@@ -990,7 +1018,7 @@ export class AIProviderService implements Disposable {
 		return result === 'cancelled'
 			? result
 			: result != null
-				? { ...result, type: 'generate-searchQuery' }
+				? { ...result, type: 'generate-searchQuery', feature: 'generate-searchQuery' }
 				: undefined;
 	}
 
@@ -1065,6 +1093,7 @@ export class AIProviderService implements Disposable {
 			...rq,
 			...result,
 			type: 'generate-rebase',
+			feature: options?.generateCommits ? 'generate-commits' : 'generate-rebase',
 		};
 	}
 

--- a/src/plus/ai/utils/-webview/ai.utils.ts
+++ b/src/plus/ai/utils/-webview/ai.utils.ts
@@ -261,6 +261,7 @@ export function getAIResultContext(result: AIResult): AIResultContext {
 	return {
 		id: result.id,
 		type: result.type,
+		feature: result.feature,
 		model: result.model,
 		usage:
 			result.usage != null


### PR DESCRIPTION

# Description
Fixes #4502

- Fills `type` field for `generate-rebase` AI event, so this field should stop being null in the feedback OTel events.
- Adds a new `feature` field. So events of `explain-changes` family have different features: `explain-branch`, `explain-commit`, `explain-stash`, `explain-wip`

# Checklist

<!-- Please check off the following -->

- [x] I have followed the guidelines in the Contributing document
- [x] My changes follow the coding style of this project
- [x] My changes build without any errors or warnings
- [x] My changes have been formatted and linted
- [ ] My changes include any required corresponding changes to the documentation (including CHANGELOG.md and README.md)
- [x] My changes have been rebased and squashed to the minimal number (typically 1) of relevant commits
- [x] My changes have a descriptive commit message with a short title, including a `Fixes $XXX -` or `Closes #XXX -` prefix to auto-close the issue that your PR addresses
