### PR TITLE
fix(azuredevops): Correctly parse repo name from path

### DIFF
--- a/src/git/remotes/azure-devops.ts
+++ b/src/git/remotes/azure-devops.ts
@@ -129,12 +129,16 @@ export class AzureDevOpsRemote extends RemoteProvider {
 		return super.owner;
 	}
 
-	override get repoName(): string | undefined {
-		if (isVsts(this.domain)) {
-			return this.path;
-		}
-		return super.repoName;
-	}
+    override get repoName(): string | undefined {
+        if (isVsts(this.domain)) {
+            // strip any leading project path and _git/ prefix, keep only the repo name
+            const match = /\/_git\/([^/]+)$/.exec(this.path);
+            if (match) {
+                return match[1];
+            }
+        }
+        return super.repoName;
+    }
 
 	override get providerDesc():
 		| {


### PR DESCRIPTION
Fixes #4560 

---

This changes the parsing code for azure devops git integration to accurately parse the repository name.

# Checklist

<!-- Please check off the following -->

- [X] I have followed the guidelines in the Contributing document
- [X] My changes follow the coding style of this project
- [X] My changes build without any errors or warnings
- [X] My changes have been formatted and linted
- [X] My changes include any required corresponding changes to the documentation (including CHANGELOG.md and README.md)
- [X] My changes have been rebased and squashed to the minimal number (typically 1) of relevant commits
- [X] My changes have a descriptive commit message with a short title, including a `Fixes $XXX -` or `Closes #XXX -` prefix to auto-close the issue that your PR addresses
