### PR TITLE
Unifies autolink enrichment keys for integrations

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -11,3 +11,4 @@ images/settings
 gitlens-*.vsix
 product.json
 tsconfig*.tsbuildinfo
+localdev*.instructions.md

--- a/src/plus/integrations/models/integration.ts
+++ b/src/plus/integrations/models/integration.ts
@@ -499,9 +499,9 @@ export abstract class IntegrationBase<
 	): Promise<IssueShape[] | undefined>;
 
 	@debug()
-	async getIssueOrPullRequest(
+	async getLinkedIssueOrPullRequest(
 		resource: T,
-		id: string,
+		link: { id: string; key: string },
 		options?: { expiryOverride?: boolean | number; type?: IssueOrPullRequestType },
 	): Promise<IssueOrPullRequest | undefined> {
 		const scope = getLogScope();
@@ -512,17 +512,17 @@ export abstract class IntegrationBase<
 		await this.refreshSessionIfExpired(scope);
 
 		const issueOrPR = this.container.cache.getIssueOrPullRequest(
-			id,
+			link.key,
 			options?.type,
 			resource,
 			this,
 			() => ({
 				value: (async () => {
 					try {
-						const result = await this.getProviderIssueOrPullRequest(
+						const result = await this.getProviderLinkedIssueOrPullRequest(
 							this._session!,
 							resource,
-							id,
+							link,
 							options?.type,
 						);
 						this.resetRequestExceptionCount('getIssueOrPullRequest');
@@ -538,10 +538,10 @@ export abstract class IntegrationBase<
 		return issueOrPR;
 	}
 
-	protected abstract getProviderIssueOrPullRequest(
+	protected abstract getProviderLinkedIssueOrPullRequest(
 		session: ProviderAuthenticationSession,
 		resource: T,
-		id: string,
+		link: { id: string; key: string },
 		type: undefined | IssueOrPullRequestType,
 	): Promise<IssueOrPullRequest | undefined>;
 

--- a/src/plus/integrations/providers/azureDevOps.ts
+++ b/src/plus/integrations/providers/azureDevOps.ts
@@ -259,10 +259,10 @@ export abstract class AzureDevOpsIntegrationBase<
 		return Promise.resolve(undefined);
 	}
 
-	protected override async getProviderIssueOrPullRequest(
+	protected override async getProviderLinkedIssueOrPullRequest(
 		{ accessToken }: AuthenticationSession,
 		repo: AzureRepositoryDescriptor,
-		id: string,
+		{ id }: { id: string; key: string },
 		type: undefined | IssueOrPullRequestType,
 	): Promise<IssueOrPullRequest | undefined> {
 		return (await this.container.azure)?.getIssueOrPullRequest(this, accessToken, repo.owner, repo.name, id, {

--- a/src/plus/integrations/providers/bitbucket-server.ts
+++ b/src/plus/integrations/providers/bitbucket-server.ts
@@ -105,10 +105,10 @@ export class BitbucketServerIntegration extends GitHostIntegration<
 		return Promise.resolve(undefined);
 	}
 
-	protected override async getProviderIssueOrPullRequest(
+	protected override async getProviderLinkedIssueOrPullRequest(
 		{ accessToken }: AuthenticationSession,
 		repo: BitbucketRepositoryDescriptor,
-		id: string,
+		{ id }: { id: string; key: string },
 		type: undefined | IssueOrPullRequestType,
 	): Promise<IssueOrPullRequest | undefined> {
 		if (type === 'issue') {

--- a/src/plus/integrations/providers/bitbucket.ts
+++ b/src/plus/integrations/providers/bitbucket.ts
@@ -87,10 +87,10 @@ export class BitbucketIntegration extends GitHostIntegration<
 		return Promise.resolve(undefined);
 	}
 
-	protected override async getProviderIssueOrPullRequest(
+	protected override async getProviderLinkedIssueOrPullRequest(
 		{ accessToken }: AuthenticationSession,
 		repo: BitbucketRepositoryDescriptor,
-		id: string,
+		{ id }: { id: string; key: string },
 		type: undefined | IssueOrPullRequestType,
 	): Promise<IssueOrPullRequest | undefined> {
 		return (await this.container.bitbucket)?.getIssueOrPullRequest(

--- a/src/plus/integrations/providers/github.ts
+++ b/src/plus/integrations/providers/github.ts
@@ -83,10 +83,10 @@ abstract class GitHubIntegrationBase<ID extends GitHubIntegrationIds> extends Gi
 		});
 	}
 
-	protected override async getProviderIssueOrPullRequest(
+	protected override async getProviderLinkedIssueOrPullRequest(
 		{ accessToken }: AuthenticationSession,
 		repo: GitHubRepositoryDescriptor,
-		id: string,
+		{ id }: { id: string; key: string },
 	): Promise<IssueOrPullRequest | undefined> {
 		return (await this.container.github)?.getIssueOrPullRequest(
 			this,

--- a/src/plus/integrations/providers/gitlab.ts
+++ b/src/plus/integrations/providers/gitlab.ts
@@ -87,10 +87,10 @@ abstract class GitLabIntegrationBase<ID extends GitLabIntegrationIds> extends Gi
 		});
 	}
 
-	protected override async getProviderIssueOrPullRequest(
+	protected override async getProviderLinkedIssueOrPullRequest(
 		{ accessToken }: AuthenticationSession,
 		repo: GitLabRepositoryDescriptor,
-		id: string,
+		{ id }: { id: string; key: string },
 	): Promise<IssueOrPullRequest | undefined> {
 		return (await this.container.gitlab)?.getIssueOrPullRequest(
 			this,

--- a/src/plus/integrations/providers/jira.ts
+++ b/src/plus/integrations/providers/jira.ts
@@ -272,15 +272,15 @@ export class JiraIntegration extends IssuesIntegration<IssuesCloudHostIntegratio
 		return results;
 	}
 
-	protected override async getProviderIssueOrPullRequest(
+	protected override async getProviderLinkedIssueOrPullRequest(
 		session: AuthenticationSession,
 		resource: JiraOrganizationDescriptor,
-		id: string,
+		{ key }: { id: string; key: string },
 	): Promise<IssueOrPullRequest | undefined> {
 		const api = await this.getProvidersApi();
 		const issue = await api.getIssue(
 			this.id,
-			{ resourceId: resource.id, number: id },
+			{ resourceId: resource.id, number: key },
 			{ accessToken: session.accessToken },
 		);
 		return issue != null ? toIssueShape(issue, this) : undefined;

--- a/src/plus/integrations/providers/linear.ts
+++ b/src/plus/integrations/providers/linear.ts
@@ -210,10 +210,10 @@ export class LinearIntegration extends IssuesIntegration<IssuesCloudHostIntegrat
 		}
 		return issues;
 	}
-	protected override async getProviderIssueOrPullRequest(
+	protected override async getProviderLinkedIssueOrPullRequest(
 		session: ProviderAuthenticationSession,
 		resource: ResourceDescriptor,
-		id: string,
+		{ id }: { id: string; key: string },
 		_type: undefined | IssueOrPullRequestType,
 	): Promise<IssueOrPullRequest | undefined> {
 		const issue = await this.getRawProviderIssue(session, resource, id);


### PR DESCRIPTION
# Description

Unifies autolink enrichment keys for integrations in order to avoid referencing the exact integration type outside of integratin class.

Updates the autolink enrichment workflow to consistently use a pair of values (id and key) when resolving issues or pull requests across integrations. This removes provider-specific logic for constructing enrichment keys and centralizes the approach, simplifying maintenance and reducing errors when linking to external systems.

Renames and refactors relevant methods in integration classes to reflect this unified signature. Enhances consistency and clarity in how autolinked items are identified and retrieved across supported providers.


# Checklist

<!-- Please check off the following -->

- [x] I have followed the guidelines in the Contributing document
- [x] My changes follow the coding style of this project
- [x] My changes build without any errors or warnings
- [x] My changes have been formatted and linted
- [x] My changes include any required corresponding changes to the documentation (including CHANGELOG.md and README.md)
- [x] My changes have been rebased and squashed to the minimal number (typically 1) of relevant commits
- [x] My changes have a descriptive commit message with a short title, including a `Fixes $XXX -` or `Closes #XXX -` prefix to auto-close the issue that your PR addresses
