### PR TITLE
Connection flow is broken when more integrations are needed to be connected

### DIFF
--- a/src/plus/integrations/integrationService.ts
+++ b/src/plus/integrations/integrationService.ts
@@ -174,6 +174,9 @@ export class IntegrationService implements Disposable {
 			if (cloudIntegrationTypes.length > 0) {
 				query += `&provider=${cloudIntegrationTypes.join(',')}`;
 			}
+			if (cloudIntegrationTypes.length > 1) {
+				query += '&flow=expanded';
+			}
 		}
 
 		const baseQuery = query;


### PR DESCRIPTION
# Description
This PR fixes connection flow when more integrations are needed to be connected.
The solution is based on this discussion: https://gitkraken-hq.slack.com/archives/C06AVHLRS80/p1757598749281269?thread_ts=1757597475.779229

### Steps to reproduce
1. Connect GitHub. _Do not_ connect Bitbucket.
2. Open Launchpad.
3. Imagine you want to connect Bitbucket
4. Click _"Connect additional integrations"_
    <img width="600" height="344" alt="image" src="https://github.com/user-attachments/assets/c9e4d0af-3f0b-4877-b7cb-b03293f5df7c" />
5. Follow the flow.

### Actual result
You jump to a login page without ability to select a new integration to connect
<img width="500" height="1064" alt="image" src="https://github.com/user-attachments/assets/f222f315-68e8-47e8-a3c6-d2b462845d54" />



### Expected result
You open a page where you can select an addition integration to connect
<img width="400" height="1600" alt="image" src="https://github.com/user-attachments/assets/5928fa7f-bf72-4517-9805-fa6927196e10" />








# Checklist

<!-- Please check off the following -->

- [x] I have followed the guidelines in the Contributing document
- [x] My changes follow the coding style of this project
- [x] My changes build without any errors or warnings
- [x] My changes have been formatted and linted
- [ ] My changes include any required corresponding changes to the documentation (including CHANGELOG.md and README.md)
- [x] My changes have been rebased and squashed to the minimal number (typically 1) of relevant commits
- [x] My changes have a descriptive commit message with a short title, including a `Fixes $XXX -` or `Closes #XXX -` prefix to auto-close the issue that your PR addresses
