### PR TITLE
Refactors composer to store hunks and safety state in webview host

### DIFF
--- a/src/webviews/apps/plus/composer/stateProvider.ts
+++ b/src/webviews/apps/plus/composer/stateProvider.ts
@@ -136,9 +136,7 @@ export class ComposerStateProvider implements StateProvider<State> {
 						...this._state,
 						hunks: msg.params.hunks,
 						commits: msg.params.commits,
-						hunkMap: msg.params.hunkMap,
 						baseCommit: msg.params.baseCommit,
-						safetyState: msg.params.safetyState,
 						loadingError: msg.params.loadingError,
 						hasChanges: msg.params.hasChanges,
 						safetyError: null, // Clear any existing safety errors

--- a/src/webviews/plus/composer/mockData.ts
+++ b/src/webviews/plus/composer/mockData.ts
@@ -1,7 +1,7 @@
 // Mock data for the composer following the proper data model
 // This represents the structure that would come from AI rebase results
 
-import type { ComposerCommit, ComposerHunk, ComposerHunkMap } from './protocol';
+import type { ComposerCommit, ComposerHunk } from './protocol';
 
 // Mock hunks following the AI rebase result structure
 export const mockHunks: ComposerHunk[] = [
@@ -349,20 +349,6 @@ export const mockCommits: ComposerCommit[] = [
 ];
 
 // Callbacks are no longer used - replaced with IPC commands
-
-// Mock hunk map (maps hunk indices to hunk headers for combined diff)
-export const mockHunkMap: ComposerHunkMap[] = [
-	{ index: 1, hunkHeader: '@@ -0,0 +1,15 @@' },
-	{ index: 2, hunkHeader: '@@ -0,0 +1,12 @@' },
-	{ index: 3, hunkHeader: '@@ -0,0 +1,18 @@' },
-	{ index: 4, hunkHeader: '@@ -0,0 +1,20 @@' },
-	{ index: 5, hunkHeader: '@@ -0,0 +1,10 @@' },
-	{ index: 6, hunkHeader: '@@ -0,0 +1,25 @@' },
-	{ index: 7, hunkHeader: '@@ -0,0 +1,30 @@' },
-	{ index: 8, hunkHeader: '@@ -0,0 +1,8 @@' },
-	{ index: 9, hunkHeader: '@@ -0,0 +1,15 @@' },
-	{ index: 10, hunkHeader: '@@ -0,0 +1,12 @@' },
-];
 
 // Mock base commit
 export const mockBaseCommit = {


### PR DESCRIPTION
Closes #4667

This is to prevent entire diffs being passed back from the app via IPC for commands like auto-compose, generate commit message, finish and commit, etc.

One thing I noticed is that the diff contents have artifacts from serialization and this can break the safety checks and the diff hashes, causing false positive errors on safety state. Also, it seems expensive to pass massive payloads like this over IPC for these ops anyway.

We still need to pass the hunks with their diffs through to the app for rendering content, but that should be the only purpose of the hunk contents in app state.

Lots of regression risk here i.e. with undo/reset history, reload, all AI ops, finish & commit, etc. so lots of testing required.