### PR TITLE
Fixes some AI cancellation cases being treated as errors

### DIFF
--- a/src/plus/ai/openRouterProvider.ts
+++ b/src/plus/ai/openRouterProvider.ts
@@ -1,5 +1,6 @@
 import { fetch } from '@env/fetch';
 import { openRouterProviderDescriptor as provider } from '../../constants.ai';
+import { isCancellationError } from '../../errors';
 import type { AIActionType, AIModel } from './models/model';
 import { OpenAICompatibleProviderBase } from './openAICompatibleProviderBase';
 
@@ -15,7 +16,15 @@ export class OpenRouterProvider extends OpenAICompatibleProviderBase<typeof prov
 	};
 
 	async getModels(): Promise<readonly AIModel<typeof provider.id>[]> {
-		const apiKey = await this.getApiKey(true);
+		let apiKey: string | undefined;
+		try {
+			apiKey = await this.getApiKey(true);
+		} catch (ex) {
+			if (isCancellationError(ex)) return [];
+
+			throw ex;
+		}
+
 		if (!apiKey) return [];
 
 		const url = 'https://openrouter.ai/api/v1/models';

--- a/src/plus/ai/utils/-webview/ai.utils.ts
+++ b/src/plus/ai/utils/-webview/ai.utils.ts
@@ -4,6 +4,7 @@ import { Schemes } from '../../../../constants';
 import type { AIProviders } from '../../../../constants.ai';
 import type { Container } from '../../../../container';
 import type { MarkdownContentMetadata } from '../../../../documents/markdown';
+import { CancellationError } from '../../../../errors';
 import { decodeGitLensRevisionUriAuthority } from '../../../../git/gitUri.authority';
 import { createDirectiveQuickPickItem, Directive } from '../../../../quickpicks/items/directive';
 import { configuration } from '../../../../system/-webview/configuration';
@@ -17,8 +18,8 @@ import { ensureAccountQuickPick } from '../../../gk/utils/-webview/acount.utils'
 import type { AIResult, AIResultContext } from '../../aiProviderService';
 import type { AIActionType, AIModel } from '../../models/model';
 
-export function ensureAccount(container: Container, silent: boolean): Promise<boolean> {
-	return ensureAccountQuickPick(
+export async function ensureAccount(container: Container, silent: boolean): Promise<boolean> {
+	const result = await ensureAccountQuickPick(
 		container,
 		createDirectiveQuickPickItem(Directive.Noop, undefined, {
 			label: 'Use AI-powered GitLens features like Generate Commit Message, Explain Commit, and more',
@@ -27,6 +28,12 @@ export function ensureAccount(container: Container, silent: boolean): Promise<bo
 		{ source: 'ai' },
 		silent,
 	);
+
+	if (!result && !silent) {
+		throw new CancellationError();
+	}
+
+	return result;
 }
 
 export function getActionName(action: AIActionType): string {


### PR DESCRIPTION
Repro steps:

1. Open commit composer
2. Try to generate commit message with no provider selected and github copilot disabled as an extension (so no vscode ai provider available) and not logged into GK (so no GK provider available as fallback)
3. Cancel or escape at any point in the flow (choosing a provider, choosing a model, sign in prompt for GK provider)

Expect for composer to treat it as a cancellation. See an error instead.

Note: these changes affect logic being used in many places because they touch core AI provider service paths, so lots of possible regressions to test:
1. AI provider selection in other places should work as before
2. AI commit message generation in other places as well as other AI ops should be spot-checked