### PR TITLE
Fixes duplication of Linear issue links in the Inspect View

### DIFF
--- a/src/plus/integrations/providers/linear.ts
+++ b/src/plus/integrations/providers/linear.ts
@@ -217,7 +217,11 @@ export class LinearIntegration extends IssuesIntegration<IssuesCloudHostIntegrat
 		_type: undefined | IssueOrPullRequestType,
 	): Promise<IssueOrPullRequest | undefined> {
 		const issue = await this.getRawProviderIssue(session, resource, id);
-		return issue && toIssueShape(issue, this);
+		const autolinkableIssue: ProviderIssue | undefined = issue && {
+			...issue,
+			url: this.getIssueAutolinkLikeUrl(issue),
+		};
+		return autolinkableIssue && toIssueShape(autolinkableIssue, this);
 	}
 	protected override async getProviderIssue(
 		session: ProviderAuthenticationSession,
@@ -258,5 +262,14 @@ export class LinearIntegration extends IssuesIntegration<IssuesCloudHostIntegrat
 			Logger.error(ex, 'getProviderIssue');
 			return undefined;
 		}
+	}
+	private getIssueAutolinkLikeUrl(issue: ProviderIssue): string | null {
+		const url = issue.url;
+		if (url == null) return null;
+		const lastSegment = url.split('/').pop();
+		if (!lastSegment || issue.number === lastSegment) {
+			return url;
+		}
+		return url.substring(0, url.length - lastSegment.length - 1);
 	}
 }


### PR DESCRIPTION
# Description
fixes #4621 (#4605)

Normalizes Linear autlink URL by removing summary stubs from its ending

<img width="600" height="384" alt="image" src="https://github.com/user-attachments/assets/dfe3be8b-c72f-42e0-8225-960fb6be7f91" />

Because it was cause of the duplication:

<img width="400" height="734" alt="Image" src="https://github.com/user-attachments/assets/ef912566-6c89-48bb-a867-2eb34226c3f4" />

# Checklist

<!-- Please check off the following -->

- [x] I have followed the guidelines in the Contributing document
- [x] My changes follow the coding style of this project
- [x] My changes build without any errors or warnings
- [x] My changes have been formatted and linted
- [ ] My changes include any required corresponding changes to the documentation (including CHANGELOG.md and README.md)
- [x] My changes have been rebased and squashed to the minimal number (typically 1) of relevant commits
- [x] My changes have a descriptive commit message with a short title, including a `Fixes $XXX -` or `Closes #XXX -` prefix to auto-close the issue that your PR addresses
