### PR TITLE
Adds support for composing without a base commit

### DIFF
--- a/src/env/node/git/git.ts
+++ b/src/env/node/git/git.ts
@@ -34,6 +34,7 @@ import {
 } from '../../../git/errors';
 import type { GitDir } from '../../../git/gitProvider';
 import type { GitDiffFilter } from '../../../git/models/diff';
+import { rootSha } from '../../../git/models/revision';
 import { parseGitRemoteUrl } from '../../../git/parsers/remoteParser';
 import { isUncommitted, isUncommittedStaged, shortenRevision } from '../../../git/utils/revision.utils';
 import { getCancellationTokenId } from '../../../system/-webview/cancellation';
@@ -68,9 +69,6 @@ export const gitConfigsStatus = ['-c', 'color.status=false'] as const;
 export const maxGitCliLength = 30000;
 
 const textDecoder = new TextDecoder('utf8');
-
-// This is a root sha of all git repo's if using sha1
-const rootSha = '4b825dc642cb6eb9a060e54bf8d69288fbee4904';
 
 export const GitErrors = {
 	alreadyCheckedOut: /already checked out/i,

--- a/src/git/gitProvider.ts
+++ b/src/git/gitProvider.ts
@@ -534,9 +534,10 @@ export interface GitPatchSubProvider {
 	): Promise<GitCommit | undefined>;
 	createUnreachableCommitsFromPatches(
 		repoPath: string,
-		base: string,
+		base: string | undefined,
 		patches: { message: string; patch: string }[],
 	): Promise<string[]>;
+	createEmptyInitialCommit(repoPath: string): Promise<string>;
 
 	validatePatch(repoPath: string | undefined, contents: string): Promise<boolean>;
 }
@@ -651,7 +652,7 @@ export interface DisposableTemporaryGitIndex extends UnifiedAsyncDisposable {
 }
 
 export interface GitStagingSubProvider {
-	createTemporaryIndex(repoPath: string, base: string): Promise<DisposableTemporaryGitIndex>;
+	createTemporaryIndex(repoPath: string, base: string | undefined): Promise<DisposableTemporaryGitIndex>;
 	stageFile(repoPath: string, pathOrUri: string | Uri): Promise<void>;
 	stageFiles(repoPath: string, pathOrUri: string[] | Uri[], options?: { intentToAdd?: boolean }): Promise<void>;
 	stageDirectory(repoPath: string, directoryOrUri: string | Uri): Promise<void>;

--- a/src/git/models/revision.ts
+++ b/src/git/models/revision.ts
@@ -1,6 +1,8 @@
 export const deletedOrMissing = '0000000000000000000000000000000000000000-';
 export const uncommitted = '0000000000000000000000000000000000000000';
 export const uncommittedStaged = '0000000000000000000000000000000000000000:';
+// This is a root sha of all git repo's if using sha1
+export const rootSha = '4b825dc642cb6eb9a060e54bf8d69288fbee4904';
 
 export type GitRevisionRange =
 	| `${GitRevisionRangeNotation}${string}`

--- a/src/webviews/apps/plus/composer/components/app.ts
+++ b/src/webviews/apps/plus/composer/components/app.ts
@@ -1582,6 +1582,7 @@ export class ComposerApp extends LitElement {
 					.canGenerateCommitsWithAI=${this.canGenerateCommitsWithAI}
 					.isPreviewMode=${this.isPreviewMode}
 					.baseCommit=${this.state.baseCommit}
+					.repoName=${this.state.baseCommit?.repoName ?? this.state.repositoryState?.current.name}
 					.customInstructions=${this.customInstructions}
 					.hasUsedAutoCompose=${this.state.hasUsedAutoCompose}
 					.hasChanges=${this.state.hasChanges}

--- a/src/webviews/apps/plus/composer/components/commit-item.ts
+++ b/src/webviews/apps/plus/composer/components/commit-item.ts
@@ -86,6 +86,9 @@ export class CommitItem extends LitElement {
 	@property({ type: Boolean })
 	first = false;
 
+	@property({ type: Boolean })
+	last = false;
+
 	override connectedCallback() {
 		super.connectedCallback?.();
 		// Set the data attribute for sortable access
@@ -120,7 +123,7 @@ export class CommitItem extends LitElement {
 			<div
 				class="composer-item commit-item ${this.selected ? ' is-selected' : ''}${this.multiSelected
 					? ' multi-selected'
-					: ''}${this.first ? ' is-first' : ''}"
+					: ''}${this.first ? ' is-first' : ''}${this.last ? ' is-last' : ''}"
 				tabindex="0"
 				@click=${this.handleClick}
 				@keydown=${this.handleClick}

--- a/src/webviews/apps/plus/composer/components/commits-panel.ts
+++ b/src/webviews/apps/plus/composer/components/commits-panel.ts
@@ -372,6 +372,9 @@ export class CommitsPanel extends LitElement {
 	baseCommit: ComposerBaseCommit | null = null;
 
 	@property({ type: String })
+	repoName: string | null = null;
+
+	@property({ type: String })
 	customInstructions: string = '';
 
 	@property({ type: Boolean })
@@ -1232,13 +1235,19 @@ export class CommitsPanel extends LitElement {
 
 							<!-- Base commit (informational only) -->
 							<div class="composer-item is-base">
-								<div class="composer-item__commit"></div>
+								<div class="composer-item__commit${this.baseCommit ? '' : ' is-empty'}"></div>
 								<div class="composer-item__content">
-									<div class="composer-item__header">${this.baseCommit?.message || 'HEAD'}</div>
+									<div
+										class="composer-item__header${this.baseCommit == null ? ' is-placeholder' : ''}"
+									>
+										${this.baseCommit?.message || 'No commits yet'}
+									</div>
 									<div class="composer-item__body">
-										<span class="repo-name">${this.baseCommit?.repoName || 'Repository'}</span>
-										<span>/</span>
-										<span class="branch-name">${this.baseCommit?.branchName || 'main'}</span>
+										<span class="repo-name">${this.repoName || 'Repository'}</span>
+										${this.baseCommit?.branchName
+											? html`<span>/</span
+													><span class="branch-name">${this.baseCommit.branchName}</span>`
+											: ''}
 									</div>
 								</div>
 							</div>
@@ -1291,6 +1300,7 @@ export class CommitsPanel extends LitElement {
 											.multiSelected=${this.selectedCommitIds.has(commit.id)}
 											.isPreviewMode=${this.isPreviewMode}
 											?first=${i === 0}
+											?last=${i === this.commits.length - 1 && !this.baseCommit}
 											@click=${(e: MouseEvent) => this.dispatchCommitSelect(commit.id, e)}
 											@keydown=${(e: KeyboardEvent) => this.dispatchCommitSelect(commit.id, e)}
 										></gl-commit-item>
@@ -1301,13 +1311,17 @@ export class CommitsPanel extends LitElement {
 
 						<!-- Base commit (informational only) -->
 						<div class="composer-item is-base">
-							<div class="composer-item__commit"></div>
+							<div class="composer-item__commit${this.baseCommit ? '' : ' is-empty'}"></div>
 							<div class="composer-item__content">
-								<div class="composer-item__header">${this.baseCommit?.message || 'HEAD'}</div>
+								<div class="composer-item__header${this.baseCommit == null ? ' is-placeholder' : ''}">
+									${this.baseCommit?.message || 'No commits yet'}
+								</div>
 								<div class="composer-item__body">
-									<span class="repo-name">${this.baseCommit?.repoName || 'Repository'}</span>
-									<span>/</span>
-									<span class="branch-name">${this.baseCommit?.branchName || 'main'}</span>
+									<span class="repo-name">${this.repoName || 'Repository'}</span>
+									${this.baseCommit?.branchName
+										? html`<span>/</span
+												><span class="branch-name">${this.baseCommit.branchName}</span>`
+										: ''}
 								</div>
 							</div>
 						</div>

--- a/src/webviews/apps/plus/composer/components/composer.css.ts
+++ b/src/webviews/apps/plus/composer/components/composer.css.ts
@@ -148,6 +148,10 @@ export const composerItemCommitStyles = css`
 		height: 50%;
 	}
 
+	.composer-item.is-last .composer-item__commit::before {
+		display: none;
+	}
+
 	.composer-item__commit::after {
 		content: '';
 		position: absolute;
@@ -167,6 +171,11 @@ export const composerItemCommitStyles = css`
 	}
 	.composer-item.is-base .composer-item__commit::before {
 		border-left-style: solid;
+	}
+
+	.composer-item__commit.is-empty::before,
+	.composer-item__commit.is-empty::after {
+		display: none;
 	}
 `;
 

--- a/src/webviews/plus/composer/protocol.ts
+++ b/src/webviews/plus/composer/protocol.ts
@@ -44,7 +44,7 @@ export interface ComposerBaseCommit {
 
 export interface ComposerSafetyState {
 	repoPath: string;
-	headSha: string;
+	headSha: string | null;
 	// branchName: string;
 	// branchRefSha: string;
 	// worktreeName: string;
@@ -65,7 +65,7 @@ export interface State extends WebviewState {
 	hunks: ComposerHunk[];
 
 	commits: ComposerCommit[];
-	baseCommit: ComposerBaseCommit;
+	baseCommit: ComposerBaseCommit | null;
 
 	// UI state
 	selectedCommitId: string | null;
@@ -114,12 +114,7 @@ export interface State extends WebviewState {
 export const initialState: Omit<State, keyof WebviewState> = {
 	hunks: [],
 	commits: [],
-	baseCommit: {
-		sha: '',
-		message: '',
-		repoName: '',
-		branchName: '',
-	},
+	baseCommit: null,
 	selectedCommitId: null,
 	selectedCommitIds: new Set<string>(),
 	selectedUnassignedSection: null,
@@ -347,7 +342,7 @@ export interface GenerateWithAIParams {
 export interface DidChangeComposerDataParams {
 	hunks: ComposerHunk[];
 	commits: ComposerCommit[];
-	baseCommit: ComposerBaseCommit;
+	baseCommit: ComposerBaseCommit | null;
 }
 
 // IPC Commands and Notifications
@@ -437,7 +432,7 @@ export const DidChangeAiModelNotification = new IpcNotification<DidChangeAiModel
 export interface GenerateCommitsParams {
 	hunkIndices: number[];
 	commits: ComposerCommit[];
-	baseCommit: ComposerBaseCommit;
+	baseCommit: ComposerBaseCommit | null;
 	customInstructions?: string;
 	isRecompose?: boolean;
 }
@@ -450,7 +445,7 @@ export interface GenerateCommitMessageParams {
 
 export interface FinishAndCommitParams {
 	commits: ComposerCommit[];
-	baseCommit: ComposerBaseCommit;
+	baseCommit: ComposerBaseCommit | null;
 }
 
 export interface ReloadComposerParams {
@@ -484,7 +479,7 @@ export interface DidSafetyErrorParams {
 export interface DidReloadComposerParams {
 	hunks: ComposerHunk[];
 	commits: ComposerCommit[];
-	baseCommit: ComposerBaseCommit;
+	baseCommit: ComposerBaseCommit | null;
 	loadingError: string | null;
 	hasChanges: boolean;
 	repositoryState?: {

--- a/src/webviews/plus/composer/utils.ts
+++ b/src/webviews/plus/composer/utils.ts
@@ -318,15 +318,11 @@ export async function getWorkingTreeDiffs(repo: Repository): Promise<WorkingTree
 export async function createSafetyState(
 	repo: Repository,
 	diffs: WorkingTreeDiffs,
-	headSha: string,
+	headSha?: string,
 ): Promise<ComposerSafetyState> {
-	if (!headSha) {
-		throw new Error('Cannot create safety state: no HEAD commit found');
-	}
-
 	return {
 		repoPath: repo.path,
-		headSha: headSha,
+		headSha: headSha ?? null,
 		hashes: {
 			staged: diffs.staged?.contents ? await sha256(diffs.staged.contents) : null,
 			unstaged: diffs.unstaged?.contents ? await sha256(diffs.unstaged.contents) : null,
@@ -355,7 +351,7 @@ export async function validateSafetyState(
 
 		// 2. Check HEAD SHA
 		const currentHeadCommit = await repo.git.commits.getCommit('HEAD');
-		const currentHeadSha = currentHeadCommit?.sha ?? 'unknown';
+		const currentHeadSha = currentHeadCommit?.sha ?? null;
 		if (currentHeadSha !== safetyState.headSha) {
 			errors.push(`HEAD commit changed from "${safetyState.headSha}" to "${currentHeadSha}"`);
 		}


### PR DESCRIPTION
Closes #4637

Strategy here is to create an empty base commit without touching the working tree by using temporary index and commit-tree, then pointing HEAD to it, and then there is a commit that we can stash on temporarily. We then proceed to create the composer commits as patches and commit them with a similar strategy, except they are on another temporary index off the root sha. Then when we reset, our stash and empty commit are orphaned but still accessible. We pop the stash as normal and then let garbage collection eliminate the temporary empty commit we created.