### PR TITLE
Improves MCP checks and adds offline check

### DIFF
--- a/src/container.ts
+++ b/src/container.ts
@@ -190,6 +190,7 @@ export class Container {
 		this._context = context;
 		this._prerelease = prerelease;
 		this._version = version;
+		this._previousVersion = previousVersion;
 		this.ensureModeApplied();
 
 		this._disposables = [
@@ -745,6 +746,11 @@ export class Container {
 	private readonly _version: string;
 	get version(): string {
 		return this._version;
+	}
+
+	private readonly _previousVersion: string | undefined;
+	get previousVersion(): string | undefined {
+		return this._previousVersion;
 	}
 
 	private readonly _views: Views;

--- a/src/env/browser/platform.ts
+++ b/src/env/browser/platform.ts
@@ -1,6 +1,7 @@
 import type { Platform } from '../node/platform';
 
 export const isWeb = true;
+export const isOffline = false;
 
 const _platform = (navigator as any)?.userAgentData?.platform;
 const _userAgent = navigator.userAgent;

--- a/src/env/node/platform.ts
+++ b/src/env/node/platform.ts
@@ -1,9 +1,10 @@
-import { tmpdir } from 'os';
+import { networkInterfaces, tmpdir } from 'os';
 import { join } from 'path';
 import { platform } from 'process';
 import { env, UIKind } from 'vscode';
 
 export const isWeb = env.uiKind === UIKind.Web;
+export const isOffline = Object.values(networkInterfaces()).every(iface => iface?.every(addr => addr.internal));
 
 export const isLinux = platform === 'linux';
 export const isMac = platform === 'darwin';

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -395,6 +395,7 @@ async function showWhatsNew(
 
 function showMcp(version: string, previousVersion: string | undefined): void {
 	if (
+		isWeb ||
 		previousVersion == null ||
 		version === previousVersion ||
 		compare(version, previousVersion) !== 1 ||

--- a/src/plus/gk/utils/-webview/mcp.utils.ts
+++ b/src/plus/gk/utils/-webview/mcp.utils.ts
@@ -1,5 +1,5 @@
 import { env, lm, version } from 'vscode';
-import { isWeb } from '@env/platform';
+import { isOffline, isWeb } from '@env/platform';
 import type { Container } from '../../../../container';
 import { configuration } from '../../../../system/-webview/configuration';
 import { satisfies } from '../../../../system/version';
@@ -15,7 +15,7 @@ export function isMcpBannerEnabled(container: Container, showAutoRegistration = 
 
 const supportedApps = ['Visual Studio Code', 'Visual Studio Code - Insiders', 'Visual Studio Code - Exploration'];
 export function supportsMcpExtensionRegistration(): boolean {
-	if (isWeb || !supportedApps.includes(env.appName)) {
+	if (isWeb || isOffline || !supportedApps.includes(env.appName)) {
 		return false;
 	}
 


### PR DESCRIPTION
Closes #4672
Closes #4673
Closes #4674

- Adds an isOffline check which does a one-time check on extension load and stores it for use. Uses this check to kick out of several MCP/CLI flows early
- Adds an isWeb check to the upgrade notification for MCP that prevents showing it in web environments
- Clears MCP autoinstall attempts when upgrading to allow folks who previously ran into the unzip issue to use the new unzip in the install process
