### PR TITLE
Refactors state providers for deferrable bootstrap

### DIFF
--- a/src/webviews/apps/commitDetails/commitDetails.ts
+++ b/src/webviews/apps/commitDetails/commitDetails.ts
@@ -40,6 +40,7 @@ import type { CreatePatchMetadataEventDetail } from '../plus/patchDetails/compon
 import { GlAppHost } from '../shared/appHost';
 import type { IssuePullRequest } from '../shared/components/rich/issue-pull-request';
 import type { WebviewPane, WebviewPaneExpandedChangeEventDetail } from '../shared/components/webview-pane';
+import type { LoggerContext } from '../shared/contexts/logger';
 import { DOM } from '../shared/dom';
 import type { HostIpc } from '../shared/ipc';
 import type { GlCommitDetails } from './components/gl-commit-details';
@@ -72,12 +73,12 @@ export class GlCommitDetailsApp extends GlAppHost<IpcSerialized<State>> {
 		return this;
 	}
 
-	protected override createStateProvider(state: IpcSerialized<State>, ipc: HostIpc): CommitDetailsStateProvider {
-		return new CommitDetailsStateProvider(this, state, ipc);
-	}
-
-	protected override onPersistState(state: IpcSerialized<State>): void {
-		this._ipc.setPersistedState({ mode: state.mode, pinned: state.pinned, preferences: state.preferences });
+	protected override createStateProvider(
+		bootstrap: string,
+		ipc: HostIpc,
+		logger: LoggerContext,
+	): CommitDetailsStateProvider {
+		return new CommitDetailsStateProvider(this, bootstrap, ipc, logger);
 	}
 
 	@state()

--- a/src/webviews/apps/commitDetails/components/gl-commit-details.ts
+++ b/src/webviews/apps/commitDetails/components/gl-commit-details.ts
@@ -59,7 +59,6 @@ export class GlCommitDetails extends GlDetailsBase {
 	get commit(): State['commit'] {
 		return this._commit;
 	}
-	// @property({ type: Object })
 	set commit(value: State['commit']) {
 		this._commit = value;
 		this.enrichedPromise = value?.enriched;

--- a/src/webviews/apps/home/home.ts
+++ b/src/webviews/apps/home/home.ts
@@ -15,6 +15,7 @@ import {
 import type { GlHomeHeader } from '../plus/shared/components/home-header';
 import { GlAppHost } from '../shared/appHost';
 import { scrollableBase } from '../shared/components/styles/lit/base.css';
+import type { LoggerContext } from '../shared/contexts/logger';
 import type { HostIpc } from '../shared/ipc';
 import type { GlAiAllAccessBanner } from './components/ai-all-access-banner';
 import { homeBaseStyles, homeStyles } from './home.css';
@@ -50,11 +51,11 @@ export class GlHomeApp extends GlAppHost<State> {
 
 	private badgeSource = { source: 'home', detail: 'badge' };
 
-	protected override createStateProvider(state: State, ipc: HostIpc): HomeStateProvider {
+	protected override createStateProvider(bootstrap: string, ipc: HostIpc, logger: LoggerContext): HomeStateProvider {
 		this.disposables.push((this._activeOverviewState = new ActiveOverviewState(ipc)));
 		this.disposables.push((this._inactiveOverviewState = new InactiveOverviewState(ipc)));
 
-		return new HomeStateProvider(this, state, ipc);
+		return new HomeStateProvider(this, bootstrap, ipc, logger);
 	}
 
 	override connectedCallback(): void {

--- a/src/webviews/apps/home/stateProvider.ts
+++ b/src/webviews/apps/home/stateProvider.ts
@@ -11,104 +11,87 @@ import {
 	DidChangeWalkthroughProgress,
 	DidCompleteDiscoveringRepositories,
 } from '../../home/protocol';
-import type { ReactiveElementHost, StateProvider } from '../shared/appHost';
-import type { Disposable } from '../shared/events';
-import type { HostIpc } from '../shared/ipc';
+import type { IpcMessage } from '../../protocol';
+import type { ReactiveElementHost } from '../shared/appHost';
+import { StateProviderBase } from '../shared/stateProviderBase';
 import { stateContext } from './context';
 
-export class HomeStateProvider implements StateProvider<State> {
-	private readonly disposable: Disposable;
-	private readonly provider: ContextProvider<{ __context__: State }, ReactiveElementHost>;
-
-	private readonly _state: State;
-	get state(): State {
-		return this._state;
+export class HomeStateProvider extends StateProviderBase<State, typeof stateContext> {
+	protected override createContextProvider(state: State): ContextProvider<typeof stateContext, ReactiveElementHost> {
+		return new ContextProvider(this.host, { context: stateContext, initialValue: state });
 	}
 
-	constructor(
-		host: ReactiveElementHost,
-		state: State,
-		private readonly _ipc: HostIpc,
-	) {
-		this._state = state;
-		this.provider = new ContextProvider(host, { context: stateContext, initialValue: state });
+	protected override onMessageReceived(msg: IpcMessage): void {
+		switch (true) {
+			case DidChangeRepositories.is(msg):
+				this._state.repositories = msg.params;
+				this._state.timestamp = Date.now();
 
-		this.disposable = this._ipc.onReceiveMessage(msg => {
-			switch (true) {
-				case DidChangeRepositories.is(msg):
-					this._state.repositories = msg.params;
-					this._state.timestamp = Date.now();
+				this.provider.setValue(this._state, true);
+				break;
+			case DidCompleteDiscoveringRepositories.is(msg):
+				this._state.repositories = msg.params.repositories;
+				this._state.discovering = msg.params.discovering;
+				this._state.timestamp = Date.now();
 
-					this.provider.setValue(this._state, true);
-					break;
-				case DidCompleteDiscoveringRepositories.is(msg):
-					this._state.repositories = msg.params.repositories;
-					this._state.discovering = msg.params.discovering;
-					this._state.timestamp = Date.now();
+				this.provider.setValue(this._state, true);
+				break;
+			case DidChangeWalkthroughProgress.is(msg):
+				this._state.walkthroughProgress = msg.params;
+				this._state.timestamp = Date.now();
 
-					this.provider.setValue(this._state, true);
-					break;
-				case DidChangeWalkthroughProgress.is(msg):
-					this._state.walkthroughProgress = msg.params;
-					this._state.timestamp = Date.now();
+				this.provider.setValue(this._state, true);
+				break;
+			case DidChangeSubscription.is(msg):
+				this._state.subscription = msg.params.subscription;
+				this._state.avatar = msg.params.avatar;
+				this._state.organizationsCount = msg.params.organizationsCount;
+				this._state.timestamp = Date.now();
 
-					this.provider.setValue(this._state, true);
-					break;
-				case DidChangeSubscription.is(msg):
-					this._state.subscription = msg.params.subscription;
-					this._state.avatar = msg.params.avatar;
-					this._state.organizationsCount = msg.params.organizationsCount;
-					this._state.timestamp = Date.now();
+				this.provider.setValue(this._state, true);
+				break;
+			case DidChangeOrgSettings.is(msg):
+				this._state.orgSettings = msg.params.orgSettings;
+				this._state.timestamp = Date.now();
 
-					this.provider.setValue(this._state, true);
-					break;
-				case DidChangeOrgSettings.is(msg):
-					this._state.orgSettings = msg.params.orgSettings;
-					this._state.timestamp = Date.now();
+				this.provider.setValue(this._state, true);
+				break;
 
-					this.provider.setValue(this._state, true);
-					break;
+			case DidChangeIntegrationsConnections.is(msg):
+				this._state.hasAnyIntegrationConnected = msg.params.hasAnyIntegrationConnected;
+				this._state.integrations = msg.params.integrations;
+				this._state.ai = msg.params.ai;
+				this._state.timestamp = Date.now();
 
-				case DidChangeIntegrationsConnections.is(msg):
-					this._state.hasAnyIntegrationConnected = msg.params.hasAnyIntegrationConnected;
-					this._state.integrations = msg.params.integrations;
-					this._state.ai = msg.params.ai;
-					this._state.timestamp = Date.now();
+				this.provider.setValue(this._state, true);
+				break;
 
-					this.provider.setValue(this._state, true);
-					break;
+			case DidChangePreviewEnabled.is(msg):
+				this._state.previewEnabled = msg.params.previewEnabled;
+				this._state.previewCollapsed = msg.params.previewCollapsed;
+				this._state.aiEnabled = msg.params.aiEnabled;
+				this._state.experimentalComposerEnabled = msg.params.experimentalComposerEnabled;
+				this._state.timestamp = Date.now();
 
-				case DidChangePreviewEnabled.is(msg):
-					this._state.previewEnabled = msg.params.previewEnabled;
-					this._state.previewCollapsed = msg.params.previewCollapsed;
-					this._state.aiEnabled = msg.params.aiEnabled;
-					this._state.experimentalComposerEnabled = msg.params.experimentalComposerEnabled;
-					this._state.timestamp = Date.now();
+				this.provider.setValue(this._state, true);
+				this.host.requestUpdate();
+				break;
 
-					this.provider.setValue(this._state, true);
-					host.requestUpdate();
-					break;
+			case DidChangeAiAllAccessBanner.is(msg):
+				this._state.aiAllAccessBannerCollapsed = msg.params;
+				this._state.timestamp = Date.now();
 
-				case DidChangeAiAllAccessBanner.is(msg):
-					this._state.aiAllAccessBannerCollapsed = msg.params;
-					this._state.timestamp = Date.now();
+				this.provider.setValue(this._state, true);
+				this.host.requestUpdate();
+				break;
+			case DidChangeMcpBanner.is(msg):
+				this._state.mcpBannerCollapsed = msg.params.mcpBannerCollapsed;
+				this._state.mcpCanAutoRegister = msg.params.mcpCanAutoRegister;
+				this._state.timestamp = Date.now();
 
-					this.provider.setValue(this._state, true);
-					host.requestUpdate();
-					break;
-				case DidChangeMcpBanner.is(msg):
-					this._state.mcpBannerCollapsed = msg.params.mcpBannerCollapsed;
-					this._state.mcpCanAutoRegister = msg.params.mcpCanAutoRegister;
-					this._state.timestamp = Date.now();
-
-					this.provider.setValue(this._state, true);
-					host.requestUpdate();
-					break;
-			}
-		});
-	}
-
-	dispose(): void {
-		this.disposable.dispose();
+				this.provider.setValue(this._state, true);
+				this.host.requestUpdate();
+				break;
+		}
 	}
 }

--- a/src/webviews/apps/plus/composer/composer.ts
+++ b/src/webviews/apps/plus/composer/composer.ts
@@ -2,15 +2,20 @@ import { html } from 'lit';
 import { customElement } from 'lit/decorators.js';
 import type { State } from '../../../plus/composer/protocol';
 import { GlAppHost } from '../../shared/appHost';
+import type { LoggerContext } from '../../shared/contexts/logger';
 import type { HostIpc } from '../../shared/ipc';
+import { ComposerStateProvider } from './stateProvider';
 import './components/app';
 import './composer.scss';
-import { ComposerStateProvider } from './stateProvider';
 
 @customElement('gl-composer-apphost')
 export class ComposerAppHost extends GlAppHost<State> {
-	protected override createStateProvider(state: State, ipc: HostIpc): ComposerStateProvider {
-		return new ComposerStateProvider(this, state, ipc);
+	protected override createStateProvider(
+		bootstrap: string,
+		ipc: HostIpc,
+		logger: LoggerContext,
+	): ComposerStateProvider {
+		return new ComposerStateProvider(this, bootstrap, ipc, logger);
 	}
 
 	override render() {

--- a/src/webviews/apps/plus/composer/stateProvider.ts
+++ b/src/webviews/apps/plus/composer/stateProvider.ts
@@ -19,267 +19,250 @@ import {
 	DidStartGeneratingNotification,
 	DidWorkingDirectoryChangeNotification,
 } from '../../../plus/composer/protocol';
-import type { ReactiveElementHost, StateProvider } from '../../shared/appHost';
-import type { Disposable } from '../../shared/events';
-import type { HostIpc } from '../../shared/ipc';
+import type { IpcMessage } from '../../../protocol';
+import type { ReactiveElementHost } from '../../shared/appHost';
+import { StateProviderBase } from '../../shared/stateProviderBase';
 import { stateContext } from './context';
 
-export class ComposerStateProvider implements StateProvider<State> {
-	private readonly disposable: Disposable;
-	private readonly provider: ContextProvider<{ __context__: State }, ReactiveElementHost>;
-
-	private readonly _state: State;
-	get state(): State {
-		return this._state;
+export class ComposerStateProvider extends StateProviderBase<State, typeof stateContext> {
+	protected override createContextProvider(state: State): ContextProvider<typeof stateContext, ReactiveElementHost> {
+		return new ContextProvider(this.host, { context: stateContext, initialValue: state });
 	}
 
-	constructor(
-		host: ReactiveElementHost,
-		state: State,
-		private readonly _ipc: HostIpc,
-	) {
-		this._state = state;
-		this.provider = new ContextProvider(host, { context: stateContext, initialValue: this._state });
+	protected override onMessageReceived(msg: IpcMessage): void {
+		switch (true) {
+			case DidStartGeneratingNotification.is(msg): {
+				const updatedState = {
+					...this._state,
+					generatingCommits: true,
+					timestamp: Date.now(),
+				};
 
-		this.disposable = this._ipc.onReceiveMessage(msg => {
-			switch (true) {
-				case DidStartGeneratingNotification.is(msg): {
-					const updatedState = {
-						...this._state,
-						generatingCommits: true,
-						timestamp: Date.now(),
-					};
-
-					(this as any)._state = updatedState;
-					this.provider.setValue(this._state, true);
-					break;
-				}
-				case DidStartGeneratingCommitMessageNotification.is(msg): {
-					const updatedState = {
-						...this._state,
-						generatingCommitMessage: msg.params.commitId,
-						timestamp: Date.now(),
-					};
-
-					(this as any)._state = updatedState;
-					this.provider.setValue(this._state, true);
-					break;
-				}
-				case DidGenerateCommitsNotification.is(msg): {
-					const updatedState = {
-						...this._state,
-						generatingCommits: false,
-						commits: msg.params.commits,
-						hunks: this._state.hunks.map(hunk => ({
-							...hunk,
-							assigned: true,
-						})),
-						hasUsedAutoCompose: true,
-						timestamp: Date.now(),
-					};
-
-					(this as any)._state = updatedState;
-					this.provider.setValue(this._state, true);
-					break;
-				}
-				case DidGenerateCommitMessageNotification.is(msg): {
-					const updatedCommits = this._state.commits.map(commit =>
-						commit.id === msg.params.commitId ? { ...commit, message: msg.params.message } : commit,
-					);
-
-					const updatedState = {
-						...this._state,
-						generatingCommitMessage: null,
-						commits: updatedCommits,
-						timestamp: Date.now(),
-					};
-
-					(this as any)._state = updatedState;
-					this.provider.setValue(this._state, true);
-					break;
-				}
-				case DidStartCommittingNotification.is(msg): {
-					const updatedState = {
-						...this._state,
-						committing: true,
-						timestamp: Date.now(),
-					};
-
-					(this as any)._state = updatedState;
-					this.provider.setValue(this._state, true);
-					break;
-				}
-				case DidFinishCommittingNotification.is(msg): {
-					const updatedState = {
-						...this._state,
-						committing: false,
-						timestamp: Date.now(),
-					};
-
-					(this as any)._state = updatedState;
-					this.provider.setValue(this._state, true);
-					break;
-				}
-				case DidSafetyErrorNotification.is(msg): {
-					const updatedState = {
-						...this._state,
-						safetyError: msg.params.error,
-						timestamp: Date.now(),
-					};
-
-					(this as any)._state = updatedState;
-					this.provider.setValue(this._state, true);
-					break;
-				}
-				case DidReloadComposerNotification.is(msg): {
-					const updatedState = {
-						...this._state,
-						hunks: msg.params.hunks,
-						commits: msg.params.commits,
-						baseCommit: msg.params.baseCommit,
-						loadingError: msg.params.loadingError,
-						hasChanges: msg.params.hasChanges,
-						safetyError: null, // Clear any existing safety errors
-						// Reset UI state to defaults
-						selectedCommitId: null,
-						selectedCommitIds: new Set<string>(),
-						selectedUnassignedSection: null,
-						selectedHunkIds: new Set<string>(),
-						// Clear any ongoing operations
-						generatingCommits: false,
-						generatingCommitMessage: null,
-						committing: false,
-						// Reset working directory change flag on reload
-						workingDirectoryHasChanged: false,
-						indexHasChanged: false,
-						timestamp: Date.now(),
-						hasUsedAutoCompose: false,
-						repositoryState: msg.params.repositoryState,
-					};
-
-					(this as any)._state = updatedState;
-					this.provider.setValue(this._state, true);
-					break;
-				}
-				case DidWorkingDirectoryChangeNotification.is(msg): {
-					const updatedState = {
-						...this._state,
-						workingDirectoryHasChanged: true,
-						timestamp: Date.now(),
-					};
-
-					(this as any)._state = updatedState;
-					this.provider.setValue(this._state, true);
-					break;
-				}
-				case DidIndexChangeNotification.is(msg): {
-					const updatedState = {
-						...this._state,
-						indexHasChanged: true,
-						timestamp: Date.now(),
-					};
-
-					(this as any)._state = updatedState;
-					this.provider.setValue(this._state, true);
-					break;
-				}
-				case DidLoadingErrorNotification.is(msg): {
-					const updatedState = {
-						...this._state,
-						loadingError: msg.params.error,
-						timestamp: Date.now(),
-					};
-
-					(this as any)._state = updatedState;
-					this.provider.setValue(this._state, true);
-					break;
-				}
-				case DidErrorAIOperationNotification.is(msg): {
-					const updatedState = {
-						...this._state,
-						aiOperationError: {
-							operation: msg.params.operation,
-							error: msg.params.error,
-						},
-						// Clear any loading states since the operation failed
-						generatingCommits: false,
-						generatingCommitMessage: null,
-						timestamp: Date.now(),
-					};
-
-					(this as any)._state = updatedState;
-					this.provider.setValue(this._state, true);
-					break;
-				}
-				case DidClearAIOperationErrorNotification.is(msg): {
-					const updatedState = {
-						...this._state,
-						aiOperationError: null,
-						timestamp: Date.now(),
-					};
-
-					(this as any)._state = updatedState;
-					this.provider.setValue(this._state, true);
-					break;
-				}
-				case DidCancelGenerateCommitsNotification.is(msg): {
-					// Clear loading state and reset to pre-generation state
-					const updatedState = {
-						...this._state,
-						generatingCommits: false,
-						timestamp: Date.now(),
-					};
-
-					(this as any)._state = updatedState;
-					this.provider.setValue(this._state, true);
-					break;
-				}
-				case DidCancelGenerateCommitMessageNotification.is(msg): {
-					// Clear loading state for commit message generation
-					const updatedState = {
-						...this._state,
-						generatingCommitMessage: null,
-						timestamp: Date.now(),
-					};
-
-					(this as any)._state = updatedState;
-					this.provider.setValue(this._state, true);
-					break;
-				}
-				case DidChangeAiEnabledNotification.is(msg): {
-					const updatedState = {
-						...this._state,
-						aiEnabled: {
-							...this._state.aiEnabled,
-							...(msg.params.org !== undefined && { org: msg.params.org }),
-							...(msg.params.config !== undefined && { config: msg.params.config }),
-						},
-						timestamp: Date.now(),
-					};
-
-					(this as any)._state = updatedState;
-					this.provider.setValue(this._state, true);
-					break;
-				}
-				case DidChangeAiModelNotification.is(msg): {
-					const updatedState = {
-						...this._state,
-						ai: {
-							...this._state.ai,
-							model: msg.params.model,
-						},
-						timestamp: Date.now(),
-					};
-
-					(this as any)._state = updatedState;
-					this.provider.setValue(this._state, true);
-					break;
-				}
+				(this as any)._state = updatedState;
+				this.provider.setValue(this._state, true);
+				break;
 			}
-		});
-	}
+			case DidStartGeneratingCommitMessageNotification.is(msg): {
+				const updatedState = {
+					...this._state,
+					generatingCommitMessage: msg.params.commitId,
+					timestamp: Date.now(),
+				};
 
-	dispose(): void {
-		this.disposable.dispose();
+				(this as any)._state = updatedState;
+				this.provider.setValue(this._state, true);
+				break;
+			}
+			case DidGenerateCommitsNotification.is(msg): {
+				const updatedState = {
+					...this._state,
+					generatingCommits: false,
+					commits: msg.params.commits,
+					hunks: this._state.hunks.map(hunk => ({
+						...hunk,
+						assigned: true,
+					})),
+					hasUsedAutoCompose: true,
+					timestamp: Date.now(),
+				};
+
+				(this as any)._state = updatedState;
+				this.provider.setValue(this._state, true);
+				break;
+			}
+			case DidGenerateCommitMessageNotification.is(msg): {
+				const updatedCommits = this._state.commits.map(commit =>
+					commit.id === msg.params.commitId ? { ...commit, message: msg.params.message } : commit,
+				);
+
+				const updatedState = {
+					...this._state,
+					generatingCommitMessage: null,
+					commits: updatedCommits,
+					timestamp: Date.now(),
+				};
+
+				(this as any)._state = updatedState;
+				this.provider.setValue(this._state, true);
+				break;
+			}
+			case DidStartCommittingNotification.is(msg): {
+				const updatedState = {
+					...this._state,
+					committing: true,
+					timestamp: Date.now(),
+				};
+
+				(this as any)._state = updatedState;
+				this.provider.setValue(this._state, true);
+				break;
+			}
+			case DidFinishCommittingNotification.is(msg): {
+				const updatedState = {
+					...this._state,
+					committing: false,
+					timestamp: Date.now(),
+				};
+
+				(this as any)._state = updatedState;
+				this.provider.setValue(this._state, true);
+				break;
+			}
+			case DidSafetyErrorNotification.is(msg): {
+				const updatedState = {
+					...this._state,
+					safetyError: msg.params.error,
+					timestamp: Date.now(),
+				};
+
+				(this as any)._state = updatedState;
+				this.provider.setValue(this._state, true);
+				break;
+			}
+			case DidReloadComposerNotification.is(msg): {
+				const updatedState = {
+					...this._state,
+					hunks: msg.params.hunks,
+					commits: msg.params.commits,
+					baseCommit: msg.params.baseCommit,
+					loadingError: msg.params.loadingError,
+					hasChanges: msg.params.hasChanges,
+					safetyError: null, // Clear any existing safety errors
+					// Reset UI state to defaults
+					selectedCommitId: null,
+					selectedCommitIds: new Set<string>(),
+					selectedUnassignedSection: null,
+					selectedHunkIds: new Set<string>(),
+					// Clear any ongoing operations
+					generatingCommits: false,
+					generatingCommitMessage: null,
+					committing: false,
+					// Reset working directory change flag on reload
+					workingDirectoryHasChanged: false,
+					indexHasChanged: false,
+					timestamp: Date.now(),
+					hasUsedAutoCompose: false,
+					repositoryState: msg.params.repositoryState,
+				};
+
+				(this as any)._state = updatedState;
+				this.provider.setValue(this._state, true);
+				break;
+			}
+			case DidWorkingDirectoryChangeNotification.is(msg): {
+				const updatedState = {
+					...this._state,
+					workingDirectoryHasChanged: true,
+					timestamp: Date.now(),
+				};
+
+				(this as any)._state = updatedState;
+				this.provider.setValue(this._state, true);
+				break;
+			}
+			case DidIndexChangeNotification.is(msg): {
+				const updatedState = {
+					...this._state,
+					indexHasChanged: true,
+					timestamp: Date.now(),
+				};
+
+				(this as any)._state = updatedState;
+				this.provider.setValue(this._state, true);
+				break;
+			}
+			case DidLoadingErrorNotification.is(msg): {
+				const updatedState = {
+					...this._state,
+					loadingError: msg.params.error,
+					timestamp: Date.now(),
+				};
+
+				(this as any)._state = updatedState;
+				this.provider.setValue(this._state, true);
+				break;
+			}
+			case DidErrorAIOperationNotification.is(msg): {
+				const updatedState = {
+					...this._state,
+					aiOperationError: {
+						operation: msg.params.operation,
+						error: msg.params.error,
+					},
+					// Clear any loading states since the operation failed
+					generatingCommits: false,
+					generatingCommitMessage: null,
+					timestamp: Date.now(),
+				};
+
+				(this as any)._state = updatedState;
+				this.provider.setValue(this._state, true);
+				break;
+			}
+			case DidClearAIOperationErrorNotification.is(msg): {
+				const updatedState = {
+					...this._state,
+					aiOperationError: null,
+					timestamp: Date.now(),
+				};
+
+				(this as any)._state = updatedState;
+				this.provider.setValue(this._state, true);
+				break;
+			}
+			case DidCancelGenerateCommitsNotification.is(msg): {
+				// Clear loading state and reset to pre-generation state
+				const updatedState = {
+					...this._state,
+					generatingCommits: false,
+					timestamp: Date.now(),
+				};
+
+				(this as any)._state = updatedState;
+				this.provider.setValue(this._state, true);
+				break;
+			}
+			case DidCancelGenerateCommitMessageNotification.is(msg): {
+				// Clear loading state for commit message generation
+				const updatedState = {
+					...this._state,
+					generatingCommitMessage: null,
+					timestamp: Date.now(),
+				};
+
+				(this as any)._state = updatedState;
+				this.provider.setValue(this._state, true);
+				break;
+			}
+			case DidChangeAiEnabledNotification.is(msg): {
+				const updatedState = {
+					...this._state,
+					aiEnabled: {
+						...this._state.aiEnabled,
+						...(msg.params.org !== undefined && { org: msg.params.org }),
+						...(msg.params.config !== undefined && { config: msg.params.config }),
+					},
+					timestamp: Date.now(),
+				};
+
+				(this as any)._state = updatedState;
+				this.provider.setValue(this._state, true);
+				break;
+			}
+			case DidChangeAiModelNotification.is(msg): {
+				const updatedState = {
+					...this._state,
+					ai: {
+						...this._state.ai,
+						model: msg.params.model,
+					},
+					timestamp: Date.now(),
+				};
+
+				(this as any)._state = updatedState;
+				this.provider.setValue(this._state, true);
+				break;
+			}
+		}
 	}
 }

--- a/src/webviews/apps/plus/graph/graph.ts
+++ b/src/webviews/apps/plus/graph/graph.ts
@@ -33,8 +33,8 @@ export class GraphAppHost extends GlAppHost<State, GraphStateProvider> {
 		return html`<gl-graph-app></gl-graph-app>`;
 	}
 
-	protected override createStateProvider(state: State, ipc: HostIpc): GraphStateProvider {
-		return new GraphStateProvider(this, state, ipc, this._logger, {
+	protected override createStateProvider(bootstrap: string, ipc: HostIpc): GraphStateProvider {
+		return new GraphStateProvider(this, bootstrap, ipc, this._logger, {
 			onStateUpdate: partial => {
 				if ('rows' in partial) {
 					this.appElement.resetHover();

--- a/src/webviews/apps/plus/timeline/stateProvider.ts
+++ b/src/webviews/apps/plus/timeline/stateProvider.ts
@@ -1,41 +1,28 @@
 import { ContextProvider } from '@lit/context';
 import type { State } from '../../../plus/timeline/protocol';
 import { DidChangeNotification } from '../../../plus/timeline/protocol';
-import type { ReactiveElementHost, StateProvider } from '../../shared/appHost';
-import type { Disposable } from '../../shared/events';
-import type { HostIpc } from '../../shared/ipc';
+import type { IpcMessage } from '../../../protocol';
+import type { ReactiveElementHost } from '../../shared/appHost';
+import { StateProviderBase } from '../../shared/stateProviderBase';
 import { stateContext } from './context';
 
-export class TimelineStateProvider implements StateProvider<State> {
-	private readonly disposable: Disposable;
-	private readonly provider: ContextProvider<{ __context__: State }, ReactiveElementHost>;
-
-	private _state: State;
-	get state(): State {
-		return this._state;
+export class TimelineStateProvider extends StateProviderBase<State, typeof stateContext> {
+	protected override createContextProvider(state: State): ContextProvider<typeof stateContext, ReactiveElementHost> {
+		return new ContextProvider(this.host, { context: stateContext, initialValue: state });
 	}
 
-	constructor(
-		host: ReactiveElementHost,
-		state: State,
-		private readonly _ipc: HostIpc,
-	) {
-		this._state = state;
-		this.provider = new ContextProvider(host, { context: stateContext, initialValue: state });
+	protected override onMessageReceived(msg: IpcMessage): void {
+		switch (true) {
+			case DidChangeNotification.is(msg):
+				this._state = { ...msg.params.state, timestamp: Date.now() };
 
-		this.disposable = this._ipc.onReceiveMessage(msg => {
-			switch (true) {
-				case DidChangeNotification.is(msg):
-					this._state = { ...msg.params.state, timestamp: Date.now() };
-
-					this.provider.setValue(this._state, true);
-					host.requestUpdate();
-					break;
-			}
-		});
+				this.provider.setValue(this._state, true);
+				this.host.requestUpdate();
+				break;
+		}
 	}
 
-	dispose(): void {
-		this.disposable.dispose();
+	protected override onPersistState(state: State): void {
+		this.ipc.setPersistedState({ config: state.config, scope: state.scope });
 	}
 }

--- a/src/webviews/apps/plus/timeline/timeline.ts
+++ b/src/webviews/apps/plus/timeline/timeline.ts
@@ -19,6 +19,7 @@ import {
 import { GlAppHost } from '../../shared/appHost';
 import type { Checkbox } from '../../shared/components/checkbox/checkbox';
 import type { GlRefButton } from '../../shared/components/ref-button';
+import type { LoggerContext } from '../../shared/contexts/logger';
 import type { HostIpc } from '../../shared/ipc';
 import { linkStyles, ruleStyles } from '../shared/components/vscode.css';
 import type { CommitEventDetail, GlTimelineChart } from './components/chart';
@@ -51,12 +52,12 @@ export class GlTimelineApp extends GlAppHost<State> {
 	@query('#chart')
 	private _chart?: GlTimelineChart;
 
-	protected override createStateProvider(state: State, ipc: HostIpc): TimelineStateProvider {
-		return new TimelineStateProvider(this, state, ipc);
-	}
-
-	protected override onPersistState(state: State): void {
-		this._ipc.setPersistedState({ config: state.config, scope: state.scope });
+	protected override createStateProvider(
+		bootstrap: string,
+		ipc: HostIpc,
+		logger: LoggerContext,
+	): TimelineStateProvider {
+		return new TimelineStateProvider(this, bootstrap, ipc, logger);
 	}
 
 	override connectedCallback(): void {

--- a/src/webviews/apps/shared/appBase.ts
+++ b/src/webviews/apps/shared/appBase.ts
@@ -15,7 +15,7 @@ import {
 	DidChangeWebviewFocusNotification,
 	DidChangeWebviewVisibilityNotification,
 	WebviewFocusChangedCommand,
-	WebviewReadyCommand,
+	WebviewReadyRequest,
 } from '../../protocol';
 import { ipcContext } from './contexts/ipc';
 import { loggerContext, LoggerContext } from './contexts/logger';
@@ -126,7 +126,7 @@ export abstract class App<
 					);
 				}
 
-				this.sendCommand(WebviewReadyCommand, undefined);
+				void this.sendRequest(WebviewReadyRequest, { bootstrap: false });
 
 				this.onInitialized?.();
 			} finally {

--- a/src/webviews/apps/shared/stateProviderBase.ts
+++ b/src/webviews/apps/shared/stateProviderBase.ts
@@ -1,0 +1,85 @@
+import type { Context, ContextProvider, ContextType } from '@lit/context';
+import { fromBase64ToString } from '@env/base64';
+import { isPromise } from '../../../system/promise';
+import type { IpcMessage, WebviewState } from '../../protocol';
+import { WebviewReadyRequest } from '../../protocol';
+import type { ReactiveElementHost } from './appHost';
+import type { LoggerContext } from './contexts/logger';
+import type { Disposable } from './events';
+import type { HostIpc } from './ipc';
+
+/**
+ * Base class for webview state providers that handles bootstrap initialization.
+ *
+ * Subclasses declare their bootstrap strategy ('sync' or 'async') and implement
+ * message handling. The base class automatically handles state initialization:
+ * - Sync: Uses bootstrap state from HTML
+ * - Async: Requests full state from extension after connection
+ */
+export abstract class StateProviderBase<State extends WebviewState, TContext extends Context<unknown, State>>
+	implements Disposable
+{
+	protected readonly disposable: Disposable;
+	protected readonly provider: ContextProvider<TContext, ReactiveElementHost>;
+
+	protected _state: State;
+	get state(): State {
+		return this._state;
+	}
+
+	get webviewId() {
+		return this._state.webviewId;
+	}
+
+	get webviewInstanceId() {
+		return this._state.webviewInstanceId;
+	}
+
+	get timestamp() {
+		return this._state.timestamp;
+	}
+
+	constructor(
+		protected host: ReactiveElementHost,
+		bootstrap: string,
+		protected ipc: HostIpc,
+		protected logger: LoggerContext,
+	) {
+		// Deserialize bootstrap from base64
+		this._state = this.ipc.deserializeIpcData<State>(fromBase64ToString(bootstrap));
+		this.logger?.log(`bootstrap duration=${Date.now() - this._state.timestamp}ms`);
+
+		this.provider = this.createContextProvider(this._state);
+		this.onPersistState?.(this._state);
+
+		this.disposable = this.ipc.onReceiveMessage(this.onMessageReceived.bind(this));
+		void this.initializeState();
+	}
+
+	dispose(): void {
+		this.disposable.dispose();
+	}
+
+	protected get deferBootstrap(): boolean {
+		return false;
+	}
+
+	protected abstract createContextProvider(state: State): ContextProvider<any, ReactiveElementHost>;
+
+	protected async initializeState(): Promise<void> {
+		if (this.deferBootstrap) {
+			const response = await this.ipc.sendRequest(WebviewReadyRequest, { bootstrap: true });
+			if (response.state != null) {
+				const state: State = (isPromise(response.state) ? await response.state : response.state) as State;
+				this._state = { ...state, timestamp: Date.now() };
+				this.provider.setValue(this._state as ContextType<TContext>, true);
+				this.host.requestUpdate();
+			}
+		} else {
+			void this.ipc.sendRequest(WebviewReadyRequest, { bootstrap: false });
+		}
+	}
+
+	protected abstract onMessageReceived(msg: IpcMessage): void;
+	protected onPersistState?(state: State): void;
+}

--- a/src/webviews/home/homeWebview.ts
+++ b/src/webviews/home/homeWebview.ts
@@ -445,7 +445,7 @@ export class HomeWebviewProvider implements WebviewProvider<State, State, HomeWe
 		}
 	}
 
-	includeBootstrap(): Promise<State> {
+	includeBootstrap(_deferrable?: boolean): Promise<State> {
 		return this.getState();
 	}
 

--- a/src/webviews/plus/composer/composerWebview.ts
+++ b/src/webviews/plus/composer/composerWebview.ts
@@ -258,7 +258,7 @@ export class ComposerWebviewProvider implements WebviewProvider<State, State, Co
 		};
 	}
 
-	includeBootstrap(): Promise<State> {
+	includeBootstrap(_deferrable?: boolean): Promise<State> {
 		return this._cache.get('bootstrap', () => this.getBootstrapState());
 	}
 

--- a/src/webviews/plus/graph/graphWebview.ts
+++ b/src/webviews/plus/graph/graphWebview.ts
@@ -487,7 +487,7 @@ export class GraphWebviewProvider implements WebviewProvider<State, State, Graph
 		}
 	}
 
-	includeBootstrap(): Promise<State> {
+	includeBootstrap(_deferrable?: boolean): Promise<State> {
 		return this.getState(true);
 	}
 
@@ -734,7 +734,11 @@ export class GraphWebviewProvider implements WebviewProvider<State, State, Graph
 	onFocusChanged(focused: boolean): void {
 		this._showActiveSelectionDetailsDebounced?.cancel();
 
-		if (!focused || this.activeSelection == null || !this.container.views.commitDetails.visible) {
+		if (
+			!focused ||
+			this.activeSelection == null ||
+			(!this.container.views.commitDetails.visible && !this.container.views.graphDetails.visible)
+		) {
 			return;
 		}
 
@@ -901,10 +905,7 @@ export class GraphWebviewProvider implements WebviewProvider<State, State, Graph
 		| undefined = undefined;
 
 	private showActiveSelectionDetails() {
-		if (this._showActiveSelectionDetailsDebounced == null) {
-			this._showActiveSelectionDetailsDebounced = debounce(this.showActiveSelectionDetailsCore.bind(this), 250);
-		}
-
+		this._showActiveSelectionDetailsDebounced ??= debounce(this.showActiveSelectionDetailsCore.bind(this), 250);
 		this._showActiveSelectionDetailsDebounced();
 	}
 
@@ -920,9 +921,7 @@ export class GraphWebviewProvider implements WebviewProvider<State, State, Graph
 				preserveFocus: true,
 				preserveVisibility: this._showDetailsView === false,
 			},
-			{
-				source: this.host.id,
-			},
+			{ source: this.host.id },
 		);
 	}
 
@@ -1130,9 +1129,7 @@ export class GraphWebviewProvider implements WebviewProvider<State, State, Graph
 						preserveFocus: e.preserveFocus,
 						preserveVisibility: false,
 					},
-					{
-						source: this.host.id,
-					},
+					{ source: this.host.id },
 				);
 
 				const details = this.host.is('editor')
@@ -1640,7 +1637,7 @@ export class GraphWebviewProvider implements WebviewProvider<State, State, Graph
 			return { search: e.search, results: undefined };
 		}
 
-		if (search == null || search.comparisonKey !== getSearchQueryComparisonKey(e.search)) {
+		if (search?.comparisonKey !== getSearchQueryComparisonKey(e.search)) {
 			if (this.repository == null) return { search: e.search, results: { error: 'No repository' } };
 
 			if (this.repository.etag !== this._etagRepository) {
@@ -1816,9 +1813,7 @@ export class GraphWebviewProvider implements WebviewProvider<State, State, Graph
 					? this._showDetailsView === false
 					: this._showDetailsView !== 'selection',
 			},
-			{
-				source: this.host.id,
-			},
+			{ source: this.host.id },
 		);
 		this._firstSelection = false;
 	}

--- a/src/webviews/plus/patchDetails/patchDetailsWebview.ts
+++ b/src/webviews/plus/patchDetails/patchDetailsWebview.ts
@@ -212,7 +212,7 @@ export class PatchDetailsWebviewProvider
 		return [true, undefined];
 	}
 
-	includeBootstrap(): Promise<Serialized<State>> {
+	includeBootstrap(_deferrable?: boolean): Promise<Serialized<State>> {
 		return this.getState(this._context);
 	}
 

--- a/src/webviews/plus/timeline/timelineWebview.ts
+++ b/src/webviews/plus/timeline/timelineWebview.ts
@@ -223,7 +223,7 @@ export class TimelineWebviewProvider implements WebviewProvider<State, State, Ti
 		return [true, { ...this.getTelemetryContext(), ...cfg }];
 	}
 
-	includeBootstrap(): Promise<State> {
+	includeBootstrap(_deferrable?: boolean): Promise<State> {
 		return this._cache.get('bootstrap', () => this.getState(this._context, false));
 	}
 

--- a/src/webviews/protocol.ts
+++ b/src/webviews/protocol.ts
@@ -72,9 +72,15 @@ export class IpcRequest<Params = void, ResponseParams = void> extends IpcCall<Pa
  */
 export class IpcNotification<Params = void> extends IpcCall<Params> {}
 
-// COMMANDS
+// COMMANDS & REQUESTS
 
-export const WebviewReadyCommand = new IpcCommand('core', 'webview/ready');
+export interface WebviewReadyResponse {
+	state?: unknown | Promise<unknown>;
+}
+export const WebviewReadyRequest = new IpcRequest<{ bootstrap?: boolean }, WebviewReadyResponse>(
+	'core',
+	'webview/ready',
+);
 
 export interface WebviewFocusChangedParams {
 	focused: boolean;

--- a/src/webviews/settings/settingsWebview.ts
+++ b/src/webviews/settings/settingsWebview.ts
@@ -88,7 +88,7 @@ export class SettingsWebviewProvider implements WebviewProvider<State, State, Se
 		return linear.maybeConnected ?? linear.isConnected();
 	}
 
-	async includeBootstrap(): Promise<State> {
+	async includeBootstrap(_deferrable?: boolean): Promise<State> {
 		const scopes: ['user' | 'workspace', string][] = [['user', 'User']];
 		if (workspace.workspaceFolders?.length) {
 			scopes.push(['workspace', 'Workspace']);

--- a/src/webviews/webviewProvider.ts
+++ b/src/webviews/webviewProvider.ts
@@ -35,7 +35,7 @@ export interface WebviewProvider<State, SerializedState = State, ShowingArgs ext
 		| Promise<[boolean, Record<`context.${string}`, string | number | boolean | undefined> | undefined]>;
 	registerCommands?(): Disposable[];
 
-	includeBootstrap?(): SerializedState | Promise<SerializedState>;
+	includeBootstrap?(deferrable?: boolean): SerializedState | Promise<SerializedState>;
 	includeHead?(): string | Promise<string>;
 	includeBody?(): string | Promise<string>;
 	includeEndOfBody?(): string | Promise<string>;


### PR DESCRIPTION
- Refactors the bootstrap management for the "modern" webviews to allow for deferred bootstrap
  - Adds a new common base for state providers to handle bootstrap and webview ready
- Refactors state management of the commit/graph details view
- Improves `commit:selected` event caching in the event bus to avoid the commit/graph details sources to pollute one another