### PR TITLE
Stops open creating PRs from a branch to itself

### DIFF
--- a/src/quickpicks/remoteProviderPicker.ts
+++ b/src/quickpicks/remoteProviderPicker.ts
@@ -62,7 +62,9 @@ export class CopyOrOpenRemoteCommandQuickPickItem extends CommandQuickPickItem {
 					}
 				} else if (resource.type === RemoteResourceType.CreatePullRequest) {
 					let branch = resource.base.branch;
-					if (branch == null) {
+					const sameBranchMergeAttempt =
+						branch === resource.head.branch && this.remote.url === resource.head.remote.url;
+					if (branch == null || sameBranchMergeAttempt) {
 						branch = await getDefaultBranchName(Container.instance, this.remote.repoPath, this.remote.name);
 						if (branch) {
 							branch = getBranchNameWithoutRemote(branch);


### PR DESCRIPTION
fixes #4709

# Description
In 8aefd7b6f60032f6fa0f37a4bfe1b5b9d49055f6 we've started taking the base branch name for "Create PR" command from branch's settings, such as `gk-merge-base`.

However, frequently happens that this option is set to the branch itself, because our config follows the `vscode-merge-branch`.

It wasn't possible to check for the equality right in `CreatePullRequestOnRemoteCommand` because on the next step we suggest user to choose a target remote. On different remotes it is possible to have same name branches on both sides of PR, we should cancel only when the PR happens within the same remote. That is why I perform that validation on a later step when both remotes have been defined.

# Checklist

<!-- Please check off the following -->

- [x] I have followed the guidelines in the Contributing document
- [x] My changes follow the coding style of this project
- [x] My changes build without any errors or warnings
- [x] My changes have been formatted and linted
- [x] My changes include any required corresponding changes to the documentation (including CHANGELOG.md and README.md)
- [x] My changes have been rebased and squashed to the minimal number (typically 1) of relevant commits
- [x] My changes have a descriptive commit message with a short title, including a `Fixes $XXX -` or `Closes #XXX -` prefix to auto-close the issue that your PR addresses
