### PR TITLE
Adds 'realpath' option to resolve symbolic links paths (#1328)

### DIFF
--- a/package.json
+++ b/package.json
@@ -5558,6 +5558,13 @@
 						"scope": "window",
 						"order": 70
 					},
+					"gitlens.realpath": {
+						"type": "boolean",
+						"default": false,
+						"markdownDescription": "[Experimental] Specifies whether to resolve symbolic links when determining file paths for Git operations",
+						"scope": "window",
+						"order": 80
+					},
 					"gitlens.insiders": {
 						"deprecationMessage": "Deprecated. Use the pre-release edition of GitLens instead",
 						"markdownDeprecationMessage": "Deprecated. Use the pre-release of GitLens instead"

--- a/src/config.ts
+++ b/src/config.ts
@@ -43,6 +43,7 @@ export interface Config {
 	readonly proxy: ProxyConfig | null;
 	readonly rebaseEditor: RebaseEditorConfig;
 	readonly remotes: RemotesConfig[] | null;
+	readonly realpath: boolean;
 	readonly showWhatsNewAfterUpgrades: boolean;
 	readonly sortBranchesBy: BranchSorting;
 	readonly sortContributorsBy: ContributorSorting;


### PR DESCRIPTION
Adds 'realpath' option to resolve symbolic links when determining file paths for Git operations (#1328, #1330)

