### PR TITLE
Stop hanging setupMCP on unclosed information message dialog

### DIFF
--- a/src/env/node/gk/cli/integration.ts
+++ b/src/env/node/gk/cli/integration.ts
@@ -157,14 +157,16 @@ export class GkCliIntegrationProvider implements Disposable {
 			if (result.usingExtensionRegistration) {
 				const learnMore = { title: 'Learn More' };
 				const confirm = { title: 'OK', isCloseAffordance: true };
-				const userResult = await window.showInformationMessage(
-					'GitKraken MCP is active in your AI chat, leveraging Git and your integrations to provide context and perform actions.',
-					learnMore,
-					confirm,
-				);
-				if (userResult === learnMore) {
-					void openUrl(urls.helpCenterMCP);
-				}
+				void (async () => {
+					const userResult = await window.showInformationMessage(
+						'GitKraken MCP is active in your AI chat, leveraging Git and your integrations to provide context and perform actions.',
+						learnMore,
+						confirm,
+					);
+					if (userResult === learnMore) {
+						void openUrl(urls.helpCenterMCP);
+					}
+				})();
 			}
 		} catch (ex) {
 			if (ex instanceof McpSetupError) {


### PR DESCRIPTION
# Description

This precedes #4626 

## The Problem

### Steps to reproduce

1. call "GitLens: Re-install GitKraken MCP" command in the palette.
2. Check that it enters `setupMCP` function.
3. `Setting up the GitKraken MCP` notification appears. Then it's changed by a success message.
4. Do not touch the notification message that appears after the installation.
5. One more time call "GitLens: Re-install GitKraken MCP" command in the palette.

### Expected result
- `setupMCP` is called one more time (you can check it in debugger or logs)
- `Setting up the GitKraken MCP` notification appears again.

### Actual result ⚠️
- it never enter `setupMCP` again ⚠️
- you do not see the `Setting up the GitKraken MCP` notification.

## Explanation

`setupMCP()` method is gated by `@gate` annotation that does not let to re-call unfinished promises.
The execution has been waiting for user interaction with the success message, therefore the `setupMCP()` execution has never been resolved, so the `@gate` have never been released. That prevented MCP installation from another attempt.

## Solution

I wrap the information message prompt in an async wrapper that is not awaited, to avoid blocking the main execution flow. This ensures the _gated_ `setupMCP` function always finished even if user does not interact with the information message.

# Checklist

<!-- Please check off the following -->

- [x] I have followed the guidelines in the Contributing document
- [x] My changes follow the coding style of this project
- [x] My changes build without any errors or warnings
- [x] My changes have been formatted and linted
- [x] My changes include any required corresponding changes to the documentation (including CHANGELOG.md and README.md)
- [x] My changes have been rebased and squashed to the minimal number (typically 1) of relevant commits
- [x] My changes have a descriptive commit message with a short title, including a `Fixes $XXX -` or `Closes #XXX -` prefix to auto-close the issue that your PR addresses
