### PR TITLE
Fixes #4776 - Azure DevOps Work Item autolinks point to wrong project

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -39,6 +39,10 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/) and this p
 
 - Fixes performance of _Show Branches and Tags_ command
 
+### Fixed
+
+- Fixes [#4776](https://github.com/gitkraken/vscode-gitlens/issues/4776) Azure DevOps Work Item autolinks pointing to wrong project when the Work Item belongs to a different project in the same organization &mdash; thanks to [PR #4777](https://github.com/gitkraken/vscode-gitlens/pull/4777) by Daniel Asher ([@danielasher115](https://github.com/danielasher115))
+
 ## [17.7.0] - 2025-11-11
 
 ### Added

--- a/README.md
+++ b/README.md
@@ -447,6 +447,7 @@ A big thanks to the people that have contributed to this project 🙏❤️:
 - Jordon Kashanchi ([@jordonkash](https://github.com/JordonKash)) &mdash; [contributions](https://github.com/gitkraken/vscode-gitlens/commits?author=jordonkash)
 - JounQin ([@JounQin](https://github.com/JounQin)) &mdash; [contributions](https://github.com/gitkraken/vscode-gitlens/commits?author=JounQin)
 - Noritaka Kobayashi ([@noritaka1166](https://github.com/noritaka1166)) &mdash; [contributions](https://github.com/gitkraken/vscode-gitlens/commits?author=noritaka1166)
+- Daniel Asher ([@danielasher115](https://github.com/danielasher115)) &mdash; [contributions](https://github.com/gitkraken/vscode-gitlens/commits?author=danielasher115)
 
 Also special thanks to the people that have provided support, testing, brainstorming, etc:
 

--- a/src/git/remotes/azure-devops.ts
+++ b/src/git/remotes/azure-devops.ts
@@ -70,8 +70,10 @@ export class AzureDevOpsRemote extends RemoteProvider {
 	}
 
 	protected override get issueLinkPattern(): string {
-		const workUrl = this.baseUrl.replace(gitRegex, '/');
-		return `${workUrl}/_workitems/edit/<num>`;
+		if (isVsts(this.domain)) {
+			return `${this.protocol}://${this.domain}/_workitems/edit/<num>`;
+		}
+		return `${this.protocol}://${this.domain}/${this.owner}/_workitems/edit/<num>`;
 	}
 
 	private _autolinks: (AutolinkReference | DynamicAutolinkReference)[] | undefined;


### PR DESCRIPTION
# Description

Fixes Azure DevOps Work Item autolinks pointing to wrong project when the Work Item belongs to a different project in the same organization.

Work Items in Azure DevOps are organization-scoped, so autolink URLs should use org-level paths (`https://dev.azure.com/org/_workitems/edit/1234`) rather than project-scoped paths (`https://dev.azure.com/org/Project/_workitems/edit/1234`).

Closes #4776

# Checklist

- [x] I have followed the guidelines in the Contributing document
- [x] My changes follow the coding style of this project
- [x] My changes build without any errors or warnings
- [x] My changes have been formatted and linted
- [x] My changes include any required corresponding changes to the documentation (including CHANGELOG.md and README.md)
- [x] My changes have been rebased and squashed to the minimal number (typically 1) of relevant commits
- [x] My changes have a descriptive commit message with a short title, including a `Fixes #4776 -` prefix to auto-close the issue that your PR addresses