### PR TITLE
Only refresh if the URI is different to avoid unnecessary reloads

### DIFF
--- a/src/views/nodes/fileHistoryTrackerNode.ts
+++ b/src/views/nodes/fileHistoryTrackerNode.ts
@@ -153,7 +153,7 @@ export class FileHistoryTrackerNode extends SubscribeableViewNode<'file-history-
 		}
 
 		// Only trigger change if the editor's URI is different from the current one
-		if (!editor?.document?.uri || (editor?.document?.uri && areUrisEqual(editor.document.uri, this.uri))) {
+		if (!editor?.document?.uri || areUrisEqual(editor.document.uri, this.uri)) {
 			return;
 		}
 


### PR DESCRIPTION
Fixes #4853

# Description

- Editor change optimization:
  * Updated the `onActiveEditorChanged` logic in `fileHistoryTrackerNode.ts` to only trigger a change if the editor's document URI is different from the node's current URI, reducing redundant updates.


<!--
Please include a summary of the changes and which issue will be addressed. Please also include relevant motivation and context.
-->

# Checklist

<!-- Please check off the following -->

- [x] I have followed the guidelines in the Contributing document
- [x] My changes follow the coding style of this project
- [x] My changes build without any errors or warnings
- [x] My changes have been formatted and linted
- [x] My changes include any required corresponding changes to the documentation (including CHANGELOG.md and README.md)
- [x] My changes have been rebased and squashed to the minimal number (typically 1) of relevant commits
- [X] My changes have a descriptive commit message with a short title, including a `Fixes $XXX -` or `Closes #XXX -` prefix to auto-close the issue that your PR addresses
