### PR TITLE
Fixes incorrect folder highlighting in webview file trees

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -35,6 +35,7 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/) and this p
 - Fixes an issue where popovers would appear in drag images when dragging commits in the _Interactive Rebase Editor_ ([#4933](https://github.com/gitkraken/vscode-gitlens/issues/4933))
 - Fixes issues with the "Reauthenticate" flow not taking effect ([#4881](https://github.com/gitkraken/vscode-gitlens/issues/4881))
 - Fixes an issue where clicking on the repository filter header in the _Branches_, _Worktrees_, _Tags_, _Remotes_, _Stashes_, and _Contributors_ views would do nothing when only 1 grouped repository exists ([#4947](https://github.com/gitkraken/vscode-gitlens/issues/4947))
+- Fixes issue in webview file trees where same named folders are highlighted when one is selected [#4801](https://github.com/gitkraken/vscode-gitlens/issues/4801)
 
 ## [17.9.0] - 2026-01-13
 

--- a/src/webviews/apps/commitDetails/components/gl-details-base.ts
+++ b/src/webviews/apps/commitDetails/components/gl-details-base.ts
@@ -334,7 +334,7 @@ export class GlDetailsBase extends LitElement {
 
 		let model: TreeModel;
 		if (item.value == null) {
-			model = this.folderToTreeModel(item.name, options);
+			model = this.folderToTreeModel(item.name, item.relativePath, options);
 		} else {
 			model = this.fileToTreeModel(item.value, options);
 		}
@@ -427,11 +427,11 @@ export class GlDetailsBase extends LitElement {
 		};
 	}
 
-	protected folderToTreeModel(name: string, options?: Partial<TreeItemBase>): TreeModel {
+	protected folderToTreeModel(name: string, relativePath: string, options?: Partial<TreeItemBase>): TreeModel {
 		return {
 			branch: false,
 			expanded: true,
-			path: name,
+			path: relativePath,
 			level: 1,
 			checkable: false,
 			checked: false,

--- a/src/webviews/apps/plus/patchDetails/components/gl-tree-base.ts
+++ b/src/webviews/apps/plus/patchDetails/components/gl-tree-base.ts
@@ -107,7 +107,7 @@ export class GlTreeBase extends GlElement {
 
 		let model: TreeModel;
 		if (item.value == null) {
-			model = this.folderToTreeModel(item.name, options);
+			model = this.folderToTreeModel(item.name, item.relativePath, options);
 		} else {
 			model = this.fileToTreeModel(item.value, options);
 		}
@@ -128,11 +128,11 @@ export class GlTreeBase extends GlElement {
 		return model;
 	}
 
-	protected folderToTreeModel(name: string, options?: Partial<TreeItemBase>): TreeModel {
+	protected folderToTreeModel(name: string, relativePath: string, options?: Partial<TreeItemBase>): TreeModel {
 		return {
 			branch: false,
 			expanded: true,
-			path: name,
+			path: relativePath,
 			level: 1,
 			checkable: false,
 			checked: false,


### PR DESCRIPTION
### Problem

Selecting a folder in the webview file tree incorrectly highlights other folders with the same name, causing confusion in navigation and selection.

### Solution

- Updates folder selection logic to use each folder's relative path for highlighting, ensuring only the intended folder is visually selected.
- Prevents ambiguity when multiple folders share the same name but reside at different locations in the tree.

### Benefit

Improves user experience and accuracy when working with nested folders in file trees within webview panels.

Fixes #4801