### PR TITLE
Moves gk metadata to a dedicated git config file

### DIFF
--- a/src/constants.ts
+++ b/src/constants.ts
@@ -59,33 +59,28 @@ export type GitCoreConfigKeys =
 	| 'init.defaultBranch'
 	| 'user.signingkey';
 
-/**
- * `gk-merge-target` means the branch that the current branch is most likely to be merged into, e.g.
- * - branch to compare with by default
- * - default target for creating a PR
- * - etc.
- *
- * `gk-merge-target-user` — merge target branch explicitly defined by user,
- *    if it's defined we use this value instead of `gk-merge-target`, but we keep storing `gk-merge-target` value that was determined automatically.
- *
- *  `gk-merge-base` means the branch that the current branch originates from, e.g. what was the base in the moment of creation.
- *   This value is used for: ... (TODO describe use cases).
- *
- * `vscode-merge-base` — value determined by VS Code that is used to determine the merge base for the current branch.
- *   once `gk-merge-base` is determined, we stop using `vscode-merge-base`
- *
- */
 export type GitConfigKeys =
+	| GitCoreConfigKeys
+	/** `vscode-merge-base` — value determined by VS Code that is used to determine the merge base for the current branch. Once `gk-merge-base` is determined, we stop using `vscode-merge-base` */
 	| `branch.${string}.vscode-merge-base`
+	/** `github-pr-owner-number` — value determined by VS Code/GitHub PR extension that is used to determine the PR number for the current branch */
+	| `branch.${string}.github-pr-owner-number`;
+
+export type GkConfigKeys =
+	/** `gk-merge-base` — the branch that the current branch was created from (the original base at branch creation time) */
 	| `branch.${string}.gk-merge-base`
+	/** `gk-merge-target` — the auto-detected branch that the current branch will likely be merged into (used for comparisons, PR targets, etc.) */
 	| `branch.${string}.gk-merge-target`
+	/** `gk-merge-target-user` — user-specified merge target branch; takes precedence over auto-detected `gk-merge-target` */
 	| `branch.${string}.gk-merge-target-user`
+	/** `gk-associated-issues` — JSON array of issue/PR entity identifiers linked to this branch */
 	| `branch.${string}.gk-associated-issues`
-	| `branch.${string}.github-pr-owner-number`
+	/** `gk-last-accessed` — ISO 8601 timestamp of when the branch was last checked out or viewed */
 	| `branch.${string}.gk-last-accessed`
+	/** `gk-last-modified` — ISO 8601 timestamp of when the branch last received a commit */
 	| `branch.${string}.gk-last-modified`;
 
-export type DeprecatedGitConfigKeys = `branch.${string}.gk-target-base`;
+export type DeprecatedGkConfigKeys = `branch.${string}.gk-target-base`;
 
 export const enum GlyphChars {
 	AngleBracketLeftHeavy = '\u2770',

--- a/src/git/gitProvider.ts
+++ b/src/git/gitProvider.ts
@@ -1,7 +1,7 @@
 import type { CancellationToken, Disposable, Event, Range, TextDocument, Uri, WorkspaceFolder } from 'vscode';
 import type { Commit, InputBox } from '../@types/vscode.git.d.js';
 import type { ForcePushMode } from '../@types/vscode.git.enums.js';
-import type { DeprecatedGitConfigKeys, GitConfigKeys, GitCoreConfigKeys } from '../constants.js';
+import type { DeprecatedGkConfigKeys, GitConfigKeys, GkConfigKeys } from '../constants.js';
 import type { SearchQuery } from '../constants.search.js';
 import type { Source } from '../constants.telemetry.js';
 import type { Features } from '../features.js';
@@ -50,6 +50,7 @@ export type CachedGitTypes =
 	| 'config'
 	| 'contributors'
 	| 'gitignore'
+	| 'gkConfig'
 	| 'providers'
 	| 'remotes'
 	| 'stashes'
@@ -462,7 +463,7 @@ export type GitConfigType = 'bool' | 'int' | 'bool-or-int' | 'path' | 'expiry-da
 export interface GitConfigSubProvider {
 	getConfig?(
 		repoPath: string | undefined,
-		key: GitCoreConfigKeys | GitConfigKeys | DeprecatedGitConfigKeys,
+		key: GitConfigKeys,
 		options?: {
 			global?: boolean;
 			/** Specifies that this Git command should always be executed locally if possible (for live share sessions) */
@@ -478,10 +479,10 @@ export interface GitConfigSubProvider {
 			/** Specifies that this Git command should always be executed locally if possible (for live share sessions) */
 			runGitLocally?: boolean;
 		},
-	): Promise<string | undefined>;
+	): Promise<Map<string, string>>;
 	setConfig?(
 		repoPath: string | undefined,
-		key: GitCoreConfigKeys | GitConfigKeys,
+		key: GitConfigKeys,
 		value: string | undefined,
 		options?: {
 			global?: boolean;
@@ -489,13 +490,27 @@ export interface GitConfigSubProvider {
 			runGitLocally?: boolean;
 		},
 	): Promise<void>;
+
 	getCurrentUser(repoPath: string): Promise<GitUser | undefined>;
 	getDefaultWorktreePath?(repoPath: string): Promise<string | undefined>;
 	getGitDir?(repoPath: string): Promise<GitDir | undefined>;
+
+	getGkConfig?(
+		repoPath: string,
+		key: GkConfigKeys | DeprecatedGkConfigKeys,
+		options?: { type?: GitConfigType },
+	): Promise<string | undefined>;
+	getGkConfigRegex?(repoPath: string, pattern: string): Promise<Map<string, string>>;
+	setGkConfig?(
+		repoPath: string,
+		key: GkConfigKeys | DeprecatedGkConfigKeys,
+		value: string | undefined,
+	): Promise<void>;
+
 	getSigningConfig?(repoPath: string): Promise<SigningConfig>;
-	validateSigningSetup?(repoPath: string): Promise<ValidationResult>;
-	setSigningConfig?(repoPath: string, config: Partial<SigningConfig>, options?: { global?: boolean }): Promise<void>;
 	getSigningConfigFlags?(config: SigningConfig): string[];
+	setSigningConfig?(repoPath: string, config: Partial<SigningConfig>, options?: { global?: boolean }): Promise<void>;
+	validateSigningSetup?(repoPath: string): Promise<ValidationResult>;
 }
 
 export interface GitContributorsResult {

--- a/src/git/models/repository.ts
+++ b/src/git/models/repository.ts
@@ -38,8 +38,8 @@ const dotGitWatcherGlobWorktreeFiles =
 	'worktrees/*,worktrees/**/index,worktrees/**/HEAD,worktrees/**/*_HEAD,worktrees/**/MERGE_*,worktrees/**/rebase-merge,worktrees/**/rebase-merge/**,worktrees/**/rebase-apply,worktrees/**/rebase-apply/**,worktrees/**/sequencer,worktrees/**/sequencer/**';
 
 const dotGitWatcherGlobRoot = `{${dotGitWatcherGlobFiles}}`;
-const dotGitWatcherGlobCommon = `{config,refs/**,info/exclude,${dotGitWatcherGlobWorktreeFiles}}`;
-const dotGitWatcherGlobCombined = `{${dotGitWatcherGlobFiles},config,refs/**,info/exclude,${dotGitWatcherGlobWorktreeFiles}}`;
+const dotGitWatcherGlobCommon = `{config,gk/config,refs/**,info/exclude,${dotGitWatcherGlobWorktreeFiles}}`;
+const dotGitWatcherGlobCombined = `{${dotGitWatcherGlobFiles},config,gk/config,refs/**,info/exclude,${dotGitWatcherGlobWorktreeFiles}}`;
 
 const gitIgnoreGlob = '.gitignore';
 
@@ -85,6 +85,8 @@ export const enum RepositoryChange {
 	RemoteProviders = 102,
 	Starred = 103,
 	Opened = 104,
+	/** Changes to GitKraken-specific config (.git/gk/config) */
+	GkConfig = 105,
 }
 
 export const enum RepositoryChangeComparisonMode {
@@ -412,7 +414,7 @@ export class Repository implements Disposable {
 		const match =
 			uri != null
 				? // Move worktrees first, since if it is in a worktree it isn't affecting this repo directly
-					/(worktrees|index|HEAD|FETCH_HEAD|ORIG_HEAD|CHERRY_PICK_HEAD|MERGE_HEAD|REBASE_HEAD|rebase-merge|rebase-apply|sequencer|REVERT_HEAD|config|info\/exclude|refs\/(?:heads|remotes|stash|tags))/.exec(
+					/(worktrees|index|HEAD|FETCH_HEAD|ORIG_HEAD|CHERRY_PICK_HEAD|MERGE_HEAD|REBASE_HEAD|rebase-merge|rebase-apply|sequencer|REVERT_HEAD|config|gk\/config|info\/exclude|refs\/(?:heads|remotes|stash|tags))/.exec(
 						this.container.git.getRelativePath(uri, base),
 					)
 				: undefined;
@@ -421,6 +423,10 @@ export class Repository implements Disposable {
 			switch (match[1]) {
 				case 'config':
 					this.fireChange(RepositoryChange.Config, RepositoryChange.Remotes);
+					return;
+
+				case 'gk/config':
+					this.fireChange(RepositoryChange.GkConfig);
 					return;
 
 				case 'info/exclude':

--- a/src/git/utils/-webview/branch.issue.utils.ts
+++ b/src/git/utils/-webview/branch.issue.utils.ts
@@ -1,5 +1,5 @@
 import type { CancellationToken } from 'vscode';
-import type { GitConfigKeys } from '../../../constants.js';
+import type { GkConfigKeys } from '../../../constants.js';
 import type { Container } from '../../../container.js';
 import type { GitConfigEntityIdentifier } from '../../../plus/integrations/providers/models.js';
 import {
@@ -36,7 +36,7 @@ export async function addAssociatedIssueToBranch(
 		associatedIssues.push(encodeIssueOrPullRequestForGitConfig(issue, owner));
 		await container.git
 			.getRepositoryService(branch.repoPath)
-			.config.setConfig?.(key, JSON.stringify(associatedIssues));
+			.config.setGkConfig?.(key, JSON.stringify(associatedIssues));
 	} catch (ex) {
 		Logger.error(ex, 'addAssociatedIssueToBranch');
 	}
@@ -98,11 +98,11 @@ export async function removeAssociatedIssueFromBranch(
 			: [];
 		associatedIssues = associatedIssues.filter(i => i.entityId !== id);
 		if (associatedIssues.length === 0) {
-			await container.git.getRepositoryService(branch.repoPath).config.setConfig?.(key, undefined);
+			await container.git.getRepositoryService(branch.repoPath).config.setGkConfig?.(key, undefined);
 		} else {
 			await container.git
 				.getRepositoryService(branch.repoPath)
-				.config.setConfig?.(key, JSON.stringify(associatedIssues));
+				.config.setGkConfig?.(key, JSON.stringify(associatedIssues));
 		}
 	} catch (ex) {
 		Logger.error(ex, 'removeAssociatedIssueFromBranch');
@@ -112,8 +112,8 @@ export async function removeAssociatedIssueFromBranch(
 async function getConfigKeyAndEncodedAssociatedIssuesForBranch(
 	container: Container,
 	branch: GitBranchReference,
-): Promise<{ key: GitConfigKeys; encoded: string | undefined }> {
-	const key = `branch.${branch.name}.gk-associated-issues` satisfies GitConfigKeys;
-	const encoded = await container.git.getRepositoryService(branch.repoPath).config.getConfig?.(key);
+): Promise<{ key: GkConfigKeys; encoded: string | undefined }> {
+	const key = `branch.${branch.name}.gk-associated-issues` satisfies GkConfigKeys;
+	const encoded = await container.git.getRepositoryService(branch.repoPath).config.getGkConfig?.(key);
 	return { key: key, encoded: encoded };
 }


### PR DESCRIPTION
### Purpose
Reduces noise in the primary Git configuration by migrating GitKraken-specific metadata to a dedicated storage location. This prevents extension-specific data from cluttering user-facing config files and avoids triggering unnecessary repository change events for standard Git operations.

### Changes
- Introduces a new configuration file located at `.git/gk/config` specifically for extension metadata like branch merge targets, associated issues, and access timestamps.
- Implements specialized configuration providers with built-in fallbacks to ensure backward compatibility with existing metadata stored in the primary Git config.
- Updates repository watchers to specifically monitor the new metadata file for changes.
- Optimizes metadata caching by sharing GitKraken configuration across worktrees through the common `.git` directory.
- Refines configuration types to clearly distinguish between core Git settings and extension-specific properties.