### PR TITLE
Stops requiring for git integration to show Linear and Jira issues on graph

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,6 +23,7 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/) and this p
 - Fixes CLI version checking and updating
 - Fixes an issue where stashing only unstaged changes could incorrectly stash everything ([#4503](https://github.com/gitkraken/vscode-gitlens/issues/4503))
 - Fixes an issue where the GitLens panel view container flickers during startup when an integration connects before repository discovery completes ([#4990](https://github.com/gitkraken/vscode-gitlens/issues/4990))
+- Fixes an issue where Jira and Linear issues were not shown on the _Commit Graph_ unless a Git hosting integration (e.g. GitHub) was also connected ([#4640](https://github.com/gitkraken/vscode-gitlens/issues/4640))
 
 ## [17.10.0] - 2026-02-11
 


### PR DESCRIPTION
Solves: #4640

Previously, graph reference metadata fetching was tied solely to hosting integrations. This change extends that capability to include dedicated issue tracking integrations.

The graph now tracks the connection state of issue integrations. If a repository has an issue integration connected, it will attempt to fetch relevant metadata, enriching the graph with issue-related context even when a full hosting integration might not be present or connected.

Metadata is reset and updated when issue integration connection states change, ensuring the graph accurately reflects available data.

# Checklist

- [x] I have followed the guidelines in the Contributing document
- [x] My changes follow the coding style of this project
- [x] My changes build without any errors or warnings
- [x] My changes have been formatted and linted
- [x] My changes include any required corresponding changes to the documentation (including CHANGELOG.md and README.md)
- [x] My changes have been rebased and squashed to the minimal number (typically 1) of relevant commits
- [x] My changes have a descriptive commit message with a short title, including a `Fixes $XXX -` or `Closes #XXX -` prefix to auto-close the issue that your PR addresses
