### PR TITLE
Fixes AuthenticationError meta-info not appearing in logs

### DIFF
--- a/src/plus/integrations/providers/github/github.ts
+++ b/src/plus/integrations/providers/github/github.ts
@@ -3009,7 +3009,7 @@ export class GitHubApi implements Disposable {
 		if (ex.reason === AuthenticationErrorReason.Unauthorized || ex.reason === AuthenticationErrorReason.Forbidden) {
 			const confirm = 'Reauthenticate';
 			const result = await window.showErrorMessage(
-				`${ex.message}. Would you like to try reauthenticating${
+				`${ex.userMessage}. Would you like to try reauthenticating${
 					ex.reason === AuthenticationErrorReason.Forbidden ? ' to provide additional access' : ''
 				}?`,
 				confirm,
@@ -3021,7 +3021,7 @@ export class GitHubApi implements Disposable {
 				this._onDidReauthenticate.fire();
 			}
 		} else {
-			void window.showErrorMessage(ex.message);
+			void window.showErrorMessage(ex.userMessage);
 		}
 	}
 

--- a/src/plus/integrations/providers/gitlab/gitlab.ts
+++ b/src/plus/integrations/providers/gitlab/gitlab.ts
@@ -1239,7 +1239,7 @@ $search: String!
 		if (ex.reason === AuthenticationErrorReason.Unauthorized || ex.reason === AuthenticationErrorReason.Forbidden) {
 			const confirm = 'Reauthenticate';
 			const result = await window.showErrorMessage(
-				`${ex.message}. Would you like to try reauthenticating${
+				`${ex.userMessage}. Would you like to try reauthenticating${
 					ex.reason === AuthenticationErrorReason.Forbidden ? ' to provide additional access' : ''
 				}?`,
 				confirm,
@@ -1250,7 +1250,7 @@ $search: String!
 				this.resetCaches();
 			}
 		} else {
-			void window.showErrorMessage(ex.message);
+			void window.showErrorMessage(ex.userMessage);
 		}
 	}
 }


### PR DESCRIPTION
Fixes #4880

After the logging migration to VS Code's LogOutputChannel (bce3282), the token details stopped being logged because LogOutputChannel uses `.message` rather than `toString()`.

- Includes authInfo in the Error's `.message` property for logging
- Adds `userMessage` property with clean text for user-facing dialogs
- Updates GitHub and GitLab providers to use `userMessage` in error popups
- Removes the now-redundant `toString()` override


# Checklist

<!-- Please check off the following -->

- [x] I have followed the guidelines in the Contributing document
- [x] My changes follow the coding style of this project
- [x] My changes build without any errors or warnings
- [x] My changes have been formatted and linted
- [x] My changes include any required corresponding changes to the documentation (including CHANGELOG.md and README.md)
- [x] My changes have been rebased and squashed to the minimal number (typically 1) of relevant commits
- [x] My changes have a descriptive commit message with a short title, including a `Fixes $XXX -` or `Closes #XXX -` prefix to auto-close the issue that your PR addresses
