### PR TITLE
Updates Merge Mate action from v0.1 to v0.2

### DIFF
--- a/.github/workflows/merge-mate-review.yml
+++ b/.github/workflows/merge-mate-review.yml
@@ -33,7 +33,7 @@ jobs:
             )
         runs-on: ubuntu-latest
         steps:
-            - uses: gitkraken/merge-mate-action/review@v0.1
+            - uses: gitkraken/merge-mate-action/review@v0.2
               with:
                   pr-number: ${{ inputs.pr-number }}
                   action: ${{ inputs.action }}

--- a/.github/workflows/merge-mate.yml
+++ b/.github/workflows/merge-mate.yml
@@ -3,6 +3,17 @@ on:
     push:
         branches: [main]
     workflow_dispatch:
+        inputs:
+            apply-policy:
+                description: 'Apply policy'
+                required: true
+                type: choice
+                options:
+                    - resolved-only
+                    - auto
+                    - hidden-only
+                    - dry-run
+                default: hidden-only
 permissions:
     contents: write
     pull-requests: write
@@ -11,11 +22,19 @@ jobs:
     sync:
         runs-on: ubuntu-latest
         steps:
-            - uses: gitkraken/merge-mate-action/sync@v0.1
+            - uses: gitkraken/merge-mate-action/sync@v0.2
               with:
                   ai-provider: gitkraken
                   ai-api-key: ${{ secrets.GK_AI_PROVISIONER_TOKEN }}
+                  apply-policy: ${{ inputs.apply-policy || 'hidden-only' }}
                   pr-filter: |
                       target-branches:
                           - "main"
                       updated: "<7d"
+                      authors:
+                          - eamodio
+                          - d13
+                          - axosoft-ramint
+                          - sergeibbb
+                          - justinrobots
+                          - ianhattendorf


### PR DESCRIPTION


# Description

## Summary
- Upgrades `gitkraken/merge-mate-action` from v0.1 to v0.2 in both sync and review workflows
- Adds `apply-policy` input to sync workflow (`resolved-only` by default — avoids triggering heavy CI for clean rebases)
- Adds `authors` filter to sync PR filter (only team members' PRs are processed)

## Changes

### Sync (`merge-mate.yml`)
- `gitkraken/merge-mate-action/sync@v0.1` → `@v0.2`
- New `workflow_dispatch` input: `apply-policy` (choice: `resolved-only`, `auto`, `hidden-only`, `dry-run`)
- New `apply-policy` parameter passed to the action (defaults to `resolved-only` on push trigger)
- New `authors` list in `pr-filter` — restricts processing to team members only

### Review (`merge-mate-review.yml`)
- `gitkraken/merge-mate-action/review@v0.1` → `@v0.2`
- Custom user allowlist guard preserved (no changes to `if` condition)
