### PR TITLE
Fixes provider id mismatch for cloud-connected self-hosted integrations

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/) and this p
 - Fixes regression in 17.11.0 that breaks git submodule support in Branches and Remotes views ([#5024](https://github.com/gitkraken/vscode-gitlens/issues/5024))
 - Fixes Interactive rebase fails: `code.exe: bad option: --wait` ([#5028](https://github.com/gitkraken/vscode-gitlens/issues/5028))
 - Fixes an issue where navigating to the line history of a newly added line would incorrectly compare against "missing" instead of the file at the parent commit ([#5030](https://github.com/gitkraken/vscode-gitlens/issues/5030))
+- Fixes provider id mismatch for cloud-connected self-hosted integrations ([#5031](https://github.com/gitkraken/vscode-gitlens/issues/5031))
 
 ## [17.11.0] - 2026-03-04
 

--- a/src/plus/integrations/providers/providersApi.ts
+++ b/src/plus/integrations/providers/providersApi.ts
@@ -113,7 +113,7 @@ export class ProvidersApi {
 				) as GetIssuesForReposFn,
 			},
 			[GitSelfManagedHostIntegrationId.CloudGitHubEnterprise]: {
-				...providersMetadata[GitSelfManagedHostIntegrationId.GitHubEnterprise],
+				...providersMetadata[GitSelfManagedHostIntegrationId.CloudGitHubEnterprise],
 				provider: providerApis.github,
 				getCurrentUserFn: providerApis.github.getCurrentUser.bind(providerApis.github) as GetCurrentUserFn,
 				getPullRequestsForReposFn: providerApis.github.getPullRequestsForRepos.bind(
@@ -164,7 +164,7 @@ export class ProvidersApi {
 				mergePullRequestFn: providerApis.gitlab.mergePullRequest.bind(providerApis.gitlab),
 			},
 			[GitSelfManagedHostIntegrationId.CloudGitLabSelfHosted]: {
-				...providersMetadata[GitCloudHostIntegrationId.GitLab],
+				...providersMetadata[GitSelfManagedHostIntegrationId.CloudGitLabSelfHosted],
 				provider: providerApis.gitlab,
 				getCurrentUserFn: providerApis.gitlab.getCurrentUser.bind(providerApis.gitlab) as GetCurrentUserFn,
 				getPullRequestsForReposFn: providerApis.gitlab.getPullRequestsForRepos.bind(


### PR DESCRIPTION
The `CloudGitLabSelfHosted` and `CloudGitHubEnterprise` entries in `ProvidersApi` were spreading metadata from the wrong `providersMetadata` key, causing a provider id mismatch error when any API call went through `ensureProviderTokenAndFunction`.

- `CloudGitLabSelfHosted` was using `providersMetadata[GitCloudHostIntegrationId.GitLab]` (id: `gitlab`) instead of `providersMetadata[GitSelfManagedHostIntegrationId.CloudGitLabSelfHosted]` (id: `cloud-gitlab-self-hosted`)
- `CloudGitHubEnterprise` was using `providersMetadata[GitSelfManagedHostIntegrationId.GitHubEnterprise]` (id: `github-enterprise`) instead of `providersMetadata[GitSelfManagedHostIntegrationId.CloudGitHubEnterprise]` (id: `cloud-github-enterprise`)