### PR TITLE
Fixes GitKraken AI model selection showing 'No models found'

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/) and this p
 
 ### Fixed
 
+- Fixes _GitKraken AI_ model selection showing 'No models found' when switching AI provider/model ([#4963](https://github.com/gitkraken/vscode-gitlens/issues/4963))
 - Fixes provider id mismatch for cloud-connected self-hosted integrations ([#5031](https://github.com/gitkraken/vscode-gitlens/issues/5031))
 - Fixes an issue where the _Launchpad_ would fail to show any pull requests when one integration provider had an authentication failure — now shows partial results with an error indicator ([#4492](https://github.com/gitkraken/vscode-gitlens/issues/4492))
 

--- a/src/plus/ai/aiProviderService.ts
+++ b/src/plus/ai/aiProviderService.ts
@@ -561,7 +561,10 @@ export class AIProviderService implements AIService, Disposable {
 			} else {
 				changed = true;
 
-				const models = await this._provider.getModels();
+				let models: readonly AIModel[] | undefined;
+				try {
+					models = await this._provider.getModels();
+				} catch {}
 				model = models?.find(m => m.id === modelId);
 				if (model == null) {
 					this._model = undefined;

--- a/src/plus/ai/gitkrakenProvider.ts
+++ b/src/plus/ai/gitkrakenProvider.ts
@@ -32,55 +32,53 @@ export class GitKrakenProvider extends OpenAICompatibleProviderBase<typeof provi
 	async getModels(): Promise<readonly AIModel<typeof provider.id>[]> {
 		const scope = getScopedLogger();
 
-		try {
-			const url = this.container.urls.getGkAIApiUrl('providers/message-prompt');
-			const rsp = await fetch(url, {
-				headers: await this.connection.getGkHeaders(undefined, undefined, {
-					Accept: 'application/json',
-				}),
-			});
-			if (!rsp.ok) {
-				throw new Error(`Getting models (${url}) failed: ${rsp.status} (${rsp.statusText})`);
-			}
+		const apiKey = await this.getApiKey(true);
+		if (!apiKey) return [];
 
-			interface ModelsResponse {
-				data: {
-					providerId: string;
-					providerName: string;
-					modelId: string;
-					modelName: string;
-					preferred: boolean;
-					maxInputTokens: number;
-					maxOutputTokens: number;
-				}[];
-				error?: null;
-			}
-
-			const result: ModelsResponse = await rsp.json();
-			if (result.error != null) {
-				throw new Error(`Getting models (${url}) failed: ${String(result.error)}`);
-			}
-
-			const models = result.data.map<GitKrakenModel>(
-				m =>
-					({
-						id: m.modelId,
-						name: m.modelName,
-						maxTokens: { input: m.maxInputTokens, output: m.maxOutputTokens },
-						provider: provider,
-						default: m.preferred,
-						temperature: null,
-					}) satisfies GitKrakenModel,
-			);
-			return models;
-		} catch (ex) {
-			if (!(ex instanceof AuthenticationRequiredError)) {
-				debugger;
-				scope?.error(ex, `Unable to get models`);
-			}
+		const url = this.container.urls.getGkAIApiUrl('providers/message-prompt');
+		const rsp = await fetch(url, {
+			headers: await this.connection.getGkHeaders(apiKey, undefined, {
+				Accept: 'application/json',
+			}),
+		});
+		if (!rsp.ok) {
+			scope?.error(undefined, `Getting models (${url}) failed: ${rsp.status} (${rsp.statusText})`);
+			throw new Error(`Getting models failed: (${rsp.status}) ${rsp.statusText}`);
 		}
 
-		return [];
+		interface ModelsResponse {
+			data: {
+				providerId: string;
+				providerName: string;
+				modelId: string;
+				modelName: string;
+				preferred: boolean;
+				maxInputTokens: number;
+				maxOutputTokens: number;
+			}[];
+			error?: null;
+		}
+
+		const result: ModelsResponse = await rsp.json();
+		if (result.error != null) {
+			scope?.error(undefined, `Getting models (${url}) failed: ${String(result.error)}`);
+			throw new Error(`Getting models failed: ${String(result.error)}`);
+		}
+
+		if (!result.data) return [];
+
+		const models = result.data.map<GitKrakenModel>(
+			m =>
+				({
+					id: m.modelId,
+					name: m.modelName,
+					maxTokens: { input: m.maxInputTokens, output: m.maxOutputTokens },
+					provider: provider,
+					default: m.preferred,
+					temperature: null,
+				}) satisfies GitKrakenModel,
+		);
+		return models;
 	}
 
 	protected getUrl(_model: AIModel<typeof provider.id>): string {

--- a/src/quickpicks/aiModelPicker.ts
+++ b/src/quickpicks/aiModelPicker.ts
@@ -136,15 +136,25 @@ export async function showAIModelPicker(
 ): Promise<ModelQuickPickItem | Directive | undefined> {
 	if (!(await ensureAccess(container, { showPicker: true }, source))) return undefined;
 
-	const models = (await container.ai.getModels(provider)) ?? [];
+	let models: readonly AIModel[];
+	let modelsError: string | undefined;
+	try {
+		models = (await container.ai.getModels(provider)) ?? [];
+	} catch (ex) {
+		models = [];
+		modelsError = ex instanceof Error ? ex.message : String(ex);
+	}
 
 	const items: Array<ModelQuickPickItem | DirectiveQuickPickItem> = [];
 
 	if (!models.length) {
 		items.push({
-			label: 'No models found',
-			description:
-				provider === 'ollama' ? 'Please install a model or check your Ollama server configuration' : undefined,
+			label: modelsError ? 'Unable to load models' : 'No models found',
+			description: modelsError
+				? modelsError
+				: provider === 'ollama'
+					? 'Please install a model or check your Ollama server configuration'
+					: undefined,
 			iconPath: new ThemeIcon('error'),
 			directive: Directive.Noop,
 		} satisfies ModelQuickPickItem | DirectiveQuickPickItem);


### PR DESCRIPTION
Fixes #4963

# Description

When selecting the GitKraken AI provider in the _Switch AI Provider/Model..._ picker, the model dropdown was always empty when selecting copilot as the provider. Tracked it down to `GitKrakenProvider.getModels()` — the whole method body was wrapped in a try/catch that silently returned `[]` on any error (auth failures, HTTP errors, bad responses). There was no way to tell whether models just didn't exist or something had actually gone wrong.

- Removes silent error swallowing in `GitKrakenProvider.getModels()` — errors now propagate so callers can handle them
- Checks for a valid auth token via `getApiKey` before making the API request, returning `[]` early if unauthenticated
- Passes the access token explicitly to `getGkHeaders()` instead of relying on the internal lookup that could throw `AuthenticationRequiredError` silently
- Adds a null guard on `result.data` to handle missing/null API response fields
- Removes a leftover `debugger` statement
- Catches `getModels()` errors in `showAIModelPicker` and shows _'Unable to load models'_ with the error description instead of the generic _'No models found'_
- Adds a defensive try/catch in `getOrUpdateModel` around the `getModels()` call used to restore a previously configured model at startup

Screenshots showing model selection from copilot:

<img width="2485" height="1381" alt="Screenshot from 2026-03-15 22-48-22" src="https://github.com/user-attachments/assets/f3861236-df75-463f-a78e-8adfce8b5632" />

<img width="2485" height="1381" alt="Screenshot from 2026-03-15 22-48-44" src="https://github.com/user-attachments/assets/1c2c4096-20b3-497c-be5b-e017bb69775c" />

# Checklist

- [x] I have followed the guidelines in the Contributing document
- [x] My changes follow the coding style of this project
- [x] My changes build without any errors or warnings
- [x] My changes have been formatted and linted
- [x] My changes include any required corresponding changes to the documentation (including CHANGELOG.md and README.md)
- [x] My changes have been rebased and squashed to the minimal number (typically 1) of relevant commits
- [x] My changes have a descriptive commit message with a short title, including a `Fixes $XXX -` or `Closes #XXX -` prefix to auto-close the issue that your PR addresses