### PR TITLE
feat: add block-no-verify PreToolUse Bash hook to .claude/settings.json

### DIFF
--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -18,6 +18,15 @@
 		],
 		"PreToolUse": [
 			{
+				"matcher": "Bash",
+				"hooks": [
+					{
+						"type": "command",
+						"command": "npx block-no-verify@1.1.2"
+					}
+				]
+			},
+			{
 				"matcher": "Edit|Write",
 				"hooks": [
 					{


### PR DESCRIPTION
## Summary

Adds `block-no-verify@1.1.2` as a new `PreToolUse` Bash hook in `.claude/settings.json`, alongside the existing `Edit|Write` PreToolUse and PostToolUse hooks.

When an agent runs `git commit` or `git push` with the hook-bypass flag, it silently skips pre-commit, commit-msg, and pre-push hooks. `block-no-verify` reads `tool_input.command` from the Claude Code hook stdin payload, detects the hook-bypass flag across all git subcommands, and exits 2 to block. The existing hooks and configuration are preserved unchanged.

Closes #5046

---

_Disclosure: I am the author and maintainer of `block-no-verify`._