### PR TITLE
Fixes misleading 'upgrade your Git' message for virtual repositories

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/) and this p
 
 ### Fixed
 
+- Fixes the _Worktrees_ view showing a misleading 'upgrade your Git' message when opening a virtual GitHub repository ([#5056](https://github.com/gitkraken/vscode-gitlens/issues/5056))
 - Fixes provider id mismatch for cloud-connected self-hosted integrations ([#5031](https://github.com/gitkraken/vscode-gitlens/issues/5031))
 - Fixes an issue where the _Launchpad_ would fail to show any pull requests when one integration provider had an authentication failure — now shows partial results with an error indicator ([#4492](https://github.com/gitkraken/vscode-gitlens/issues/4492))
 

--- a/contributions.json
+++ b/contributions.json
@@ -19632,43 +19632,47 @@
 				},
 				{
 					"contents": "Unlock this feature for privately hosted repos with [GitLens Pro](https://help.gitkraken.com/gitlens/gitlens-community-vs-gitlens-pro/).",
-					"when": "!gitlens:views:scm:grouped:loading && gitlens:views:scm:grouped:view == worktrees && gitlens:plus:state != 6"
+					"when": "!gitlens:views:scm:grouped:loading && gitlens:views:scm:grouped:view == worktrees && !gitlens:hasVirtualFolders && gitlens:plus:state != 6"
 				},
 				{
 					"contents": "[Create Worktree...](command:gitlens.views.createWorktree)",
-					"when": "!gitlens:views:scm:grouped:loading && gitlens:views:scm:grouped:view == worktrees && !gitlens:plus:required && !gitlens:feature:unsupported:git:worktrees"
+					"when": "!gitlens:views:scm:grouped:loading && gitlens:views:scm:grouped:view == worktrees && !gitlens:hasVirtualFolders && !gitlens:plus:required && !gitlens:feature:unsupported:git:worktrees"
 				},
 				{
 					"contents": "[Resend Verification Email](command:gitlens.plus.resendVerification?%7B%22source%22%3A%22worktrees%22%7D)\n\nYou must verify your email before you can continue or [recheck Status](command:gitlens.plus.validate?%7B%22source%22%3A%22worktrees%22%7D).",
-					"when": "!gitlens:views:scm:grouped:loading && gitlens:views:scm:grouped:view == worktrees && gitlens:plus:state == -1"
+					"when": "!gitlens:views:scm:grouped:loading && gitlens:views:scm:grouped:view == worktrees && !gitlens:hasVirtualFolders && gitlens:plus:state == -1"
 				},
 				{
 					"contents": "[Try GitLens Pro](command:gitlens.plus.signUp?%7B%22source%22%3A%22worktrees%22%7D)\n\nGet 14 days of GitLens Pro for free — no credit card required. Or [sign in](command:gitlens.plus.login?%7B%22source%22%3A%22worktrees%22%7D).",
-					"when": "!gitlens:views:scm:grouped:loading && gitlens:views:scm:grouped:view == worktrees && gitlens:plus:required && gitlens:plus:state == 0"
+					"when": "!gitlens:views:scm:grouped:loading && gitlens:views:scm:grouped:view == worktrees && !gitlens:hasVirtualFolders && gitlens:plus:required && gitlens:plus:state == 0"
 				},
 				{
 					"contents": "[Upgrade to Pro](command:gitlens.plus.upgrade?%7B%22source%22%3A%22worktrees%22%7D)",
-					"when": "!gitlens:views:scm:grouped:loading && gitlens:views:scm:grouped:view == worktrees && gitlens:plus:required && gitlens:plus:state == 4"
+					"when": "!gitlens:views:scm:grouped:loading && gitlens:views:scm:grouped:view == worktrees && !gitlens:hasVirtualFolders && gitlens:plus:required && gitlens:plus:state == 4"
 				},
 				{
 					"contents": "Limited-time sale on GitLens Pro.",
-					"when": "!gitlens:views:scm:grouped:loading && gitlens:views:scm:grouped:view == worktrees && gitlens:plus:required && gitlens:plus:state == 4 && gitlens:promo && gitlens:promo != pro50"
+					"when": "!gitlens:views:scm:grouped:loading && gitlens:views:scm:grouped:view == worktrees && !gitlens:hasVirtualFolders && gitlens:plus:required && gitlens:plus:state == 4 && gitlens:promo && gitlens:promo != pro50"
 				},
 				{
 					"contents": "Save up to 50% on GitLens Pro.",
-					"when": "!gitlens:views:scm:grouped:loading && gitlens:views:scm:grouped:view == worktrees && gitlens:plus:required && gitlens:plus:state == 4 && gitlens:promo == pro50"
+					"when": "!gitlens:views:scm:grouped:loading && gitlens:views:scm:grouped:view == worktrees && !gitlens:hasVirtualFolders && gitlens:plus:required && gitlens:plus:state == 4 && gitlens:promo == pro50"
 				},
 				{
 					"contents": "Your Pro trial has ended. Please upgrade for full access to Worktrees and other Pro features.",
-					"when": "!gitlens:views:scm:grouped:loading && gitlens:views:scm:grouped:view == worktrees && gitlens:plus:required && gitlens:plus:state == 4"
+					"when": "!gitlens:views:scm:grouped:loading && gitlens:views:scm:grouped:view == worktrees && !gitlens:hasVirtualFolders && gitlens:plus:required && gitlens:plus:state == 4"
 				},
 				{
 					"contents": "[Continue](command:gitlens.plus.reactivateProTrial?%7B%22source%22%3A%22worktrees%22%7D)\n\nReactivate your Pro trial and experience Worktrees and all the new Pro features — free for another 14 days!",
-					"when": "!gitlens:views:scm:grouped:loading && gitlens:views:scm:grouped:view == worktrees && gitlens:plus:required && gitlens:plus:state == 5"
+					"when": "!gitlens:views:scm:grouped:loading && gitlens:views:scm:grouped:view == worktrees && !gitlens:hasVirtualFolders && gitlens:plus:required && gitlens:plus:state == 5"
+				},
+				{
+					"contents": "Worktrees are not available for virtual repositories.",
+					"when": "!gitlens:views:scm:grouped:loading && gitlens:views:scm:grouped:view == worktrees && gitlens:hasVirtualFolders"
 				},
 				{
 					"contents": "⚠ Worktrees are not supported by your version of Git. Please upgrade to a more recent version.",
-					"when": "!gitlens:views:scm:grouped:loading && gitlens:views:scm:grouped:view == worktrees && !gitlens:plus:required && gitlens:feature:unsupported:git:worktrees"
+					"when": "!gitlens:views:scm:grouped:loading && gitlens:views:scm:grouped:view == worktrees && !gitlens:hasVirtualFolders && !gitlens:plus:required && gitlens:feature:unsupported:git:worktrees"
 				}
 			]
 		},
@@ -19811,8 +19815,12 @@
 					"when": "gitlens:plus:required && gitlens:plus:state == 5"
 				},
 				{
+					"contents": "Worktrees are not available for virtual repositories.",
+					"when": "gitlens:hasVirtualFolders"
+				},
+				{
 					"contents": "⚠ Worktrees are not supported by your version of Git. Please upgrade to a more recent version.",
-					"when": "!gitlens:plus:required && gitlens:feature:unsupported:git:worktrees"
+					"when": "!gitlens:hasVirtualFolders && !gitlens:plus:required && gitlens:feature:unsupported:git:worktrees"
 				}
 			]
 		}

--- a/package.json
+++ b/package.json
@@ -26907,52 +26907,57 @@
 			{
 				"view": "gitlens.views.scm.grouped",
 				"contents": "Unlock this feature for privately hosted repos with [GitLens Pro](https://help.gitkraken.com/gitlens/gitlens-community-vs-gitlens-pro/).",
-				"when": "!gitlens:views:scm:grouped:loading && gitlens:views:scm:grouped:view == worktrees && gitlens:plus:state != 6"
+				"when": "!gitlens:views:scm:grouped:loading && gitlens:views:scm:grouped:view == worktrees && !gitlens:hasVirtualFolders && gitlens:plus:state != 6"
 			},
 			{
 				"view": "gitlens.views.scm.grouped",
 				"contents": "[Create Worktree...](command:gitlens.views.createWorktree)",
-				"when": "!gitlens:views:scm:grouped:loading && gitlens:views:scm:grouped:view == worktrees && !gitlens:plus:required && !gitlens:feature:unsupported:git:worktrees"
+				"when": "!gitlens:views:scm:grouped:loading && gitlens:views:scm:grouped:view == worktrees && !gitlens:hasVirtualFolders && !gitlens:plus:required && !gitlens:feature:unsupported:git:worktrees"
 			},
 			{
 				"view": "gitlens.views.scm.grouped",
 				"contents": "[Resend Verification Email](command:gitlens.plus.resendVerification?%7B%22source%22%3A%22worktrees%22%7D)\n\nYou must verify your email before you can continue or [recheck Status](command:gitlens.plus.validate?%7B%22source%22%3A%22worktrees%22%7D).",
-				"when": "!gitlens:views:scm:grouped:loading && gitlens:views:scm:grouped:view == worktrees && gitlens:plus:state == -1"
+				"when": "!gitlens:views:scm:grouped:loading && gitlens:views:scm:grouped:view == worktrees && !gitlens:hasVirtualFolders && gitlens:plus:state == -1"
 			},
 			{
 				"view": "gitlens.views.scm.grouped",
 				"contents": "[Try GitLens Pro](command:gitlens.plus.signUp?%7B%22source%22%3A%22worktrees%22%7D)\n\nGet 14 days of GitLens Pro for free — no credit card required. Or [sign in](command:gitlens.plus.login?%7B%22source%22%3A%22worktrees%22%7D).",
-				"when": "!gitlens:views:scm:grouped:loading && gitlens:views:scm:grouped:view == worktrees && gitlens:plus:required && gitlens:plus:state == 0"
+				"when": "!gitlens:views:scm:grouped:loading && gitlens:views:scm:grouped:view == worktrees && !gitlens:hasVirtualFolders && gitlens:plus:required && gitlens:plus:state == 0"
 			},
 			{
 				"view": "gitlens.views.scm.grouped",
 				"contents": "[Upgrade to Pro](command:gitlens.plus.upgrade?%7B%22source%22%3A%22worktrees%22%7D)",
-				"when": "!gitlens:views:scm:grouped:loading && gitlens:views:scm:grouped:view == worktrees && gitlens:plus:required && gitlens:plus:state == 4"
+				"when": "!gitlens:views:scm:grouped:loading && gitlens:views:scm:grouped:view == worktrees && !gitlens:hasVirtualFolders && gitlens:plus:required && gitlens:plus:state == 4"
 			},
 			{
 				"view": "gitlens.views.scm.grouped",
 				"contents": "Limited-time sale on GitLens Pro.",
-				"when": "!gitlens:views:scm:grouped:loading && gitlens:views:scm:grouped:view == worktrees && gitlens:plus:required && gitlens:plus:state == 4 && gitlens:promo && gitlens:promo != pro50"
+				"when": "!gitlens:views:scm:grouped:loading && gitlens:views:scm:grouped:view == worktrees && !gitlens:hasVirtualFolders && gitlens:plus:required && gitlens:plus:state == 4 && gitlens:promo && gitlens:promo != pro50"
 			},
 			{
 				"view": "gitlens.views.scm.grouped",
 				"contents": "Save up to 50% on GitLens Pro.",
-				"when": "!gitlens:views:scm:grouped:loading && gitlens:views:scm:grouped:view == worktrees && gitlens:plus:required && gitlens:plus:state == 4 && gitlens:promo == pro50"
+				"when": "!gitlens:views:scm:grouped:loading && gitlens:views:scm:grouped:view == worktrees && !gitlens:hasVirtualFolders && gitlens:plus:required && gitlens:plus:state == 4 && gitlens:promo == pro50"
 			},
 			{
 				"view": "gitlens.views.scm.grouped",
 				"contents": "Your Pro trial has ended. Please upgrade for full access to Worktrees and other Pro features.",
-				"when": "!gitlens:views:scm:grouped:loading && gitlens:views:scm:grouped:view == worktrees && gitlens:plus:required && gitlens:plus:state == 4"
+				"when": "!gitlens:views:scm:grouped:loading && gitlens:views:scm:grouped:view == worktrees && !gitlens:hasVirtualFolders && gitlens:plus:required && gitlens:plus:state == 4"
 			},
 			{
 				"view": "gitlens.views.scm.grouped",
 				"contents": "[Continue](command:gitlens.plus.reactivateProTrial?%7B%22source%22%3A%22worktrees%22%7D)\n\nReactivate your Pro trial and experience Worktrees and all the new Pro features — free for another 14 days!",
-				"when": "!gitlens:views:scm:grouped:loading && gitlens:views:scm:grouped:view == worktrees && gitlens:plus:required && gitlens:plus:state == 5"
+				"when": "!gitlens:views:scm:grouped:loading && gitlens:views:scm:grouped:view == worktrees && !gitlens:hasVirtualFolders && gitlens:plus:required && gitlens:plus:state == 5"
+			},
+			{
+				"view": "gitlens.views.scm.grouped",
+				"contents": "Worktrees are not available for virtual repositories.",
+				"when": "!gitlens:views:scm:grouped:loading && gitlens:views:scm:grouped:view == worktrees && gitlens:hasVirtualFolders"
 			},
 			{
 				"view": "gitlens.views.scm.grouped",
 				"contents": "⚠ Worktrees are not supported by your version of Git. Please upgrade to a more recent version.",
-				"when": "!gitlens:views:scm:grouped:loading && gitlens:views:scm:grouped:view == worktrees && !gitlens:plus:required && gitlens:feature:unsupported:git:worktrees"
+				"when": "!gitlens:views:scm:grouped:loading && gitlens:views:scm:grouped:view == worktrees && !gitlens:hasVirtualFolders && !gitlens:plus:required && gitlens:feature:unsupported:git:worktrees"
 			},
 			{
 				"view": "gitlens.views.searchAndCompare",
@@ -27039,8 +27044,13 @@
 			},
 			{
 				"view": "gitlens.views.worktrees",
+				"contents": "Worktrees are not available for virtual repositories.",
+				"when": "gitlens:hasVirtualFolders"
+			},
+			{
+				"view": "gitlens.views.worktrees",
 				"contents": "⚠ Worktrees are not supported by your version of Git. Please upgrade to a more recent version.",
-				"when": "!gitlens:plus:required && gitlens:feature:unsupported:git:worktrees"
+				"when": "!gitlens:hasVirtualFolders && !gitlens:plus:required && gitlens:feature:unsupported:git:worktrees"
 			}
 		],
 		"views": {

--- a/src/constants.views.ts
+++ b/src/constants.views.ts
@@ -43,6 +43,9 @@ export type GroupableTreeViewTypes = Extract<
 >;
 export type GroupableTreeViewIds<T extends GroupableTreeViewTypes = GroupableTreeViewTypes> = TreeViewIds<T>;
 
+/** Grouped views that require a local repository and are unavailable for virtual repositories */
+export const localOnlyGroupedViews: ReadonlySet<GroupableTreeViewTypes> = new Set(['worktrees', 'stashes']);
+
 export type WebviewPanelTypes = 'composer' | 'graph' | 'patchDetails' | 'settings' | 'timeline';
 export type WebviewPanelIds = `gitlens.${WebviewPanelTypes}`;
 

--- a/src/views/views.ts
+++ b/src/views/views.ts
@@ -1,6 +1,7 @@
 import type { ConfigurationChangeEvent, MessageItem } from 'vscode';
 import { Disposable, env, ExtensionMode, window } from 'vscode';
 import type { GroupableTreeViewTypes, TreeViewTypes } from '../constants.views.js';
+import { localOnlyGroupedViews } from '../constants.views.js';
 import type { Container } from '../container.js';
 import type { GitContributor } from '../git/models/contributor.js';
 import type {
@@ -101,6 +102,7 @@ export class Views implements Disposable {
 		return this._scmGroupedViews;
 	}
 
+	private _hasVirtualFolders: boolean | undefined;
 	private _welcomeDismissed = false;
 
 	constructor(
@@ -109,6 +111,7 @@ export class Views implements Disposable {
 	) {
 		this._disposable = Disposable.from(
 			configuration.onDidChange(this.onConfigurationChanged, this),
+			container.git.onDidChangeRepositories(this.onRepositoriesChanged, this),
 			new ViewCommands(container),
 			...this.registerViews(),
 			...this.registerWebviewViews(webviews),
@@ -181,6 +184,14 @@ export class Views implements Disposable {
 		}
 
 		if (configuration.changed(e, 'views.scm.grouped.views')) {
+			this.updateScmGroupedViewsRegistration();
+		}
+	}
+
+	private onRepositoriesChanged(): void {
+		const hasVirtualFolders = getContext('gitlens:hasVirtualFolders');
+		if (this._hasVirtualFolders !== hasVirtualFolders) {
+			this._hasVirtualFolders = hasVirtualFolders;
 			this.updateScmGroupedViewsRegistration();
 		}
 	}
@@ -589,6 +600,11 @@ export class Views implements Disposable {
 		void setContext('gitlens:views:scm:grouped:welcome', !this._welcomeDismissed);
 
 		this._scmGroupedViews = getScmGroupedViewsFromConfig();
+		if (getContext('gitlens:hasVirtualFolders')) {
+			for (const view of localOnlyGroupedViews) {
+				this._scmGroupedViews.delete(view);
+			}
+		}
 
 		if (this._scmGroupedViews.size) {
 			if (this._welcomeDismissed || bypassWelcomeView) {


### PR DESCRIPTION
- Filters local-only views (worktrees, stashes) from the grouped SCM view when virtual folders are present
- Re-evaluates grouped view availability when repositories change
- Gates all worktrees welcome content with !gitlens:hasVirtualFolders
- Adds 'Worktrees are not available for virtual repositories' message

Fixes #5056