### PR TITLE
Adds packages node_modules to vscodeignore

### DIFF
--- a/.vscodeignore
+++ b/.vscodeignore
@@ -11,6 +11,7 @@ images/docs
 images/icons/**
 images/originals/**
 node_modules/**
+packages/**/node_modules/**
 out/**
 packages/*/node_modules/**
 packages/*/src/**


### PR DESCRIPTION
Adds `packages/**/node_modules/**` to `.vscodeignore` to exclude nested node_modules from the extension package.