### PR TITLE
Fixes build pipeline lint and package failures

### DIFF
--- a/src/env/node/git/__tests__/shell.test.ts
+++ b/src/env/node/git/__tests__/shell.test.ts
@@ -1,5 +1,6 @@
 /* eslint-disable @typescript-eslint/require-await */
 import * as assert from 'assert';
+import * as process from 'process';
 import * as sinon from 'sinon';
 import { CancelledRunError, RunError } from '../shell.errors.js';
 import { run, runSpawn } from '../shell.js';

--- a/webpack.config.mjs
+++ b/webpack.config.mjs
@@ -656,7 +656,7 @@ function getWebviewConfig(webviews, overrides, mode, env) {
 							new CssMinimizerPlugin({
 								minimizerOptions: {
 									preset: [
-										'cssnano-preset-advanced',
+										require.resolve('cssnano-preset-advanced'),
 										{
 											autoprefixer: false,
 											discardUnused: false,


### PR DESCRIPTION
## Summary
- Adds missing `import * as process from 'process'` in `shell.test.ts` to fix `no-restricted-globals` ESLint error
- Resolves `cssnano-preset-advanced` path in `webpack.config.mjs` via `require.resolve()` to fix pnpm virtual store resolution in jest-worker threads during `pnpm run package`

## Test plan
- [x] `pnpm run rebuild` passes
- [x] `pnpm run pretty:check` passes
- [x] `pnpm run lint` passes (0 errors, 0 warnings)
- [x] `pnpm run test` passes (519 passing)
- [x] `pnpm run package` passes (VSIX created)

🤖 Generated with [Claude Code](https://claude.com/claude-code)