### PR TITLE
ci: Harden Marketplace release pipelines against supply-chain attacks

### DIFF
--- a/.github/workflows/cd-pre.yml
+++ b/.github/workflows/cd-pre.yml
@@ -15,7 +15,7 @@ jobs:
             status: ${{ steps.earlyexit.outputs.status }}
         steps:
             - name: Checkout code
-              uses: actions/checkout@v4
+              uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
               with:
                   fetch-depth: 0
             - id: earlyexit
@@ -51,15 +51,17 @@ jobs:
         needs: check
         runs-on: ubuntu-latest
         if: needs.check.outputs.status == 'changed'
+        permissions:
+            contents: read
         steps:
             - name: Checkout code
-              uses: actions/checkout@v4
+              uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
             - name: Setup node
-              uses: actions/setup-node@v4
+              uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4
               with:
                   node-version: '22'
             - name: Setup pnpm
-              uses: pnpm/action-setup@v3
+              uses: pnpm/action-setup@a3252b78c470c02df07e9d59298aecedc3ccdd6d # v3
               with:
                   version: 10
             - name: Install
@@ -75,7 +77,7 @@ jobs:
             - name: Publish extension to OpenVSIX
               run: pnpm ovsx publish ./${{ env.PACKAGE_NAME }}.vsix -p ${{ secrets.GITLENS_OPENVSIX_PAT }}
             - name: Publish artifact
-              uses: actions/upload-artifact@v4
+              uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4
               with:
                   name: ${{ env.PACKAGE_NAME }}.vsix
                   path: ./${{ env.PACKAGE_NAME }}.vsix

--- a/.github/workflows/cd-stable.yml
+++ b/.github/workflows/cd-stable.yml
@@ -13,13 +13,13 @@ jobs:
             contents: write
         steps:
             - name: Checkout code
-              uses: actions/checkout@v4
+              uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
             - name: Setup node
-              uses: actions/setup-node@v4
+              uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4
               with:
                   node-version: '22'
             - name: Setup pnpm
-              uses: pnpm/action-setup@v3
+              uses: pnpm/action-setup@a3252b78c470c02df07e9d59298aecedc3ccdd6d # v3
               with:
                   version: 10
             - name: Setup Environment
@@ -36,13 +36,13 @@ jobs:
               run: pnpm ovsx publish ./${{ env.PACKAGE_NAME }}.vsix -p ${{ secrets.GITLENS_OPENVSIX_PAT }}
             - name: Generate Changelog
               id: changelog
-              uses: mindsers/changelog-reader-action@v2
+              uses: mindsers/changelog-reader-action@32aa5b4c155d76c94e4ec883a223c947b2f02656 # v2
               with:
                   version: ${{ env.PACKAGE_VERSION }}
                   path: ./CHANGELOG.md
             - name: Create GitHub release
               id: create_release
-              uses: softprops/action-gh-release@v2
+              uses: softprops/action-gh-release@153bb8e04406b158c6c84fc1615b65b24149a1fe # v2
               env:
                   GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
               with:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -13,6 +13,9 @@ on:
             - ready_for_review
     workflow_dispatch:
 
+permissions:
+    contents: read
+
 jobs:
     build:
         name: Format, Typecheck, Lint, & Build
@@ -21,7 +24,7 @@ jobs:
         timeout-minutes: 10
         steps:
             - name: Checkout
-              uses: actions/checkout@v4
+              uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
 
             - name: Calc tools versions
               id: tools-versions
@@ -32,12 +35,12 @@ jobs:
                   echo "pnpm-version=$PNPM_VERSION" >> $GITHUB_OUTPUT
 
             - name: Setup Node.js
-              uses: actions/setup-node@v4
+              uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4
               with:
                   node-version: ${{ steps.tools-versions.outputs.node-version }}
 
             - name: Install pnpm
-              uses: pnpm/action-setup@v4
+              uses: pnpm/action-setup@b906affcce14559ad1aafd4ab0e942779e9f58b1 # v4
               with:
                   version: ${{ steps.tools-versions.outputs.pnpm-version }}
 
@@ -47,7 +50,7 @@ jobs:
                   echo "STORE_PATH=$(pnpm store path --silent)" >> $GITHUB_ENV
 
             - name: Setup pnpm cache
-              uses: actions/cache@v4
+              uses: actions/cache@0057852bfaa89a56745cba8c7296529d2fc39830 # v4
               with:
                   path: ${{ env.STORE_PATH }}
                   key: ${{ runner.os }}-pnpm-store-${{ hashFiles('**/pnpm-lock.yaml') }}
@@ -70,7 +73,7 @@ jobs:
         timeout-minutes: 15
         steps:
             - name: Checkout
-              uses: actions/checkout@v4
+              uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
 
             - name: Calc tools versions
               id: tools-versions
@@ -81,12 +84,12 @@ jobs:
                   echo "pnpm-version=$PNPM_VERSION" >> $GITHUB_OUTPUT
 
             - name: Setup Node.js
-              uses: actions/setup-node@v4
+              uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4
               with:
                   node-version: ${{ steps.tools-versions.outputs.node-version }}
 
             - name: Install pnpm
-              uses: pnpm/action-setup@v4
+              uses: pnpm/action-setup@b906affcce14559ad1aafd4ab0e942779e9f58b1 # v4
               with:
                   version: ${{ steps.tools-versions.outputs.pnpm-version }}
 
@@ -96,7 +99,7 @@ jobs:
                   echo "STORE_PATH=$(pnpm store path --silent)" >> $GITHUB_ENV
 
             - name: Setup pnpm cache
-              uses: actions/cache@v4
+              uses: actions/cache@0057852bfaa89a56745cba8c7296529d2fc39830 # v4
               with:
                   path: ${{ env.STORE_PATH }}
                   key: ${{ runner.os }}-pnpm-store-${{ hashFiles('**/pnpm-lock.yaml') }}
@@ -119,7 +122,7 @@ jobs:
         timeout-minutes: 20
         steps:
             - name: Checkout
-              uses: actions/checkout@v4
+              uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
 
             - name: Calc tools versions
               id: tools-versions
@@ -130,12 +133,12 @@ jobs:
                   echo "pnpm-version=$PNPM_VERSION" >> $GITHUB_OUTPUT
 
             - name: Setup Node.js
-              uses: actions/setup-node@v4
+              uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4
               with:
                   node-version: ${{ steps.tools-versions.outputs.node-version }}
 
             - name: Install pnpm
-              uses: pnpm/action-setup@v4
+              uses: pnpm/action-setup@b906affcce14559ad1aafd4ab0e942779e9f58b1 # v4
               with:
                   version: ${{ steps.tools-versions.outputs.pnpm-version }}
 
@@ -145,7 +148,7 @@ jobs:
                   echo "STORE_PATH=$(pnpm store path --silent)" >> $GITHUB_ENV
 
             - name: Setup pnpm cache
-              uses: actions/cache@v4
+              uses: actions/cache@0057852bfaa89a56745cba8c7296529d2fc39830 # v4
               with:
                   path: ${{ env.STORE_PATH }}
                   key: ${{ runner.os }}-pnpm-store-${{ hashFiles('**/pnpm-lock.yaml') }}
@@ -163,7 +166,7 @@ jobs:
 
             - name: Upload test results
               if: failure()
-              uses: actions/upload-artifact@v4
+              uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4
               with:
                   name: playwright-results
                   path: out/test-results/
@@ -171,7 +174,7 @@ jobs:
 
             - name: Upload Playwright report
               if: failure()
-              uses: actions/upload-artifact@v4
+              uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4
               with:
                   name: playwright-report
                   path: playwright-report/


### PR DESCRIPTION
## Summary

This PR hardens the **Marketplace release pipelines** and the **CI pipeline** of `gitkraken/vscode-gitlens` against supply-chain attacks by pinning all GitHub Actions to immutable commit SHAs and enforcing least-privilege permissions.

GitLens publishes to the **VS Code Marketplace** (millions of installs) and **OpenVSIX** — making the release pipelines exceptionally high-value targets. A compromised mutable action tag could silently inject malicious code into the published `.vsix` artifact, affecting all downstream users.

## Changes

### `.github/workflows/cd-stable.yml`
- Pinned `actions/checkout@v4` → `@34e114876b0b11c390a56381ad16ebd13914f8d5`
- Pinned `actions/setup-node@v4` → `@49933ea5288caeca8642d1e84afbd3f7d6820020`
- Pinned `pnpm/action-setup@v3` → `@a3252b78c470c02df07e9d59298aecedc3ccdd6d`
- Pinned `mindsers/changelog-reader-action@v2` → `@32aa5b4c155d76c94e4ec883a223c947b2f02656`
- Pinned `softprops/action-gh-release@v2` → `@153bb8e04406b158c6c84fc1615b65b24149a1fe`

### `.github/workflows/cd-pre.yml`
- Pinned `actions/checkout@v4` → `@34e114876b0b11c390a56381ad16ebd13914f8d5`
- Pinned `actions/setup-node@v4` → `@49933ea5288caeca8642d1e84afbd3f7d6820020`
- Pinned `pnpm/action-setup@v3` → `@a3252b78c470c02df07e9d59298aecedc3ccdd6d`
- Pinned `actions/upload-artifact@v4` → `@ea165f8d65b6e75b540449e92b4886f43607fa02`
- **Added `permissions: { contents: read }` to the `publish` job** to enforce least-privilege (the `check` job already had proper permissions)

### `.github/workflows/ci.yml`
- **Added top-level `permissions: { contents: read }`** to restrict default GITHUB_TOKEN scope across all three jobs (`build`, `unit-tests`, `e2e-tests`)
- Pinned `actions/checkout@v4` → `@34e114876b0b11c390a56381ad16ebd13914f8d5`
- Pinned `actions/setup-node@v4` → `@49933ea5288caeca8642d1e84afbd3f7d6820020`
- Pinned `pnpm/action-setup@v4` → `@b906affcce14559ad1aafd4ab0e942779e9f58b1`
- Pinned `actions/cache@v4` → `@0057852bfaa89a56745cba8c7296529d2fc39830`
- Pinned `actions/upload-artifact@v4` → `@ea165f8d65b6e75b540449e92b4886f43607fa02`

## Security Rationale

Mutable version tags (e.g., `@v4`) allow action authors — or an attacker who gains write access — to silently substitute the code that runs during CI/CD. Pinning to immutable commit SHAs eliminates this attack vector entirely. Adding explicit `permissions` blocks enforces least privilege, limiting what the `GITHUB_TOKEN` can access.

This is especially critical for the `cd-stable.yml` and `cd-pre.yml` pipelines which handle **Marketplace PATs** and produce the `.vsix` artifacts that ship to millions of developers.

All `# v...` comments are preserved next to pinned SHAs for maintainability.

Consistent with [OSSF Scorecard](https://securityscorecards.dev/), [StepSecurity Harden-Runner](https://github.com/step-security/harden-runner), and the [GitHub Actions Security Hardening Guide](https://docs.github.com/en/actions/security-guides/security-hardening-for-github-actions).