### PR TITLE
Adds git notes support via ${notes} format token - closes #2432

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/) and this p
 
 ### Added
 
+- Adds support for displaying git notes in blame annotations, hovers, and status bar via the `${notes}` format token ([#2432](https://github.com/gitkraken/vscode-gitlens/issues/2432)) thanks to [PR #5085](5085) by Matt M ([@Mattwmaster58](https://github.com/Mattwmaster58))
 - Adds a conflict files panel to the _Interactive Rebase_ editor &mdash; shows conflicting files with per-file conflict counts, conflict status indicators, and actions to view current or incoming changes ([#5040](https://github.com/gitkraken/vscode-gitlens/issues/5040))
 - Adds branch activity dates to the _Home_ view recents &mdash; sorts by most recent activity and displays the most relevant activity label ([#5034](https://github.com/gitkraken/vscode-gitlens/issues/5034))
 

--- a/README.md
+++ b/README.md
@@ -448,6 +448,7 @@ A big thanks to the people that have contributed to this project 🙏❤️:
 - JounQin ([@JounQin](https://github.com/JounQin)) &mdash; [contributions](https://github.com/gitkraken/vscode-gitlens/commits?author=JounQin)
 - Noritaka Kobayashi ([@noritaka1166](https://github.com/noritaka1166)) &mdash; [contributions](https://github.com/gitkraken/vscode-gitlens/commits?author=noritaka1166)
 - Daniel Asher ([@danielasher115](https://github.com/danielasher115)) &mdash; [contributions](https://github.com/gitkraken/vscode-gitlens/commits?author=danielasher115)
+- Matt M ([@Mattwmaster58](https://github.com/Mattwmaster58)) &mdash; [contributions](https://github.com/gitkraken/vscode-gitlens/commits?author=Mattwmaster58)
 
 Also special thanks to the people that have provided support, testing, brainstorming, etc:
 

--- a/src/annotations/lineAnnotationController.ts
+++ b/src/annotations/lineAnnotationController.ts
@@ -287,6 +287,19 @@ export class LineAnnotationController implements Disposable {
 				? this.container.git.getRepositoryService(repoPath).getBranchesAndTagsTipsLookup()
 				: undefined;
 
+		const getNotesForLines = !uncommittedOnly && repoPath != null && CommitFormatter.has(cfg.format, 'notes');
+		if (getNotesForLines) {
+			const seen = new Set<string>();
+			await Promise.allSettled(
+				Array.from(lines.values(), state => {
+					if (state.commit.isUncommitted || seen.has(state.commit.ref)) return Promise.resolve();
+					seen.add(state.commit.ref);
+					return state.commit.ensureNotes(cancellation);
+				}),
+			);
+		}
+		if (cancellation.isCancellationRequested) return;
+
 		async function updateDecorations(
 			container: Container,
 			editor: TextEditor,

--- a/src/env/node/git/sub-providers/commits.ts
+++ b/src/env/node/git/sub-providers/commits.ts
@@ -115,6 +115,20 @@ export class CommitsGitSubProvider implements GitCommitsSubProvider {
 	}
 
 	@debug({ exit: true })
+	async getCommitNotes(repoPath: string, rev: string, cancellation?: CancellationToken): Promise<string | undefined> {
+		const result = await this.git.exec(
+			{ cwd: repoPath, cancellation: cancellation, errors: 'ignore' },
+			'notes',
+			'show',
+			rev,
+		);
+		if (result.cancelled || cancellation?.isCancellationRequested) throw new CancellationError();
+
+		const data = result.stdout.trim();
+		return data || undefined;
+	}
+
+	@debug({ exit: true })
 	async getCommitCount(repoPath: string, rev: string, cancellation?: CancellationToken): Promise<number | undefined> {
 		const result = await this.git.exec(
 			{ cwd: repoPath, cancellation: cancellation, errors: 'ignore' },
@@ -1394,6 +1408,7 @@ function createCommit(
 ) {
 	const message = c.message.trim();
 	const index = message.indexOf('\n');
+	const notes = c.notes?.trim() || null;
 
 	return new GitCommit(
 		container,
@@ -1416,6 +1431,10 @@ function createCommit(
 		c.stats,
 		undefined,
 		c.tips?.split(' '),
+		undefined,
+		undefined,
+		undefined,
+		notes,
 	);
 }
 

--- a/src/git/formatters/commitFormatter.ts
+++ b/src/git/formatters/commitFormatter.ts
@@ -119,6 +119,7 @@ export interface CommitFormatOptions extends FormatOptions {
 		id?: TokenOptions;
 		link?: TokenOptions;
 		message?: TokenOptions;
+		notes?: TokenOptions;
 		pullRequest?: TokenOptions;
 		pullRequestAgo?: TokenOptions;
 		pullRequestAgoOrDate?: TokenOptions;
@@ -713,6 +714,10 @@ export class CommitFormatter extends Formatter<GitCommit, CommitFormatOptions> {
 			),
 			this._options.tokenOptions.footnotes,
 		);
+	}
+
+	get notes(): string {
+		return this._padOrTruncate(this._item.notes ?? '', this._options.tokenOptions.notes);
 	}
 
 	get id(): string {

--- a/src/git/gitProvider.ts
+++ b/src/git/gitProvider.ts
@@ -339,6 +339,7 @@ export interface GitCommitsSubProvider {
 		options?: { firstIfNotFound?: boolean | undefined },
 		cancellation?: CancellationToken,
 	): Promise<GitCommit | undefined>;
+	getCommitNotes?(repoPath: string, rev: string, cancellation?: CancellationToken): Promise<string | undefined>;
 	getIncomingActivity?(
 		repoPath: string,
 		options?: IncomingActivityOptions,

--- a/src/git/models/commit.ts
+++ b/src/git/models/commit.ts
@@ -1,4 +1,5 @@
 /* eslint-disable @typescript-eslint/no-restricted-imports -- TODO need to deal with sharing rich class shapes to webviews */
+import type { CancellationToken } from 'vscode';
 import { Uri } from 'vscode';
 import type { EnrichedAutolink } from '../../autolinks/models/autolinks.js';
 import { getAvatarUri, getCachedAvatarUri } from '../../avatars.js';
@@ -88,11 +89,13 @@ export class GitCommit implements GitRevisionReference {
 		stashName?: string | undefined,
 		stashOnRef?: string | undefined,
 		parentTimestamps?: GitStashParentInfo[] | undefined,
+		notes?: string | null | undefined,
 	) {
 		this.ref = sha;
 		this.shortSha = sha.substring(0, this.container.CommitShaFormatting.length);
 		this.tips = tips;
 		this.parentTimestamps = parentTimestamps;
+		this._notes = notes;
 
 		if (stashName) {
 			this.refType = 'stash';
@@ -130,6 +133,11 @@ export class GitCommit implements GitRevisionReference {
 		}
 
 		this.lines = ensureArray(lines) ?? [];
+	}
+
+	private _notes: string | undefined | null;
+	get notes(): string | undefined {
+		return this._notes ?? undefined;
 	}
 
 	get date(): Date {
@@ -588,6 +596,14 @@ export class GitCommit implements GitRevisionReference {
 		return this.author.getCachedAvatarUri(options);
 	}
 
+	@gate()
+	async ensureNotes(cancellation?: CancellationToken): Promise<void> {
+		if (this.isUncommitted || this._notes !== undefined) return;
+
+		const svc = this.container.git.getRepositoryService(this.repoPath);
+		this._notes = (await svc.commits.getCommitNotes?.(this.sha, cancellation)) ?? null;
+	}
+
 	async getSignature(): Promise<CommitSignature | undefined> {
 		if (this.isUncommitted) return undefined;
 		if (this._signature === null) return undefined;
@@ -745,6 +761,7 @@ export class GitCommit implements GitRevisionReference {
 			this.stashName,
 			this.stashOnRef,
 			this.getChangedValue(changes.parentTimestamps, this.parentTimestamps),
+			this._notes,
 		) as T;
 	}
 
@@ -771,6 +788,7 @@ export class GitCommit implements GitRevisionReference {
 					this.stashName,
 					this.stashOnRef,
 					this.parentTimestamps,
+					this._notes,
 				) as T);
 	}
 

--- a/src/git/parsers/__tests__/logParser.test.ts
+++ b/src/git/parsers/__tests__/logParser.test.ts
@@ -23,7 +23,7 @@ suite('Log Parser - File Parsing Test Suite', () => {
 	}
 
 	// Helper to create a mock commit record with files
-	// Format from commitsMapping: sha, author, authorEmail, authorDate, committer, committerEmail, committerDate, parents, tips, message
+	// Format from commitsMapping: sha, author, authorEmail, authorDate, committer, committerEmail, committerDate, parents, tips, notes, message
 	// The file content comes as a separate field AFTER the message field
 	function createCommitRecord(
 		sha: string,
@@ -35,8 +35,8 @@ suite('Log Parser - File Parsing Test Suite', () => {
 		// File content: --raw lines first, then --numstat lines, separated by newlines
 		const fileContent = [...rawLines, ...numstatLines].join('\n');
 
-		// Format: recordSep + 10 mapped fields + 1 file content field, all separated by fieldSep
-		// When fieldCount === keys.length (10), the parser reads the file content field
+		// Format: recordSep + 11 mapped fields + 1 file content field, all separated by fieldSep
+		// When fieldCount === keys.length (11), the parser reads the file content field
 		const fields = [
 			sha, // sha (field 0)
 			'Test Author', // author (field 1)
@@ -47,8 +47,9 @@ suite('Log Parser - File Parsing Test Suite', () => {
 			'1234567890', // committerDate (field 6)
 			'', // parents (field 7)
 			'', // tips (field 8)
-			'Test commit message', // message (field 9)
-			fileContent, // file content (field 10, parsed when fieldCount === 10)
+			'', // notes (field 9)
+			'Test commit message', // message (field 10)
+			fileContent, // file content (field 11, parsed when fieldCount === 11)
 		];
 		return recordSep + fields.join(fieldSep);
 	}

--- a/src/git/parsers/logParser.ts
+++ b/src/git/parsers/logParser.ts
@@ -14,6 +14,7 @@ const commitsMapping = {
 	committerDate: '%ct',
 	parents: '%P',
 	tips: '%D',
+	notes: '%N',
 	message: '%B',
 };
 

--- a/src/hovers/hovers.ts
+++ b/src/hovers/hovers.ts
@@ -245,6 +245,9 @@ export async function detailsMessage(
 		!commit.isUncommitted &&
 		CommitFormatter.has(options.format, 'signature');
 
+	const showNotes =
+		!commit.isUncommitted && commit.notes === undefined && CommitFormatter.has(options.format, 'notes');
+
 	const [
 		enrichedAutolinksResult,
 		prResult,
@@ -252,6 +255,7 @@ export async function detailsMessage(
 		previousLineComparisonUrisResult,
 		_fullDetailsResult,
 		signedResult,
+		_notesResult,
 	] = await Promise.allSettled([
 		enhancedAutolinks
 			? pauseOnCancelOrTimeoutMapTuplePromise(
@@ -279,6 +283,7 @@ export async function detailsMessage(
 			: undefined,
 		commit.message == null ? commit.ensureFullDetails() : undefined,
 		showSignature ? commit.isSigned() : undefined,
+		showNotes ? commit.ensureNotes(options?.cancellation) : undefined,
 	]);
 
 	if (options?.cancellation?.isCancellationRequested) return undefined;

--- a/src/webviews/apps/settings/settings.html
+++ b/src/webviews/apps/settings/settings.html
@@ -510,6 +510,10 @@
 						</td>
 						<td><span class="token" data-token="pullRequestState">pullRequestState</span></td>
 					</tr>
+					<tr>
+						<td>Git Notes<br /><i>Notes attached to the commit via git notes</i></td>
+						<td><span class="token" data-token="notes">notes</span></td>
+					</tr>
 					<!-- <tr>
 						<td>Author Avatar</td>
 						<td><span class="token" data-token="avatar">avatar</span></td>

--- a/src/webviews/settings/settingsWebview.ts
+++ b/src/webviews/settings/settingsWebview.ts
@@ -235,6 +235,11 @@ export class SettingsWebviewProvider implements WebviewProvider<State, State, Se
 					},
 					undefined,
 					[],
+					undefined,
+					undefined,
+					undefined,
+					undefined,
+					params.type === 'commit-uncommitted' ? undefined : 'Some note content',
 				);
 
 				let includePullRequest = false;


### PR DESCRIPTION
# Description

Add basic support for ${notes} token in every commit token context I could think of. There was a bit of complexity because depending on where we get the commit info from, the note info can come for free (log), or requires a git invocation (blame). See: #2432 

This is my first time in the codebase, a lot of this was done with AI - though I did review all the changed lines and tested everything manually myself.

## Demo

<img width="993" height="414" alt="image" src="https://github.com/user-attachments/assets/5ff391e3-b633-44aa-9711-d6f1e07133f0" />

<img width="1713" height="442" alt="image" src="https://github.com/user-attachments/assets/3a93bf8f-444d-4393-8f1e-a2e3da6c6eab" />



# Checklist

<!-- Please check off the following -->

- [x] I have followed the guidelines in the Contributing document
- [x] My changes follow the coding style of this project
- [x] My changes build without any errors or warnings
- [x] My changes have been formatted and linted
- [x] My changes include any required corresponding changes to the documentation (including CHANGELOG.md and README.md)
- [x] My changes have been rebased and squashed to the minimal number (typically 1) of relevant commits
- [x] My changes have a descriptive commit message with a short title, including a `Fixes $XXX -` or `Closes #XXX -` prefix to auto-close the issue that your PR addresses
