### PR TITLE
Disables no-return-await ESLint rule

### DIFF
--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -218,7 +218,7 @@ export default defineConfig(
 			'no-restricted-globals': ['error', 'process'],
 			'no-restricted-imports': 'off',
 			'no-return-assign': 'error',
-			'no-return-await': 'warn',
+			'no-return-await': 'off', // Disabled in favor of @typescript-eslint/return-await
 			'no-self-compare': 'error',
 			'no-sequences': 'error',
 			'no-template-curly-in-string': 'warn',
@@ -409,6 +409,7 @@ export default defineConfig(
 			'@typescript-eslint/prefer-optional-chain': 'warn',
 			'@typescript-eslint/prefer-promise-reject-errors': ['error', { allowEmptyReject: true }],
 			'@typescript-eslint/prefer-reduce-type-parameter': 'warn',
+			'@typescript-eslint/return-await': ['error', 'error-handling-correctness-only'], // Included in strictTypeChecked, but pinned explicitly to prevent silent loss if the preset changes
 			'@typescript-eslint/restrict-template-expressions': [
 				'error',
 				{ allowAny: true, allowBoolean: true, allowNumber: true, allowNullish: true },

--- a/packages/git-cli/src/providers/patch.ts
+++ b/packages/git-cli/src/providers/patch.ts
@@ -150,7 +150,7 @@ export class PatchGitSubProvider implements GitPatchSubProvider {
 			undefined,
 			options,
 		);
-		// eslint-disable-next-line no-return-await -- await is needed for the disposableIndex to be disposed properly after
+		// await is needed for the disposableIndex to be disposed properly after
 		return await this.provider.commits.getCommit(repoPath, sha);
 	}
 

--- a/packages/utils/src/decorators/sequentialize.ts
+++ b/packages/utils/src/decorators/sequentialize.ts
@@ -69,7 +69,7 @@ export function sequentialize<T extends (...args: any[]) => any>(
 			}
 
 			const state: SequentializeState | undefined = this[prop];
-			// eslint-disable-next-line no-return-await, @typescript-eslint/no-unsafe-return
+			// eslint-disable-next-line @typescript-eslint/no-unsafe-return
 			const run = async () => await fn.apply(this, args);
 
 			// Compute the dedupe key once

--- a/packages/utils/src/function.ts
+++ b/packages/utils/src/function.ts
@@ -93,7 +93,7 @@ export function sequentialize<T extends (...args: any[]) => Promise<any>>(fn: T)
 	let promise: Promise<unknown> | undefined;
 
 	return function (...args: any[]): Promise<any> {
-		// eslint-disable-next-line no-return-await, @typescript-eslint/no-unsafe-return
+		// eslint-disable-next-line @typescript-eslint/no-unsafe-return
 		const run = async () => await fn(...args);
 		if (promise == null) {
 			promise = run();

--- a/src/env/node/gk/cli/utils.ts
+++ b/src/env/node/gk/cli/utils.ts
@@ -118,7 +118,7 @@ export async function runCLICommand(args: string[], options?: { cwd?: string }):
 		throw new Error('CLI is not installed');
 	}
 
-	// eslint-disable-next-line no-return-await -- await is needed for the scope to be properly disposed
+	// await is needed for the scope to be properly disposed
 	return await run(command, args, 'utf8', { cwd: cwd });
 }
 


### PR DESCRIPTION
## Summary
Solves contradictory rules `no-return-await` and `@typescript-eslint/return-await`:
<img width="600" alt="image" src="https://github.com/user-attachments/assets/f146c24f-31ca-47f5-888d-c3bf906bcf91" />

<img width="600" alt="image" src="https://github.com/user-attachments/assets/0977114b-1097-4490-8d33-c0b090ac8518" />

- Disables the `no-return-await` ESLint rule in the configuration
- Removes an unnecessary comment in the `runCLICommand` function

## Test plan
- [ ] Verify ESLint runs cleanly with the updated config
- [ ] Verify no regressions in CLI command execution
