### PR TITLE
Fix E2E smoke test hanging when GitHub VPN is active

### DIFF
--- a/tests/e2e/specs/smoke.test.ts
+++ b/tests/e2e/specs/smoke.test.ts
@@ -41,8 +41,9 @@ const test = base.extend({
 				await git.stage('stash-test.txt');
 				await git.stash('Test stash');
 
-				// Add a remote (fake URL, just for UI testing)
-				await git.addRemote('origin', 'https://github.com/test/test-repo.git');
+				// Add a remote (fake URL with non-GitHub host — avoids GitLens trying to connect to GitHub
+				// integration, which can cause multi-second network timeouts if VPN is active)
+				await git.addRemote('origin', 'https://example.com/test/test-repo.git');
 
 				return repoDir;
 			},


### PR DESCRIPTION
## Problem

When running E2E smoke tests with an active VPN, the test would hang for several seconds. The root cause was that the fake remote URL used `github.com` as the host, causing GitLens to attempt to connect to the GitHub integration in the background — resulting in network timeouts.

## Fix

Changed the fake remote URL in the smoke test fixture from `https://github.com/test/test-repo.git` to `https://example.com/test/test-repo.git`. Using a non-GitHub host prevents GitLens from triggering any GitHub integration connection attempts during testing.

## Changes

- `tests/e2e/specs/smoke.test.ts` — replaced fake remote URL host with `example.com`