### PR TITLE
Fixes strict locator violation in blame E2E tests

### DIFF
--- a/tests/e2e/specs/blame.test.ts
+++ b/tests/e2e/specs/blame.test.ts
@@ -70,7 +70,7 @@ test.describe('Blame Annotations', () => {
 
 	test.beforeEach(async ({ vscode }) => {
 		await vscode.gitlens.openFile('blame-test.ts');
-		await expect(vscode.page.locator('.monaco-editor .view-lines')).toBeVisible({ timeout: MaxTimeout });
+		await expect(vscode.page.locator('.monaco-editor .view-lines').first()).toBeVisible({ timeout: MaxTimeout });
 		// Click on editor to ensure it has focus (ActiveEditorCommand requires a focused editor)
 		await vscode.page.locator('.monaco-editor .view-lines').first().click();
 		await vscode.page.waitForTimeout(1000);
@@ -184,7 +184,7 @@ largeFileTest.describe('Blame Annotations — Large File', () => {
 
 		// Open spec.html — a ~50K-70K line file
 		await vscode.gitlens.openFile('spec.html');
-		await expect(vscode.page.locator('.monaco-editor .view-lines')).toBeVisible({ timeout: MaxTimeout });
+		await expect(vscode.page.locator('.monaco-editor .view-lines').first()).toBeVisible({ timeout: MaxTimeout });
 
 		// Click on editor to ensure focus, then wait for file to load
 		await vscode.page.locator('.monaco-editor .view-lines').first().click();


### PR DESCRIPTION
## Summary

- Adds `.first()` to `.monaco-editor .view-lines` locator assertions in `blame.test.ts` to prevent Playwright strict mode failures
- The locator resolves to 2 elements when an interactive input editor (e.g. Copilot chat) is open alongside the main editor
- Lines 190 and the equivalent `click()` calls already used `.first()` — this aligns the `toBeVisible()` assertions to match

## Root cause

VS Code renders a second `.monaco-editor .view-lines` element for the interactive input editor panel. Playwright's strict mode requires locators to resolve to exactly one element — without `.first()` the assertion throws a `strict mode violation` error.

## Test plan

- [x] Ran full E2E suite locally: **110 passed, 1 skipped, 0 failed** (was: 109 passed, 1 failed)
- [x] Fix applies to both `test.beforeEach` (line 73) and the large-file test (line 187)

🤖 Generated with [Claude Code](https://claude.com/claude-code)