### PR TITLE
Adds MCP E2E test infrastructure

### DIFF
--- a/tests/e2e/fixtures/mcp.ts
+++ b/tests/e2e/fixtures/mcp.ts
@@ -1,0 +1,37 @@
+import { McpClient, findGkCliFromArgs, findLatestIpcFile, waitForCliInstall } from '../helpers/mcpHelper.js';
+import { test as base } from '../baseTest.js';
+
+export { expect } from '@playwright/test';
+export type { McpMessage, McpClient } from '../helpers/mcpHelper.js';
+
+interface McpFixtures {
+	/** Ready-to-use McpClient for the current VS Code worker instance. */
+	mcpClient: McpClient;
+}
+
+/**
+ * Extended Playwright test fixture that provides a McpClient.
+ *
+ * Derives the gk CLI path from `--user-data-dir` (the temp directory
+ * E2E tests use), waits for GitLens to auto-install the CLI on first run,
+ * then constructs a McpClient with the latest live IPC discovery file.
+ *
+ * Usage:
+ * ```ts
+ * import { mcpTest as test, expect } from '../fixtures/mcp.js';
+ *
+ * test('tools/list returns git_status', async ({ mcpClient }) => {
+ *   const tools = await mcpClient.listTools();
+ *   expect(tools).toContain('git_status');
+ * });
+ * ```
+ */
+export const mcpTest = base.extend<McpFixtures>({
+	mcpClient: async ({ vscode }, use) => {
+		const gkPath = findGkCliFromArgs(vscode.electron.args);
+		await waitForCliInstall(gkPath);
+		const ipcFilePath = findLatestIpcFile();
+		const client = new McpClient(gkPath, ipcFilePath);
+		await use(client);
+	},
+});

--- a/tests/e2e/fixtures/mcp.ts
+++ b/tests/e2e/fixtures/mcp.ts
@@ -1,5 +1,5 @@
-import { McpClient, findGkCliFromArgs, findLatestIpcFile, waitForCliInstall } from '../helpers/mcpHelper.js';
 import { test as base } from '../baseTest.js';
+import { findGkCliFromArgs, findLatestIpcFile, McpClient, waitForCliInstall } from '../helpers/mcpHelper.js';
 
 export { expect } from '@playwright/test';
 export type { McpMessage, McpClient } from '../helpers/mcpHelper.js';
@@ -31,6 +31,9 @@ export const mcpTest = base.extend<McpFixtures>({
 		const gkPath = findGkCliFromArgs(vscode.electron.args);
 		await waitForCliInstall(gkPath);
 		const ipcFilePath = findLatestIpcFile();
+		if (ipcFilePath == null) {
+			console.warn('[mcpTest] No live IPC file found — GK_GL_PATH will not be set');
+		}
 		const client = new McpClient(gkPath, ipcFilePath);
 		await use(client);
 	},

--- a/tests/e2e/fixtures/mcp.ts
+++ b/tests/e2e/fixtures/mcp.ts
@@ -2,7 +2,7 @@ import { test as base } from '../baseTest.js';
 import { findGkCliFromArgs, findLatestIpcFile, McpClient, waitForCliInstall } from '../helpers/mcpHelper.js';
 
 export { expect } from '@playwright/test';
-export type { McpMessage, McpClient } from '../helpers/mcpHelper.js';
+export type { McpConfigResult, McpMessage, McpClient } from '../helpers/mcpHelper.js';
 
 interface McpFixtures {
 	/** Ready-to-use McpClient for the current VS Code worker instance. */

--- a/tests/e2e/fixtures/mcp.ts
+++ b/tests/e2e/fixtures/mcp.ts
@@ -30,9 +30,10 @@ export const mcpTest = base.extend<McpFixtures>({
 	mcpClient: async ({ vscode }, use) => {
 		const gkPath = findGkCliFromArgs(vscode.electron.args);
 		await waitForCliInstall(gkPath);
-		const ipcFilePath = findLatestIpcFile();
+		const vscodePid = vscode.electron.app.process().pid;
+		const ipcFilePath = findLatestIpcFile(vscodePid);
 		if (ipcFilePath == null) {
-			console.warn('[mcpTest] No live IPC file found — GK_GL_PATH will not be set');
+			console.warn(`[mcpTest] No live IPC file found for pid=${vscodePid} — GK_GL_PATH will not be set`);
 		}
 		const client = new McpClient(gkPath, ipcFilePath);
 		await use(client);

--- a/tests/e2e/helpers/mcpHelper.ts
+++ b/tests/e2e/helpers/mcpHelper.ts
@@ -227,6 +227,7 @@ export class McpClient {
 			const timer = setTimeout(() => {
 				if (!resolved) {
 					resolved = true;
+					proc.stdin.end();
 					proc.kill();
 					reject(
 						new Error(
@@ -259,6 +260,7 @@ export class McpClient {
 				if (msg.id === targetId && !resolved) {
 					resolved = true;
 					clearTimeout(timer);
+					proc.stdin.end();
 					proc.kill();
 					resolve(msg);
 				}
@@ -284,9 +286,10 @@ export class McpClient {
 				}
 			});
 
+			// Keep stdin open after writing so elicitation/create responses can be sent.
+			// stdin is closed in the resolve/timeout/close paths above.
 			const payload = `${messages.map(m => JSON.stringify(m)).join('\n')}\n`;
 			proc.stdin.write(payload);
-			proc.stdin.end();
 		});
 	}
 }

--- a/tests/e2e/helpers/mcpHelper.ts
+++ b/tests/e2e/helpers/mcpHelper.ts
@@ -71,10 +71,17 @@ export function findLatestIpcFile(vscodePid?: number): string | undefined {
 	for (const { fullPath } of candidates) {
 		try {
 			const data = JSON.parse(readFileSync(fullPath, 'utf8')) as { pid: number };
-			process.kill(data.pid, 0); // throws if process is dead
-			return fullPath;
+			try {
+				process.kill(data.pid, 0);
+				return fullPath;
+			} catch (killErr) {
+				const code = (killErr as { code?: string }).code;
+				// EPERM means the process exists but we can't signal it — still valid
+				if (code === 'EPERM') return fullPath;
+				// ESRCH means the process is gone — skip
+			}
 		} catch {
-			// dead process or unreadable file — skip
+			// unreadable or invalid file — skip
 		}
 	}
 	return undefined;
@@ -137,7 +144,10 @@ export class McpClient {
 	 * Calls `gk mcp config <host>` and returns the parsed McpConfiguration.
 	 * Useful for smoke-testing the config output format.
 	 */
-	async getMcpConfig(options?: { experimental?: boolean; insiders?: boolean }): Promise<McpConfigResult> {
+	async getMcpConfig(
+		options?: { experimental?: boolean; insiders?: boolean },
+		timeoutMs = 30_000,
+	): Promise<McpConfigResult> {
 		const args = ['mcp', 'config', this.host, '--source=gitlens', `--scheme=${this.host}`];
 		if (options?.experimental) {
 			args.push('--experimental');
@@ -152,11 +162,26 @@ export class McpClient {
 				stdio: ['pipe', 'pipe', 'pipe'],
 			});
 
+			let settled = false;
 			let stdout = '';
 			let stderr = '';
 			proc.stdout.on('data', (chunk: Buffer) => (stdout += chunk.toString()));
 			proc.stderr.on('data', (chunk: Buffer) => (stderr += chunk.toString()));
+
+			const timer = setTimeout(() => {
+				if (!settled) {
+					settled = true;
+					proc.kill();
+					reject(
+						new Error(`gk mcp config timed out after ${timeoutMs}ms${stderr ? `\nstderr: ${stderr}` : ''}`),
+					);
+				}
+			}, timeoutMs);
+
 			proc.on('close', (code: number | null) => {
+				if (settled) return;
+				settled = true;
+				clearTimeout(timer);
 				// Strip "checking for updates..." noise before parsing
 				const clean = stdout.replace(/checking for updates\.\.\./gi, '').trim();
 				if (code != null && code !== 0) {
@@ -177,7 +202,13 @@ export class McpClient {
 					);
 				}
 			});
-			proc.on('error', reject);
+			proc.on('error', (err: Error) => {
+				if (!settled) {
+					settled = true;
+					clearTimeout(timer);
+					reject(err);
+				}
+			});
 		});
 	}
 
@@ -222,7 +253,13 @@ export class McpClient {
 
 			let resolved = false;
 			let stderr = '';
+			let exitCode: number | null = null;
+			let exitSignal: string | null = null;
 			proc.stderr.on('data', (chunk: Buffer) => (stderr += chunk.toString()));
+			proc.on('close', (code, signal) => {
+				exitCode = code;
+				exitSignal = signal;
+			});
 
 			const timer = setTimeout(() => {
 				if (!resolved) {
@@ -270,9 +307,11 @@ export class McpClient {
 				if (!resolved) {
 					resolved = true;
 					clearTimeout(timer);
+					const exitInfo =
+						exitCode != null ? `code=${exitCode}` : exitSignal != null ? `signal=${exitSignal}` : 'unknown';
 					reject(
 						new Error(
-							`McpClient: process exited before response id=${targetId} was received${stderr ? `\nstderr: ${stderr}` : ''}`,
+							`McpClient: process exited (${exitInfo}) before response id=${targetId} was received${stderr ? `\nstderr: ${stderr}` : ''}`,
 						),
 					);
 				}

--- a/tests/e2e/helpers/mcpHelper.ts
+++ b/tests/e2e/helpers/mcpHelper.ts
@@ -1,0 +1,246 @@
+import { existsSync, readdirSync, readFileSync, statSync } from 'node:fs';
+import os from 'node:os';
+import path from 'node:path';
+import { spawn } from 'node:child_process';
+import * as readline from 'node:readline';
+
+export type McpMessage = {
+	jsonrpc: '2.0';
+	id?: number | null;
+	method?: string;
+	params?: unknown;
+	result?: unknown;
+	error?: { code: number; message: string };
+};
+
+type McpConfigResult = {
+	name: string;
+	type: string;
+	command: string;
+	args: string[];
+	version?: string;
+};
+
+/**
+ * Derives the path to the gk CLI executable from VS Code launch arguments.
+ * In E2E tests, gk is installed into the temp user-data-dir, not the real AppData.
+ */
+export function findGkCliFromArgs(electronArgs: string[]): string {
+	const userDataDirArg = electronArgs.find(a => a.startsWith('--user-data-dir='));
+	if (userDataDirArg == null) throw new Error('--user-data-dir not found in electron args');
+
+	const userDataDir = userDataDirArg.replace('--user-data-dir=', '');
+	const bin = process.platform === 'win32' ? 'gk.exe' : 'gk';
+	return path.join(userDataDir, 'User', 'globalStorage', 'eamodio.gitlens', bin);
+}
+
+/**
+ * Finds the most recent live IPC discovery file.
+ * GitLens writes one file per session to %TEMP%/gitkraken/gitlens/.
+ * Validates the process is still alive via process.kill(pid, 0).
+ */
+export function findLatestIpcFile(): string | undefined {
+	const tmpDir = path.join(os.tmpdir(), 'gitkraken', 'gitlens');
+	if (!existsSync(tmpDir)) return undefined;
+
+	const candidates = readdirSync(tmpDir)
+		.filter(f => f.startsWith('gitlens-ipc-server-') && f.endsWith('.json'))
+		.map(f => {
+			const fullPath = path.join(tmpDir, f);
+			try {
+				return { fullPath, mtime: statSync(fullPath).mtime };
+			} catch {
+				return null;
+			}
+		})
+		.filter((x): x is { fullPath: string; mtime: Date } => x != null)
+		.sort((a, b) => b.mtime.getTime() - a.mtime.getTime());
+
+	for (const { fullPath } of candidates) {
+		try {
+			const data = JSON.parse(readFileSync(fullPath, 'utf8')) as { pid: number };
+			process.kill(data.pid, 0); // throws if process is dead
+			return fullPath;
+		} catch {
+			// dead process or unreadable file — skip
+		}
+	}
+	return undefined;
+}
+
+/**
+ * Waits for the gk CLI proxy binary to appear on disk.
+ * GitLens auto-installs it on first activation (~5–6 s).
+ */
+export async function waitForCliInstall(gkPath: string, timeoutMs = 30_000): Promise<void> {
+	const deadline = Date.now() + timeoutMs;
+	while (Date.now() < deadline) {
+		if (existsSync(gkPath)) return;
+		await new Promise(r => setTimeout(r, 500));
+	}
+	throw new Error(`GK CLI not found at "${gkPath}" after ${timeoutMs}ms`);
+}
+
+/**
+ * Minimal stdio MCP client for E2E testing.
+ * Spawns gk.exe as a fresh process for each call.
+ */
+export class McpClient {
+	constructor(
+		readonly gkPath: string,
+		readonly ipcFilePath: string | undefined,
+		private readonly host: 'vscode' | 'cursor' = 'vscode',
+	) {}
+
+	/** Returns names of all tools exposed by the MCP server. */
+	async listTools(): Promise<string[]> {
+		const msg = await this.sendRequests(
+			[
+				this.initMsg(),
+				this.notificationMsg(),
+				{ jsonrpc: '2.0' as const, id: 2, method: 'tools/list', params: {} },
+			],
+			2,
+		);
+		return ((msg?.result as any)?.tools ?? []).map((t: { name: string }) => t.name) as string[];
+	}
+
+	/** Calls a single MCP tool and returns the tool-response message. */
+	async callTool(toolName: string, args: Record<string, unknown>): Promise<McpMessage> {
+		const msg = await this.sendRequests(
+			[
+				this.initMsg(),
+				this.notificationMsg(),
+				{ jsonrpc: '2.0' as const, id: 3, method: 'tools/call', params: { name: toolName, arguments: args } },
+			],
+			3,
+		);
+		return msg ?? { jsonrpc: '2.0', id: 3, error: { code: -1, message: 'No response received' } };
+	}
+
+	/**
+	 * Calls `gk mcp config <host>` and returns the parsed McpConfiguration.
+	 * Useful for smoke-testing the config output format.
+	 */
+	async getMcpConfig(options?: { experimental?: boolean; insiders?: boolean }): Promise<McpConfigResult> {
+		const args = ['mcp', 'config', this.host, '--source=gitlens', `--scheme=${this.host}`];
+		if (options?.experimental) args.push('--experimental');
+		if (options?.insiders) args.push('--insiders');
+
+		return new Promise((resolve, reject) => {
+			const proc = spawn(this.gkPath, args, {
+				env: this.buildEnv(),
+				stdio: ['pipe', 'pipe', 'pipe'],
+			});
+
+			let stdout = '';
+			proc.stdout.on('data', (chunk: Buffer) => (stdout += chunk.toString()));
+			proc.on('close', () => {
+				// Strip "checking for updates..." noise before parsing
+				const clean = stdout.replace(/checking for updates\.\.\./gi, '').trim();
+				try {
+					resolve(JSON.parse(clean) as McpConfigResult);
+				} catch {
+					reject(new Error(`gk mcp config returned non-JSON: ${clean.slice(0, 200)}`));
+				}
+			});
+			proc.on('error', reject);
+		});
+	}
+
+	// ── Private helpers ──────────────────────────────────────────────────────
+
+	private buildEnv(): NodeJS.ProcessEnv {
+		const env: NodeJS.ProcessEnv = { ...process.env };
+		if (this.ipcFilePath != null) env['GK_GL_PATH'] = this.ipcFilePath;
+		return env;
+	}
+
+	private initMsg() {
+		return {
+			jsonrpc: '2.0' as const,
+			id: 1,
+			method: 'initialize',
+			params: {
+				protocolVersion: '2024-11-05',
+				capabilities: {},
+				clientInfo: { name: 'gitlens-e2e-test', version: '1.0' },
+			},
+		};
+	}
+
+	private notificationMsg() {
+		return { jsonrpc: '2.0' as const, method: 'notifications/initialized', params: {} };
+	}
+
+	/**
+	 * Spawns gk mcp, sends all messages, waits for the response with `targetId`,
+	 * and handles elicitation/create by auto-cancelling (safe default for tests).
+	 */
+	private sendRequests(messages: object[], targetId: number, timeoutMs = 30_000): Promise<McpMessage | undefined> {
+		return new Promise((resolve, reject) => {
+			const proc = spawn(
+				this.gkPath,
+				['mcp', `--host=${this.host}`, '--source=gitlens', `--scheme=${this.host}`],
+				{ env: this.buildEnv(), stdio: ['pipe', 'pipe', 'pipe'] },
+			);
+
+			let resolved = false;
+			const timer = setTimeout(() => {
+				if (!resolved) {
+					resolved = true;
+					proc.kill();
+					reject(new Error(`McpClient: timeout after ${timeoutMs}ms waiting for id=${targetId}`));
+				}
+			}, timeoutMs);
+
+			const rl = readline.createInterface({ input: proc.stdout, crlfDelay: Infinity });
+
+			rl.on('line', (line: string) => {
+				const trimmed = line.trim();
+				if (!trimmed) return;
+				let msg: McpMessage;
+				try {
+					msg = JSON.parse(trimmed) as McpMessage;
+				} catch {
+					return; // non-JSON line (e.g. CLI update check)
+				}
+
+				// Auto-cancel any elicitation requests so tests don't hang
+				if (msg.method === 'elicitation/create') {
+					proc.stdin.write(
+						JSON.stringify({ jsonrpc: '2.0', id: (msg as any).id, result: { action: 'cancel' } }) + '\n',
+					);
+					return;
+				}
+
+				if (msg.id === targetId && !resolved) {
+					resolved = true;
+					clearTimeout(timer);
+					proc.kill();
+					resolve(msg);
+				}
+			});
+
+			rl.on('close', () => {
+				if (!resolved) {
+					resolved = true;
+					clearTimeout(timer);
+					resolve(undefined);
+				}
+			});
+
+			proc.on('error', (err: Error) => {
+				if (!resolved) {
+					resolved = true;
+					clearTimeout(timer);
+					reject(err);
+				}
+			});
+
+			const payload = messages.map(m => JSON.stringify(m)).join('\n') + '\n';
+			proc.stdin.write(payload);
+			proc.stdin.end();
+		});
+	}
+}

--- a/tests/e2e/helpers/mcpHelper.ts
+++ b/tests/e2e/helpers/mcpHelper.ts
@@ -1,7 +1,8 @@
+import { spawn } from 'node:child_process';
 import { existsSync, readdirSync, readFileSync, statSync } from 'node:fs';
 import os from 'node:os';
 import path from 'node:path';
-import { spawn } from 'node:child_process';
+import process from 'node:process';
 import * as readline from 'node:readline';
 
 export type McpMessage = {
@@ -13,7 +14,7 @@ export type McpMessage = {
 	error?: { code: number; message: string };
 };
 
-type McpConfigResult = {
+export type McpConfigResult = {
 	name: string;
 	type: string;
 	command: string;
@@ -48,7 +49,7 @@ export function findLatestIpcFile(): string | undefined {
 		.map(f => {
 			const fullPath = path.join(tmpDir, f);
 			try {
-				return { fullPath, mtime: statSync(fullPath).mtime };
+				return { fullPath: fullPath, mtime: statSync(fullPath).mtime };
 			} catch {
 				return null;
 			}
@@ -102,7 +103,7 @@ export class McpClient {
 			],
 			2,
 		);
-		return ((msg?.result as any)?.tools ?? []).map((t: { name: string }) => t.name) as string[];
+		return ((msg?.result as { tools?: { name: string }[] })?.tools ?? []).map(t => t.name);
 	}
 
 	/** Calls a single MCP tool and returns the tool-response message. */
@@ -124,8 +125,12 @@ export class McpClient {
 	 */
 	async getMcpConfig(options?: { experimental?: boolean; insiders?: boolean }): Promise<McpConfigResult> {
 		const args = ['mcp', 'config', this.host, '--source=gitlens', `--scheme=${this.host}`];
-		if (options?.experimental) args.push('--experimental');
-		if (options?.insiders) args.push('--insiders');
+		if (options?.experimental) {
+			args.push('--experimental');
+		}
+		if (options?.insiders) {
+			args.push('--insiders');
+		}
 
 		return new Promise((resolve, reject) => {
 			const proc = spawn(this.gkPath, args, {
@@ -134,14 +139,20 @@ export class McpClient {
 			});
 
 			let stdout = '';
+			let stderr = '';
 			proc.stdout.on('data', (chunk: Buffer) => (stdout += chunk.toString()));
+			proc.stderr.on('data', (chunk: Buffer) => (stderr += chunk.toString()));
 			proc.on('close', () => {
 				// Strip "checking for updates..." noise before parsing
 				const clean = stdout.replace(/checking for updates\.\.\./gi, '').trim();
 				try {
 					resolve(JSON.parse(clean) as McpConfigResult);
 				} catch {
-					reject(new Error(`gk mcp config returned non-JSON: ${clean.slice(0, 200)}`));
+					reject(
+						new Error(
+							`gk mcp config returned non-JSON: ${clean.slice(0, 200)}${stderr ? `\nstderr: ${stderr}` : ''}`,
+						),
+					);
 				}
 			});
 			proc.on('error', reject);
@@ -152,7 +163,9 @@ export class McpClient {
 
 	private buildEnv(): NodeJS.ProcessEnv {
 		const env: NodeJS.ProcessEnv = { ...process.env };
-		if (this.ipcFilePath != null) env['GK_GL_PATH'] = this.ipcFilePath;
+		if (this.ipcFilePath != null) {
+			env['GK_GL_PATH'] = this.ipcFilePath;
+		}
 		return env;
 	}
 
@@ -186,11 +199,18 @@ export class McpClient {
 			);
 
 			let resolved = false;
+			let stderr = '';
+			proc.stderr.on('data', (chunk: Buffer) => (stderr += chunk.toString()));
+
 			const timer = setTimeout(() => {
 				if (!resolved) {
 					resolved = true;
 					proc.kill();
-					reject(new Error(`McpClient: timeout after ${timeoutMs}ms waiting for id=${targetId}`));
+					reject(
+						new Error(
+							`McpClient: timeout after ${timeoutMs}ms waiting for id=${targetId}${stderr ? `\nstderr: ${stderr}` : ''}`,
+						),
+					);
 				}
 			}, timeoutMs);
 
@@ -209,7 +229,7 @@ export class McpClient {
 				// Auto-cancel any elicitation requests so tests don't hang
 				if (msg.method === 'elicitation/create') {
 					proc.stdin.write(
-						JSON.stringify({ jsonrpc: '2.0', id: (msg as any).id, result: { action: 'cancel' } }) + '\n',
+						`${JSON.stringify({ jsonrpc: '2.0', id: msg.id, result: { action: 'cancel' } })}\n`,
 					);
 					return;
 				}
@@ -238,7 +258,7 @@ export class McpClient {
 				}
 			});
 
-			const payload = messages.map(m => JSON.stringify(m)).join('\n') + '\n';
+			const payload = `${messages.map(m => JSON.stringify(m)).join('\n')}\n`;
 			proc.stdin.write(payload);
 			proc.stdin.end();
 		});

--- a/tests/e2e/helpers/mcpHelper.ts
+++ b/tests/e2e/helpers/mcpHelper.ts
@@ -2,7 +2,7 @@ import { spawn } from 'node:child_process';
 import { existsSync, readdirSync, readFileSync, statSync } from 'node:fs';
 import os from 'node:os';
 import path from 'node:path';
-import process from 'node:process';
+import * as process from 'node:process';
 import * as readline from 'node:readline';
 
 export type McpMessage = {

--- a/tests/e2e/helpers/mcpHelper.ts
+++ b/tests/e2e/helpers/mcpHelper.ts
@@ -103,6 +103,9 @@ export class McpClient {
 			],
 			2,
 		);
+		if (msg?.error) {
+			throw new Error(`MCP tools/list failed: [${msg.error.code}] ${msg.error.message}`);
+		}
 		return ((msg?.result as { tools?: { name: string }[] })?.tools ?? []).map(t => t.name);
 	}
 
@@ -142,9 +145,17 @@ export class McpClient {
 			let stderr = '';
 			proc.stdout.on('data', (chunk: Buffer) => (stdout += chunk.toString()));
 			proc.stderr.on('data', (chunk: Buffer) => (stderr += chunk.toString()));
-			proc.on('close', () => {
+			proc.on('close', (code: number | null) => {
 				// Strip "checking for updates..." noise before parsing
 				const clean = stdout.replace(/checking for updates\.\.\./gi, '').trim();
+				if (code != null && code !== 0) {
+					reject(
+						new Error(
+							`gk mcp config exited with code ${code}: ${clean.slice(0, 200)}${stderr ? `\nstderr: ${stderr}` : ''}`,
+						),
+					);
+					return;
+				}
 				try {
 					resolve(JSON.parse(clean) as McpConfigResult);
 				} catch {
@@ -246,7 +257,11 @@ export class McpClient {
 				if (!resolved) {
 					resolved = true;
 					clearTimeout(timer);
-					resolve(undefined);
+					reject(
+						new Error(
+							`McpClient: process exited before response id=${targetId} was received${stderr ? `\nstderr: ${stderr}` : ''}`,
+						),
+					);
 				}
 			});
 

--- a/tests/e2e/helpers/mcpHelper.ts
+++ b/tests/e2e/helpers/mcpHelper.ts
@@ -36,16 +36,27 @@ export function findGkCliFromArgs(electronArgs: string[]): string {
 }
 
 /**
- * Finds the most recent live IPC discovery file.
- * GitLens writes one file per session to %TEMP%/gitkraken/gitlens/.
- * Validates the process is still alive via process.kill(pid, 0).
+ * Finds the IPC discovery file for a specific VS Code process.
+ * GitLens writes one file per session to %TEMP%/gitkraken/gitlens/
+ * with format: gitlens-ipc-server-{pid}-{port}.json.
+ *
+ * When `vscodePid` is provided, only files belonging to that process are considered,
+ * preventing cross-worker contamination in parallel Playwright runs.
+ * Falls back to the newest live file when no pid is given.
  */
-export function findLatestIpcFile(): string | undefined {
+export function findLatestIpcFile(vscodePid?: number): string | undefined {
 	const tmpDir = path.join(os.tmpdir(), 'gitkraken', 'gitlens');
 	if (!existsSync(tmpDir)) return undefined;
 
 	const candidates = readdirSync(tmpDir)
-		.filter(f => f.startsWith('gitlens-ipc-server-') && f.endsWith('.json'))
+		.filter(f => {
+			if (!f.startsWith('gitlens-ipc-server-') || !f.endsWith('.json')) return false;
+			if (vscodePid != null) {
+				// File format: gitlens-ipc-server-{pid}-{port}.json
+				return f.startsWith(`gitlens-ipc-server-${vscodePid}-`);
+			}
+			return true;
+		})
 		.map(f => {
 			const fullPath = path.join(tmpDir, f);
 			try {

--- a/tests/e2e/helpers/mcpHelper.ts
+++ b/tests/e2e/helpers/mcpHelper.ts
@@ -129,7 +129,7 @@ export class McpClient {
 
 	/** Calls a single MCP tool and returns the tool-response message. */
 	async callTool(toolName: string, args: Record<string, unknown>): Promise<McpMessage> {
-		const msg = await this.sendRequests(
+		return this.sendRequests(
 			[
 				this.initMsg(),
 				this.notificationMsg(),
@@ -137,7 +137,6 @@ export class McpClient {
 			],
 			3,
 		);
-		return msg ?? { jsonrpc: '2.0', id: 3, error: { code: -1, message: 'No response received' } };
 	}
 
 	/**
@@ -183,7 +182,7 @@ export class McpClient {
 				settled = true;
 				clearTimeout(timer);
 				// Strip "checking for updates..." noise before parsing
-				const clean = stdout.replace(/checking for updates\.\.\./gi, '').trim();
+				const clean = stdout.replace(/checking for updates.../gi, '').trim();
 				if (code != null && code !== 0) {
 					reject(
 						new Error(
@@ -243,7 +242,7 @@ export class McpClient {
 	 * Spawns gk mcp, sends all messages, waits for the response with `targetId`,
 	 * and handles elicitation/create by auto-cancelling (safe default for tests).
 	 */
-	private sendRequests(messages: object[], targetId: number, timeoutMs = 30_000): Promise<McpMessage | undefined> {
+	private sendRequests(messages: object[], targetId: number, timeoutMs = 30_000): Promise<McpMessage> {
 		return new Promise((resolve, reject) => {
 			const proc = spawn(
 				this.gkPath,
@@ -251,19 +250,13 @@ export class McpClient {
 				{ env: this.buildEnv(), stdio: ['pipe', 'pipe', 'pipe'] },
 			);
 
-			let resolved = false;
+			let settled = false;
 			let stderr = '';
-			let exitCode: number | null = null;
-			let exitSignal: string | null = null;
 			proc.stderr.on('data', (chunk: Buffer) => (stderr += chunk.toString()));
-			proc.on('close', (code, signal) => {
-				exitCode = code;
-				exitSignal = signal;
-			});
 
 			const timer = setTimeout(() => {
-				if (!resolved) {
-					resolved = true;
+				if (!settled) {
+					settled = true;
 					proc.stdin.end();
 					proc.kill();
 					reject(
@@ -277,6 +270,8 @@ export class McpClient {
 			const rl = readline.createInterface({ input: proc.stdout, crlfDelay: Infinity });
 
 			rl.on('line', (line: string) => {
+				if (settled) return;
+
 				const trimmed = line.trim();
 				if (!trimmed) return;
 				let msg: McpMessage;
@@ -294,21 +289,21 @@ export class McpClient {
 					return;
 				}
 
-				if (msg.id === targetId && !resolved) {
-					resolved = true;
+				if (msg.id === targetId) {
+					settled = true;
 					clearTimeout(timer);
+					rl.close();
 					proc.stdin.end();
 					proc.kill();
 					resolve(msg);
 				}
 			});
 
-			rl.on('close', () => {
-				if (!resolved) {
-					resolved = true;
+			proc.on('close', (code, signal) => {
+				if (!settled) {
+					settled = true;
 					clearTimeout(timer);
-					const exitInfo =
-						exitCode != null ? `code=${exitCode}` : exitSignal != null ? `signal=${exitSignal}` : 'unknown';
+					const exitInfo = code != null ? `code=${code}` : signal != null ? `signal=${signal}` : 'unknown';
 					reject(
 						new Error(
 							`McpClient: process exited (${exitInfo}) before response id=${targetId} was received${stderr ? `\nstderr: ${stderr}` : ''}`,
@@ -318,8 +313,8 @@ export class McpClient {
 			});
 
 			proc.on('error', (err: Error) => {
-				if (!resolved) {
-					resolved = true;
+				if (!settled) {
+					settled = true;
 					clearTimeout(timer);
 					reject(err);
 				}


### PR DESCRIPTION
## Summary

- Introduces `McpClient` — minimal stdio JSON-RPC 2.0 client that spawns `gk mcp` as a fresh process per call, handles `initialize` / `tools/list` / `tools/call`, and auto-cancels `elicitation/create` requests
- Adds `findGkCliFromArgs` — derives gk proxy path from `--user-data-dir` electron launch arg (cross-platform: `gk.exe` on Windows, `gk` on macOS/Linux)
- Adds `findLatestIpcFile` — locates the live IPC discovery file via `os.tmpdir()`, filters dead processes via `process.kill(pid, 0)`
- Adds `waitForCliInstall` — polls for gk binary appearance (~5–6 s on first run, 30 s timeout)
- Adds `mcpTest` Playwright fixture — wires all helpers into a ready-to-use `McpClient` scoped to the worker VS Code instance; warns if IPC file is not found
- Exports `McpConfigResult` type for use in test files
- stderr is captured in all `gk` subprocess calls and included in timeout/error messages for easier debugging

## Test plan

- [x] `pnpm run lint` — no errors
- [x] `pnpm exec tsc --noEmit` — no errors
- [ ] Smoke E2E tests (`mcp.smoke.test.ts`) will use this fixture in the follow-up PR

🤖 Generated with [Claude Code](https://claude.com/claude-code)