### PR TITLE
Fix MCP experimental flag passed to wrong CLI command

### DIFF
--- a/package.json
+++ b/package.json
@@ -4197,6 +4197,16 @@
 						"scope": "window",
 						"order": 50
 					},
+					"gitlens.gitkraken.mcp.experimental.enabled": {
+						"type": "boolean",
+						"default": false,
+						"markdownDescription": "Specifies whether to enable experimental features for the GitKraken MCP server (passes `--experimental` flag to the CLI)",
+						"scope": "window",
+						"order": 55,
+						"tags": [
+							"experimental"
+						]
+					},
 					"gitlens.terminal.overrideGitEditor": {
 						"type": "boolean",
 						"default": true,

--- a/src/env/node/gk/mcp/integrationBase.ts
+++ b/src/env/node/gk/mcp/integrationBase.ts
@@ -141,9 +141,6 @@ export abstract class GkMcpProviderBase implements Disposable {
 
 		try {
 			const args = ['mcp', 'config', appName, '--source=gitlens', `--scheme=${env.uriScheme}`];
-			if (configuration.get('gitkraken.mcp.experimental.enabled')) {
-				args.push('--experimental');
-			}
 			if (configuration.get('gitkraken.cli.insiders.enabled')) {
 				args.push('--insiders');
 			}
@@ -166,6 +163,12 @@ export abstract class GkMcpProviderBase implements Disposable {
 
 			if (!config.type || !config.command || !Array.isArray(config.args)) {
 				throw new Error(`Invalid MCP configuration: missing required properties (${output})`);
+			}
+
+			// Append --experimental to the MCP server args (not the config command)
+			// so the server itself runs with experimental features enabled
+			if (configuration.get('gitkraken.mcp.experimental.enabled') && !config.args.includes('--experimental')) {
+				config.args.push('--experimental');
 			}
 
 			this.onRegistrationCompleted(cliInstall.version);


### PR DESCRIPTION
## Summary

Fixes the `--experimental` flag for the GitKraken MCP server not taking effect when enabled via `gitlens.gitkraken.mcp.experimental.enabled` setting.

### Root cause

Commit e4abb9b00 ("Adds JSON-only setting for GK CLI --experimental flag") introduced the `gitkraken.mcp.experimental.enabled` setting and added code to pass `--experimental` to the CLI. However, the flag was appended to the **`gk mcp config`** command (the configuration query), not to the MCP server's runtime args.

The two-stage flow works like this:

1. **Config query**: GitLens runs `gk mcp config vscode --source=gitlens --scheme=vscode` to get the server definition
2. **Server startup**: VS Code starts the MCP server using the `command` and `args` from the config response

The `mcp config` subcommand does **not** recognize `--experimental` — it warns "unknown flag" and ignores it. Even if it did, the flag would only affect the config query, not the actual MCP server process. The returned `args` array never included `--experimental`, so the MCP server always started without experimental features.

**Verified against CLI versions:**
- `gk.exe` v3.1.55-rc.2 (bundled) — `Warning: unknown flag: --experimental`
- `gk-insiders.exe` v3.1.55-rc.3 — `Warning: unknown flag: --experimental`

### Fix

- **Moves** `--experimental` injection from the config query args to the returned `config.args` array, so the MCP server itself receives the flag at startup
- **Adds** a guard (`!config.args.includes('--experimental')`) to avoid duplication if a future CLI version starts including it in the config response
- **Registers** `gitlens.gitkraken.mcp.experimental.enabled` in `package.json` so VS Code recognizes it as a valid setting (was only defined in `src/config.ts` TypeScript types)

### Before (broken)

```
GitLens calls:  gk mcp config vscode --source=gitlens --scheme=vscode --experimental
CLI warns:      "unknown flag: --experimental"
CLI returns:    { args: ["mcp", "--host=vscode", "--source=gitlens", "--scheme=vscode"] }
Server starts:  gk.exe mcp --host=vscode --source=gitlens --scheme=vscode  ← no --experimental
```

### After (fixed)

```
GitLens calls:  gk mcp config vscode --source=gitlens --scheme=vscode
CLI returns:    { args: ["mcp", "--host=vscode", "--source=gitlens", "--scheme=vscode"] }
GitLens adds:   args.push("--experimental")
Server starts:  gk.exe mcp --host=vscode --source=gitlens --scheme=vscode --experimental  ✓
```

## Test plan

- [ ] Set `"gitlens.gitkraken.mcp.experimental.enabled": true` in settings.json
- [ ] Reload VS Code and verify the GitKraken MCP server starts with `--experimental` flag
- [ ] Verify experimental tools (e.g. `git_status`) appear in VS Code Copilot chat via `@gitkraken`
- [ ] Verify that with the setting set to `false` (default), `--experimental` is NOT appended
- [ ] Verify the setting appears as a recognized configuration in VS Code settings UI

🤖 Generated with [Claude Code](https://claude.com/claude-code)