### PR TITLE
Adds skills and pipeline script for issue triage and development

### DIFF
--- a/.claude/skills/challenge-plan/SKILL.md
+++ b/.claude/skills/challenge-plan/SKILL.md
@@ -15,8 +15,10 @@ Stress-test a proposed plan before implementation begins. Extract assumptions, v
 
 ```
 /challenge-plan [proposed plan, implementation outline, or design decision]
+/challenge-plan --scope .work/dev/5096/
 ```
 
+- **`--scope <path>`**: When provided, read `plan.md` from the given directory as the plan to challenge, and read `goals.md` from the same directory for context (success criteria, verified claims, constraints). Use the goals document to evaluate whether the plan actually delivers what was scoped. When `--scope` is absent, the skill works exactly as it does today (interactive, prompt-driven).
 - `deep-planning` formulates the best approach
 - **`challenge-plan`** stress-tests the chosen approach
 - `analyze` evaluates code paths and edge cases during/after implementation

--- a/.claude/skills/deep-planning/SKILL.md
+++ b/.claude/skills/deep-planning/SKILL.md
@@ -15,8 +15,10 @@ Find the **best** approach to a task — not just a good one. Investigate the co
 
 ```
 /deep-planning [task, feature, refactor, or design decision]
+/deep-planning --scope .work/dev/5096/
 ```
 
+- **`--scope <path>`**: When provided, read `goals.md` from the given directory as the task input instead of expecting the task description in the prompt. The goals document contains success criteria, verified claims, user experience requirements, code landscape, and constraints — use all of these to inform your planning. When `--scope` is absent, the skill works exactly as it does today (interactive, prompt-driven).
 - If adjacent skills like `brainstorming` or `writing-plans` are available, use them as complements.
 - If they are not available in the current environment, continue with this skill. It is self-contained.
 

--- a/.claude/skills/deep-review/SKILL.md
+++ b/.claude/skills/deep-review/SKILL.md
@@ -13,8 +13,10 @@ Root-cause, merge-blocking review that traces every modified code path end-to-en
 
 ```
 /deep-review [target]
+/deep-review branch --scope .work/dev/5096/
 ```
 
+- **`--scope <path>`**: When provided, read `goals.md` from the given directory to understand the original intent, success criteria, and user experience requirements. Use this to evaluate whether the implementation actually delivers what was scoped — not just whether the code is correct in isolation. When `--scope` is absent, the skill works exactly as it does today.
 - No argument: review staged changes (`git diff --cached`)
 - `all`: all uncommitted changes
 - `branch`: changes vs base branch (`git diff main...HEAD`)

--- a/.claude/skills/dev-scope/SKILL.md
+++ b/.claude/skills/dev-scope/SKILL.md
@@ -1,0 +1,302 @@
+---
+name: dev-scope
+description: Scope a unit of work into a goals document — defines what and why, not how. Bridge between triage output and dev planning. Produces .work/dev/{identifier}/goals.md for /deep-planning to consume.
+---
+
+# /dev-scope - Scope Work into Goals
+
+Take a unit of work and produce a goals document that anchors _why_ throughout the dev pipeline. Defines what needs to happen, what the user should experience, and what constraints matter — not how to build it.
+
+This is the bridge between triage and dev. Investigation tells you what's broken and where. Goals tell you what the user should experience when it's fixed, what "done" looks like, and what constraints aren't about the code.
+
+## Usage
+
+```
+/dev-scope <number>                    # Issue with or without investigation
+/dev-scope <number> [number...]        # Multiple issues (one goals.md each)
+/dev-scope "<description>"             # Idea or task with no issue
+```
+
+## Design Principle
+
+**Detect the gap, recommend the step, don't absorb it.** When context is missing (e.g., a bug without an investigation report), tell the user what's missing and recommend the appropriate skill. Do not silently perform another skill's job.
+
+---
+
+## Instructions
+
+### Stage 0 — Determine Input and Create Dev Folder
+
+**Issue mode (one or more numbers):**
+
+1. For each issue, fetch full context:
+
+```bash
+gh issue view <number> --repo gitkraken/vscode-gitlens --json number,title,body,comments,labels,state,author,createdAt,updatedAt,milestone,assignees
+```
+
+2. Determine if the issue is a bug or feature request from its labels, type, and content.
+
+3. Create the dev folder: `.work/dev/<number>/`
+
+**Description mode (quoted string, no issue number):**
+
+1. Create a descriptive slug from the description (lowercase, hyphens, max 50 chars). Example: `"add natural language search"` becomes `add-natural-language-search`.
+
+2. Create the dev folder: `.work/dev/<slug>/`
+
+3. There is no issue to fetch — the description is the entire input. Skip to Stage 2.
+
+### Stage 1 — Gather Existing Context
+
+**For bugs — check for investigation report:**
+
+Search for an investigation report that covers this issue:
+
+```bash
+ls -t .work/triage/reports/*INVESTIGATION-DECISIONS.json 2>/dev/null | head -5
+```
+
+If found, read the JSON and look for an entry where `issueNumber` matches. If a matching entry exists:
+
+- Import: `rootCauseSummary`, `proposedFix`, `affectedFiles`, `estimatedEffort`, `riskLevel`, `confidence`, `sourceAttribution`
+- Note the source file path for the goals doc's Source section
+- Do NOT re-investigate — this work is already done
+
+If no investigation report exists for this bug:
+
+> **Stop and recommend.** Present this to the user:
+>
+> No investigation report found for #NNNN. This is a bug — running `/investigate NNNN` first will give `/dev-scope` root cause analysis, affected files, and fix direction to build on.
+>
+> Proceed without investigation, or run `/investigate` first?
+
+Wait for the user's response. If they say proceed, continue with what's available from the issue alone. If they want investigation first, stop and let them run it.
+
+**For features and explorations:**
+
+No investigation lookup needed. Proceed directly to Stage 2.
+
+### Stage 2 — Verify Claims Against Codebase
+
+Treat every verifiable claim from the issue as a hypothesis. This applies to ALL issue types — bugs and features alike.
+
+**What to verify:**
+
+- UI elements mentioned (views, buttons, menus, status bar items) — do they exist? Are they named correctly?
+- Settings or configuration options referenced — do they exist in `package.json` or `src/config.ts`?
+- Commands referenced — do they exist in `contributions.json` or `src/constants.commands.ts`?
+- Described behavior ("when I click X, Y happens") — does the code path support this?
+- Error messages quoted — do they appear in the source?
+- Version-specific claims ("this worked in v14") — check CHANGELOG or git history if practical
+
+**How to verify:**
+
+Use `Grep` and `Glob` for quick lookups. Read relevant source files when behavior claims need tracing. Do not launch full investigations — this is lightweight verification, not root cause analysis.
+
+**Record results in three buckets:**
+
+- **Confirmed** — claim checked out against current code
+- **Disputed** — claim contradicts what the code shows (include what the code actually does)
+- **Unverifiable** — can't confirm or deny from code alone (e.g., "intermittent", "sometimes", environment-specific)
+
+If the issue has no verifiable claims (pure feature request described abstractly), note "No verifiable claims — feature request described in abstract terms" and move on.
+
+### Stage 3 — Map User Experience
+
+This is the layer that investigation reports don't cover and that `/deep-planning` will lose if nobody writes it down.
+
+**For bugs:**
+
+- **Trigger**: What does the user do that causes the bug? (action, context, preconditions)
+- **Current experience**: What does the user actually see/experience? (the broken state)
+- **Expected experience**: What should happen instead? (the fixed state, from the user's perspective)
+- **Workarounds**: Are there any? What's the cost of using them?
+- **Workflow context**: What was the user doing before this, and what are they trying to do after?
+
+**For features:**
+
+- **Trigger**: What initiates this feature? (command, UI interaction, automatic detection)
+- **Expected flow**: Step-by-step from the user's perspective — what they see, what they do, what happens
+- **Edge cases**: What happens when things go wrong, inputs are unexpected, or the feature can't complete?
+- **Discoverability**: How does the user learn this feature exists?
+- **Workflow context**: What was the user doing before this, and what do they do after?
+
+**For ideas/explorations:**
+
+- Map what you can. If the UX is undefined, say so — that's useful signal for `/deep-planning`.
+
+### Stage 4 — Map Code Landscape
+
+Identify the code areas this work will touch. This is not a plan — it's a map so `/deep-planning` knows where to look.
+
+- **Entry points**: Commands, event handlers, IPC messages, or activation paths relevant to this work
+- **Affected paths**: Code paths that will be modified or impacted — both Node.js and browser where applicable
+- **Patterns to follow**: Existing patterns in the codebase this work should align with (find a similar feature and reference it)
+- **Risk areas**: Shared code, cross-environment paths (`src/env/node/` vs `src/env/browser/`), decorator-wrapped methods, high-traffic code paths
+
+For bugs with investigation reports, the affected files are already known — verify they're still accurate and add any patterns or risk areas the investigation didn't cover.
+
+For features, use `Grep` and `Glob` to find analogous features and map the relevant code areas. Reference specific files and functions.
+
+### Stage 5 — Define Success Criteria
+
+Write specific, testable conditions that define "done." These should cover both technical and UX dimensions.
+
+**Good success criteria:**
+
+- "The Commit Graph renders branch labels for all local branches, not just the current branch"
+- "Clicking a blame annotation opens the commit details panel within 200ms"
+- "The feature works in both desktop and web (vscode.dev) environments"
+
+**Bad success criteria:**
+
+- "The bug is fixed" (not testable)
+- "Performance is improved" (not specific)
+- "The feature works correctly" (circular)
+
+### Stage 6 — Identify Constraints
+
+Note things that must not break, performance requirements, environment considerations, and any scope boundaries.
+
+Common constraint categories:
+
+- **Behavioral**: Existing features that must continue working
+- **Performance**: Operations that must stay within time/memory budgets
+- **Environmental**: Must work in Node.js, browser, or both
+- **Compatibility**: VS Code version requirements, API limitations
+- **Scope**: What is explicitly out of scope for this unit of work
+
+### Stage 7 — Assess Scoping Confidence
+
+Before writing the goals doc, assess confidence across three dimensions:
+
+- **Claims**: Tally confirmed, disputed, and unverifiable counts from Stage 2. This is mechanical — just count the buckets.
+- **Code landscape**: How confident are you that the entry points, affected paths, and risk areas are complete? Rate High (clear, well-mapped area), Medium (found the main paths but the area is complex — may be missing some), or Low (couldn't confidently identify the relevant code). Include a brief reason if not High.
+- **UX completeness**: Is the user experience section fully mapped, partially mapped, or minimal? Rate Complete (all fields filled with specifics), Partial (some fields are inferred or vague), or Minimal (UX is largely undefined — common for explorations). Note what's missing if not Complete.
+- **Overall**: The lowest of code landscape and UX completeness drives this. If claims have more disputed/unverifiable than confirmed, that also pulls it down.
+
+This gives `/deep-planning` actionable signal — "code landscape is Low confidence, verify entry points before committing to an approach."
+
+### Stage 8 — Produce Goals Document
+
+Write the goals document to `.work/dev/{identifier}/goals.md`.
+
+---
+
+## Output Format
+
+```markdown
+# Goals: #{issue} — {title}
+
+(or for ideas without an issue:)
+
+# Goals: {descriptive title}
+
+## Source
+
+- Issue: {GitHub URL or "none"}
+- Type: Bug | Feature | Exploration
+- Investigation: {path to investigation report entry or "none"}
+
+## Summary
+
+{2-3 sentence distillation of what needs to happen and why. Lead with the user impact, not the technical problem.}
+
+## Verified Claims
+
+{For each verified claim: what was checked and what the code confirmed.
+If no verifiable claims: "No verifiable claims — [reason]."}
+
+## Disputed / Unverifiable Claims
+
+{Claims that didn't check out or couldn't be verified. Include what the code actually shows for disputed claims. Critical for /deep-planning — these are landmines.
+If none: "All verifiable claims confirmed."}
+
+## Success Criteria
+
+{Specific, testable conditions — both technical and UX.}
+
+## User Experience
+
+- **Trigger**: {what the user does to initiate this}
+- **Expected flow**: {step-by-step from the user's perspective}
+- **Edge cases**: {what happens when things go wrong, from the user's POV}
+- **Workflow context**: {what the user was doing before and what they do after}
+
+(For bugs, also include:)
+
+- **Current experience**: {the broken state}
+- **Workarounds**: {if any, and their cost}
+
+## Code Landscape
+
+- **Entry points**: {files and functions}
+- **Affected paths**: {code paths that will be modified or impacted}
+- **Patterns to follow**: {existing patterns this should align with — reference specific files}
+- **Risk areas**: {shared code, cross-environment paths, decorator-wrapped methods}
+
+## Constraints
+
+{Things that must not break, performance requirements, environment considerations, scope boundaries.}
+
+## Investigation Import
+
+(Only present when an investigation report was found. Omit entirely otherwise.)
+
+- **Root cause**: {from investigation}
+- **Proposed fix direction**: {from investigation}
+- **Affected files**: {from investigation}
+- **Effort estimate**: {from investigation}
+- **Risk level**: {from investigation}
+- **Confidence**: {from investigation}
+
+## Scoping Confidence
+
+- **Claims**: N confirmed, N disputed, N unverifiable
+- **Code landscape**: High | Medium | Low — {why, if not High}
+- **UX completeness**: Complete | Partial | Minimal — {what's missing}
+- **Overall**: High | Medium | Low
+```
+
+---
+
+## Multiple Issues
+
+When invoked with multiple issue numbers, process each independently. Produce one `goals.md` per issue in separate dev folders. Present a summary at the end:
+
+```
+Scoped N issues:
+- .work/dev/5096/goals.md — #5096: Commit graph branch labels missing
+- .work/dev/5084/goals.md — #5084: Blame annotations slow on large files
+```
+
+---
+
+## Chaining
+
+This skill bridges the triage and dev pipelines:
+
+```
+Triage pipeline                          Dev pipeline
+━━━━━━━━━━━━━━━                          ━━━━━━━━━━━━
+/triage → /investigate → /prioritize →   /dev-scope → /deep-planning → /challenge-plan → [implement]
+```
+
+Upstream: Consumes investigation reports from `/investigate` (optional, auto-detected).
+Downstream: `/deep-planning` consumes the `goals.md` produced by this skill.
+
+```
+/dev-scope 5096                          # Bug — looks for investigation report
+/dev-scope 5096 5084                     # Multiple issues — one goals.md each
+/dev-scope "natural language search"     # Idea — no issue, full extraction
+```
+
+## Anti-Patterns
+
+- **Re-investigating bugs** — If `/investigate` already ran, import its findings. Don't redo the work.
+- **Skipping claim verification** — Reporter claims are hypotheses, not facts. Always verify what you can.
+- **Technical-only success criteria** — Every goals doc needs UX-level success criteria, not just code-level.
+- **Absorbing other skills' jobs** — Don't silently run `/investigate` or start planning _how_. Stay in the _what_ and _why_.
+- **Empty UX section** — If you can't map the user experience, say what's unknown. An explicit gap is better than a missing section.
+- **Skipping code landscape for features** — Features need code mapping too. Find analogous features and reference them.

--- a/.claude/skills/investigate/SKILL.md
+++ b/.claude/skills/investigate/SKILL.md
@@ -1,25 +1,63 @@
 ---
 name: investigate
-description: Structured investigation of a bug or unexpected behavior before implementing a fix
+description: Investigate bugs — single-issue deep root cause analysis or batch parallel investigation from a report or issue list
 ---
 
 # /investigate - Bug Investigation
 
-Perform structured root cause analysis before implementing any fix.
+Perform structured root cause analysis of bugs. Operates in two modes: single-issue deep investigation or batch parallel investigation across multiple issues.
 
 ## Usage
 
 ```
-/investigate [symptom description or issue reference]
+/investigate <symptom or issue reference>                         # Single deep investigation
+/investigate <number> <number> [number...]                        # Batch parallel investigation
+/investigate --from-report [path] [--verdict "..."] [--max 10]   # Batch from triage report
 ```
 
-## Instructions
+- Single issue number or symptom — Deep investigation with full code tracing (runs in current agent)
+- Two or more issue numbers — Parallel investigation via subagents, produces report files
+- `--from-report` — Reads a triage decisions JSON. If path omitted, uses most recent `*-DECISIONS.json` in `.work/triage/reports/`.
+- `--verdict` — Filter report to specific verdict(s). Defaults to `Valid - Needs Triage`. Comma-separated. Only applies with `--from-report`.
+- `--max` — Maximum parallel investigations. Defaults to 10. Only applies to batch mode.
+
+## Mode Selection
+
+**Single mode** — invoked with one issue number or a symptom description. Performs a deep, thorough investigation in the current agent context. Best for focused debugging.
+
+**Batch mode** — invoked with 2+ issue numbers or `--from-report`. Spawns parallel subagents, each performing an independent investigation. Produces report files. Best for processing a queue of issues.
+
+---
+
+## Single Mode Instructions
 
 ### 1. Understand the Symptom
 
 - Restate the symptom to confirm understanding
 - Identify: extension host or webview? Node.js or browser? Which feature area?
 - Ask clarifying questions if ambiguous
+
+### 1a. Relevance Assessment (for issues older than 1 year)
+
+If the issue is older than 1 year, perform a quick relevance check before the full investigation:
+
+1. Identify the feature area, code paths, UI elements, settings, or commands mentioned in the issue
+2. Check if the referenced files still exist using `Glob` or `Grep`
+3. If they exist, check `git log --since="<issue creation date>" -- <relevant files>` for significant changes
+4. If files have been deleted or substantially rewritten, include a **Relevance Assessment** in the output:
+
+```markdown
+### Relevance Assessment
+
+[One of:
+
+- "Code path still exists — issue may still be relevant"
+- "Code path no longer exists — [file(s)] deleted/removed since issue was filed"
+- "Feature area significantly refactored — [summary of changes since issue creation]"
+- "Unable to map issue to specific code paths — proceeding with investigation"]
+```
+
+If the code path no longer exists, note this prominently and consider whether the investigation should continue or if the issue should be recommended for closure.
 
 ### 2. Trace the Code Path
 
@@ -40,7 +78,16 @@ Perform structured root cause analysis before implementing any fix.
 - Check both `src/env/node/` and `src/env/browser/` paths
 - Check sub-providers: `src/env/node/git/sub-providers/` and `src/git/sub-providers/`
 
-### 5. Present Findings
+### 5. Assess Source Attribution
+
+Before presenting findings, assess where the diagnosis came from:
+
+- **Independent analysis** — Root cause was determined primarily by tracing code paths, reading implementations, and forming hypotheses from code evidence. The issue description described symptoms but did not point to the cause.
+- **Confirmed reporter's diagnosis** — The issue already contained detailed code references, file paths, or a proposed root cause. The investigation verified these claims against the current code but did not independently discover the cause.
+
+Be honest about this. Both are valuable — confirming a reporter's analysis is useful — but the reader should know what the investigation actually contributed.
+
+### 6. Present Findings
 
 ```markdown
 ## Investigation: [Symptom]
@@ -48,6 +95,10 @@ Perform structured root cause analysis before implementing any fix.
 ### Symptom
 
 [What goes wrong]
+
+### Source Attribution
+
+[One of: "Independent analysis from code tracing" | "Confirms reporter's diagnosis — the issue included [specific detail: code references / file paths / root cause hypothesis] which this investigation verified against current code" | "Mixed — [explain what came from the issue vs. independent tracing]"]
 
 ### Code Path
 
@@ -72,9 +123,185 @@ Perform structured root cause analysis before implementing any fix.
 - Platform paths verified: Node.js [yes/no], Browser [yes/no]
 ```
 
-### 6. Get Confirmation
+### 7. Get Confirmation
 
 Present findings and proposed fix. Wait for user confirmation before implementing.
+
+---
+
+## Batch Mode Instructions
+
+### Stage 0 — Load and Filter Issues
+
+**Direct mode (2+ issue numbers):**
+
+Use the provided issue numbers directly. Proceed to Stage 1.
+
+**From-report mode (`--from-report`):**
+
+1. Read the decisions JSON file specified (or find the most recent `*-DECISIONS.json` in `.work/triage/reports/`)
+2. Filter verdicts to only those matching the `--verdict` filter AND where the issue is a bug (check `recommendedLabels` or the corresponding markdown report for type info)
+3. If no matching issues are found, report that and stop
+4. If more issues match than `--max`, take the first N and note how many were skipped
+
+### Stage 1 — Fetch Issue Context
+
+For each qualifying issue, use the GitHub CLI to fetch the full issue body and comments:
+
+```bash
+gh issue view <number> --repo <repo> --json title,body,comments,labels,state,author,createdAt,updatedAt
+```
+
+The repo slug comes from the decisions JSON's corresponding evidence pack, or default to `gitkraken/vscode-gitlens`.
+
+### Stage 2 — Spawn Investigation Subagents
+
+For each issue, spawn a subagent (using the Agent tool) with:
+
+- `subagent_type`: general-purpose
+- A prompt that includes:
+  1. The issue number, title, body, and comments (formatted for readability)
+  2. The labels and any existing evidence summary from the triage verdict
+  3. Instructions to follow the single-mode investigation methodology:
+     - Understand the symptom from the issue description
+     - Trace the relevant code path in the codebase
+     - Form at least 2 hypotheses
+     - Gather evidence by reading code
+     - Assess source attribution: was the root cause found independently via code tracing, or was it confirming analysis already present in the issue?
+     - Estimate effort (Small/Medium/Large) and risk (Low/Medium/High) based on the scope of the fix
+     - Present findings in the investigation format
+  4. A critical instruction: **If there is not enough information in the issue to form a meaningful hypothesis, or if the investigation yields only low-confidence results, state that clearly and do not force a conclusion.** It is perfectly acceptable to report "insufficient information to investigate" or "investigation inconclusive".
+  5. The subagent should write its findings to stdout (not to files) — you will collect the results
+
+Run subagents in parallel where possible. Each subagent operates independently.
+
+### Stage 3 — Collect and Report
+
+Gather all subagent results and produce report files:
+
+**File**: `.work/triage/reports/YYYY-MM-DD-INVESTIGATION-REPORT.md`
+
+```markdown
+# Investigation Report — YYYY-MM-DD
+
+Source: <decisions file path or "direct">
+Issues investigated: N
+Issues with findings: N
+Issues inconclusive: N
+
+---
+
+## Findings
+
+### [#NNNN — Title](https://github.com/<owner>/<repo>/issues/NNNN)
+
+- **Author**: @username (team) | @username
+- **Triage verdict**: <original verdict from triage, or "N/A" for direct mode>
+- **Investigation result**: Confirmed Bug | Likely Fixed | Cannot Reproduce from Description | Inconclusive | Insufficient Information
+- **Confidence**: High | Medium | Low
+- **Source attribution**: Independent analysis | Confirms reporter's diagnosis | Mixed
+- **Estimated effort**: Small (hours) | Medium (1-3 days) | Large (3+ days) | Unknown
+- **Risk level**: Low | Medium | High | Unknown
+
+#### Symptom
+
+<restated from issue>
+
+#### Code Path
+
+<entry point> -> <function chain with file:line references>
+
+#### Root Cause Analysis
+
+<findings or "insufficient information to determine">
+
+#### Alternative Causes Considered
+
+1. <alternative> — ruled out because <evidence>
+
+#### Recommendation
+
+<what to do next — fix approach, request specific info from reporter, close, etc.>
+
+---
+
+## Inconclusive Issues
+
+Issues where investigation could not reach a meaningful conclusion:
+
+- [#NNNN — Title](https://github.com/<owner>/<repo>/issues/NNNN) — <reason: insufficient repro info | vague description | external dependency | etc.>
+
+---
+
+## Classification Matrix
+
+Buckets confirmed/likely bugs by estimated effort and risk to aid prioritization:
+
+| Issue | Effort | Risk | Summary                       |
+| ----- | ------ | ---- | ----------------------------- |
+| #NNNN | Small  | Low  | <one-line description of fix> |
+| #NNNN | Medium | High | <one-line description of fix> |
+
+**Effort guide**: Small = isolated change, hours of work; Medium = multiple files/systems, 1-3 days; Large = architectural or cross-cutting, 3+ days.
+**Risk guide**: Low = safe, localized change; Medium = touches shared code or has edge cases; High = could regress other features or affects critical paths.
+
+### Quick Wins (Small effort, Low/Medium risk)
+
+- #NNNN — <title>
+
+### Needs Planning (Medium/Large effort or High risk)
+
+- #NNNN — <title> — <why it needs planning>
+
+---
+
+## Summary
+
+- **Confirmed bugs**: N (list issue numbers)
+- **Likely already fixed**: N (list issue numbers)
+- **Inconclusive**: N (list issue numbers)
+- **Skipped (over max)**: N
+```
+
+Write the markdown file and report its path to the user.
+
+#### Machine-Readable JSON
+
+Also produce a machine-readable companion file: `.work/triage/reports/YYYY-MM-DD-INVESTIGATION-DECISIONS.json`
+
+```json
+{
+	"reportId": "<uuid>",
+	"sourceDecisionsFile": "<path to triage decisions that triggered this, or null for direct mode>",
+	"generatedAt": "<ISO timestamp>",
+	"investigations": [
+		{
+			"issueNumber": 1234,
+			"result": "Confirmed Bug | Likely Fixed | Cannot Reproduce | Inconclusive | Insufficient Information",
+			"confidence": "High | Medium | Low",
+			"sourceAttribution": "Independent | Confirms Reporter | Mixed",
+			"estimatedEffort": "Small | Medium | Large | Unknown",
+			"riskLevel": "Low | Medium | High | Unknown",
+			"rootCauseSummary": "...",
+			"proposedFix": "...",
+			"affectedFiles": ["src/path/to/file.ts"],
+			"recommendation": "Fix | Request Info | Close | Needs Planning"
+		}
+	]
+}
+```
+
+Generate a UUID for `reportId`. Write both files and confirm their paths to the user.
+
+---
+
+## Important Notes
+
+- Batch mode is intentionally expensive — each subagent performs a full code investigation. The user has opted in to this cost.
+- Do NOT skip the investigation for an issue just because it seems complex. Let the subagent try and report what it finds.
+- DO skip issues that are clearly feature requests mislabeled as bugs — note these in the report.
+- Subagent failures (timeouts, errors) should be noted in the report, not silently dropped.
+- If a subagent finds that a bug has already been fixed (e.g., the code path no longer has the described behavior), report that as "Likely Fixed" — this is valuable triage signal.
 
 ## Anti-Patterns
 
@@ -91,6 +318,20 @@ Present findings and proposed fix. Wait for user confirmation before implementin
 4. **Platform-specific bugs**: Something working in Node.js may fail in browser (and vice versa). Always check the `@env/` abstraction layer.
 5. **Scope/context bugs**: `getScopedLogger()` returns stale scope after `await` in browser. Capture the scope before the first `await`.
 6. **Suppressing errors instead of fixing them**: Do NOT silence errors by catching and ignoring them. Fix the root cause or propagate them properly (e.g., use `errors: throw` so catch blocks handle them).
+
+## Chaining
+
+This skill can be used standalone or as part of the issue workflow pipeline:
+
+```
+/triage recent → /investigate --from-report → /prioritize --from-report → /update-issues
+/triage 5096   → /investigate 5096          → /prioritize 5096          → /update-issues
+/investigate 5096 5084                        (standalone batch)
+/investigate #5096                            (standalone single)
+```
+
+Upstream: `--from-report` consumes triage decisions JSON from `/triage`.
+Downstream: `/prioritize --from-report` consumes the investigation decisions JSON. `/update-issues` can also consume it directly.
 
 ## Decorator Reference
 

--- a/.claude/skills/investigate/SKILL.md
+++ b/.claude/skills/investigate/SKILL.md
@@ -285,7 +285,9 @@ Also produce a machine-readable companion file: `.work/triage/reports/YYYY-MM-DD
 			"rootCauseSummary": "...",
 			"proposedFix": "...",
 			"affectedFiles": ["src/path/to/file.ts"],
-			"recommendation": "Fix | Request Info | Close | Needs Planning"
+			"blockedBy": null | "vscode" | "git" | "cli" | "language-server" | "other",
+			"blockedDetail": "...",
+			"recommendation": "Fix | Request Info | Close | Needs Planning | Blocked"
 		}
 	]
 }

--- a/.claude/skills/prioritize/SKILL.md
+++ b/.claude/skills/prioritize/SKILL.md
@@ -35,7 +35,7 @@ Read the evidence pack JSON printed to stdout.
 
 Read the JSON file and auto-detect report type:
 
-- Has `verdicts` array → **Triage decisions**. Filter to issues with actionable verdicts (`Valid - Needs Triage`, `Valid - Already Triaged`, `Relabel - Bug`, `Relabel - Feature Request`). Skip close or request-more-info verdicts — those are already resolved.
+- Has `verdicts` array → **Triage decisions**. Filter to issues with actionable verdicts (`Valid - Needs Triage`, `Valid - Already Triaged`, `Retype - Bug`, `Retype - Feature Request`). Skip close or request-more-info verdicts — those are already resolved.
 - Has `investigations` array → **Investigation decisions**. For each issue, combine investigation findings (effort, risk, root cause, confidence) with evidence pack data.
 
 For each qualifying issue, you need the evidence pack data. If the corresponding evidence pack is available in `.work/triage/packs/`, read it. Otherwise, run the `single` command to fetch data for the issue numbers.

--- a/.claude/skills/prioritize/SKILL.md
+++ b/.claude/skills/prioritize/SKILL.md
@@ -1,0 +1,215 @@
+---
+name: prioritize
+description: Prioritize triaged/investigated issues — recommends shortlist, backlog, won't fix, or community contribution with priority signals and draft communications
+---
+
+# /prioritize - Issue Prioritization & Resolution
+
+Evaluate triaged or investigated issues and recommend resolution: shortlist, backlog, won't fix, or community contribution. Produces priority signal summaries and optional draft communications.
+
+## Usage
+
+```
+/prioritize <number> [number...]
+/prioritize --from-report [path]
+```
+
+- Issue numbers — Fetches evidence pack via `single` command, performs resolution analysis
+- `--from-report` — Reads a report JSON file (auto-detects type: triage decisions, investigation decisions, or resolutions). If path omitted, uses the most recent report JSON in `.work/triage/reports/`.
+
+## Instructions
+
+### Stage 0 — Gather Data
+
+**Direct mode (issue numbers):**
+
+Run the CLI to build an evidence pack for the specified issues:
+
+```bash
+node --experimental-strip-types ./scripts/issues/triage.mts single <numbers...>
+```
+
+Read the evidence pack JSON printed to stdout.
+
+**From-report mode (`--from-report`):**
+
+Read the JSON file and auto-detect report type:
+
+- Has `verdicts` array → **Triage decisions**. Filter to issues with actionable verdicts (`Valid - Needs Triage`, `Valid - Already Triaged`, `Relabel - Bug`, `Relabel - Feature Request`). Skip close or request-more-info verdicts — those are already resolved.
+- Has `investigations` array → **Investigation decisions**. For each issue, combine investigation findings (effort, risk, root cause, confidence) with evidence pack data.
+
+For each qualifying issue, you need the evidence pack data. If the corresponding evidence pack is available in `.work/triage/packs/`, read it. Otherwise, run the `single` command to fetch data for the issue numbers.
+
+### Stage 1 — Gather Related Issue Counts
+
+For each issue being evaluated, search for related issues:
+
+```bash
+gh search issues --repo gitkraken/vscode-gitlens "<significant keywords from title>" --state open --json number --limit 20
+```
+
+Extract 3-5 significant keywords from the issue title (skip common words like "the", "is", "not", "when", "with", "does", "after"). Count results excluding the issue itself.
+
+**Rate budget:** Maximum 25 search calls per invocation. If evaluating more issues than that, prioritize issues with higher reaction counts or those from investigation reports.
+
+### Stage 2 — Evaluate Each Issue
+
+For each issue, assess these priority signals:
+
+| Signal                | Source                                            | How to assess                                                        |
+| --------------------- | ------------------------------------------------- | -------------------------------------------------------------------- |
+| Reactions (thumbs-up) | Evidence pack `reactions.thumbsUp`                | 0-2: low, 3-10: moderate, 11+: high demand                           |
+| Related issues        | Stage 1 search results + `duplicateCandidates`    | 0: isolated, 1-2: some impact, 3+: recurring                         |
+| Severity              | Issue content analysis                            | Data loss > crash > broken workflow > degraded experience > cosmetic |
+| Estimated effort      | Investigation report or inferred from description | Small (hours) / Medium (1-3 days) / Large (3+ days)                  |
+| Issue age             | `createdAt`                                       | Calculate days since creation                                        |
+| Activity recency      | `lastActivityAt`                                  | Days since last activity                                             |
+| Comment count         | `commentCount`                                    | Volume of discussion                                                 |
+
+### Stage 3 — Recommend Resolution
+
+Apply this decision framework:
+
+1. **Won't Fix** — Issue is out of scope for GitLens OR describes behavior that is working as designed. Requires clear evidence.
+
+2. **Community Contribution** — Feature request that is a good idea but too niche for the team to prioritize. Signals: low reaction count, specific/narrow use case, effort > Small.
+
+3. **Shortlist** — Should be done in the near term. Signals: high reactions (11+), high severity (data loss, crash, broken workflow), many related issues (3+), OR confirmed bug from investigation with Small/Medium effort.
+
+4. **Backlog** — Should be done, but lower priority or insufficient impact-to-effort ratio. Default for valid issues that don't meet shortlist criteria.
+
+The skill does NOT auto-decide. Present the signals, recommendation, and confidence level. A human makes the final call.
+
+### Stage 4 — Draft Communications (when applicable)
+
+Draft a comment only when the verdict is clear-cut:
+
+- **Won't Fix**: Explain why (out of scope or working as designed), thank the reporter, suggest alternatives if applicable
+- **Community Contribution**: Explain the feature is welcome as a contribution, provide relevant context about the codebase area (file paths, approach hints), link to contribution guidelines
+
+Do NOT draft comments for shortlist or backlog — those are internal planning decisions.
+
+### Output
+
+Produce two files in `.work/triage/reports/`:
+
+#### 1. Markdown Report
+
+File: `YYYY-MM-DD-RESOLUTION-REPORT.md`
+
+**Single issue:**
+
+```markdown
+# Resolution Report — YYYY-MM-DD
+
+Issues evaluated: 1
+
+---
+
+### [#NNNN — Title](https://github.com/gitkraken/vscode-gitlens/issues/NNNN)
+
+- **Author**: @username (team) | @username
+- **Recommendation**: Shortlist | Backlog | Won't Fix | Community Contribution
+- **Confidence**: High | Medium | Low
+
+#### Priority Signals
+
+| Signal                | Value                  | Assessment                          |
+| --------------------- | ---------------------- | ----------------------------------- |
+| Reactions (thumbs-up) | N                      | Low / Moderate / High demand        |
+| Related issues        | N open, N closed       | Isolated / Some impact / Recurring  |
+| Severity              | [level]                | [assessment]                        |
+| Estimated effort      | Small / Medium / Large | [source: investigation or inferred] |
+| Age                   | N days                 | [assessment]                        |
+| Last activity         | N days ago             | [assessment]                        |
+
+#### Rationale
+
+[2-3 sentences explaining why this recommendation, citing specific signals]
+
+#### Draft Message (if applicable)
+
+> [Draft comment for won't-fix or community-contribution verdicts]
+```
+
+**Batch (multiple issues):**
+
+```markdown
+# Resolution Report — YYYY-MM-DD
+
+Issues evaluated: N
+Source: [direct | triage decisions | investigation decisions]
+
+## Summary
+
+| Recommendation         | Count | Issues       |
+| ---------------------- | ----- | ------------ |
+| Shortlist              | N     | #NNNN, #NNNN |
+| Backlog                | N     | #NNNN, #NNNN |
+| Won't Fix              | N     | #NNNN        |
+| Community Contribution | N     | #NNNN        |
+
+## Shortlist (recommended for near-term work)
+
+[Per-issue details, ordered by priority — highest reactions + severity first]
+
+## Backlog
+
+[Per-issue details, ordered by priority]
+
+## Won't Fix
+
+[Per-issue details]
+
+## Community Contribution
+
+[Per-issue details]
+```
+
+#### 2. Machine-Readable JSON
+
+File: `YYYY-MM-DD-RESOLUTIONS.json`
+
+```json
+{
+  "reportId": "<uuid>",
+  "generatedAt": "<ISO timestamp>",
+  "source": "direct | triage | investigation",
+  "sourceFile": "<path to source file if from-triage or from-investigation>",
+  "resolutions": [
+    {
+      "issueNumber": 1234,
+      "issueTitle": "...",
+      "recommendation": "shortlist | backlog | wont-fix | community-contribution",
+      "confidence": "High | Medium | Low",
+      "prioritySignals": {
+        "reactionsThumbsUp": 45,
+        "relatedIssueCount": 5,
+        "severity": "broken-workflow | crash | data-loss | degraded-experience | cosmetic",
+        "estimatedEffort": "Small | Medium | Large | Unknown",
+        "ageInDays": 840,
+        "lastActivityDaysAgo": 90,
+        "commentCount": 12
+      },
+      "rationale": "...",
+      "draftMessage": "..." | null,
+      "recommendedMilestone": "Shortlist | Backlog" | null,
+      "recommendedLabels": []
+    }
+  ]
+}
+```
+
+Generate a UUID for `reportId`. Write both files and confirm their paths to the user.
+
+## Chaining
+
+This skill can be used standalone or as part of the issue workflow pipeline:
+
+```
+/triage recent → /investigate --from-report → /prioritize --from-report → /update-issues
+/triage 5096   → /investigate 5096          → /prioritize 5096          → /update-issues
+/prioritize 5096 5084 5070                    (standalone, direct mode)
+```
+
+Downstream: `/update-issues` can consume the resolutions JSON to apply recommendations to GitHub.

--- a/.claude/skills/prioritize/SKILL.md
+++ b/.claude/skills/prioritize/SKILL.md
@@ -122,6 +122,7 @@ Issues evaluated: 1
 | Estimated effort      | Small / Medium / Large | [source: investigation or inferred] |
 | Age                   | N days                 | [assessment]                        |
 | Last activity         | N days ago             | [assessment]                        |
+| Comments              | N                      | [assessment]                        |
 
 #### Rationale
 
@@ -165,6 +166,8 @@ Source: [direct | triage decisions | investigation decisions]
 
 [Per-issue details]
 ```
+
+Omit recommendation sections that have no issues — the Summary table already shows the full breakdown. Each per-issue entry in a recommendation section should use the same Priority Signals table and Rationale format as the single-issue template.
 
 #### 2. Machine-Readable JSON
 

--- a/.claude/skills/triage/SKILL.md
+++ b/.claude/skills/triage/SKILL.md
@@ -1,0 +1,327 @@
+---
+name: triage
+description: Triage GitHub issues using an evidence pack — evaluates issues and produces a structured report with verdicts, confidence levels, and recommended actions
+---
+
+# /triage - Issue Triage Toolkit
+
+Evaluate GitHub issues using a pre-assembled evidence pack and produce a structured triage report.
+
+## Usage
+
+```
+/triage <number> [number...]           # Single issue(s)
+/triage recent [--since 7d]            # Recent batch
+/triage audit [--older-than 180d] [--batch-size 50] [--label bug]  # Historical batch
+/triage <any mode> --skip-trust        # Skip reporter claim verification for team-member issues
+```
+
+## Instructions
+
+### Stage 0 — Prepare Evidence Pack
+
+Run the CLI to ensure data is fresh. Forward all arguments after the command name.
+
+**Single-issue mode:** When invoked with issue numbers, use the `single` command:
+
+```bash
+node --experimental-strip-types ./scripts/issues/triage.mts single <number> [number...]
+```
+
+**Batch modes:** Forward the command and arguments directly:
+
+```bash
+node --experimental-strip-types ./scripts/issues/triage.mts <recent|audit> [args]
+```
+
+The script prints the absolute path to the evidence pack JSON on stdout. Read that file.
+
+Parse the pack JSON. It contains:
+
+- `meta` — run metadata (workflow, query params, schema version)
+- `teamMembers` — list of GitHub org member logins
+- `issues` — array of enriched issues with computed evidence fields
+
+### Stage 1 — Quick Pass (all issues)
+
+For each issue in `pack.issues`, evaluate in order:
+
+#### 1. Spam/junk check
+
+Is the body empty, incoherent, or unrelated to GitLens?
+
+**Critical rule**: Organization-level members (`isTeamMember: true`) can NEVER be marked spam. Team-member issues often have minimal descriptions and must not be flagged. For contributors (`authorAssociation: "CONTRIBUTOR"`) apply lenient standards. For outsiders (`authorAssociation: "NONE"`), apply standard spam criteria.
+
+#### 2. Type and label correctness
+
+Does `issue.type` match the actual nature of the report? Do the labels correctly categorize it? Note any relabeling needed. Use label descriptions from the evidence pack to understand what each label means.
+
+#### 3. Already triaged check
+
+Does the issue have a milestone, assignee, or triage-specific label indicating it has been processed? If so, classify as `Valid - Already Triaged`.
+
+#### 4. Needs more info check
+
+Is the issue a bug report lacking environment details (VS Code version, extension version, OS, reproduction steps)? Is it a feature request with no description of the desired behavior? Classify as `Request More Info` if evidence is insufficient to evaluate further.
+
+#### 5. Reporter claim verification
+
+Verify reporter claims against the codebase before assigning any verdict above Low confidence. Skip this step for team-member issues when `--skip-trust` is passed.
+
+**Identify testable claims** — scan the issue body for references to specific settings (`gitlens.*`), commands, UI elements, error messages, described behavior, or code paths. These are the reporter's assertions about what exists and what happened.
+
+**Spot-check 1–3 claims** using `Grep` or `Glob`:
+
+- Does the referenced setting exist in `package.json` or `src/config.ts`?
+- Does the referenced command exist in `contributions.json`?
+- Does the described UI element, view, or menu item exist?
+- Does the error message appear in the codebase?
+- Does the described code path or behavior match the implementation?
+
+**Record each checked claim** as one of:
+
+- **Confirmed** — the claim matches what's in the codebase
+- **Disputed** — the claim contradicts what's in the codebase (e.g., setting doesn't exist, behavior works differently)
+- **Unverifiable** — the claim can't be checked from code alone (e.g., "it crashes on my machine," timing-dependent behavior)
+
+**Confidence gate**: If no claims can be verified (all unverifiable or no testable claims present), cap the verdict confidence at Low regardless of other evidence strength. Disputed claims should further lower confidence or shift the verdict toward `Request More Info` or `Close - Invalid` depending on severity.
+
+#### 6. Duplicate candidate scoring
+
+For each entry in `duplicateCandidates`:
+
+- If the canonical issue is closed-fixed, escalate to Stage 2 for deeper analysis
+- If the canonical issue is open, note as `Close - Duplicate` candidate pending Stage 2 confirmation
+- Evaluate `similarityBasis` to judge how strong the duplicate signal is
+
+### Stage 2 — Deep Pass (unresolved and high-value cases only)
+
+Apply only to issues not yet resolved to a high-confidence verdict in Stage 1.
+
+#### 7. Feature-exists check (feature requests)
+
+Does the requested feature already exist in the extension? Check against CHANGELOG entries (`changelogEntry` field), known feature areas, or codebase evidence if needed. If the feature already exists, classify as `Close - Invalid` with a note about the existing feature.
+
+#### 8. Bug-still-valid hypothesis (bug reports)
+
+Is there evidence the behavior described still exists? Cross-reference with `changelogEntry`. If a changelog entry exists for this issue, it is strong evidence of a fix — but must be corroborated by at least one other source:
+
+- Linked PR state (merged PR that addresses the fix)
+- Maintainer timeline comment confirming the fix
+- Investigation evidence from the codebase
+
+Do NOT classify as `Close - Fixed` on changelog evidence alone.
+
+#### 9. Fixed-status decision — Two-Source Rule
+
+To classify an issue as `Close - Fixed`, you MUST have at least two independent evidence sources:
+
+1. Changelog reference (`changelogEntry` is non-null)
+2. Linked PR or commit (a merged PR in `linkedPrs`)
+3. Maintainer timeline comment confirming the fix
+4. Codebase investigation evidence
+
+If only one source is present, downgrade to `Request More Info` or `Valid - Needs Triage`.
+
+#### 10. Third-party cause classification
+
+Is the issue caused by a VS Code API limitation, a platform OS issue, or a third-party extension conflict? Note this as evidence for `Close - Invalid` with an explicit reason.
+
+#### 11. Stale evaluation (audit and single mode)
+
+Does the issue meet ALL THREE stale criteria:
+
+- (a) No activity for >= `staleInactivityDays` (365 days) — check `lastActivityAt`
+- (b) The referenced feature/UI still exists or the fix was addressed elsewhere
+- (c) No missing mandatory evidence that would block a reliable verdict
+
+Only then classify as `Close - Stale`. Check `supersessionIndicators` for evidence of supersession.
+
+**Codebase-level staleness signals:** If the issue references specific UI elements, settings, commands, or code paths, check whether they still exist in the codebase. If the referenced functionality has been removed, substantially redesigned, or renamed, that is strong evidence for staleness. Use `Grep` or `Glob` to quickly verify existence of referenced features.
+
+#### 11a. Stale-but-needs-verification (audit and single mode)
+
+Separate from `Close - Stale`, identify issues that are old and inactive but where the code path still exists and the issue may still be valid. Classify as `Request More Info` when ALL of:
+
+- (a) No activity for a significant period (e.g., 6+ months) — check `lastActivityAt`
+- (b) The reported GitLens version is significantly outdated
+- (c) No upvotes or low engagement (`reactions.thumbsUp` is 0-1)
+- (d) The code path still exists (not eligible for `Close - Stale`)
+
+The `Request More Info` comment should ask the reporter to verify the issue still occurs on the current version and provide updated environment details. This triggers the `needs-more-info` label via `/update-issues`, which activates existing automation that auto-closes if no response within a set timeframe.
+
+### Safety Gate
+
+Before assigning ANY verdict:
+
+- Confirm all required evidence fields for that verdict class are satisfied
+- If any required evidence is missing or confidence is `Low`, downgrade to `Request More Info` or `Valid - Needs Triage`
+- If you cannot justify a verdict with available evidence, defer to human review by classifying as `Valid - Needs Triage` with a note of your impression
+- Set `requiresHumanApproval: true` for ALL close recommendations (`Close - Fixed`, `Close - Duplicate`, `Close - Invalid`, `Close - Stale`)
+- Never override the two-source rule for `Close - Fixed`
+- Never classify a team member's issue as spam
+
+### Evidence Requirements by Verdict
+
+| Verdict                   | Required Evidence                                                                |
+| ------------------------- | -------------------------------------------------------------------------------- |
+| Close - Fixed             | 2+ of: changelog entry, merged linked PR, maintainer comment, code investigation |
+| Close - Duplicate         | Identified canonical issue number + both issues describe same behavior           |
+| Close - Invalid           | Clear evidence of third-party cause, spam, or misunderstanding                   |
+| Close - Stale             | No activity for 365+ days + feature still exists or addressed elsewhere          |
+| Request More Info         | Specific description of what information is missing                              |
+| Relabel - Bug             | Evidence issue describes a defect, not a feature request                         |
+| Relabel - Feature Request | Evidence issue describes desired new behavior, not a defect                      |
+| Valid - Needs Triage      | Insufficient evidence for any other verdict                                      |
+| Valid - Already Triaged   | Has milestone, assignee, or triage labels                                        |
+
+### Output
+
+Construct issue URLs as `https://github.com/<pack.meta.repo>/issues/<number>` and link every issue reference in both the markdown report and JSON output.
+
+Produce two files in `.work/triage/reports/`:
+
+#### 1. Markdown Report
+
+For reactive mode: `YYYY-MM-DD-TRIAGE-REPORT.md`
+For audit mode: `YYYY-MM-DD-AUDIT-REPORT-batch-N.md`
+For single mode: `YYYY-MM-DD-TRIAGE-REPORT.md`
+
+Use this structure:
+
+```markdown
+# [Triage / Audit] Report — YYYY-MM-DD [Batch N]
+
+Run ID: <runId>
+Generated: <timestamp>
+Workflow: reactive | audit
+Query: <query params summary>
+Issues evaluated: N
+Issues requiring human approval: N
+
+---
+
+## Issues to Close Now
+
+> All items in this section require human review before action is taken.
+
+### [#NNNN — Title](https://github.com/<owner>/<repo>/issues/NNNN)
+
+- **Author**: @username (team) | @username
+- **Verdict**: Close - Fixed | Close - Duplicate | Close - Invalid | Close - Stale
+- **Confidence**: High | Medium | Low
+- **Type**: <issue type> | **Labels**: <label list>
+- **Claims**: <checked claims with status: confirmed/disputed/unverifiable — omit if verification was skipped>
+- **Evidence**: <concise evidence summary>
+- **Recommended action**: <specific action to take>
+- **Requires human approval**: Yes
+
+---
+
+## Issues Needing a Maintainer Comment
+
+### [#NNNN — Title](https://github.com/<owner>/<repo>/issues/NNNN)
+
+- **Author**: @username (team) | @username
+- **Verdict**: Request More Info
+- **Confidence**: High | Medium | Low
+- **Claims**: <checked claims with status — omit if verification was skipped>
+- **Evidence**: <what is known>
+- **Recommended action**: <specific comment to post>
+
+---
+
+## Issues Needing Relabeling
+
+### [#NNNN — Title](https://github.com/<owner>/<repo>/issues/NNNN)
+
+- **Author**: @username (team) | @username
+- **Verdict**: Relabel - Bug | Relabel - Feature Request
+- **Confidence**: High | Medium | Low
+- **Claims**: <checked claims with status — omit if verification was skipped>
+- **Evidence**: <why the current label is wrong>
+- **Current type/labels**: <current>
+- **Recommended labels**: <changes to make>
+
+---
+
+## Issues to Enter Investigation Queue
+
+### [#NNNN — Title](https://github.com/<owner>/<repo>/issues/NNNN)
+
+- **Author**: @username (team) | @username
+- **Verdict**: Valid - Needs Triage
+- **Confidence**: Medium | Low
+- **Claims**: <checked claims with status — omit if verification was skipped>
+- **Evidence**: <what is known and what needs investigation>
+
+---
+
+## Issues Already Triaged (No Immediate Action)
+
+- [#NNNN — Title](https://github.com/<owner>/<repo>/issues/NNNN) — <reason it's already triaged>
+
+---
+
+## Quality Metadata
+
+- Low-confidence verdicts: N (X%)
+- Human approval required: N
+- Issues skipped (Stage 1 resolved): N
+- Issues escalated to Stage 2: N
+```
+
+#### 2. Machine-Readable Decisions JSON
+
+File: `YYYY-MM-DD-DECISIONS[-batch-N].json`
+
+```json
+{
+	"reportId": "<uuid>",
+	"runId": "<uuid from pack>",
+	"schemaVersion": "1.0",
+	"generatedAt": "<ISO timestamp>",
+	"workflow": "reactive | audit | single",
+	"verdicts": [
+		{
+			"issueNumber": 1234,
+			"verdict": "<VerdictClass>",
+			"confidence": "High | Medium | Low",
+			"evidenceChecklistStatus": {
+				"changelogReference": true,
+				"linkedPrOrCommit": true,
+				"maintainerTimelineComment": false,
+				"investigationEvidence": false
+			},
+			"claimsVerification": [
+				{
+					"claim": "setting gitlens.foo exists",
+					"status": "confirmed | disputed | unverifiable",
+					"detail": "optional — what was found or why it couldn't be checked"
+				}
+			],
+			"recommendedLabels": [],
+			"recommendedActions": ["close"],
+			"requiresHumanApproval": true,
+			"evidenceSummary": "...",
+			"canonicalDuplicateNumber": null,
+			"canonicalDuplicateStatus": null
+		}
+	]
+}
+```
+
+Generate a UUID for `reportId`. Use the `runId` from the evidence pack's `meta.runId`.
+
+Write both files and confirm their paths to the user.
+
+## Chaining
+
+This skill can be used standalone or as part of the issue workflow pipeline:
+
+```
+/triage recent → /investigate --from-report → /prioritize --from-report → /update-issues
+/triage 5096   → /investigate 5096          → /prioritize 5096          → /update-issues
+```
+
+Downstream skills consume the decisions JSON produced by this skill.

--- a/.claude/skills/triage/SKILL.md
+++ b/.claude/skills/triage/SKILL.md
@@ -189,6 +189,8 @@ For reactive mode: `YYYY-MM-DD-TRIAGE-REPORT.md`
 For audit mode: `YYYY-MM-DD-AUDIT-REPORT-batch-N.md`
 For single mode: `YYYY-MM-DD-TRIAGE-REPORT.md`
 
+**Single-issue brevity rule:** When evaluating only 1 issue, omit any verdict-group sections that have no issues (e.g., skip "Issues to Close Now" entirely if there are none). Only include sections that contain at least one issue, plus the Quality Metadata section. This keeps the report focused and scannable. For batch triage (2+ issues), include all sections — the grouping serves as a useful overview even when some groups are empty.
+
 Use this structure:
 
 ```markdown
@@ -254,8 +256,9 @@ Issues requiring human approval: N
 - **Author**: @username (team) | @username
 - **Verdict**: Valid - Needs Triage
 - **Confidence**: Medium | Low
-- **Claims**: <checked claims with status — omit if verification was skipped>
-- **Evidence**: <what is known and what needs investigation>
+- **Type**: <issue type> | **Labels**: <current labels> | **Recommended labels**: <area labels to add based on feature area identified during evaluation, e.g. area-graph, area-ai, area-integrations — or "none" if current labels are sufficient>
+- **Claims**: <1-2 sentence summary per checked claim with status: confirmed/disputed/unverifiable — omit if verification was skipped>
+- **Evidence**: <what is known and what needs investigation — keep to 2-4 bullet points>
 
 ---
 
@@ -314,6 +317,11 @@ File: `YYYY-MM-DD-DECISIONS[-batch-N].json`
 ```
 
 Generate a UUID for `reportId`. Use the `runId` from the evidence pack's `meta.runId`.
+
+**Field guidance:**
+
+- `evidenceChecklistStatus` — Used for the Two-Source Rule (Stage 2, step 9). These fields track formal evidence sources for close decisions, NOT claim verification from Stage 1. `investigationEvidence` should only be `true` if a formal `/investigate` report exists or you performed a Stage 2 code investigation that confirms/refutes the bug status. Claim verification (Stage 1, step 5) does not count as investigation evidence.
+- `recommendedLabels` — Always include recommended area labels (e.g., `area-graph`, `area-ai`, `area-cli`, `area-integrations`) based on the feature area identified during evaluation. Include type corrections (e.g., `bug`, `enhancement`) and status labels (e.g., `triaged`). Check the evidence pack's label descriptions for available area labels.
 
 Write both files and confirm their paths to the user.
 

--- a/.claude/skills/triage/SKILL.md
+++ b/.claude/skills/triage/SKILL.md
@@ -12,7 +12,7 @@ Evaluate GitHub issues using a pre-assembled evidence pack and produce a structu
 ```
 /triage <number> [number...]           # Single issue(s)
 /triage recent [--since 7d]            # Recent batch
-/triage audit [--older-than 180d] [--batch-size 50] [--label bug]  # Historical batch
+/triage audit [--older-than 180d] [--batch-size 50] [--type bug]   # Historical batch
 /triage <any mode> --skip-trust        # Skip reporter claim verification for team-member issues
 ```
 
@@ -100,7 +100,7 @@ Apply only to issues not yet resolved to a high-confidence verdict in Stage 1.
 
 #### 7. Feature-exists check (feature requests)
 
-Does the requested feature already exist in the extension? Check against CHANGELOG entries (`changelogEntry` field), known feature areas, or codebase evidence if needed. If the feature already exists, classify as `Close - Invalid` with a note about the existing feature.
+Does the requested feature already exist in the extension? Check against CHANGELOG entries (`changelogEntry` field), known feature areas, or codebase evidence if needed. If the feature already exists, classify as `Close - Already Exists` with a note explaining the existing feature and how to access it.
 
 #### 8. Bug-still-valid hypothesis (bug reports)
 
@@ -157,23 +157,25 @@ Before assigning ANY verdict:
 - Confirm all required evidence fields for that verdict class are satisfied
 - If any required evidence is missing or confidence is `Low`, downgrade to `Request More Info` or `Valid - Needs Triage`
 - If you cannot justify a verdict with available evidence, defer to human review by classifying as `Valid - Needs Triage` with a note of your impression
-- Set `requiresHumanApproval: true` for ALL close recommendations (`Close - Fixed`, `Close - Duplicate`, `Close - Invalid`, `Close - Stale`)
+- Set `requiresHumanApproval: true` for ALL close recommendations (`Close - Fixed`, `Close - Duplicate`, `Close - Not a Bug`, `Close - Already Exists`, `Close - Invalid`, `Close - Stale`)
 - Never override the two-source rule for `Close - Fixed`
 - Never classify a team member's issue as spam
 
 ### Evidence Requirements by Verdict
 
-| Verdict                   | Required Evidence                                                                |
-| ------------------------- | -------------------------------------------------------------------------------- |
-| Close - Fixed             | 2+ of: changelog entry, merged linked PR, maintainer comment, code investigation |
-| Close - Duplicate         | Identified canonical issue number + both issues describe same behavior           |
-| Close - Invalid           | Clear evidence of third-party cause, spam, or misunderstanding                   |
-| Close - Stale             | No activity for 365+ days + feature still exists or addressed elsewhere          |
-| Request More Info         | Specific description of what information is missing                              |
-| Relabel - Bug             | Evidence issue describes a defect, not a feature request                         |
-| Relabel - Feature Request | Evidence issue describes desired new behavior, not a defect                      |
-| Valid - Needs Triage      | Insufficient evidence for any other verdict                                      |
-| Valid - Already Triaged   | Has milestone, assignee, or triage labels                                        |
+| Verdict                  | Required Evidence                                                                              |
+| ------------------------ | ---------------------------------------------------------------------------------------------- |
+| Close - Fixed            | 2+ of: changelog entry, merged linked PR, maintainer comment, code investigation               |
+| Close - Duplicate        | Identified canonical issue number + both issues describe same behavior                         |
+| Close - Not a Bug        | Evidence the reported behavior is expected, user error, or environment-specific (not a defect) |
+| Close - Already Exists   | Codebase or CHANGELOG evidence the requested feature already ships                             |
+| Close - Invalid          | Clear evidence of third-party cause, spam, or misunderstanding                                 |
+| Close - Stale            | No activity for 365+ days + feature still exists or addressed elsewhere                        |
+| Request More Info        | Specific description of what information is missing                                            |
+| Retype - Bug             | Evidence issue describes a defect, not a feature request                                       |
+| Retype - Feature Request | Evidence issue describes desired new behavior, not a defect                                    |
+| Valid - Needs Triage     | Insufficient evidence for any other verdict                                                    |
+| Valid - Already Triaged  | Has milestone, assignee, or triage labels                                                      |
 
 ### Output
 
@@ -208,7 +210,7 @@ Issues requiring human approval: N
 ### [#NNNN — Title](https://github.com/<owner>/<repo>/issues/NNNN)
 
 - **Author**: @username (team) | @username
-- **Verdict**: Close - Fixed | Close - Duplicate | Close - Invalid | Close - Stale
+- **Verdict**: Close - Fixed | Close - Duplicate | Close - Not a Bug | Close - Already Exists | Close - Invalid | Close - Stale
 - **Confidence**: High | Medium | Low
 - **Type**: <issue type> | **Labels**: <label list>
 - **Claims**: <checked claims with status: confirmed/disputed/unverifiable — omit if verification was skipped>
@@ -231,17 +233,17 @@ Issues requiring human approval: N
 
 ---
 
-## Issues Needing Relabeling
+## Issues Needing Retyping
 
 ### [#NNNN — Title](https://github.com/<owner>/<repo>/issues/NNNN)
 
 - **Author**: @username (team) | @username
-- **Verdict**: Relabel - Bug | Relabel - Feature Request
+- **Verdict**: Retype - Bug | Retype - Feature Request
 - **Confidence**: High | Medium | Low
 - **Claims**: <checked claims with status — omit if verification was skipped>
-- **Evidence**: <why the current label is wrong>
-- **Current type/labels**: <current>
-- **Recommended labels**: <changes to make>
+- **Evidence**: <why the current type is wrong>
+- **Current type**: <current>
+- **Recommended type**: <new type>
 
 ---
 

--- a/.claude/skills/update-issues/SKILL.md
+++ b/.claude/skills/update-issues/SKILL.md
@@ -1,0 +1,183 @@
+---
+name: update-issues
+description: Update GitHub issues from triage, investigation, or prioritization reports — adds labels, posts comments, sets milestones, and closes issues with safety checks
+---
+
+# /update-issues - Update GitHub Issues from Reports
+
+Read a triage, investigation, or prioritization report and apply the recommended actions to GitHub. This is the only skill in the issue workflow that modifies GitHub state.
+
+## Usage
+
+```
+/update-issues --from-report [path] [--dry-run]
+```
+
+- `--from-report` — Path to a report JSON file (auto-detects type: triage decisions, investigation decisions, or resolutions). If path omitted, uses the most recent report JSON in `.work/triage/reports/`.
+- `--dry-run` — Show what would be done without making changes. This is the DEFAULT behavior on first invocation — you must confirm before actions are applied.
+
+## Instructions
+
+### Stage 0 — Load Report
+
+Read the JSON file and determine report type:
+
+- Has `verdicts` array → **Triage decisions** (`DECISIONS-*.json`)
+- Has `investigations` array → **Investigation decisions** (`*-INVESTIGATION-DECISIONS.json`)
+- Has `resolutions` array → **Resolution decisions** (`RESOLUTIONS-*.json`)
+
+### Stage 1 — Translate Recommendations to Actions
+
+For each issue in the report, determine the GitHub actions to take:
+
+**From triage decisions:**
+
+| Verdict                   | Actions                                                                                   |
+| ------------------------- | ----------------------------------------------------------------------------------------- |
+| Close - Fixed             | Close issue (reason: completed), add label `triaged`, remove label `triage`               |
+| Close - Duplicate         | Close issue (reason: not planned), comment linking canonical issue, add label `duplicate` |
+| Close - Invalid           | Close issue (reason: not planned), comment with explanation                               |
+| Close - Stale             | Close issue (reason: not planned), comment explaining staleness                           |
+| Request More Info         | Add label `needs-more-info`, comment requesting specific info                             |
+| Relabel - Bug             | Change issue type/labels to bug                                                           |
+| Relabel - Feature Request | Change issue type/labels to enhancement                                                   |
+| Valid - Needs Triage      | No action (needs investigation first)                                                     |
+| Valid - Already Triaged   | No action                                                                                 |
+
+**From investigation decisions:**
+
+| Result                      | Actions                                                                          |
+| --------------------------- | -------------------------------------------------------------------------------- |
+| Confirmed Bug               | Add label `triaged`, remove label `triage`                                       |
+| Likely Fixed                | Add label `needs-more-info`, comment asking reporter to verify on latest version |
+| Cannot Reproduce            | Add label `needs-more-info`, comment requesting updated repro steps              |
+| Inconclusive / Insufficient | No action (needs human review)                                                   |
+
+**From resolution decisions:**
+
+| Recommendation         | Actions                                                                  |
+| ---------------------- | ------------------------------------------------------------------------ |
+| shortlist              | Set milestone to "Shortlist", add label `triaged`, remove label `triage` |
+| backlog                | Set milestone to "Backlog", add label `triaged`, remove label `triage`   |
+| wont-fix               | Close issue (reason: not planned), comment with rationale                |
+| community-contribution | Add label `needs-help`, comment inviting contribution                    |
+
+### Stage 2 — Pre-flight State Check
+
+**Critical:** Before applying ANY action, verify current issue state:
+
+```bash
+gh issue view <number> --repo gitkraken/vscode-gitlens --json state,labels,milestone
+```
+
+For each issue, check:
+
+- **Already closed?** → Skip close actions, warn user
+- **Labels already applied?** → Skip redundant label additions
+- **Milestone already set?** → Skip if same milestone, warn if different
+- **Report age** → If the report is older than 24 hours, warn that issue state may have changed
+
+### Stage 3 — Present Dry Run
+
+Before executing any actions, present a summary table:
+
+```markdown
+## Actions to Apply
+
+| Issue | Action        | Details                             | Status                       |
+| ----- | ------------- | ----------------------------------- | ---------------------------- |
+| #1234 | Close         | Reason: not planned, Comment: "..." | Ready                        |
+| #1234 | Add label     | `duplicate`                         | Ready                        |
+| #2345 | Add label     | `needs-more-info`                   | Ready                        |
+| #2345 | Comment       | "Could you provide..."              | Ready                        |
+| #3456 | Set milestone | Backlog                             | Ready                        |
+| #4567 | Close         | Reason: completed                   | ⚠️ Already closed — skipping |
+
+### Summary
+
+- Actions ready: N
+- Skipped (already applied): N
+- Warnings: N
+```
+
+**Ask for confirmation before proceeding.** The user may choose to:
+
+- Apply all ready actions
+- Apply selectively (specify issue numbers)
+- Cancel
+
+### Stage 4 — Execute Actions
+
+Execute approved actions using `gh` CLI:
+
+```bash
+# Add label
+gh issue edit <number> --repo gitkraken/vscode-gitlens --add-label "<label>"
+
+# Remove label
+gh issue edit <number> --repo gitkraken/vscode-gitlens --remove-label "<label>"
+
+# Set milestone
+gh issue edit <number> --repo gitkraken/vscode-gitlens --milestone "<milestone>"
+
+# Post comment
+gh issue comment <number> --repo gitkraken/vscode-gitlens --body "<message>"
+
+# Close with reason and comment
+gh issue close <number> --repo gitkraken/vscode-gitlens --reason "not planned" --comment "<message>"
+
+# Close as completed
+gh issue close <number> --repo gitkraken/vscode-gitlens --reason "completed" --comment "<message>"
+```
+
+**Execution order per issue:** Labels first, then milestone, then comment, then close (if applicable). This ensures the issue has correct metadata before closing.
+
+**Error handling:** If a `gh` command fails, log the error and continue with remaining actions. Report all failures at the end.
+
+### Stage 5 — Audit Log
+
+Write an audit log to `.work/triage/reports/YYYY-MM-DD-ACTIONS.md`:
+
+```markdown
+# Actions Applied — YYYY-MM-DD
+
+Source report: <path to source JSON>
+Report type: triage | investigation | resolution
+Applied at: <ISO timestamp>
+Applied by: <git user>
+
+## Actions Taken
+
+| Issue | Action                        | Result                                  |
+| ----- | ----------------------------- | --------------------------------------- |
+| #1234 | Closed (not planned)          | ✓ Success                               |
+| #1234 | Added label `duplicate`       | ✓ Success                               |
+| #2345 | Added label `needs-more-info` | ✓ Success                               |
+| #2345 | Posted comment                | ✓ Success                               |
+| #3456 | Set milestone: Backlog        | ✗ Failed: milestone "Backlog" not found |
+
+## Summary
+
+- Successful: N
+- Failed: N
+- Skipped: N
+```
+
+## Safety Rules
+
+1. **Dry-run first** — ALWAYS show the action plan and get confirmation before executing
+2. **Pre-flight checks** — ALWAYS verify current issue state before acting
+3. **Close confirmation** — Closing issues requires explicit user approval for EACH issue
+4. **No label creation** — Only use existing labels. If a recommended label doesn't exist, warn and skip
+5. **No force operations** — Never use `--force` or bypass safety checks
+6. **Audit everything** — Every action taken must be logged
+
+## Chaining
+
+This skill consumes output from the other issue workflow skills:
+
+```
+/triage recent → /update-issues                                      (apply triage verdicts)
+/triage recent → /investigate --from-report → /update-issues         (apply investigation results)
+/triage recent → /investigate --from-report → /prioritize --from-report → /update-issues  (full pipeline)
+```

--- a/.claude/skills/update-issues/SKILL.md
+++ b/.claude/skills/update-issues/SKILL.md
@@ -32,35 +32,38 @@ For each issue in the report, determine the GitHub actions to take:
 
 **From triage decisions:**
 
-| Verdict                   | Actions                                                                                   |
-| ------------------------- | ----------------------------------------------------------------------------------------- |
-| Close - Fixed             | Close issue (reason: completed), add label `triaged`, remove label `triage`               |
-| Close - Duplicate         | Close issue (reason: not planned), comment linking canonical issue, add label `duplicate` |
-| Close - Invalid           | Close issue (reason: not planned), comment with explanation                               |
-| Close - Stale             | Close issue (reason: not planned), comment explaining staleness                           |
-| Request More Info         | Add label `needs-more-info`, comment requesting specific info                             |
-| Relabel - Bug             | Change issue type/labels to bug                                                           |
-| Relabel - Feature Request | Change issue type/labels to enhancement                                                   |
-| Valid - Needs Triage      | No action (needs investigation first)                                                     |
-| Valid - Already Triaged   | No action                                                                                 |
+| Verdict                  | Actions                                                                                                |
+| ------------------------ | ------------------------------------------------------------------------------------------------------ |
+| Close - Fixed            | Close issue (reason: completed), add label `triaged`, remove label `triage`                            |
+| Close - Duplicate        | Close issue (reason: not planned), comment linking canonical issue, add label `duplicate`              |
+| Close - Not a Bug        | Close issue (reason: not planned), add label `not-bug`, comment explaining why this is not a defect    |
+| Close - Already Exists   | Close issue (reason: not planned), add label `already-exists`, comment explaining the existing feature |
+| Close - Invalid          | Close issue (reason: not planned), comment with explanation                                            |
+| Close - Stale            | Close issue (reason: not planned), comment explaining staleness                                        |
+| Request More Info        | Add label `needs-more-info`, comment requesting specific info                                          |
+| Retype - Bug             | Change issue type to bug                                                                               |
+| Retype - Feature Request | Change issue type to enhancement                                                                       |
+| Valid - Needs Triage     | No action (needs investigation first)                                                                  |
+| Valid - Already Triaged  | No action                                                                                              |
 
 **From investigation decisions:**
 
-| Result                      | Actions                                                                          |
-| --------------------------- | -------------------------------------------------------------------------------- |
-| Confirmed Bug               | Add label `triaged`, remove label `triage`                                       |
-| Likely Fixed                | Add label `needs-more-info`, comment asking reporter to verify on latest version |
-| Cannot Reproduce            | Add label `needs-more-info`, comment requesting updated repro steps              |
-| Inconclusive / Insufficient | No action (needs human review)                                                   |
+| Result                      | Actions                                                                                                                                                                                |
+| --------------------------- | -------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| Confirmed Bug               | Add label `triaged`, remove label `triage`                                                                                                                                             |
+| Confirmed Bug (blocked)     | Add label `triaged`, remove label `triage`, add blocked label (`blocked`, `blocked: vscode`, `blocked: git`, `blocked: cli`, or `blocked: language-server` based on `blockedBy` field) |
+| Likely Fixed                | Add label `needs-more-info`, comment asking reporter to verify on latest version                                                                                                       |
+| Cannot Reproduce            | Add label `needs-more-info`, comment requesting updated repro steps                                                                                                                    |
+| Inconclusive / Insufficient | No action (needs human review)                                                                                                                                                         |
 
 **From resolution decisions:**
 
-| Recommendation         | Actions                                                                  |
-| ---------------------- | ------------------------------------------------------------------------ |
-| shortlist              | Set milestone to "Shortlist", add label `triaged`, remove label `triage` |
-| backlog                | Set milestone to "Backlog", add label `triaged`, remove label `triage`   |
-| wont-fix               | Close issue (reason: not planned), comment with rationale                |
-| community-contribution | Add label `needs-help`, comment inviting contribution                    |
+| Recommendation         | Actions                                                                                             |
+| ---------------------- | --------------------------------------------------------------------------------------------------- |
+| shortlist              | Set milestone to "Shortlist", add label `triaged`, remove label `triage`                            |
+| backlog                | Set milestone to "Backlog", add label `triaged`, remove label `triage`                              |
+| wont-fix               | Close issue (reason: not planned), add label `wontfix`, comment with rationale                      |
+| community-contribution | Add label `needs-help` (if bug) or `needs-champion` (if enhancement), comment inviting contribution |
 
 ### Stage 2 — Pre-flight State Check
 

--- a/.claude/skills/ux-review/SKILL.md
+++ b/.claude/skills/ux-review/SKILL.md
@@ -1,0 +1,188 @@
+---
+name: ux-review
+description: Use when reviewing a change set for user experience quality — traces user flows instead of code paths, validates that the implementation delivers the right experience against the goals doc's UX spec
+---
+
+# /ux-review - User Experience Review
+
+Traces user flows end-to-end against the goals doc. Validates that the implementation delivers the right experience — not just that the code is correct, but that the user gets the outcome they expect in a way that feels right.
+
+**Use `/deep-review` for code path correctness. Use `/ux-review` for user flow validation. Different lenses.**
+
+## Usage
+
+```
+/ux-review [target] --scope .work/dev/{id}/
+```
+
+- **`--scope <path>`** (required): Path to the dev folder containing `goals.md`. The goals doc is not optional for UX review — without it, there's no authoritative description of intended user experience to review against. If no goals doc exists, **stop and tell the user** to run `/dev-scope` first or provide the UX intent inline.
+- No argument: review staged changes (`git diff --cached`)
+- `all`: all uncommitted changes
+- `branch`: changes vs base branch (`git diff main...HEAD`)
+- `pr`: current PR changes (`gh pr diff`)
+- `commit:SHA`: specific commit
+
+## When to Use /ux-review vs /deep-review
+
+| Skill          | Traces     | Finds                                                        |
+| -------------- | ---------- | ------------------------------------------------------------ |
+| `/deep-review` | Code paths | Bugs, regressions, performance issues, design problems       |
+| `/ux-review`   | User flows | Dead ends, missing feedback, discoverability gaps, UX breaks |
+
+Use both together for user-facing changes: `/deep-review` catches code-level issues, `/ux-review` catches experience-level issues.
+
+## When to Skip
+
+Not every change needs a UX review. Skip when:
+
+- The change is purely internal (refactor, performance optimization, test infrastructure) with no user-facing surface
+- The change is a one-line bug fix where the UX impact is obvious and contained
+- There is no goals.md and the user confirms the change has no UX dimension
+
+When in doubt, run it — a quick "no UX findings" is cheap, a shipped UX bug is not.
+
+## Step 1: Gather Context
+
+1. **Read the goals doc** at `{scope}/goals.md` — focus on the **User Experience** and **Success Criteria** sections. These are the spec you're reviewing against.
+2. **Get the diff** using the target argument (same as `/deep-review`):
+   - No argument: `git diff --cached`
+   - `all`: `git diff HEAD`
+   - `branch`: `git diff main...HEAD`
+   - `pr`: `gh pr diff`
+   - `commit:SHA`: `git show SHA`
+3. **Read all modified files in full** — not just the diff hunks. Understand surrounding context for user-facing behavior.
+
+## Step 2: Identify User-Facing Changes
+
+For each change in the diff, determine:
+
+- **What surface it appears on**: editor, tree view, webview, quick pick, status bar, notification, command palette, context menu, terminal
+- **What triggers it**: user action (click, command, keybinding), automatic (on file open, on repo change), event-driven (timer, external)
+- **What the user sees**: before, during, and after the change takes effect
+
+Filter out changes with no user-facing surface — note them as "no UX impact" and move on.
+
+## Step 3: Trace User Flows
+
+Unlike `/deep-review` which traces code paths from the diff, trace **user paths**:
+
+1. **Start from the goals doc's UX section** — this is the spec. The review checks the diff against it.
+2. **Walk each flow end-to-end** — starting from the trigger described in goals.md through to completion. Note every point where the implementation diverges from the described experience.
+3. **Check what's NOT in the diff** — missing implementations are UX bugs. If goals.md describes an error state and the diff doesn't handle it, that's a finding.
+
+## Step 4: Evaluate Against Seven Lenses
+
+Not every lens applies to every change — skip lenses that don't apply and say so.
+
+### 1. Flow Delivery
+
+Does the implementation actually deliver the user flow described in `goals.md`?
+
+- **Happy path**: Walk through the expected flow step by step. Does each step in the goals doc have a corresponding implementation? Are there gaps where the user would hit a dead end?
+- **Error paths**: What does the user see when things go wrong? Is the error actionable ("couldn't find remote -- check your network connection") or opaque ("operation failed")? Does the error leave the user in a recoverable state?
+- **Edge cases**: What happens with empty states, first-time use, missing data, concurrent operations, large inputs? Check the edge cases listed in goals.md -- are they handled?
+- **Entry/exit**: Does the flow start from the right place (command palette, context menu, button, automatic trigger)? When it ends, does the user land somewhere sensible?
+
+### 2. Feedback & Responsiveness
+
+Does the UI communicate what's happening at every stage?
+
+- **Loading states**: Operations that take time (git commands, API calls, file parsing) -- does the user see progress, a spinner, or at minimum that something is happening? Silence longer than ~200ms needs feedback.
+- **Success confirmation**: When an action completes, does the user know it worked? Not every action needs a toast -- sometimes the UI updating is confirmation enough. But destructive or irreversible actions need explicit confirmation.
+- **Failure communication**: When something fails, is the failure visible where the user is looking? A logged error the user never sees is not feedback.
+- **State transitions**: When the UI changes state (loading -> loaded, editing -> saved, collapsed -> expanded), are transitions smooth or jarring?
+
+### 3. Discoverability
+
+Can users find and understand this feature?
+
+- **Location**: Is the feature accessible from the right surface? (command palette, context menu, view action, editor gutter, status bar -- wherever the user would naturally look for it)
+- **Naming**: Do command names, menu labels, and tooltips use language the user thinks in? Avoid internal jargon. A user searching the command palette should find this with the words they'd naturally type.
+- **First encounter**: If this is a new feature, how does a user learn it exists? Is there a walkthrough step, a what's new entry, a contextual hint?
+- **Affordances**: Do interactive elements look interactive? Do disabled elements explain why they're disabled (via tooltip or contextual message)?
+
+### 4. Consistency
+
+Does it feel like GitLens?
+
+- **Interaction patterns**: Does this feature follow the same patterns as similar existing features? If GitLens already has a way to do something analogous, this should work the same way unless there's a clear reason not to.
+- **Terminology**: Does it use the same words GitLens uses elsewhere for the same concepts? (e.g., "repository" vs "repo", "stash" vs "shelf")
+- **Visual language**: Icons, tree item structures, webview layouts, quick pick formats -- do they match existing GitLens conventions?
+- **Behavior expectations**: If the user has learned how one GitLens feature works, does that knowledge transfer to this one?
+
+### 5. Workflow Integration
+
+Does it fit into how people actually work in VS Code?
+
+- **Flow preservation**: Does the feature keep the user in their flow, or does it yank them out of context? A modal dialog when a notification would do, or a full view switch when an inline indicator would suffice -- these are flow breaks.
+- **Reversibility**: Can the user undo or back out? Destructive actions need confirmation. Multi-step flows need a way to go back or cancel.
+- **Composability**: Does the feature work well alongside other VS Code features and other GitLens features? Does it conflict with common keybindings, monopolize panels, or break expected multi-repo behavior?
+- **Interruption cost**: If the user is in the middle of something else (editing, reviewing, rebasing), does this feature interrupt them? Does it steal focus?
+
+### 6. Information Design
+
+Is the right information presented at the right time?
+
+- **Progressive disclosure**: Does the UI show the essential information first and let the user drill into details? Or does it dump everything at once?
+- **Information hierarchy**: Is the most important information the most visually prominent? In tree views, hover details, webview panels -- does the eye go to what matters?
+- **Density**: Is the information density appropriate for the context? Tree views should be scannable. Detail panels can be richer. Quick picks should be concise.
+- **Empty states**: When there's no data to show, does the user see a helpful message, or a blank void? Empty states are opportunities to guide ("No stashes yet -- use `git stash` to save work in progress").
+
+### 7. Accessibility
+
+Can all users use this feature effectively?
+
+- **Keyboard**: Can every interaction be performed via keyboard? Tab order logical? Custom interactive elements have keyboard handlers?
+- **Screen reader**: Do elements have appropriate ARIA labels, roles, and states? Do dynamic updates use live regions?
+- **Focus management**: After actions that change the UI (open/close panels, navigate lists), is focus placed somewhere sensible? Modals trap focus?
+- **Contrast and theming**: Does the feature respect VS Code's theme? No hardcoded colors? Works in high contrast themes?
+
+## Review Rules
+
+- The goals doc's UX section is the spec — review against it, not your own UX preferences
+- If the goals doc's UX section is incomplete, flag that as a finding, don't invent requirements
+- Missing implementations of described user flows are UX bugs, not "future work"
+- A technically correct feature that's undiscoverable is still a failure
+- Do not evaluate code quality, performance internals, or test coverage — that's `/deep-review` and `/review`
+- Do not evaluate visual design of webview CSS (layout, spacing, color) beyond theming compliance — that requires visual inspection of a running extension
+- Do not run the extension or interact with it — this is a code-level review of user-facing behavior, not a manual QA pass
+
+## Output Format
+
+### Findings (ordered by severity)
+
+For each finding include:
+
+| Field          | Values                                                                                                   |
+| -------------- | -------------------------------------------------------------------------------------------------------- |
+| **lens**       | flow delivery / feedback / discoverability / consistency / workflow / information design / accessibility |
+| **severity**   | critical (blocks merge) / high (should fix) / medium (fix soon) / low (note)                             |
+| **confidence** | confirmed / likely / low-confidence                                                                      |
+| **location**   | file:line or user-facing surface (e.g., "Commit Graph context menu")                                     |
+
+Then: **what the user experiences**, **what they should experience instead**, **suggested fix**.
+
+### Example Finding
+
+> **lens**: feedback | **severity**: high | **confidence**: confirmed
+> **location**: `src/commands/git/push.ts:142` -> push command error path
+>
+> **Issue**: When push fails due to no upstream branch, the error is caught and logged but the user sees nothing -- no notification, no status bar update, no output channel message. The operation silently fails.
+>
+> **Expected**: The user should see an actionable notification: "No upstream branch set for {branch}. Set upstream?" with a button to run `git push --set-upstream`.
+>
+> **Fix**: Add a `window.showWarningMessage` in the `PushError.is(ex, 'noUpstream')` branch with an action button that runs the set-upstream command.
+
+### Required Sections
+
+1. **Findings** — ordered by severity, using the format above
+2. **Flow walkthrough** — the end-to-end user flow as implemented, annotated with where it matches and diverges from goals.md
+3. **Workflow impact summary** — which existing user workflows this change touches and how they're affected. A change doesn't exist in isolation — identify the broader workflows that pass through the modified surfaces (e.g., a push behavior change affects commit->push->PR, stash->branch->push, etc.). For each impacted workflow: name it, describe what changed from the user's perspective, and flag whether the change is neutral, improved, or degraded.
+4. **What works well** — UX strengths worth calling out
+5. **Open questions** — things that need manual testing (interactions you can't fully evaluate from code alone)
+6. **Verdict** — one of:
+   - **UX approved** — the experience matches the intent
+   - **UX approved with follow-ups** — minor issues that don't block merge
+   - **UX needs work before merge** — the experience diverges from goals.md in ways that matter
+
+If no issues found, say so explicitly, then list **residual risks** and **open questions for manual testing**.

--- a/.gitignore
+++ b/.gitignore
@@ -3,6 +3,7 @@
 .claude/worktrees/**
 .codex
 .DS_Store
+.work/
 .eslintcache*
 .superpowers
 .tasks

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -230,20 +230,29 @@ Reference examples and critical rules for common tasks.
 
 Skills provide detailed, step-by-step workflows for common tasks. Invoke with `/{skill-name}`.
 
-| Skill              | Purpose                                                    |
-| ------------------ | ---------------------------------------------------------- |
-| `/investigate`     | Structured bug investigation with root cause analysis      |
-| `/analyze`         | Deep design/implementation analysis, devil's advocate      |
-| `/review`          | Code review against standards + impact completeness audit  |
-| `/commit`          | Git commit with GitLens conventions                        |
-| `/create-issue`    | Create GitHub issues from code changes                     |
-| `/audit-commits`   | Audit commit range for issues and CHANGELOG entries        |
-| `/add-command`     | Scaffold a new VS Code command                             |
-| `/add-webview`     | Scaffold a new webview with IPC, Lit app, registration     |
-| `/add-test`        | Generate unit or E2E test files                            |
-| `/add-icon`        | Add icon to GL Icons font                                  |
-| `/add-ai-provider` | Add a new AI provider integration                          |
-| `/inspect-live`    | Launch VS Code with GitLens via Playwright inspect UI/logs |
+| Skill              | Purpose                                                                     |
+| ------------------ | --------------------------------------------------------------------------- |
+| `/triage`          | Triage GitHub issues — verdicts, confidence levels, recommended actions     |
+| `/investigate`     | Structured bug investigation with root cause analysis                       |
+| `/prioritize`      | Prioritize triaged issues — shortlist, backlog, won't fix, community        |
+| `/update-issues`   | Update GitHub issues from triage/investigation/prioritization reports       |
+| `/dev-scope`       | Scope work into a goals doc — defines what and why, not how                 |
+| `/deep-planning`   | Design implementation approach — investigates codebase, presents trade-offs |
+| `/challenge-plan`  | Stress-test a proposed plan or architecture decision                        |
+| `/analyze`         | Deep design/implementation analysis, devil's advocate                       |
+| `/review`          | Code review against standards + impact completeness audit                   |
+| `/deep-review`     | Deep merge-blocking review — traces code paths for correctness              |
+| `/ux-review`       | UX review — traces user flows against goals doc                             |
+| `/commit`          | Git commit with GitLens conventions                                         |
+| `/create-issue`    | Create GitHub issues from code changes                                      |
+| `/audit-commits`   | Audit commit range for issues and CHANGELOG entries                         |
+| `/worktree`        | Create isolated git worktrees for feature work                              |
+| `/add-command`     | Scaffold a new VS Code command                                              |
+| `/add-webview`     | Scaffold a new webview with IPC, Lit app, registration                      |
+| `/add-test`        | Generate unit or E2E test files                                             |
+| `/add-icon`        | Add icon to GL Icons font                                                   |
+| `/add-ai-provider` | Add a new AI provider integration                                           |
+| `/inspect-live`    | Launch VS Code with GitLens via Playwright inspect UI/logs                  |
 
 ### Canonical Examples
 

--- a/docs/triage-dev-skills.md
+++ b/docs/triage-dev-skills.md
@@ -1,0 +1,722 @@
+# Issue Workflow Skills — Usage Guide
+
+How to use the issue workflow skills to triage, investigate, prioritize, update GitHub issues, and take issues from triage through to implementation.
+
+## Skills Overview
+
+### Triage Pipeline — Evaluate and categorize issues
+
+| Skill            | Purpose                                         | Modifies GitHub? |
+| ---------------- | ----------------------------------------------- | ---------------- |
+| `/triage`        | First-pass review: categorize, filter, verdict  | No               |
+| `/investigate`   | Root cause analysis — single deep dive or batch | No               |
+| `/prioritize`    | Recommend resolution: shortlist, backlog, etc.  | No               |
+| `/update-issues` | Apply recommendations to GitHub issues          | **Yes**          |
+
+### Dev Pipeline — Scope, plan, and review implementation
+
+| Skill             | Purpose                                                 | Modifies code? |
+| ----------------- | ------------------------------------------------------- | -------------- |
+| `/dev-scope`      | Define what and why — bridge from triage to planning    | No             |
+| `/deep-planning`  | Design technical approach — trade-offs and alternatives | No             |
+| `/challenge-plan` | Stress-test the plan before implementation              | No             |
+| `/deep-review`    | Post-implementation code review against goals           | No             |
+| `/ux-review`      | Post-implementation UX review against goals             | No             |
+| `/commit`         | Create well-formatted git commits                       | **Yes**        |
+
+All analysis skills are read-only. Only `/update-issues` modifies GitHub state (with confirmation), and `/commit` modifies git state.
+
+---
+
+## Quick Reference
+
+| I want to...                                       | Run this                                                                                                                |
+| -------------------------------------------------- | ----------------------------------------------------------------------------------------------------------------------- |
+| Triage one issue                                   | `/triage 5096`                                                                                                          |
+| Triage this week's new issues                      | `/triage recent`                                                                                                        |
+| Triage with a 14-day window                        | `/triage recent --since 14d`                                                                                            |
+| Audit old backlog issues                           | `/triage audit --older-than 365d`                                                                                       |
+| Investigate a specific bug                         | `/investigate #5096`                                                                                                    |
+| Batch-investigate bugs from a triage report        | `/investigate --from-report`                                                                                            |
+| Investigate specific issues without triaging first | `/investigate 5096 5084`                                                                                                |
+| Get priority/milestone recommendations             | `/prioritize 5096`                                                                                                      |
+| Get recommendations from a report                  | `/prioritize --from-report`                                                                                             |
+| Update GitHub issues from a report                 | `/update-issues --from-report`                                                                                          |
+| Dry-run to see what would be updated               | `/update-issues --from-report --dry-run`                                                                                |
+| Full pipeline: triage through update               | `/triage recent` then `/investigate --from-report` then `/prioritize --from-report` then `/update-issues --from-report` |
+| Scope an issue for development                     | `/dev-scope 5096`                                                                                                       |
+| Scope a feature idea                               | `/dev-scope "add natural language search"`                                                                              |
+| Plan implementation for a scoped issue             | `/deep-planning --scope .work/dev/5096/`                                                                                |
+| Stress-test a plan before implementing             | `/challenge-plan --scope .work/dev/5096/`                                                                               |
+| Review implementation against goals                | `/deep-review branch --scope .work/dev/5096/`                                                                           |
+| Review UX against goals                            | `/ux-review branch --scope .work/dev/5096/`                                                                             |
+| Run the full triage pipeline via script            | `pnpm workflow triage recent`                                                                                           |
+| Run the full dev pipeline via script               | `pnpm workflow dev 5096`                                                                                                |
+| Run a pipeline with second-opinion review          | `pnpm workflow triage recent --rubber-duck`                                                                             |
+
+---
+
+## Workflows by Outcome
+
+### Outcome 1: Engineers spend less time figuring out what to work on
+
+**Problem:** Engineers don't know which issues are highest priority, and issues lack enough context to start work.
+
+**Workflow A — Prioritize recent issues:**
+
+```
+/triage recent --since 14d
+/prioritize --from-report
+```
+
+1. `/triage recent` evaluates recent issues and produces a triage report with verdicts
+2. `/prioritize --from-report` reads the triage decisions and produces a resolution report ranking issues by priority signals (reactions, severity, related issues, effort)
+
+The resolution report's **Shortlist** section shows the highest-priority issues with rationale. The **Priority Signals** table for each issue gives engineers concrete data (e.g., "45 thumbs-up, 3 related issues, broken workflow").
+
+**Workflow B — Prioritize with investigation context:**
+
+```
+/triage recent
+/investigate --from-report
+/prioritize --from-report
+```
+
+Adding `/investigate --from-report` between triage and prioritize provides root cause analysis, effort estimates, and fix approaches. The resolution report then has more accurate effort/risk data to drive recommendations.
+
+**Workflow C — Quick prioritization of specific issues:**
+
+```
+/prioritize 5096 5084 5070
+```
+
+Skip triage entirely. Directly evaluate specific issues for priority signals and produce recommendations. Useful when someone asks "which of these should we work on next?"
+
+---
+
+### Outcome 2: Engineers spend less time on low-value issue review
+
+**Problem:** Engineers waste time reviewing issues with missing info, duplicates, spam, and out-of-scope requests.
+
+**Workflow A — Weekly triage of incoming issues:**
+
+```
+/triage recent
+/update-issues --from-report
+```
+
+1. `/triage recent` evaluates all issues opened in the last 7 days. It produces:
+   - **Spam/junk** identified and flagged
+   - **Duplicates** linked to canonical issues
+   - **Missing info** with draft comments requesting specifics (logs, repo setup, version)
+   - **Miscategorized** issues flagged for relabeling (bug vs. enhancement)
+   - **Out of scope** issues identified
+2. `/update-issues --from-report` reads the triage decisions and presents a dry-run of all recommended label changes, comments, and closures. Approve to execute.
+
+**Workflow B — Triage a specific issue someone reported:**
+
+```
+/triage 5096
+```
+
+Quick single-issue triage. Checks for sufficient info, duplicates, correct categorization, and scope. Returns a verdict with confidence level.
+
+**Workflow C — Triage with label filter:**
+
+```
+/triage audit --older-than 180d --label bug
+```
+
+Focus triage on a specific category of backlog issues.
+
+---
+
+### Outcome 3: Engineers spend less time investigating bugs
+
+**Problem:** Bug investigation is time-consuming — requires reading the issue, tracing code, forming hypotheses, and writing up findings.
+
+**Workflow A — Investigate a single bug:**
+
+```
+/investigate #5096
+```
+
+Produces a structured investigation report with: symptom, code path trace, root cause hypothesis (with confidence), alternative causes considered, proposed fix, and impact assessment (files to modify, call sites, platform paths). For old issues (> 1 year), includes a relevance assessment checking if the code path still exists.
+
+**Workflow B — Batch investigation from triage:**
+
+```
+/triage recent
+/investigate --from-report
+```
+
+1. `/triage recent` identifies issues needing investigation (`Valid - Needs Triage` verdict)
+2. `/investigate --from-report` reads the triage decisions, spawns parallel investigation subagents for each qualifying bug, and produces:
+   - Per-issue investigation reports with root cause, effort, and risk
+   - A **Classification Matrix** bucketing issues by effort x risk
+   - **Quick Wins** section (small effort, low/medium risk)
+   - **Needs Planning** section (medium/large effort or high risk)
+
+**Workflow C — Investigate specific issues directly:**
+
+```
+/investigate 5096 5084 5070
+```
+
+Skip triage — investigate specific issue numbers directly (batch mode with parallel subagents). Useful when you already know which issues need investigation.
+
+**Workflow D — Apply investigation results:**
+
+```
+/investigate --from-report
+/update-issues --from-report
+```
+
+After investigation, `/update-issues` can consume the investigation decisions JSON to label confirmed bugs as `triaged` and request more info for issues that can't be reproduced.
+
+---
+
+### Outcome 4: Leadership has clear signals for planning
+
+**Problem:** PMs and EMs need priority signals, milestone recommendations, and aggregate views to inform roadmap decisions.
+
+**Workflow A — Full pipeline for planning:**
+
+```
+/triage recent --since 30d
+/investigate --from-report
+/prioritize --from-report
+```
+
+The resolution report provides:
+
+- **Summary table** with counts by recommendation (Shortlist: 5, Backlog: 12, Won't Fix: 3, Community Contribution: 2)
+- **Per-issue priority signals** (reactions, related issues, severity, effort, age, activity)
+- **Rationale** for each recommendation grounded in specific data
+- **Machine-readable JSON** (`YYYY-MM-DD-RESOLUTIONS.json`) for downstream tooling
+
+**Workflow B — Quick planning view for specific issues:**
+
+```
+/prioritize 5096 5084 5070 4999 4800
+```
+
+Evaluate a hand-picked set of issues and get priority recommendations. Useful for sprint planning when you have a candidate list.
+
+**Workflow C — Planning signals without investigation:**
+
+```
+/triage recent
+/prioritize --from-report
+```
+
+Faster than the full pipeline — skips investigation. Effort estimates are inferred from issue descriptions rather than codebase analysis. Good enough for initial planning; run investigation later for shortlisted items.
+
+**What leadership gets from each report:**
+
+| Report               | Key signals for leadership                                             |
+| -------------------- | ---------------------------------------------------------------------- |
+| Triage report        | Issue volume, quality (spam/duplicate %), investigation queue size     |
+| Investigation report | Classification matrix, quick wins list, needs-planning list            |
+| Resolution report    | Shortlist/backlog split, priority signals per issue, aggregate summary |
+
+---
+
+### Outcome 5: Reduce the rotting of old issues
+
+**Problem:** 876 open issues dating back to 2018. Many are stale, outdated, or already fixed.
+
+**Workflow A — Systematic backlog audit (batch processing):**
+
+```
+/triage audit --older-than 365d --batch-size 50
+/update-issues --from-report
+```
+
+Run in batches. The triage skill in audit mode:
+
+- Checks for **stale issues** (365+ days inactive, feature still exists or superseded)
+- Checks for **codebase-level staleness** (referenced UI/settings/commands no longer exist)
+- Identifies **issues needing verification** (old version, no activity, low engagement → `Request More Info` which triggers auto-close automation if no response)
+- Detects **already fixed** issues using the Two-Source Rule (changelog + merged PR)
+
+Repeat with `--batch 2`, `--batch 3`, etc. to work through the full backlog.
+
+**Workflow B — Targeted audit of a specific age range:**
+
+```
+/triage audit --older-than 180d --label enhancement
+```
+
+Focus on enhancement requests older than 6 months. These often accumulate as "nice to have" items that never get prioritized.
+
+**Workflow C — Re-evaluate old issues with investigation:**
+
+```
+/triage audit --older-than 365d
+/investigate --from-report
+/prioritize --from-report
+/update-issues --from-report
+```
+
+The full pipeline on old issues. Investigation includes a **Relevance Assessment** for issues older than 1 year, checking whether the affected code paths still exist. The prioritize step provides milestone recommendations. Update-issues closes stale issues, requests verification on uncertain ones, and labels confirmed bugs.
+
+**Workflow D — Spot-check specific old issues:**
+
+```
+/triage 1234 2345 3456
+```
+
+Triage a handful of specific old issues. Useful when a user asks about an old issue or when reviewing issues referenced in a PR.
+
+**Staleness detection — two paths:**
+
+| Condition                                                   | Triage verdict      | Update-issues behavior                                                                                     |
+| ----------------------------------------------------------- | ------------------- | ---------------------------------------------------------------------------------------------------------- |
+| Code refactored or removed since issue filed                | `Close - Stale`     | Close with explanatory comment                                                                             |
+| Old version, no activity, low engagement, code still exists | `Request More Info` | Add `needs-more-info` label + comment asking to verify on current version (triggers auto-close automation) |
+
+---
+
+## Dev Pipeline — From Issue to Implementation
+
+The dev pipeline takes an issue (or idea) from scoping through implementation review. It connects to the triage pipeline — triage identifies and prioritizes issues, then dev-scope picks them up for implementation.
+
+### How the Pipelines Connect
+
+```
+TRIAGE PIPELINE                         DEV PIPELINE
+───────────────────────────             ────────────────────────────
+/triage (categorize issues)             /dev-scope (define what & why)
+   ↓ DECISIONS.json                        ↓ goals.md
+/investigate (root cause analysis)      /deep-planning (design approach)
+   ↓ INVESTIGATION-DECISIONS.json          ↓ plan.md
+/prioritize (rank & recommend)          /challenge-plan (stress-test plan)
+   ↓ RESOLUTIONS.json                      ↓ challenge.md
+/update-issues (apply to GitHub)        ── IMPLEMENTATION (you write code) ──
+   ↓ ACTIONS.md                         /deep-review (code review)
+[GitHub Updated]                           ↓ review.md
+                                        /ux-review (UX review)
+                                           ↓ ux-review.md
+                                        /commit
+```
+
+The bridge between pipelines is `/dev-scope`. It reads investigation reports (if they exist) and imports root cause, effort, and risk data into the goals document — so `/deep-planning` doesn't re-investigate from scratch.
+
+### Outcome 6: Engineers start implementation with clear scope and a validated plan
+
+**Problem:** Engineers jump into coding without a clear definition of done, miss edge cases, and discover architectural issues mid-implementation.
+
+**Workflow A — Full dev pipeline from a triaged issue:**
+
+```
+/dev-scope 5096
+/deep-planning --scope .work/dev/5096/
+/challenge-plan --scope .work/dev/5096/
+```
+
+1. `/dev-scope 5096` fetches the GitHub issue, verifies claims against the codebase, and produces `goals.md` — defining success criteria, UX flow, code landscape, and constraints. If an investigation report exists, it imports root cause and effort data.
+2. `/deep-planning --scope .work/dev/5096/` reads `goals.md`, investigates the codebase for existing patterns and utilities, researches external approaches, and produces `plan.md` with 1-3 approaches and a recommended path.
+3. `/challenge-plan --scope .work/dev/5096/` reads both `goals.md` and `plan.md`, verifies assumptions against code, runs a pre-mortem, and produces `challenge.md` with a verdict:
+   - **Ready** — proceed to implementation
+   - **Needs Revision** — plan has issues that should be addressed first
+   - **Reconsider** — blocking issues found, needs human judgment
+
+**Workflow B — Scope a feature idea (no issue):**
+
+```
+/dev-scope "add natural language search to the command palette"
+/deep-planning --scope .work/dev/add-natural-language-search/
+/challenge-plan --scope .work/dev/add-natural-language-search/
+```
+
+Same pipeline, but starting from a description instead of a GitHub issue number. The identifier becomes a slug used for the `.work/dev/` folder.
+
+**Workflow C — Post-implementation review:**
+
+```
+/deep-review branch --scope .work/dev/5096/
+/ux-review branch --scope .work/dev/5096/
+/commit
+```
+
+After implementing the changes, run reviews against the goals document:
+
+1. `/deep-review` traces code paths for correctness, verifying the implementation matches success criteria
+2. `/ux-review` walks through user flows, checking discoverability, accessibility, and workflow continuity
+3. `/commit` creates a well-formatted commit following GitLens conventions
+
+**Workflow D — End-to-end from triage to implementation:**
+
+```
+/triage 5096
+/investigate #5096
+/dev-scope 5096
+/deep-planning --scope .work/dev/5096/
+/challenge-plan --scope .work/dev/5096/
+── implement changes ──
+/deep-review branch --scope .work/dev/5096/
+/ux-review branch --scope .work/dev/5096/
+/commit
+```
+
+The complete journey from raw issue to merged code.
+
+---
+
+### Dev Pipeline Artifacts
+
+All dev artifacts are written to `.work/dev/{identifier}/` where identifier is an issue number or slug.
+
+| File              | Producer          | Consumer                                                          |
+| ----------------- | ----------------- | ----------------------------------------------------------------- |
+| `goals.md`        | `/dev-scope`      | `/deep-planning`, `/challenge-plan`, `/deep-review`, `/ux-review` |
+| `plan.md`         | `/deep-planning`  | `/challenge-plan`                                                 |
+| `challenge.md`    | `/challenge-plan` | Human review, workflow script                                     |
+| `challenge.rd.md` | Rubber duck       | Primary agent (for revision)                                      |
+| `review.md`       | `/deep-review`    | Human review                                                      |
+| `review.rd.md`    | Rubber duck       | Primary agent (for revision)                                      |
+| `ux-review.md`    | `/ux-review`      | Human review                                                      |
+| `ux-review.rd.md` | Rubber duck       | Primary agent (for revision)                                      |
+
+---
+
+## Workflow Orchestration Script
+
+The `pnpm workflow` command automates running pipeline stages sequentially. It builds evidence packs, invokes AI agents for each stage, and optionally runs a rubber-duck second-opinion pass.
+
+### Usage
+
+```bash
+# Triage pipeline
+pnpm workflow triage recent                          # Triage last 7 days of issues
+pnpm workflow triage recent --since 14d              # Custom lookback window
+pnpm workflow triage audit --older-than 365d         # Audit old issues
+pnpm workflow triage audit --older-than 180d --label bug  # Filtered audit
+pnpm workflow triage single 5096 5084                # Triage specific issues
+
+# Dev pipeline
+pnpm workflow dev 5096                               # Scope → plan → challenge for issue
+pnpm workflow dev "refactor-caching"                 # Scope → plan → challenge for idea
+pnpm workflow dev 5096 --skip-to review              # Post-implementation reviews only
+```
+
+### Global Options
+
+| Option                     | Description                                     |
+| -------------------------- | ----------------------------------------------- |
+| `--agent <claude\|auggie>` | Primary agent CLI (default: `claude`)           |
+| `--model <model>`          | Model override for the primary agent            |
+| `--rubber-duck`, `--rd`    | Enable second-opinion pass on evaluative stages |
+| `--duck-model <model>`     | Override the auto-selected second-opinion model |
+| `--skip-to <stage>`        | Resume pipeline from a specific stage           |
+| `--dry-run`                | Show what would run without executing           |
+| `--silent`                 | Suppress macOS notifications                    |
+
+### Triage Pipeline Options
+
+| Option                    | Description                                  |
+| ------------------------- | -------------------------------------------- |
+| `--since <duration>`      | Lookback window for `recent` (default: `7d`) |
+| `--older-than <duration>` | Age threshold for `audit` (default: `180d`)  |
+| `--batch-size <n>`        | Issues per batch for `audit` (default: `50`) |
+| `--label <label>`         | Filter issues by label                       |
+
+**Triage skip-to stages:** `triage`, `investigate`, `prioritize`
+
+### Dev Pipeline Options
+
+**Dev skip-to stages:** `scope`, `plan`, `challenge`, `review`, `ux-review`, `commit`
+
+The dev pipeline has two phases separated by manual implementation:
+
+1. **Pre-implementation** (`scope` → `plan` → `challenge`) — produces goals, plan, and challenge artifacts, then stops for you to implement
+2. **Post-implementation** (`review` → `ux-review` → `commit`) — resumed with `--skip-to review` after you've written the code
+
+### Rubber Duck (Second-Opinion) Mode
+
+When `--rubber-duck` is enabled, evaluative stages get a second pass from a different AI model family. The system automatically pairs model families for diverse perspectives:
+
+| Primary family | Duck model    |
+| -------------- | ------------- |
+| Claude         | Gemini        |
+| Gemini         | Claude (Opus) |
+| GPT            | Claude (Opus) |
+
+You can override the duck model with `--duck-model <model>`. The script warns if the duck is the same family as the primary.
+
+**Stages that support rubber duck:**
+
+- **Triage pipeline:** `investigate`, `prioritize`
+- **Dev pipeline:** `challenge`, `review`, `ux-review`
+
+**How it works:**
+
+1. Primary agent produces the artifact
+2. Duck agent reads the artifact and provides 3-5 high-value concerns the primary may have missed
+3. Primary agent revises the artifact incorporating the feedback
+4. A "Second-Opinion Review" section is appended documenting what changed
+
+Duck critique is saved alongside the artifact (e.g., `challenge.rd.md` next to `challenge.md`). Duck failure is non-blocking — if it fails, the original artifact is preserved.
+
+### Pipeline Flow Control
+
+The workflow script handles stage dependencies and stopping points:
+
+**Triage pipeline** runs all stages sequentially, then prints the `/update-issues` command for manual execution (the script never applies changes to GitHub automatically).
+
+**Dev pipeline** stops at two natural boundaries:
+
+1. After challenge — if the verdict is "Reconsider" or "Needs Revision", the script stops and prints instructions for how to resume
+2. After pre-implementation — the script stops and prints the `--skip-to review` command for after you've implemented
+
+```bash
+# Example: challenge returns "Needs Revision"
+pnpm workflow dev 5096
+# → Script stops with:
+#   "The plan has issues that should be addressed."
+#   "Review: .work/dev/5096/challenge.md"
+#
+# After revising the plan:
+pnpm workflow dev 5096 --skip-to challenge    # Re-challenge
+# or
+pnpm workflow dev 5096 --skip-to review       # Skip to implementation reviews
+```
+
+### Examples
+
+```bash
+# Weekly triage with second opinion
+pnpm workflow triage recent --rubber-duck
+
+# Triage with Auggie + Gemini as primary, Claude as duck
+pnpm workflow triage recent --agent auggie --model gemini-3.1-pro-preview --rubber-duck
+
+# Dry-run to see what the pipeline would do
+pnpm workflow dev 5096 --dry-run
+
+# Full dev pipeline with rubber duck
+pnpm workflow dev 5096 --rubber-duck
+
+# Resume post-implementation reviews with custom duck model
+pnpm workflow dev 5096 --skip-to review --rubber-duck --duck-model gpt5.4
+```
+
+---
+
+## Composability Reference
+
+Every skill works standalone or chained. Here are all supported input modes:
+
+### `/triage`
+
+| Input            | Example                                           |
+| ---------------- | ------------------------------------------------- |
+| Single issue     | `/triage 5096`                                    |
+| Multiple issues  | `/triage 5096 5084 5070`                          |
+| Recent batch     | `/triage recent --since 7d`                       |
+| Historical batch | `/triage audit --older-than 180d --batch-size 50` |
+| Filtered batch   | `/triage audit --older-than 180d --label bug`     |
+
+**Output:** `.work/triage/reports/YYYY-MM-DD-TRIAGE-REPORT.md` + `YYYY-MM-DD-DECISIONS.json`
+
+### `/investigate`
+
+| Input               | Example                                                                         |
+| ------------------- | ------------------------------------------------------------------------------- |
+| Symptom description | `/investigate blame annotations not showing`                                    |
+| Single issue        | `/investigate #5096`                                                            |
+| Multiple issues     | `/investigate 5096 5084` (batch mode with parallel subagents)                   |
+| From report         | `/investigate --from-report` (uses most recent decisions JSON)                  |
+| Specific report     | `/investigate --from-report .work/triage/reports/2026-04-01-DECISIONS.json`     |
+| Filtered verdicts   | `/investigate --from-report --verdict "Valid - Needs Triage,Request More Info"` |
+| Limited parallelism | `/investigate --from-report --max 5`                                            |
+
+**Output (single):** Investigation report in conversation (not written to file)
+**Output (batch):** `.work/triage/reports/YYYY-MM-DD-INVESTIGATION-REPORT.md` + `YYYY-MM-DD-INVESTIGATION-DECISIONS.json`
+
+### `/prioritize`
+
+| Input                | Example                                                                       |
+| -------------------- | ----------------------------------------------------------------------------- |
+| Direct issue numbers | `/prioritize 5096 5084 5070`                                                  |
+| From report          | `/prioritize --from-report` (uses most recent report JSON, auto-detects type) |
+| Specific report      | `/prioritize --from-report .work/triage/reports/2026-04-01-DECISIONS.json`    |
+
+**Output:** `.work/triage/reports/YYYY-MM-DD-RESOLUTION-REPORT.md` + `YYYY-MM-DD-RESOLUTIONS.json`
+
+### `/update-issues`
+
+| Input           | Example                                                                          |
+| --------------- | -------------------------------------------------------------------------------- |
+| From report     | `/update-issues --from-report` (uses most recent report JSON, auto-detects type) |
+| Specific report | `/update-issues --from-report .work/triage/reports/2026-04-01-RESOLUTIONS.json`  |
+| Dry-run only    | `/update-issues --from-report --dry-run`                                         |
+
+**Consumes:** Any of the three JSON report types (triage decisions, investigation decisions, resolutions)
+
+**Output:** Dry-run table → user confirmation → execution → `.work/triage/reports/YYYY-MM-DD-ACTIONS.md` audit log
+
+### `/dev-scope`
+
+| Input           | Example                                         |
+| --------------- | ----------------------------------------------- |
+| Single issue    | `/dev-scope 5096`                               |
+| Multiple issues | `/dev-scope 5096 5084` (separate goals.md each) |
+| Feature idea    | `/dev-scope "add natural language search"`      |
+
+**Output:** `.work/dev/{identifier}/goals.md`
+
+### `/deep-planning`
+
+| Input       | Example                                  |
+| ----------- | ---------------------------------------- |
+| Scoped      | `/deep-planning --scope .work/dev/5096/` |
+| Interactive | `/deep-planning <task description>`      |
+
+**Output:** `.work/dev/{identifier}/plan.md`
+
+### `/challenge-plan`
+
+| Input       | Example                                   |
+| ----------- | ----------------------------------------- |
+| Scoped      | `/challenge-plan --scope .work/dev/5096/` |
+| Interactive | `/challenge-plan <proposed plan>`         |
+
+**Output:** `.work/dev/{identifier}/challenge.md`
+
+**Verdicts:** `Ready` (proceed), `Needs Revision` (fix plan first), `Reconsider` (blocking — needs human judgment)
+
+### `/deep-review`
+
+| Input  | Example                                       |
+| ------ | --------------------------------------------- |
+| Scoped | `/deep-review branch --scope .work/dev/5096/` |
+
+**Output:** `.work/dev/{identifier}/review.md`
+
+### `/ux-review`
+
+| Input  | Example                                     |
+| ------ | ------------------------------------------- |
+| Scoped | `/ux-review branch --scope .work/dev/5096/` |
+
+**Output:** `.work/dev/{identifier}/ux-review.md`
+
+---
+
+## Pipeline Chains
+
+### Minimal: Triage + Update
+
+```
+/triage recent → /update-issues --from-report
+```
+
+Triage issues, then apply labels/comments/closures. Good for weekly inbox processing.
+
+### Standard: Triage + Investigate + Update
+
+```
+/triage recent → /investigate --from-report → /update-issues --from-report
+```
+
+Triage, then investigate bugs, then apply results. Good when you need to understand root causes before acting.
+
+### Full: Triage + Investigate + Prioritize + Update
+
+```
+/triage recent → /investigate --from-report → /prioritize --from-report → /update-issues --from-report
+```
+
+Triage, investigate, get planning recommendations, then apply. Good for milestone/sprint planning.
+
+### Shortcut: Prioritize + Update
+
+```
+/prioritize 5096 5084 → /update-issues --from-report
+```
+
+Skip triage and investigation. Get recommendations and apply. Good for ad-hoc prioritization of known issues.
+
+### Dev: Scope + Plan + Challenge
+
+```
+/dev-scope 5096 → /deep-planning --scope .work/dev/5096/ → /challenge-plan --scope .work/dev/5096/
+```
+
+Scope an issue, design the approach, and stress-test it. The standard pre-implementation workflow.
+
+### Dev: Post-Implementation Reviews
+
+```
+/deep-review branch --scope .work/dev/5096/ → /ux-review branch --scope .work/dev/5096/ → /commit
+```
+
+After implementing, review code and UX against the goals document.
+
+### Cross-Pipeline: Triage to Dev
+
+```
+/triage 5096 → /investigate #5096 → /dev-scope 5096 → /deep-planning --scope .work/dev/5096/
+```
+
+Full journey from raw issue to implementation plan. `/dev-scope` imports investigation findings into `goals.md`.
+
+---
+
+## Output Files
+
+### Triage pipeline
+
+All triage reports are written to `.work/triage/reports/`. Each analysis skill produces both a human-readable markdown report and a machine-readable JSON file.
+
+| File pattern                     | Producer         | Consumer                                                                                  |
+| -------------------------------- | ---------------- | ----------------------------------------------------------------------------------------- |
+| `*-TRIAGE-REPORT.md`             | `/triage`        | Humans                                                                                    |
+| `*-DECISIONS.json`               | `/triage`        | `/investigate --from-report`, `/prioritize --from-report`, `/update-issues --from-report` |
+| `*-INVESTIGATION-REPORT.md`      | `/investigate`   | Humans                                                                                    |
+| `*-INVESTIGATION-DECISIONS.json` | `/investigate`   | `/prioritize --from-report`, `/update-issues --from-report`                               |
+| `*-RESOLUTION-REPORT.md`         | `/prioritize`    | Humans                                                                                    |
+| `*-RESOLUTIONS.json`             | `/prioritize`    | `/update-issues --from-report`                                                            |
+| `*-ACTIONS.md`                   | `/update-issues` | Humans (audit trail)                                                                      |
+
+### Dev pipeline
+
+All dev artifacts are written to `.work/dev/{identifier}/` where identifier is an issue number or slug.
+
+| File              | Producer          | Consumer                                                          |
+| ----------------- | ----------------- | ----------------------------------------------------------------- |
+| `goals.md`        | `/dev-scope`      | `/deep-planning`, `/challenge-plan`, `/deep-review`, `/ux-review` |
+| `plan.md`         | `/deep-planning`  | `/challenge-plan`                                                 |
+| `challenge.md`    | `/challenge-plan` | Human review, workflow script verdict detection                   |
+| `challenge.rd.md` | Rubber duck       | Primary agent (revision pass)                                     |
+| `review.md`       | `/deep-review`    | Human review                                                      |
+| `review.rd.md`    | Rubber duck       | Primary agent (revision pass)                                     |
+| `ux-review.md`    | `/ux-review`      | Human review                                                      |
+| `ux-review.rd.md` | Rubber duck       | Primary agent (revision pass)                                     |
+
+---
+
+## Safety Model
+
+1. **Analysis is read-only** — `/triage`, `/investigate`, `/prioritize`, `/dev-scope`, `/deep-planning`, `/challenge-plan`, `/deep-review`, and `/ux-review` never modify GitHub issues or code
+2. **Update requires confirmation** — `/update-issues` always shows a dry-run first and requires explicit approval
+3. **Pre-flight checks** — `/update-issues` verifies current issue state before each action, skipping stale or redundant changes
+4. **Close confirmation** — Closing issues requires per-issue approval
+5. **Audit trail** — Every applied action is logged to `.work/triage/reports/*-ACTIONS.md`
+6. **Human-in-the-loop** — All close recommendations require human approval (`requiresHumanApproval: true`)
+7. **Challenge gate** — The workflow script stops if `/challenge-plan` returns "Reconsider" or "Needs Revision", preventing implementation on a flawed plan
+8. **Implementation boundary** — The workflow script never implements code automatically; it stops after the challenge stage and waits for manual `--skip-to review`
+
+---
+
+## Limitations and Notes
+
+- **Single-issue duplicate detection is limited.** When triaging a single issue (`/triage 5096`), duplicate detection only cross-references against other issues in the same evidence pack. For a single issue, there's nothing to cross-reference. Use `/prioritize` which searches the full repo for related issues, or use batch triage (`/triage recent`) for better duplicate detection.
+- **Specific iteration milestones require human judgment.** The `/prioritize` skill recommends "Shortlist" or "Backlog" milestones but does not assign issues to specific iterations/sprints. Deciding which sprint an issue belongs to requires team context that the skills don't have. Use the priority signals from `/prioritize` to inform that decision.
+- **Rate limits constrain batch sizes.** `/prioritize` uses GitHub's Search API (30 requests/min) for related-issue counting. Batches of 25+ issues will approach the rate limit. The skill budgets accordingly but large batches may take longer.
+- **Investigation cost scales with issue count.** `/investigate` in batch mode spawns a parallel subagent per issue. Each performs a full codebase investigation. Use `--max` to control parallelism.
+- **Dev pipeline requires manual implementation.** The workflow script runs pre-implementation stages (scope, plan, challenge) then stops. You write the code. Then resume with `--skip-to review` for post-implementation reviews.
+- **Challenge verdicts are advisory.** The workflow script stops on "Reconsider" and "Needs Revision" verdicts, but you can override with `--skip-to review` if you've addressed the concerns outside the script.
+- **Rubber duck is non-blocking.** If the second-opinion agent fails (network error, model unavailable), the original artifact is preserved and the pipeline continues.

--- a/docs/triage-dev-skills.md
+++ b/docs/triage-dev-skills.md
@@ -124,7 +124,7 @@ Quick single-issue triage. Checks for sufficient info, duplicates, correct categ
 **Workflow C — Triage with label filter:**
 
 ```
-/triage audit --older-than 180d --label bug
+/triage audit --older-than 180d --type bug
 ```
 
 Focus triage on a specific category of backlog issues.
@@ -245,7 +245,7 @@ Repeat with `--batch 2`, `--batch 3`, etc. to work through the full backlog.
 **Workflow B — Targeted audit of a specific age range:**
 
 ```
-/triage audit --older-than 180d --label enhancement
+/triage audit --older-than 180d --type enhancement
 ```
 
 Focus on enhancement requests older than 6 months. These often accumulate as "nice to have" items that never get prioritized.
@@ -392,7 +392,7 @@ The `pnpm workflow` command automates running pipeline stages sequentially. It b
 pnpm workflow triage recent                          # Triage last 7 days of issues
 pnpm workflow triage recent --since 14d              # Custom lookback window
 pnpm workflow triage audit --older-than 365d         # Audit old issues
-pnpm workflow triage audit --older-than 180d --label bug  # Filtered audit
+pnpm workflow triage audit --older-than 180d --type bug  # Filtered audit
 pnpm workflow triage single 5096 5084                # Triage specific issues
 
 # Dev pipeline
@@ -415,12 +415,13 @@ pnpm workflow dev 5096 --skip-to review              # Post-implementation revie
 
 ### Triage Pipeline Options
 
-| Option                    | Description                                  |
-| ------------------------- | -------------------------------------------- |
-| `--since <duration>`      | Lookback window for `recent` (default: `7d`) |
-| `--older-than <duration>` | Age threshold for `audit` (default: `180d`)  |
-| `--batch-size <n>`        | Issues per batch for `audit` (default: `50`) |
-| `--label <label>`         | Filter issues by label                       |
+| Option                    | Description                                   |
+| ------------------------- | --------------------------------------------- |
+| `--since <duration>`      | Lookback window for `recent` (default: `7d`)  |
+| `--older-than <duration>` | Age threshold for `audit` (default: `180d`)   |
+| `--batch-size <n>`        | Issues per batch for `audit` (default: `50`)  |
+| `--label <label>`         | Filter issues by label                        |
+| `--type <type>`           | Filter issues by type (e.g. bug, enhancement) |
 
 **Triage skip-to stages:** `triage`, `investigate`, `prioritize`
 
@@ -516,7 +517,7 @@ Every skill works standalone or chained. Here are all supported input modes:
 | Multiple issues  | `/triage 5096 5084 5070`                          |
 | Recent batch     | `/triage recent --since 7d`                       |
 | Historical batch | `/triage audit --older-than 180d --batch-size 50` |
-| Filtered batch   | `/triage audit --older-than 180d --label bug`     |
+| Filtered batch   | `/triage audit --older-than 180d --type bug`      |
 
 **Output:** `.work/triage/reports/YYYY-MM-DD-TRIAGE-REPORT.md` + `YYYY-MM-DD-DECISIONS.json`
 

--- a/package.json
+++ b/package.json
@@ -27696,6 +27696,7 @@
 		"test": "vscode-test",
 		"test:packages": "pnpm -r --filter './packages/*' run test",
 		"test:e2e": "playwright test -c tests/e2e/playwright.config.ts",
+		"workflow": "node --experimental-strip-types ./scripts/issues/workflow.mts",
 		"test:e2e:insiders": "set VSCODE_VERSION=insiders && playwright test -c tests/e2e/playwright.config.ts",
 		"build:e2e-runner": "esbuild tests/e2e/runner/src/index.ts --bundle --outfile=tests/e2e/runner/dist/index.js --platform=node --external:vscode --format=cjs",
 		"watch": "node ./scripts/build.mjs --watch",

--- a/scripts/issues/build-pack.mts
+++ b/scripts/issues/build-pack.mts
@@ -1,0 +1,365 @@
+import { randomUUID } from 'node:crypto';
+import { copyFile, mkdir, writeFile } from 'node:fs/promises';
+import { join } from 'node:path';
+import { config } from './config.mts';
+import { fetchChangelogLookup } from './fetch-changelog.mts';
+import { fetchIssues, fetchSingleIssues } from './fetch-issues.mts';
+import { fetchLabels } from './fetch-labels.mts';
+import { fetchTeamMembers } from './fetch-team.mts';
+import type {
+	AuditQueryParams,
+	ChangelogEntry,
+	DuplicateCandidate,
+	EnrichedIssue,
+	EvidencePack,
+	GitHubIssue,
+	IssueLabel,
+	ReactionSummary,
+	ReactiveQueryParams,
+	RepositoryLabel,
+	RunMetadata,
+	SingleQueryParams,
+	Workflow,
+} from './types.mts';
+
+// Common English stop words excluded from keyword matching
+const stopWords = new Set([
+	'a',
+	'an',
+	'the',
+	'and',
+	'or',
+	'but',
+	'in',
+	'on',
+	'at',
+	'to',
+	'for',
+	'of',
+	'with',
+	'by',
+	'is',
+	'are',
+	'was',
+	'were',
+	'be',
+	'been',
+	'being',
+	'have',
+	'has',
+	'had',
+	'do',
+	'does',
+	'did',
+	'will',
+	'would',
+	'could',
+	'should',
+	'may',
+	'might',
+	'can',
+	'not',
+	'no',
+	'it',
+	'its',
+	'this',
+	'that',
+	'these',
+	'those',
+	'i',
+	'my',
+	'me',
+	'we',
+	'our',
+	'you',
+	'your',
+	'he',
+	'she',
+	'they',
+	'them',
+	'their',
+	'what',
+	'which',
+	'who',
+	'when',
+	'where',
+	'how',
+	'all',
+	'each',
+	'every',
+	'both',
+	'few',
+	'more',
+	'some',
+	'any',
+	'if',
+	'from',
+	'as',
+	'so',
+	'than',
+	'too',
+	'very',
+	'just',
+	'about',
+]);
+
+// Phrases that indicate an issue has been superseded
+const supersessionPatterns = [
+	/\bsuperseded\s+by\b/i,
+	/\breplaced\s+by\b/i,
+	/\bremoved\s+in\b/i,
+	/\bdeprecated\s+in\s+favor\b/i,
+	/\bno\s+longer\s+(?:relevant|applicable|needed)\b/i,
+	/\brevert(?:ed|s)?\s+(?:in|by)\b/i,
+];
+
+export async function buildPack(
+	mode: Workflow,
+	params: ReactiveQueryParams | AuditQueryParams | SingleQueryParams,
+	forceRefresh?: boolean,
+): Promise<string> {
+	console.error('Fetching team members, labels, changelog, and issues...');
+
+	// Determine issue fetcher based on mode
+	let issueFetcher: Promise<GitHubIssue[]>;
+	if (mode === 'single') {
+		issueFetcher = fetchSingleIssues(params as SingleQueryParams);
+	} else if (mode === 'reactive') {
+		issueFetcher = fetchIssues('reactive', params as ReactiveQueryParams);
+	} else {
+		issueFetcher = fetchIssues('audit', params as AuditQueryParams);
+	}
+
+	// Fetch all data in parallel
+	const [teamMembers, labels, changelogLookup, rawIssues] = await Promise.all([
+		fetchTeamMembers(forceRefresh),
+		fetchLabels(forceRefresh),
+		fetchChangelogLookup(forceRefresh),
+		issueFetcher,
+	]);
+
+	const labelMap = new Map<string, RepositoryLabel>(labels.map(l => [l.name, l]));
+	const teamSet = new Set(teamMembers.map(m => m.toLowerCase()));
+
+	console.error(`Enriching ${rawIssues.length} issues...`);
+
+	// Enrich each issue
+	const enrichedIssues: EnrichedIssue[] = rawIssues.map(raw =>
+		enrichIssue(raw, teamSet, labelMap, changelogLookup, mode),
+	);
+
+	// Add duplicate candidates (requires full list for cross-referencing)
+	addDuplicateCandidates(enrichedIssues, rawIssues);
+
+	// Assemble the evidence pack
+	const runId = randomUUID();
+	const now = new Date().toISOString();
+
+	const meta: RunMetadata = {
+		runId,
+		timestamp: now,
+		schemaVersion: config.schemaVersion,
+		workflow: mode,
+		queryParams: params,
+		teamMembersRefreshedAt: now,
+		changelogRefreshedAt: now,
+		repo: `${config.owner}/${config.repo}`,
+	};
+
+	const pack: EvidencePack = {
+		meta,
+		teamMembers,
+		issues: enrichedIssues,
+	};
+
+	// Write pack file
+	await mkdir(config.packsDir, { recursive: true });
+	const packPath = join(config.packsDir, `${runId}.json`);
+	await writeFile(packPath, JSON.stringify(pack, null, '\t'));
+
+	// Write latest symlink (as copy for cross-platform compatibility)
+	let latestName: string;
+	if (mode === 'reactive') {
+		latestName = 'latest-reactive.json';
+	} else if (mode === 'audit') {
+		latestName = `latest-audit-batch-${(params as AuditQueryParams).batchNumber}.json`;
+	} else {
+		latestName = 'latest-single.json';
+	}
+	const latestPath = join(config.packsDir, latestName);
+	await copyFile(packPath, latestPath);
+
+	console.error(`Evidence pack written: ${packPath}`);
+	return packPath;
+}
+
+const reactionContentMap: Record<string, keyof Omit<ReactionSummary, 'total'>> = {
+	THUMBS_UP: 'thumbsUp',
+	THUMBS_DOWN: 'thumbsDown',
+	LAUGH: 'laugh',
+	HOORAY: 'hooray',
+	CONFUSED: 'confused',
+	HEART: 'heart',
+	ROCKET: 'rocket',
+	EYES: 'eyes',
+};
+
+function mapReactions(groups: Array<{ content: string; totalCount: number }>): ReactionSummary {
+	const reactions: ReactionSummary = {
+		thumbsUp: 0,
+		thumbsDown: 0,
+		laugh: 0,
+		hooray: 0,
+		confused: 0,
+		heart: 0,
+		rocket: 0,
+		eyes: 0,
+		total: 0,
+	};
+
+	for (const g of groups) {
+		const key = reactionContentMap[g.content];
+		if (key != null) {
+			reactions[key] = g.totalCount;
+			reactions.total += g.totalCount;
+		}
+	}
+
+	return reactions;
+}
+
+function enrichIssue(
+	raw: GitHubIssue,
+	teamSet: Set<string>,
+	labelMap: Map<string, RepositoryLabel>,
+	changelogLookup: Record<string, ChangelogEntry>,
+	mode: Workflow,
+): EnrichedIssue {
+	// 1. isTeamMember
+	const isTeamMember = teamSet.has(raw.author.toLowerCase());
+
+	// 2. Enrich labels with descriptions
+	const labels: IssueLabel[] = raw.labels.map(name => {
+		const label = labelMap.get(name);
+		return { name, description: label?.description ?? '' };
+	});
+
+	// 3. changelogEntry
+	const changelogEntry = changelogLookup[`#${raw.number}`] ?? null;
+
+	// 4. lastActivityAt
+	const dates = [raw.updatedAt, ...raw.comments.map(c => c.createdAt)];
+	const lastActivityAt = dates.reduce((a, b) => (a > b ? a : b));
+
+	// 5. reactions
+	const reactions = mapReactions(raw.reactionGroups);
+
+	// 6. supersessionIndicators (audit and single mode)
+	const supersessionIndicators: string[] = [];
+	if (mode === 'audit' || mode === 'single') {
+		const textToScan = [raw.body, ...raw.comments.map(c => c.body)].join('\n');
+		for (const pattern of supersessionPatterns) {
+			const match = textToScan.match(pattern);
+			if (match) {
+				supersessionIndicators.push(match[0]);
+			}
+		}
+
+		// Check if any linked PR is a revert
+		for (const pr of raw.linkedPrs) {
+			if (/\brevert\b/i.test(pr.title)) {
+				supersessionIndicators.push(`Linked PR #${pr.number} appears to be a revert: "${pr.title}"`);
+			}
+		}
+	}
+
+	return {
+		number: raw.number,
+		title: raw.title,
+		body: raw.body,
+		state: raw.state,
+		type: raw.type,
+		labels,
+		author: raw.author,
+		authorAssociation: raw.authorAssociation,
+		assignees: raw.assignees,
+		milestone: raw.milestone,
+		createdAt: raw.createdAt,
+		updatedAt: raw.updatedAt,
+		closedAt: raw.closedAt,
+		comments: raw.comments,
+		commentCount: raw.commentCount,
+		linkedPrs: raw.linkedPrs,
+		isTeamMember,
+		reactions,
+		changelogEntry,
+		lastActivityAt,
+		duplicateCandidates: [], // Filled in by addDuplicateCandidates
+		supersessionIndicators,
+	};
+}
+
+function addDuplicateCandidates(enriched: EnrichedIssue[], raw: GitHubIssue[]): void {
+	const issueMap = new Map<number, EnrichedIssue>(enriched.map(i => [i.number, i]));
+
+	for (const issue of enriched) {
+		const candidates: DuplicateCandidate[] = [];
+		const seen = new Set<number>();
+
+		// Cross-reference pass: scan body and comments for #NNN patterns
+		const textToScan = [issue.body, ...issue.comments.map(c => c.body)].join('\n');
+		const refs = [...textToScan.matchAll(/#(\d+)/g)];
+		for (const ref of refs) {
+			const refNum = parseInt(ref[1], 10);
+			if (refNum === issue.number || seen.has(refNum)) continue;
+			seen.add(refNum);
+
+			const target = issueMap.get(refNum);
+			if (target) {
+				candidates.push({
+					number: target.number,
+					title: target.title,
+					state: target.state,
+					closedAt: target.closedAt,
+					similarityBasis: 'body-cross-reference',
+				});
+			}
+
+			if (candidates.length >= config.duplicateCandidateLimit) break;
+		}
+
+		// Keyword pass: only if no cross-reference candidates found
+		if (candidates.length === 0) {
+			const issueWords = significantWords(issue.title);
+			if (issueWords.size >= 3) {
+				for (const other of enriched) {
+					if (other.number === issue.number) continue;
+					const otherWords = significantWords(other.title);
+					const overlap = [...issueWords].filter(w => otherWords.has(w));
+					if (overlap.length >= 3) {
+						candidates.push({
+							number: other.number,
+							title: other.title,
+							state: other.state,
+							closedAt: other.closedAt,
+							similarityBasis: `title-keyword-match (${overlap.join(', ')})`,
+						});
+						if (candidates.length >= config.duplicateCandidateLimit) break;
+					}
+				}
+			}
+		}
+
+		issue.duplicateCandidates = candidates;
+	}
+}
+
+function significantWords(text: string): Set<string> {
+	return new Set(
+		text
+			.toLowerCase()
+			.replace(/[^a-z0-9\s]/g, '')
+			.split(/\s+/)
+			.filter(w => w.length > 2 && !stopWords.has(w)),
+	);
+}

--- a/scripts/issues/config.mts
+++ b/scripts/issues/config.mts
@@ -1,0 +1,18 @@
+export const config = {
+	owner: 'gitkraken',
+	repo: 'vscode-gitlens',
+	cacheDir: '.work/triage/cache',
+	packsDir: '.work/triage/packs',
+	reportsDir: '.work/triage/reports',
+	teamCacheTtlMs: 4 * 60 * 60 * 1000, // 4 hours
+	changelogCacheTtlMs: 1 * 60 * 60 * 1000, // 1 hour
+	labelsCacheTtlMs: 24 * 60 * 60 * 1000, // 24 hours
+	issueCommentLimit: 3,
+	duplicateCandidateLimit: 5,
+	staleInactivityDays: 365,
+	auditBatchSize: 50,
+	singleIssueBatchLimit: 10, // Max issues per GraphQL alias query
+	graphqlRetryMaxAttempts: 3,
+	graphqlRetryBackoffMs: 60_000, // 60 seconds, doubled on each retry
+	schemaVersion: '1.0',
+} as const;

--- a/scripts/issues/fetch-changelog.mts
+++ b/scripts/issues/fetch-changelog.mts
@@ -1,0 +1,86 @@
+import { mkdir, readFile, writeFile } from 'node:fs/promises';
+import { join } from 'node:path';
+import { config } from './config.mts';
+import type { CacheFile, ChangelogEntry } from './types.mts';
+
+const cacheFile = join(config.cacheDir, 'changelog-lookup.json');
+
+type ChangeType = ChangelogEntry['changeType'];
+
+const changeTypeMap: Record<string, ChangeType> = {
+	added: 'Added',
+	changed: 'Changed',
+	fixed: 'Fixed',
+	deprecated: 'Deprecated',
+	removed: 'Removed',
+};
+
+export async function fetchChangelogLookup(forceRefresh?: boolean): Promise<Record<string, ChangelogEntry>> {
+	if (!forceRefresh) {
+		try {
+			const raw = await readFile(cacheFile, 'utf8');
+			const cached: CacheFile<Record<string, ChangelogEntry>> = JSON.parse(raw);
+			const age = Date.now() - new Date(cached.fetchedAt).getTime();
+			if (age < config.changelogCacheTtlMs) {
+				return cached.data;
+			}
+		} catch {
+			// Cache miss — parse fresh
+		}
+	}
+
+	const content = await readFile('CHANGELOG.md', 'utf8');
+	const lookup = parseChangelog(content);
+
+	await mkdir(config.cacheDir, { recursive: true });
+	const cache: CacheFile<Record<string, ChangelogEntry>> = {
+		fetchedAt: new Date().toISOString(),
+		data: lookup,
+	};
+	await writeFile(cacheFile, JSON.stringify(cache, null, '\t'));
+
+	return lookup;
+}
+
+function parseChangelog(content: string): Record<string, ChangelogEntry> {
+	const lookup: Record<string, ChangelogEntry> = {};
+
+	let currentVersion: string | null = null;
+	let currentChangeType: ChangeType | null = null;
+
+	for (const line of content.split('\n')) {
+		// Version header: ## [x.y.z] or ## [Unreleased]
+		const versionMatch = line.match(/^## \[([^\]]+)\]/);
+		if (versionMatch) {
+			currentVersion = versionMatch[1];
+			currentChangeType = null;
+			continue;
+		}
+
+		// Change type sub-header: ### Added, ### Fixed, etc.
+		const typeMatch = line.match(/^### (\w+)/);
+		if (typeMatch) {
+			const mapped = changeTypeMap[typeMatch[1].toLowerCase()];
+			currentChangeType = mapped ?? null;
+			continue;
+		}
+
+		// List item with issue references
+		if (currentVersion != null && currentChangeType != null && line.match(/^\s*-\s/)) {
+			const issueRefs = [...line.matchAll(/#(\d+)/g)];
+			for (const ref of issueRefs) {
+				const key = `#${ref[1]}`;
+				// Keep the earliest released version (first occurrence wins
+				// since changelog is ordered newest-first, the last write wins
+				// for "earliest" — so we always overwrite to get the oldest)
+				lookup[key] = {
+					version: currentVersion,
+					changeType: currentChangeType,
+					entry: line.replace(/^\s*-\s*/, '').trim(),
+				};
+			}
+		}
+	}
+
+	return lookup;
+}

--- a/scripts/issues/fetch-issues.mts
+++ b/scripts/issues/fetch-issues.mts
@@ -1,0 +1,386 @@
+import { execFile } from 'node:child_process';
+import { mkdir, readFile, writeFile, unlink } from 'node:fs/promises';
+import { join } from 'node:path';
+import { promisify } from 'node:util';
+import { config } from './config.mts';
+import type {
+	AuditCursor,
+	AuditQueryParams,
+	GitHubIssue,
+	IssueComment,
+	LinkedPr,
+	ReactiveQueryParams,
+	SingleQueryParams,
+} from './types.mts';
+
+const execFileAsync = promisify(execFile);
+
+const cursorFile = join(config.cacheDir, 'audit-cursor.json');
+
+export async function fetchIssues(mode: 'reactive', params: ReactiveQueryParams): Promise<GitHubIssue[]>;
+export async function fetchIssues(mode: 'audit', params: AuditQueryParams): Promise<GitHubIssue[]>;
+export async function fetchIssues(
+	mode: 'reactive' | 'audit',
+	params: ReactiveQueryParams | AuditQueryParams,
+): Promise<GitHubIssue[]> {
+	if (mode === 'reactive') {
+		return fetchReactiveIssues(params as ReactiveQueryParams);
+	}
+	return fetchAuditIssues(params as AuditQueryParams);
+}
+
+function parseDuration(duration: string): number {
+	const match = duration.match(/^(\d+)d$/);
+	if (!match) throw new Error(`Invalid duration format: ${duration} (expected e.g. "7d")`);
+	return parseInt(match[1], 10);
+}
+
+function daysAgo(days: number): string {
+	const d = new Date();
+	d.setDate(d.getDate() - days);
+	return d.toISOString().split('T')[0];
+}
+
+async function fetchReactiveIssues(params: ReactiveQueryParams): Promise<GitHubIssue[]> {
+	const days = parseDuration(params.since);
+	const sinceDate = daysAgo(days);
+
+	const query = `
+		query($owner: String!, $repo: String!, $cursor: String) {
+			repository(owner: $owner, name: $repo) {
+				issues(
+					first: 100
+					after: $cursor
+					states: OPEN
+					filterBy: { since: "${sinceDate}T00:00:00Z" }
+					orderBy: { field: CREATED_AT, direction: DESC }
+				) {
+					pageInfo { hasNextPage endCursor }
+					nodes {
+						...IssueFields
+					}
+				}
+			}
+		}
+		${issueFragment}
+	`;
+
+	return paginateGraphQL(query);
+}
+
+async function fetchAuditIssues(params: AuditQueryParams): Promise<GitHubIssue[]> {
+	const days = parseDuration(params.olderThan);
+	const beforeDate = daysAgo(days);
+	const batchSize = params.batchSize;
+
+	// Check for saved cursor to resume
+	let savedCursor: AuditCursor | null = null;
+	try {
+		const raw = await readFile(cursorFile, 'utf8');
+		savedCursor = JSON.parse(raw);
+		if (savedCursor != null && savedCursor.batchNumber !== params.batchNumber) {
+			savedCursor = null; // Different batch — start fresh
+		}
+	} catch {
+		// No cursor file
+	}
+
+	const labelFilter = params.labelFilter ? `labels: ["${params.labelFilter}"]` : '';
+
+	const query = `
+		query($owner: String!, $repo: String!, $cursor: String) {
+			repository(owner: $owner, name: $repo) {
+				issues(
+					first: ${batchSize}
+					after: $cursor
+					states: OPEN
+					filterBy: { ${labelFilter} }
+					orderBy: { field: CREATED_AT, direction: ASC }
+				) {
+					pageInfo { hasNextPage endCursor }
+					nodes {
+						...IssueFields
+					}
+				}
+			}
+		}
+		${issueFragment}
+	`;
+
+	const startCursor = savedCursor?.endCursor ?? null;
+	const issues = await fetchSinglePage(query, startCursor, params.batchNumber);
+
+	// Filter to only issues older than the threshold
+	const filtered = issues.filter(i => i.createdAt <= `${beforeDate}T23:59:59Z`);
+
+	// Save cursor for resume
+	// We only fetch one page for audit mode, so save cursor from this page
+	// The cursor is embedded in the response — we handle this in fetchSinglePage
+
+	return filtered;
+}
+
+const issueFragment = `
+	fragment IssueFields on Issue {
+		number
+		title
+		body
+		state
+		issueType { name }
+		labels(first: 20) { nodes { name } }
+		author { login }
+		authorAssociation
+		assignees(first: 10) { nodes { login } }
+		milestone { title }
+		createdAt
+		updatedAt
+		closedAt
+		reactionGroups {
+			content
+			reactors(first: 0) { totalCount }
+		}
+		comments(last: ${config.issueCommentLimit}) {
+			totalCount
+			nodes {
+				author { login }
+				authorAssociation
+				body
+				createdAt
+			}
+		}
+		timelineItems(last: 20, itemTypes: [CROSS_REFERENCED_EVENT, CONNECTED_EVENT]) {
+			nodes {
+				... on CrossReferencedEvent {
+					source {
+						... on PullRequest {
+							number
+							title
+							state
+							mergedAt
+						}
+					}
+				}
+				... on ConnectedEvent {
+					subject {
+						... on PullRequest {
+							number
+							title
+							state
+							mergedAt
+						}
+					}
+				}
+			}
+		}
+	}
+`;
+
+interface GraphQLIssueNode {
+	number: number;
+	title: string;
+	body: string;
+	state: 'OPEN' | 'CLOSED';
+	issueType: { name: string } | null;
+	labels: { nodes: Array<{ name: string }> };
+	author: { login: string } | null;
+	authorAssociation: string;
+	assignees: { nodes: Array<{ login: string }> };
+	milestone: { title: string } | null;
+	createdAt: string;
+	updatedAt: string;
+	closedAt: string | null;
+	reactionGroups: Array<{ content: string; reactors: { totalCount: number } }>;
+	comments: {
+		totalCount: number;
+		nodes: Array<{
+			author: { login: string } | null;
+			authorAssociation: string;
+			body: string;
+			createdAt: string;
+		}>;
+	};
+	timelineItems: {
+		nodes: Array<{
+			source?: { number?: number; title?: string; state?: string; mergedAt?: string | null };
+			subject?: { number?: number; title?: string; state?: string; mergedAt?: string | null };
+		}>;
+	};
+}
+
+function mapIssueNode(node: GraphQLIssueNode): GitHubIssue {
+	const linkedPrs: LinkedPr[] = [];
+	const seenPrs = new Set<number>();
+
+	for (const item of node.timelineItems.nodes) {
+		const pr = item.source ?? item.subject;
+		if (pr?.number != null && !seenPrs.has(pr.number)) {
+			seenPrs.add(pr.number);
+			linkedPrs.push({
+				number: pr.number,
+				title: pr.title ?? '',
+				state: pr.mergedAt ? 'merged' : ((pr.state?.toLowerCase() as 'open' | 'closed') ?? 'open'),
+				mergedAt: pr.mergedAt ?? null,
+			});
+		}
+	}
+
+	const comments: IssueComment[] = node.comments.nodes.map(c => ({
+		author: c.author?.login ?? 'ghost',
+		authorAssociation: c.authorAssociation,
+		body: c.body,
+		createdAt: c.createdAt,
+	}));
+
+	const reactionGroups = (node.reactionGroups ?? []).map(g => ({
+		content: g.content,
+		totalCount: g.reactors.totalCount,
+	}));
+
+	return {
+		number: node.number,
+		title: node.title,
+		body: node.body,
+		state: node.state === 'OPEN' ? 'open' : 'closed',
+		type: node.issueType?.name ?? null,
+		labels: node.labels.nodes.map(l => l.name),
+		author: node.author?.login ?? 'ghost',
+		authorAssociation: node.authorAssociation,
+		assignees: node.assignees.nodes.map(a => a.login),
+		milestone: node.milestone?.title ?? null,
+		createdAt: node.createdAt,
+		updatedAt: node.updatedAt,
+		closedAt: node.closedAt,
+		comments,
+		commentCount: node.comments.totalCount,
+		linkedPrs,
+		reactionGroups,
+	};
+}
+
+async function execGraphQL(query: string, cursor: string | null): Promise<string> {
+	// gh api graphql expects variables as individual -F (non-string/JSON) or -f (string) flags
+	const args = ['api', 'graphql', '-f', `query=${query}`, '-F', `owner=${config.owner}`, '-F', `repo=${config.repo}`];
+	if (cursor != null) {
+		args.push('-F', `cursor=${cursor}`);
+	}
+
+	let lastError: Error | null = null;
+	for (let attempt = 0; attempt < config.graphqlRetryMaxAttempts; attempt++) {
+		try {
+			const { stdout } = await execFileAsync('gh', args, { maxBuffer: 50 * 1024 * 1024 });
+			return stdout;
+		} catch (err: unknown) {
+			lastError = err instanceof Error ? err : new Error(String(err));
+			const msg = lastError.message.toLowerCase();
+			if (msg.includes('rate limit') || msg.includes('secondary rate')) {
+				const backoff = config.graphqlRetryBackoffMs * Math.pow(2, attempt);
+				console.error(
+					`Rate limited. Retrying in ${backoff / 1000}s (attempt ${attempt + 1}/${config.graphqlRetryMaxAttempts})...`,
+				);
+				await new Promise(resolve => setTimeout(resolve, backoff));
+				continue;
+			}
+			throw lastError;
+		}
+	}
+	throw lastError ?? new Error('GraphQL request failed after retries');
+}
+
+async function paginateGraphQL(query: string): Promise<GitHubIssue[]> {
+	const issues: GitHubIssue[] = [];
+	let cursor: string | null = null;
+
+	while (true) {
+		const raw = await execGraphQL(query, cursor);
+		const response = JSON.parse(raw);
+
+		if (response.errors?.length) {
+			throw new Error(`GraphQL errors: ${JSON.stringify(response.errors)}`);
+		}
+
+		const connection = response.data.repository.issues;
+		const nodes: GraphQLIssueNode[] = connection.nodes;
+		issues.push(...nodes.map(mapIssueNode));
+
+		if (!connection.pageInfo.hasNextPage) break;
+		cursor = connection.pageInfo.endCursor;
+	}
+
+	return issues;
+}
+
+async function fetchSinglePage(query: string, cursor: string | null, batchNumber: number = 0): Promise<GitHubIssue[]> {
+	const raw = await execGraphQL(query, cursor);
+	const response = JSON.parse(raw);
+
+	if (response.errors?.length) {
+		throw new Error(`GraphQL errors: ${JSON.stringify(response.errors)}`);
+	}
+
+	const connection = response.data.repository.issues;
+	const nodes: GraphQLIssueNode[] = connection.nodes;
+	const issues = nodes.map(mapIssueNode);
+
+	// Save cursor for audit checkpoint/resume
+	await mkdir(config.cacheDir, { recursive: true });
+	const auditCursor: AuditCursor = {
+		endCursor: connection.pageInfo.endCursor,
+		hasNextPage: connection.pageInfo.hasNextPage,
+		batchNumber: batchNumber,
+		totalFetched: issues.length,
+	};
+	await writeFile(cursorFile, JSON.stringify(auditCursor, null, '\t'));
+
+	return issues;
+}
+
+export async function fetchSingleIssues(params: SingleQueryParams): Promise<GitHubIssue[]> {
+	const chunkSize = config.singleIssueBatchLimit;
+	const allIssues: GitHubIssue[] = [];
+
+	for (let i = 0; i < params.issueNumbers.length; i += chunkSize) {
+		const chunk = params.issueNumbers.slice(i, i + chunkSize);
+		const aliases = chunk.map(n => `i${n}: issue(number: ${n}) { ...IssueFields }`).join('\n');
+
+		const query = `
+			query($owner: String!, $repo: String!) {
+				repository(owner: $owner, name: $repo) {
+					${aliases}
+				}
+			}
+			${issueFragment}
+		`;
+
+		const raw = await execGraphQL(query, null);
+		const response = JSON.parse(raw);
+
+		if (response.errors?.length) {
+			// Some issues may not exist — filter out null results
+			const nonNullErrors = response.errors.filter((e: { type?: string }) => e.type !== 'NOT_FOUND');
+			if (nonNullErrors.length > 0) {
+				throw new Error(`GraphQL errors: ${JSON.stringify(nonNullErrors)}`);
+			}
+		}
+
+		const repo = response.data.repository;
+		for (const num of chunk) {
+			const node: GraphQLIssueNode | null = repo[`i${num}`];
+			if (node != null) {
+				allIssues.push(mapIssueNode(node));
+			} else {
+				console.error(`Warning: issue #${num} not found, skipping`);
+			}
+		}
+	}
+
+	return allIssues;
+}
+
+/** Remove the audit cursor file (called when a batch completes successfully). */
+export async function clearAuditCursor(): Promise<void> {
+	try {
+		await unlink(cursorFile);
+	} catch {
+		// Already gone
+	}
+}

--- a/scripts/issues/fetch-issues.mts
+++ b/scripts/issues/fetch-issues.mts
@@ -111,7 +111,13 @@ async function fetchAuditIssues(params: AuditQueryParams): Promise<GitHubIssue[]
 	const issues = await fetchSinglePage(query, startCursor, params.batchNumber);
 
 	// Filter to only issues older than the threshold
-	const filtered = issues.filter(i => i.createdAt <= `${beforeDate}T23:59:59Z`);
+	let filtered = issues.filter(i => i.createdAt <= `${beforeDate}T23:59:59Z`);
+
+	// Client-side type filter (GitHub GraphQL filterBy doesn't support issue types)
+	if (params.typeFilter) {
+		const typeFilter = params.typeFilter.toLowerCase();
+		filtered = filtered.filter(i => i.type?.toLowerCase() === typeFilter);
+	}
 
 	// Save cursor for resume
 	// We only fetch one page for audit mode, so save cursor from this page

--- a/scripts/issues/fetch-labels.mts
+++ b/scripts/issues/fetch-labels.mts
@@ -1,0 +1,51 @@
+import { execFile } from 'node:child_process';
+import { mkdir, readFile, writeFile } from 'node:fs/promises';
+import { join } from 'node:path';
+import { promisify } from 'node:util';
+import { config } from './config.mts';
+import type { CacheFile, RepositoryLabel } from './types.mts';
+
+const execFileAsync = promisify(execFile);
+
+const cacheFile = join(config.cacheDir, 'labels.json');
+
+export async function fetchLabels(forceRefresh?: boolean): Promise<RepositoryLabel[]> {
+	if (!forceRefresh) {
+		try {
+			const raw = await readFile(cacheFile, 'utf8');
+			const cached: CacheFile<RepositoryLabel[]> = JSON.parse(raw);
+			const age = Date.now() - new Date(cached.fetchedAt).getTime();
+			if (age < config.labelsCacheTtlMs) {
+				return cached.data;
+			}
+		} catch {
+			// Cache miss — fetch fresh
+		}
+	}
+
+	const { stdout } = await execFileAsync('gh', [
+		'api',
+		`repos/${config.owner}/${config.repo}/labels`,
+		'--paginate',
+		'--jq',
+		'[.[] | {name: .name, description: (.description // "")}]',
+	]);
+
+	// gh --paginate with --jq outputs one JSON array per page; merge them
+	const labels: RepositoryLabel[] = [];
+	for (const line of stdout.trim().split('\n')) {
+		if (line) {
+			const parsed: RepositoryLabel[] = JSON.parse(line);
+			labels.push(...parsed);
+		}
+	}
+
+	await mkdir(config.cacheDir, { recursive: true });
+	const cache: CacheFile<RepositoryLabel[]> = {
+		fetchedAt: new Date().toISOString(),
+		data: labels,
+	};
+	await writeFile(cacheFile, JSON.stringify(cache, null, '\t'));
+
+	return labels;
+}

--- a/scripts/issues/fetch-team.mts
+++ b/scripts/issues/fetch-team.mts
@@ -1,0 +1,51 @@
+import { execFile } from 'node:child_process';
+import { mkdir, readFile, writeFile } from 'node:fs/promises';
+import { join } from 'node:path';
+import { promisify } from 'node:util';
+import { config } from './config.mts';
+import type { CacheFile } from './types.mts';
+
+const execFileAsync = promisify(execFile);
+
+const cacheFile = join(config.cacheDir, 'team-members.json');
+
+export async function fetchTeamMembers(forceRefresh?: boolean): Promise<string[]> {
+	if (!forceRefresh) {
+		try {
+			const raw = await readFile(cacheFile, 'utf8');
+			const cached: CacheFile<string[]> = JSON.parse(raw);
+			const age = Date.now() - new Date(cached.fetchedAt).getTime();
+			if (age < config.teamCacheTtlMs) {
+				return cached.data;
+			}
+		} catch {
+			// Cache miss — fetch fresh
+		}
+	}
+
+	const { stdout } = await execFileAsync('gh', [
+		'api',
+		`/orgs/${config.owner}/members`,
+		'--paginate',
+		'--jq',
+		'[.[].login]',
+	]);
+
+	// gh --paginate with --jq outputs one JSON array per page; merge them
+	const members: string[] = [];
+	for (const line of stdout.trim().split('\n')) {
+		if (line) {
+			const parsed: string[] = JSON.parse(line);
+			members.push(...parsed);
+		}
+	}
+
+	await mkdir(config.cacheDir, { recursive: true });
+	const cache: CacheFile<string[]> = {
+		fetchedAt: new Date().toISOString(),
+		data: members,
+	};
+	await writeFile(cacheFile, JSON.stringify(cache, null, '\t'));
+
+	return members;
+}

--- a/scripts/issues/triage.mts
+++ b/scripts/issues/triage.mts
@@ -1,0 +1,183 @@
+import { parseArgs } from 'node:util';
+import { readFile, stat } from 'node:fs/promises';
+import { join, resolve } from 'node:path';
+import { config } from './config.mts';
+import { buildPack } from './build-pack.mts';
+import type { AuditQueryParams, EvidencePack, ReactiveQueryParams, SingleQueryParams } from './types.mts';
+
+const oneHourMs = 60 * 60 * 1000;
+
+async function main(): Promise<void> {
+	const command = process.argv[2];
+	if (!command || !['recent', 'audit', 'single'].includes(command)) {
+		printUsage();
+		process.exit(1);
+	}
+
+	// Parse args after the command
+	const rawArgs = process.argv.slice(3);
+
+	if (command === 'recent') {
+		await runRecent(rawArgs);
+	} else if (command === 'audit') {
+		await runAudit(rawArgs);
+	} else {
+		await runSingle(rawArgs);
+	}
+}
+
+function printUsage(): void {
+	console.error(`Usage: pnpm triage:<command> -- [options]
+
+Commands:
+  recent    Reactive triage of recently opened issues
+  audit     Retroactive audit of historical backlog
+  single    Fetch specific issues by number
+
+Options (recent):
+  --since <duration>     Lookback window, e.g. 7d, 14d (default: 7d)
+  --force-refresh        Bypass cache for all fetch steps
+
+Options (audit):
+  --older-than <duration>  Age threshold, e.g. 180d (default: 180d)
+  --batch-size <n>         Issues per batch (default: 50)
+  --label <label>          Filter by label (optional)
+  --batch <n>              Resume at batch number N (default: 1)
+  --force-refresh          Bypass cache for all fetch steps
+
+Options (single):
+  <number> [number...]   One or more issue numbers (required)
+  --force-refresh        Bypass cache for all fetch steps`);
+}
+
+async function runRecent(rawArgs: string[]): Promise<void> {
+	const { values } = parseArgs({
+		args: rawArgs,
+		options: {
+			since: { type: 'string', default: '7d' },
+			'force-refresh': { type: 'boolean', default: false },
+		},
+		strict: false,
+	});
+
+	const params: ReactiveQueryParams = {
+		since: values.since as string,
+	};
+	const forceRefresh = values['force-refresh'] as boolean;
+
+	// Check for a fresh existing pack
+	if (!forceRefresh) {
+		const existingPath = await findFreshPack('reactive');
+		if (existingPath) {
+			console.log(resolve(existingPath));
+			return;
+		}
+	}
+
+	const packPath = await buildPack('reactive', params, forceRefresh);
+	console.log(resolve(packPath));
+}
+
+async function runAudit(rawArgs: string[]): Promise<void> {
+	const { values } = parseArgs({
+		args: rawArgs,
+		options: {
+			'older-than': { type: 'string', default: '180d' },
+			'batch-size': { type: 'string', default: String(config.auditBatchSize) },
+			label: { type: 'string' },
+			batch: { type: 'string', default: '1' },
+			'force-refresh': { type: 'boolean', default: false },
+		},
+		strict: false,
+	});
+
+	const params: AuditQueryParams = {
+		olderThan: values['older-than'] as string,
+		batchSize: parseInt(values['batch-size'] as string, 10),
+		labelFilter: (values.label as string) ?? null,
+		batchNumber: parseInt(values.batch as string, 10),
+	};
+	const forceRefresh = values['force-refresh'] as boolean;
+
+	// Check for a fresh existing pack for this batch
+	if (!forceRefresh) {
+		const existingPath = await findFreshPack('audit', params.batchNumber);
+		if (existingPath) {
+			console.log(resolve(existingPath));
+			return;
+		}
+	}
+
+	const packPath = await buildPack('audit', params, forceRefresh);
+	console.log(resolve(packPath));
+}
+
+async function runSingle(rawArgs: string[]): Promise<void> {
+	// Single mode always fetches fresh data (no cache check) since the user
+	// is requesting specific issues and likely wants current state.
+	// Parse issue numbers from positional args and flags
+	const { values, positionals } = parseArgs({
+		args: rawArgs,
+		options: {
+			'force-refresh': { type: 'boolean', default: false },
+		},
+		strict: false,
+		allowPositionals: true,
+	});
+
+	const issueNumbers = positionals.map(n => parseInt(n, 10)).filter(n => !isNaN(n) && n > 0);
+
+	if (issueNumbers.length === 0) {
+		console.error('Error: at least one issue number is required for single mode');
+		printUsage();
+		process.exit(1);
+	}
+
+	const forceRefresh = values['force-refresh'] as boolean;
+
+	const params: SingleQueryParams = { issueNumbers };
+	const packPath = await buildPack('single', params, forceRefresh);
+	console.log(resolve(packPath));
+}
+
+async function findFreshPack(mode: 'reactive' | 'audit', batchNumber?: number): Promise<string | null> {
+	const latestName = mode === 'reactive' ? 'latest-reactive.json' : `latest-audit-batch-${batchNumber}.json`;
+	const latestPath = join(config.packsDir, latestName);
+
+	try {
+		const info = await stat(latestPath);
+		const ageMs = Date.now() - info.mtimeMs;
+
+		// "Fresh" means created within the last hour for reactive
+		if (mode === 'reactive' && ageMs < oneHourMs) {
+			// Verify pack can be read and has matching params
+			const raw = await readFile(latestPath, 'utf8');
+			const pack: EvidencePack = JSON.parse(raw);
+			if (pack.meta.workflow === 'reactive') {
+				return latestPath;
+			}
+		}
+
+		// For audit, check that batch number matches
+		if (mode === 'audit' && ageMs < oneHourMs) {
+			const raw = await readFile(latestPath, 'utf8');
+			const pack: EvidencePack = JSON.parse(raw);
+			if (
+				pack.meta.workflow === 'audit' &&
+				'batchNumber' in pack.meta.queryParams &&
+				pack.meta.queryParams.batchNumber === batchNumber
+			) {
+				return latestPath;
+			}
+		}
+	} catch {
+		// No existing pack
+	}
+
+	return null;
+}
+
+main().catch(err => {
+	console.error('Fatal error:', err);
+	process.exit(1);
+});

--- a/scripts/issues/triage.mts
+++ b/scripts/issues/triage.mts
@@ -42,6 +42,7 @@ Options (audit):
   --older-than <duration>  Age threshold, e.g. 180d (default: 180d)
   --batch-size <n>         Issues per batch (default: 50)
   --label <label>          Filter by label (optional)
+  --type <type>            Filter by issue type, e.g. bug, enhancement (optional)
   --batch <n>              Resume at batch number N (default: 1)
   --force-refresh          Bypass cache for all fetch steps
 
@@ -85,6 +86,7 @@ async function runAudit(rawArgs: string[]): Promise<void> {
 			'older-than': { type: 'string', default: '180d' },
 			'batch-size': { type: 'string', default: String(config.auditBatchSize) },
 			label: { type: 'string' },
+			type: { type: 'string' },
 			batch: { type: 'string', default: '1' },
 			'force-refresh': { type: 'boolean', default: false },
 		},
@@ -95,6 +97,7 @@ async function runAudit(rawArgs: string[]): Promise<void> {
 		olderThan: values['older-than'] as string,
 		batchSize: parseInt(values['batch-size'] as string, 10),
 		labelFilter: (values.label as string) ?? null,
+		typeFilter: (values.type as string) ?? null,
 		batchNumber: parseInt(values.batch as string, 10),
 	};
 	const forceRefresh = values['force-refresh'] as boolean;

--- a/scripts/issues/types.mts
+++ b/scripts/issues/types.mts
@@ -6,11 +6,13 @@ export type Workflow = 'reactive' | 'audit' | 'single';
 export type VerdictClass =
 	| 'Close - Fixed'
 	| 'Close - Duplicate'
+	| 'Close - Not a Bug'
+	| 'Close - Already Exists'
 	| 'Close - Invalid'
 	| 'Close - Stale'
 	| 'Request More Info'
-	| 'Relabel - Bug'
-	| 'Relabel - Feature Request'
+	| 'Retype - Bug'
+	| 'Retype - Feature Request'
 	| 'Valid - Needs Triage'
 	| 'Valid - Already Triaged';
 
@@ -22,6 +24,7 @@ export interface AuditQueryParams {
 	olderThan: string;
 	batchSize: number;
 	labelFilter: string | null;
+	typeFilter: string | null;
 	batchNumber: number;
 }
 

--- a/scripts/issues/types.mts
+++ b/scripts/issues/types.mts
@@ -1,0 +1,156 @@
+// Evidence pack schema types for the triage toolkit.
+// No runtime logic — type definitions only.
+
+export type Workflow = 'reactive' | 'audit' | 'single';
+
+export type VerdictClass =
+	| 'Close - Fixed'
+	| 'Close - Duplicate'
+	| 'Close - Invalid'
+	| 'Close - Stale'
+	| 'Request More Info'
+	| 'Relabel - Bug'
+	| 'Relabel - Feature Request'
+	| 'Valid - Needs Triage'
+	| 'Valid - Already Triaged';
+
+export interface ReactiveQueryParams {
+	since: string;
+}
+
+export interface AuditQueryParams {
+	olderThan: string;
+	batchSize: number;
+	labelFilter: string | null;
+	batchNumber: number;
+}
+
+export interface SingleQueryParams {
+	issueNumbers: number[];
+}
+
+export interface RunMetadata {
+	runId: string;
+	timestamp: string;
+	schemaVersion: string;
+	workflow: Workflow;
+	queryParams: ReactiveQueryParams | AuditQueryParams | SingleQueryParams;
+	teamMembersRefreshedAt: string;
+	changelogRefreshedAt: string;
+	repo: string;
+}
+
+export interface IssueLabel {
+	name: string;
+	description: string;
+}
+
+export interface IssueComment {
+	author: string;
+	authorAssociation: string;
+	body: string;
+	createdAt: string;
+}
+
+export interface LinkedPr {
+	number: number;
+	title: string;
+	state: 'open' | 'closed' | 'merged';
+	mergedAt: string | null;
+}
+
+export interface ChangelogEntry {
+	version: string;
+	changeType: 'Added' | 'Changed' | 'Fixed' | 'Deprecated' | 'Removed';
+	entry: string;
+}
+
+export interface DuplicateCandidate {
+	number: number;
+	title: string;
+	state: 'open' | 'closed';
+	closedAt: string | null;
+	similarityBasis: string;
+}
+
+export interface ReactionSummary {
+	thumbsUp: number;
+	thumbsDown: number;
+	laugh: number;
+	hooray: number;
+	confused: number;
+	heart: number;
+	rocket: number;
+	eyes: number;
+	total: number;
+}
+
+/** Raw issue fields from GitHub (before enrichment). */
+export interface GitHubIssue {
+	number: number;
+	title: string;
+	body: string;
+	state: 'open' | 'closed';
+	type: string | null;
+	labels: string[];
+	author: string;
+	authorAssociation: string;
+	assignees: string[];
+	milestone: string | null;
+	createdAt: string;
+	updatedAt: string;
+	closedAt: string | null;
+	comments: IssueComment[];
+	commentCount: number;
+	linkedPrs: LinkedPr[];
+	reactionGroups: Array<{ content: string; totalCount: number }>;
+}
+
+/** Enriched issue with computed evidence fields. */
+export interface EnrichedIssue extends Omit<GitHubIssue, 'labels' | 'reactionGroups'> {
+	reactions: ReactionSummary;
+	labels: IssueLabel[];
+	isTeamMember: boolean;
+	changelogEntry: ChangelogEntry | null;
+	lastActivityAt: string;
+	duplicateCandidates: DuplicateCandidate[];
+	supersessionIndicators: string[];
+}
+
+export interface EvidencePack {
+	meta: RunMetadata;
+	teamMembers: string[];
+	issues: EnrichedIssue[];
+}
+
+export interface TriageVerdict {
+	issueNumber: number;
+	verdict: VerdictClass;
+	confidence: 'High' | 'Medium' | 'Low';
+	evidenceChecklistStatus: Record<string, boolean>;
+	recommendedLabels: string[];
+	recommendedActions: string[];
+	requiresHumanApproval: boolean;
+	evidenceSummary: string;
+	canonicalDuplicateNumber: number | null;
+	canonicalDuplicateStatus: string | null;
+}
+
+export interface RepositoryLabel {
+	name: string;
+	description: string;
+}
+
+/** Cache file wrapper with timestamp. */
+export interface CacheFile<T> {
+	fetchedAt: string;
+	data: T;
+}
+
+/** Audit cursor for checkpoint/resume. */
+export interface AuditCursor {
+	endCursor: string | null;
+	hasNextPage: boolean;
+	batchNumber: number;
+	totalFetched: number;
+}

--- a/scripts/issues/workflow.mts
+++ b/scripts/issues/workflow.mts
@@ -385,6 +385,7 @@ async function runTriagePipeline(
 			'older-than': { type: 'string', default: '180d' },
 			'batch-size': { type: 'string', default: '50' },
 			label: { type: 'string' },
+			type: { type: 'string' },
 			batch: { type: 'string', default: '1' },
 			'force-refresh': { type: 'boolean', default: false },
 			'skip-to': { type: 'string' },

--- a/scripts/issues/workflow.mts
+++ b/scripts/issues/workflow.mts
@@ -21,7 +21,7 @@
  *   --rubber-duck, --rd      Second-opinion pass on evaluative stages
  */
 
-import { execFileSync, execSync, spawnSync } from 'node:child_process';
+import { execFileSync, spawnSync } from 'node:child_process';
 import { writeFileSync } from 'node:fs';
 import { readFile, access, mkdir, stat, readdir } from 'node:fs/promises';
 import { dirname, resolve, join } from 'node:path';
@@ -89,15 +89,8 @@ function resolveDuckModel(agent: AgentType, mainModel?: string, duckOverride?: s
 
 function notify(title: string, message: string, silent: boolean): void {
 	if (silent) return;
-	try {
-		const escaped = message.replace(/\\/g, '\\\\').replace(/"/g, '\\"');
-		const escapedTitle = title.replace(/\\/g, '\\\\').replace(/"/g, '\\"');
-		execSync(`osascript -e 'display notification "${escaped}" with title "${escapedTitle}" sound name "Glass"'`, {
-			stdio: 'ignore',
-		});
-	} catch {
-		// Notification failure is non-fatal
-	}
+	log('🔔', `${title}: ${message}`);
+	process.stderr.write('\x07');
 }
 
 function log(icon: string, message: string): void {

--- a/scripts/issues/workflow.mts
+++ b/scripts/issues/workflow.mts
@@ -21,7 +21,7 @@
  *   --rubber-duck, --rd      Second-opinion pass on evaluative stages
  */
 
-import { execSync, spawnSync } from 'node:child_process';
+import { execFileSync, execSync, spawnSync } from 'node:child_process';
 import { writeFileSync } from 'node:fs';
 import { readFile, access, mkdir, stat, readdir } from 'node:fs/promises';
 import { dirname, resolve, join } from 'node:path';
@@ -90,8 +90,9 @@ function resolveDuckModel(agent: AgentType, mainModel?: string, duckOverride?: s
 function notify(title: string, message: string, silent: boolean): void {
 	if (silent) return;
 	try {
-		const escaped = message.replace(/"/g, '\\"');
-		execSync(`osascript -e 'display notification "${escaped}" with title "${title}" sound name "Glass"'`, {
+		const escaped = message.replace(/\\/g, '\\\\').replace(/"/g, '\\"');
+		const escapedTitle = title.replace(/\\/g, '\\\\').replace(/"/g, '\\"');
+		execSync(`osascript -e 'display notification "${escaped}" with title "${escapedTitle}" sound name "Glass"'`, {
 			stdio: 'ignore',
 		});
 	} catch {
@@ -412,17 +413,16 @@ async function runTriagePipeline(
 	if (startIdx === 0) {
 		divider('Stage 0: Building evidence pack');
 
-		const triageArgs = [triageCommand, ...restArgs].join(' ');
 		const triageScript = resolve(dirname(fileURLToPath(import.meta.url)), 'triage.mts');
-		const triageCmd = `node --experimental-strip-types ${triageScript} ${triageArgs}`;
+		const triageExecArgs = ['--experimental-strip-types', triageScript, triageCommand, ...restArgs];
 
 		if (globalOpts.dryRun) {
-			log('🏜️', `[dry-run] ${triageCmd}`);
+			log('🏜️', `[dry-run] node ${triageExecArgs.join(' ')}`);
 			packPath = '/tmp/dry-run-pack.json';
 		} else {
-			log('▶', `Running: ${triageCmd}`);
+			log('▶', `Running: node ${triageExecArgs.join(' ')}`);
 			try {
-				packPath = execSync(triageCmd, { encoding: 'utf8' }).trim();
+				packPath = execFileSync('node', triageExecArgs, { encoding: 'utf8' }).trim();
 				log('✓', `Evidence pack: ${packPath}`);
 			} catch (err: unknown) {
 				log('✗', `Failed to build evidence pack`);

--- a/scripts/issues/workflow.mts
+++ b/scripts/issues/workflow.mts
@@ -1,0 +1,854 @@
+/**
+ * Orchestration script for the issue-to-delivery workflow.
+ *
+ * Chains pipeline stages as sequential AI CLI invocations (Claude or Auggie).
+ * Two pipelines: triage (evaluate → investigate → prioritize → update)
+ * and dev (scope → plan → challenge → [implement] → review).
+ *
+ * Usage:
+ *   pnpm workflow triage recent [--since 7d] [--skip-to investigate|prioritize]
+ *   pnpm workflow triage audit [--older-than 365d] [--batch-size 50]
+ *   pnpm workflow triage single 5096 5084
+ *   pnpm workflow dev 5096 [--skip-to plan|challenge|review|commit]
+ *   pnpm workflow dev "refactor-caching"
+ *
+ * Options:
+ *   --silent                 Suppress macOS notifications
+ *   --agent <claude|auggie>  Primary agent CLI (default: claude)
+ *   --model <model>          Model override for primary agent
+ *   --duck-model <model>     Override the auto-selected duck model
+ *   --dry-run                Show what would run without executing
+ *   --rubber-duck, --rd      Second-opinion pass on evaluative stages
+ */
+
+import { execSync, spawnSync } from 'node:child_process';
+import { writeFileSync } from 'node:fs';
+import { readFile, access, mkdir, stat, readdir } from 'node:fs/promises';
+import { dirname, resolve, join } from 'node:path';
+import { fileURLToPath } from 'node:url';
+import { parseArgs } from 'node:util';
+
+// ── Constants ────────────────────────────────────────────────────────
+
+const workDir = '.work';
+const triageReportsDir = join(workDir, 'triage', 'reports');
+const devDir = join(workDir, 'dev');
+
+const triageStages = ['triage', 'investigate', 'prioritize'] as const;
+const devPreStages = ['scope', 'plan', 'challenge'] as const;
+const devPostStages = ['review', 'ux-review', 'commit'] as const;
+const devStages = [...devPreStages, ...devPostStages] as const;
+
+type TriageStage = (typeof triageStages)[number];
+type DevStage = (typeof devStages)[number];
+
+type AgentType = 'claude' | 'auggie';
+type ModelFamily = 'claude' | 'gemini' | 'gpt';
+type RunOpts = { dryRun?: boolean };
+type AgentRunner = {
+	run(prompt: string, opts: RunOpts): boolean;
+	runToFile(prompt: string, outputPath: string, opts: RunOpts): boolean;
+};
+
+function detectFamily(agent: AgentType, model?: string): ModelFamily {
+	if (agent === 'claude') return 'claude';
+	if (!model) return 'claude'; // auggie defaults to Claude models
+
+	const lower = model.toLowerCase();
+	if (/^(opus|sonnet|haiku|claude)/.test(lower)) return 'claude';
+	if (/^gemini/.test(lower)) return 'gemini';
+	if (/^gpt/.test(lower)) return 'gpt';
+
+	log('⚠', `Unknown model family for "${model}" — defaulting to claude`);
+	return 'claude';
+}
+
+const duckPairingTable: Record<ModelFamily, string> = {
+	claude: 'gemini-3.1-pro-preview',
+	gemini: 'opus4.6',
+	gpt: 'opus4.6',
+};
+
+function resolveDuckModel(agent: AgentType, mainModel?: string, duckOverride?: string): string {
+	if (duckOverride) {
+		const mainFamily = detectFamily(agent, mainModel);
+		const duckFamily = detectFamily('auggie', duckOverride);
+		if (mainFamily === duckFamily) {
+			log(
+				'⚠',
+				`Duck model "${duckOverride}" is same family as main (${mainFamily}) — second opinion may be less valuable`,
+			);
+		}
+		return duckOverride;
+	}
+	const family = detectFamily(agent, mainModel);
+	return duckPairingTable[family];
+}
+
+// ── Helpers ──────────────────────────────────────────────────────────
+
+function notify(title: string, message: string, silent: boolean): void {
+	if (silent) return;
+	try {
+		const escaped = message.replace(/"/g, '\\"');
+		execSync(`osascript -e 'display notification "${escaped}" with title "${title}" sound name "Glass"'`, {
+			stdio: 'ignore',
+		});
+	} catch {
+		// Notification failure is non-fatal
+	}
+}
+
+function log(icon: string, message: string): void {
+	const ts = new Date().toLocaleTimeString('en-US', { hour12: false });
+	console.log(`${icon} [${ts}] ${message}`);
+}
+
+function divider(label: string): void {
+	console.log(`\n${'─'.repeat(60)}`);
+	console.log(`  ${label}`);
+	console.log(`${'─'.repeat(60)}\n`);
+}
+
+function createRunner(agent: AgentType, opts: { model?: string; capture?: boolean }): AgentRunner {
+	const binary = agent === 'claude' ? 'claude' : 'auggie';
+	const capture = opts.capture ?? false;
+
+	function buildArgs(prompt: string): string[] {
+		if (agent === 'claude') {
+			return ['-p', prompt, '--permission-mode', 'bypassPermissions'];
+		}
+		// Auggie
+		if (capture) {
+			return ['--print', '--quiet', prompt];
+		}
+		return ['-p', prompt];
+	}
+
+	function run(prompt: string, runOpts: RunOpts): boolean {
+		const args = buildArgs(prompt);
+		if (opts.model) args.push('--model', opts.model);
+
+		if (runOpts.dryRun) {
+			log('🏜️', `[dry-run] ${binary} ${args.join(' ')}`);
+			return true;
+		}
+
+		const truncated = `${prompt.slice(0, 80)}${prompt.length > 80 ? '...' : ''}`;
+		log('▶', `Running: ${binary} "${truncated}"`);
+
+		const result = spawnSync(binary, args, {
+			stdio: capture ? 'pipe' : 'inherit',
+			encoding: capture ? 'utf8' : undefined,
+			env: { ...process.env },
+		});
+
+		if (result.status !== 0) {
+			log('✗', `${binary} exited with code ${result.status}`);
+			if (capture && result.stderr?.length) {
+				console.error(result.stderr);
+			}
+			return false;
+		}
+
+		log('✓', 'Stage complete');
+		return true;
+	}
+
+	function runCaptured(prompt: string, runOpts: RunOpts): { ok: boolean; stdout: string } {
+		const args = buildArgs(prompt);
+		if (opts.model) args.push('--model', opts.model);
+
+		if (runOpts.dryRun) {
+			log('🏜️', `[dry-run] ${binary} ${args.join(' ')}`);
+			return { ok: true, stdout: '' };
+		}
+
+		const truncated = `${prompt.slice(0, 80)}${prompt.length > 80 ? '...' : ''}`;
+		log('▶', `Running: ${binary} "${truncated}"`);
+
+		const result = spawnSync(binary, args, {
+			stdio: 'pipe',
+			encoding: 'utf8',
+			env: { ...process.env },
+		});
+
+		if (result.status !== 0) {
+			log('✗', `${binary} exited with code ${result.status}`);
+			if (result.stderr?.length) {
+				console.error(result.stderr);
+			}
+			return { ok: false, stdout: '' };
+		}
+
+		return { ok: true, stdout: result.stdout ?? '' };
+	}
+
+	function runToFile(prompt: string, outputPath: string, runOpts: RunOpts): boolean {
+		if (capture) {
+			// Capture mode: run and write stdout to file
+			const { ok, stdout } = runCaptured(prompt, runOpts);
+			if (!ok) return false;
+			if (!runOpts.dryRun) {
+				writeFileSync(outputPath, stdout, 'utf8');
+				log('✓', `Output saved to ${outputPath}`);
+			}
+			return true;
+		}
+		// Non-capture mode: append save instruction to prompt
+		const savePrompt = `${prompt}\n\nIMPORTANT: After completing the analysis, save the full output to ${outputPath} using the Write tool.`;
+		return run(savePrompt, runOpts);
+	}
+
+	return { run, runToFile };
+}
+
+type RubberDuckStage = 'investigate' | 'prioritize' | 'challenge' | 'review' | 'ux-review';
+
+const rubberDuckPrompts: Record<RubberDuckStage, string> = {
+	investigate: [
+		'You are a second-opinion reviewer for a bug investigation.',
+		'Read the investigation artifact and the triage report.',
+		'Surface 3-5 high-value concerns: alternative root causes not explored,',
+		'misleading correlations, code paths not traced, or reproduction gaps.',
+		'Be specific — reference files and code paths.',
+		'Do NOT re-investigate from scratch. Focus only on what the primary missed.',
+	].join(' '),
+	prioritize: [
+		'You are a second-opinion reviewer for a prioritization decision.',
+		'Read the prioritization artifact and the investigation reports.',
+		'Surface 3-5 high-value concerns: severity miscalibrations, missing user-impact signals,',
+		'opportunity costs overlooked, or issues that should move between tiers.',
+		'Be specific — reference issue numbers and the reasoning that seems weakest.',
+		'Do NOT re-prioritize from scratch. Focus only on what the primary missed.',
+	].join(' '),
+	challenge: [
+		'You are a second-opinion reviewer for a plan challenge analysis.',
+		'Read the challenge artifact and the plan + goals it evaluated.',
+		'Surface a short list (3-5) of high-value concerns the primary reviewer may have missed:',
+		'blind spots in assumptions, architectural risks not covered, pre-mortem scenarios overlooked,',
+		'or severity misclassifications. Be specific — reference files, code paths, or constraints.',
+		'Do NOT re-review from scratch. Focus only on what the primary missed.',
+	].join(' '),
+	review: [
+		'You are a second-opinion reviewer for a deep code review.',
+		'Read the review artifact and the goals document.',
+		'Surface a short list (3-5) of high-value concerns the primary reviewer may have missed:',
+		'code paths not traced, edge cases overlooked, cross-environment issues (Node vs browser),',
+		'decorator interactions missed, or severity misclassifications.',
+		'Be specific — reference files, line numbers, and code paths.',
+		'Do NOT re-review from scratch. Focus only on what the primary missed.',
+	].join(' '),
+	'ux-review': [
+		'You are a second-opinion reviewer for a UX review.',
+		'Read the UX review artifact and the goals document.',
+		'Surface a short list (3-5) of high-value concerns the primary reviewer may have missed:',
+		'user flows not walked through, accessibility gaps, discoverability issues,',
+		'workflow interruptions, or mismatches between the goals UX spec and the actual implementation.',
+		'Be specific — reference UI elements, commands, and interaction patterns.',
+		'Do NOT re-review from scratch. Focus only on what the primary missed.',
+	].join(' '),
+};
+
+async function runRubberDuck(
+	stage: RubberDuckStage,
+	artifactPath: string,
+	contextFiles: string[],
+	opts: { main: AgentRunner; duck: AgentRunner; scopeFlag: string; dryRun?: boolean },
+): Promise<boolean> {
+	const rdPath = artifactPath.replace(/\.md$/, '.rd.md');
+
+	// Step 1: Run duck critique
+	divider(`Rubber Duck: ${stage}`);
+
+	const contextList = contextFiles.join(', ');
+	const duckPrompt = [
+		rubberDuckPrompts[stage],
+		`\nPrimary artifact: ${artifactPath}`,
+		contextList ? `Context files: ${contextList}` : '',
+		'\nRead these files and provide your critique.',
+	]
+		.filter(Boolean)
+		.join('\n');
+
+	if (!opts.duck.runToFile(duckPrompt, rdPath, { dryRun: opts.dryRun })) {
+		log('⚠', 'Rubber duck failed — continuing with original artifact');
+		return true; // Duck is advisory, not blocking
+	}
+
+	// Step 2: Have the primary model revise
+	divider(`Revision: ${stage}`);
+
+	const revisePrompt = [
+		`A second reviewer (different AI model) provided a critique of the ${stage} analysis.`,
+		`Read the critique at ${rdPath} and the original artifact at ${artifactPath}.`,
+		`Re-evaluate the original analysis incorporating this feedback.`,
+		`Update the artifact at ${artifactPath}, noting which concerns you accepted and which you disagree with and why.`,
+		`Add a "## Second-Opinion Review" section at the end documenting what changed.`,
+		opts.scopeFlag,
+	].join(' ');
+
+	if (!opts.main.run(revisePrompt, { dryRun: opts.dryRun })) {
+		log('⚠', 'Revision failed — original artifact preserved');
+		return true; // Revision failure is non-fatal
+	}
+
+	return true;
+}
+
+async function fileExists(path: string): Promise<boolean> {
+	try {
+		await access(path);
+		return true;
+	} catch {
+		return false;
+	}
+}
+
+async function ensureDir(path: string): Promise<void> {
+	await mkdir(path, { recursive: true });
+}
+
+async function detectChallengeVerdict(devFolder: string): Promise<'Ready' | 'Needs Revision' | 'Reconsider' | null> {
+	const challengePath = join(devFolder, 'challenge.md');
+	if (!(await fileExists(challengePath))) return null;
+
+	const content = await readFile(challengePath, 'utf8');
+
+	// Look for the verdict in the ### Verdict section
+	const verdictMatch = content.match(/###\s*Verdict\s*\n+\s*(Ready|Needs Revision|Reconsider)/i);
+	if (verdictMatch) {
+		const raw = verdictMatch[1]!;
+		if (/reconsider/i.test(raw)) return 'Reconsider';
+		if (/needs revision/i.test(raw)) return 'Needs Revision';
+		if (/ready/i.test(raw)) return 'Ready';
+	}
+
+	return null;
+}
+
+function resolveIdentifier(input: string): { identifier: string; isIssue: boolean } {
+	const num = parseInt(input, 10);
+	if (!isNaN(num) && num > 0) {
+		return { identifier: String(num), isIssue: true };
+	}
+	// Slug: lowercase, hyphens, max 50 chars
+	const slug = input
+		.toLowerCase()
+		.replace(/[^a-z0-9\s-]/g, '')
+		.replace(/\s+/g, '-')
+		.slice(0, 50);
+	return { identifier: slug, isIssue: false };
+}
+
+function printCopyPaste(label: string, command: string): void {
+	console.log(`\n  ${label}:`);
+	console.log(`  ┌──────────────────────────────────────────────`);
+	console.log(`  │ ${command}`);
+	console.log(`  └──────────────────────────────────────────────\n`);
+}
+
+async function findLatestReport(pattern: RegExp): Promise<string | undefined> {
+	try {
+		const files = await readdir(triageReportsDir);
+		const matches = files.filter((f: string) => pattern.test(f));
+		if (matches.length === 0) return undefined;
+
+		// Find most recent by mtime
+		let latest: { file: string; mtime: number } | undefined;
+		for (const file of matches) {
+			const fullPath = join(triageReportsDir, file);
+			const s = await stat(fullPath);
+			if (!latest || s.mtimeMs > latest.mtime) {
+				latest = { file: fullPath, mtime: s.mtimeMs };
+			}
+		}
+		return latest?.file;
+	} catch {
+		return undefined;
+	}
+}
+
+// ── Triage Pipeline ──────────────────────────────────────────────────
+
+async function runTriagePipeline(
+	rawArgs: string[],
+	globalOpts: GlobalOpts,
+	main: AgentRunner,
+	duck?: AgentRunner,
+): Promise<void> {
+	const triageCommand = rawArgs[0];
+	if (!triageCommand || !['recent', 'audit', 'single'].includes(triageCommand)) {
+		console.error('Usage: pnpm workflow triage <recent|audit|single> [options]');
+		process.exit(1);
+	}
+
+	const restArgs = rawArgs.slice(1);
+	const { values } = parseArgs({
+		args: restArgs,
+		options: {
+			since: { type: 'string', default: '7d' },
+			'older-than': { type: 'string', default: '180d' },
+			'batch-size': { type: 'string', default: '50' },
+			label: { type: 'string' },
+			batch: { type: 'string', default: '1' },
+			'force-refresh': { type: 'boolean', default: false },
+			'skip-to': { type: 'string' },
+		},
+		strict: false,
+		allowPositionals: true,
+	});
+
+	const skipTo = values['skip-to'] as TriageStage | undefined;
+	if (skipTo && !triageStages.includes(skipTo as TriageStage)) {
+		console.error(`Invalid --skip-to stage: ${skipTo}. Valid: ${triageStages.join(', ')}`);
+		process.exit(1);
+	}
+
+	const startIdx = skipTo ? triageStages.indexOf(skipTo as TriageStage) : 0;
+
+	// Stage 0: Build evidence pack (unless skipping past triage)
+	let packPath: string | undefined;
+	if (startIdx === 0) {
+		divider('Stage 0: Building evidence pack');
+
+		const triageArgs = [triageCommand, ...restArgs].join(' ');
+		const triageScript = resolve(dirname(fileURLToPath(import.meta.url)), 'triage.mts');
+		const triageCmd = `node --experimental-strip-types ${triageScript} ${triageArgs}`;
+
+		if (globalOpts.dryRun) {
+			log('🏜️', `[dry-run] ${triageCmd}`);
+			packPath = '/tmp/dry-run-pack.json';
+		} else {
+			log('▶', `Running: ${triageCmd}`);
+			try {
+				packPath = execSync(triageCmd, { encoding: 'utf8' }).trim();
+				log('✓', `Evidence pack: ${packPath}`);
+			} catch (err: unknown) {
+				log('✗', `Failed to build evidence pack`);
+				if (err && typeof err === 'object' && 'stderr' in err) {
+					console.error((err as { stderr: string }).stderr);
+				}
+				process.exit(1);
+			}
+		}
+	}
+
+	// Stage 1: /triage
+	if (startIdx <= 0) {
+		divider('Stage 1: Triage');
+		const prompt = packPath ? `/triage ${packPath}` : `/triage --from-report`;
+		if (!main.run(prompt, globalOpts)) {
+			log('✗', 'Triage stage failed');
+			notify('Workflow', 'Triage stage failed', globalOpts.silent);
+			process.exit(1);
+		}
+	}
+
+	// Stage 2: /investigate --from-report
+	if (startIdx <= 1) {
+		divider('Stage 2: Investigate');
+		if (!main.run('/investigate --from-report', globalOpts)) {
+			log('✗', 'Investigation stage failed');
+			notify('Workflow', 'Investigation stage failed', globalOpts.silent);
+			process.exit(1);
+		}
+
+		if (duck) {
+			const investigatePath = await findLatestReport(/-INVESTIGATION-REPORT\.md$/);
+			if (investigatePath) {
+				const triageDecisions = await findLatestReport(/-DECISIONS\.json$/);
+				const contextFiles = triageDecisions ? [triageDecisions] : [];
+				await runRubberDuck('investigate', investigatePath, contextFiles, {
+					main,
+					duck,
+					scopeFlag: '',
+					dryRun: globalOpts.dryRun,
+				});
+			} else {
+				log('⚠', 'No investigation report found for rubber duck — skipping');
+			}
+		}
+	}
+
+	// Stage 3: /prioritize --from-report
+	if (startIdx <= 2) {
+		divider('Stage 3: Prioritize');
+		if (!main.run('/prioritize --from-report', globalOpts)) {
+			log('✗', 'Prioritization stage failed');
+			notify('Workflow', 'Prioritization stage failed', globalOpts.silent);
+			process.exit(1);
+		}
+
+		if (duck) {
+			const prioritizePath = await findLatestReport(/-RESOLUTION-REPORT\.md$/);
+			if (prioritizePath) {
+				const investigationReport = await findLatestReport(/-INVESTIGATION-REPORT\.md$/);
+				const investigationDecisions = await findLatestReport(/-INVESTIGATION-DECISIONS\.json$/);
+				const contextFiles = [investigationReport, investigationDecisions].filter(
+					(f): f is string => f != null,
+				);
+				await runRubberDuck('prioritize', prioritizePath, contextFiles, {
+					main,
+					duck,
+					scopeFlag: '',
+					dryRun: globalOpts.dryRun,
+				});
+			} else {
+				log('⚠', 'No prioritization report found for rubber duck — skipping');
+			}
+		}
+	}
+
+	// Done — print update-issues command for human
+	divider('Pipeline Complete');
+	log('✓', 'Triage pipeline finished. Review the reports, then apply:');
+	notify('Workflow', 'Triage pipeline complete — ready for update-issues', globalOpts.silent);
+
+	const bin = globalOpts.agent === 'auggie' ? 'auggie -p' : 'claude -p';
+	printCopyPaste('Apply decisions to GitHub', '/update-issues --from-report');
+	printCopyPaste('Or run non-interactively', `${bin} "/update-issues --from-report"`);
+}
+
+// ── Dev Pipeline ─────────────────────────────────────────────────────
+
+async function runDevPipeline(
+	rawArgs: string[],
+	globalOpts: GlobalOpts,
+	main: AgentRunner,
+	duck?: AgentRunner,
+): Promise<void> {
+	if (rawArgs.length === 0) {
+		console.error('Usage: pnpm workflow dev <issue-number|"description"> [options]');
+		process.exit(1);
+	}
+
+	// First positional is the identifier (could be a number or quoted string)
+	const inputIdentifier = rawArgs[0]!;
+	const restArgs = rawArgs.slice(1);
+
+	const { values } = parseArgs({
+		args: restArgs,
+		options: {
+			'skip-to': { type: 'string' },
+		},
+		strict: false,
+	});
+
+	const { identifier, isIssue } = resolveIdentifier(inputIdentifier);
+	const devFolder = join(devDir, identifier);
+	const scopeFlag = `--scope ${devFolder}/`;
+
+	const skipTo = values['skip-to'] as DevStage | undefined;
+	if (skipTo && !devStages.includes(skipTo as DevStage)) {
+		console.error(`Invalid --skip-to stage: ${skipTo}. Valid: ${devStages.join(', ')}`);
+		process.exit(1);
+	}
+
+	// Determine which phase we're in
+	const isPreImpl = !skipTo || devPreStages.includes(skipTo as (typeof devPreStages)[number]);
+	const startPreIdx = skipTo && isPreImpl ? devPreStages.indexOf(skipTo as (typeof devPreStages)[number]) : 0;
+	const startPostIdx = skipTo && !isPreImpl ? devPostStages.indexOf(skipTo as (typeof devPostStages)[number]) : 0;
+
+	await ensureDir(devFolder);
+
+	if (isPreImpl) {
+		// ── Pre-implementation stages ────────────────────────────
+
+		// Stage 1: /dev-scope
+		if (startPreIdx <= 0) {
+			divider(`Stage 1: Scope — ${isIssue ? `#${identifier}` : identifier}`);
+			const scopeInput = isIssue ? identifier : `"${inputIdentifier}"`;
+			if (!main.run(`/dev-scope ${scopeInput}`, globalOpts)) {
+				log('✗', 'Scoping stage failed');
+				notify('Workflow', 'Dev scoping failed', globalOpts.silent);
+				process.exit(1);
+			}
+
+			// Verify goals.md was produced
+			if (!globalOpts.dryRun && !(await fileExists(join(devFolder, 'goals.md')))) {
+				log('✗', `Expected ${devFolder}/goals.md was not created`);
+				process.exit(1);
+			}
+		}
+
+		// Stage 2: /deep-planning
+		if (startPreIdx <= 1) {
+			divider('Stage 2: Plan');
+			if (!main.run(`/deep-planning ${scopeFlag}`, globalOpts)) {
+				log('✗', 'Planning stage failed');
+				notify('Workflow', 'Dev planning failed', globalOpts.silent);
+				process.exit(1);
+			}
+		}
+
+		// Stage 3: /challenge-plan
+		if (startPreIdx <= 2) {
+			divider('Stage 3: Challenge');
+			const challengePrompt = `/challenge-plan ${scopeFlag}`;
+			if (duck) {
+				const challengePath = join(devFolder, 'challenge.md');
+				if (!main.runToFile(challengePrompt, challengePath, globalOpts)) {
+					log('✗', 'Challenge stage failed');
+					notify('Workflow', 'Plan challenge failed', globalOpts.silent);
+					process.exit(1);
+				}
+				await runRubberDuck(
+					'challenge',
+					challengePath,
+					[join(devFolder, 'goals.md'), join(devFolder, 'plan.md')],
+					{ main, duck, scopeFlag, dryRun: globalOpts.dryRun },
+				);
+			} else {
+				if (!main.run(challengePrompt, globalOpts)) {
+					log('✗', 'Challenge stage failed');
+					notify('Workflow', 'Plan challenge failed', globalOpts.silent);
+					process.exit(1);
+				}
+			}
+
+			// Check verdict
+			if (!globalOpts.dryRun) {
+				const verdict = await detectChallengeVerdict(devFolder);
+				if (verdict === 'Reconsider') {
+					log('⚠', 'Challenge verdict: RECONSIDER — pipeline stopped');
+					notify('Workflow', 'Plan challenged — RECONSIDER verdict. Review needed.', globalOpts.silent);
+					console.log(`\n  The challenge found issues that need human judgment.`);
+					console.log(`  Review: ${devFolder}/challenge.md`);
+					console.log(`  Then either revise the plan or override and resume:\n`);
+					printCopyPaste(
+						'Resume from challenge after revision',
+						`pnpm workflow dev ${inputIdentifier} --skip-to challenge`,
+					);
+					printCopyPaste(
+						'Skip to implementation anyway',
+						`pnpm workflow dev ${inputIdentifier} --skip-to review`,
+					);
+					process.exit(0);
+				}
+				if (verdict === 'Needs Revision') {
+					log('⚠', 'Challenge verdict: NEEDS REVISION');
+					notify('Workflow', 'Plan needs revision before implementation.', globalOpts.silent);
+					console.log(`\n  The plan has issues that should be addressed.`);
+					console.log(`  Review: ${devFolder}/challenge.md`);
+					console.log(`  Revise the plan, then re-challenge or proceed:\n`);
+					printCopyPaste(
+						'Re-challenge after revision',
+						`pnpm workflow dev ${inputIdentifier} --skip-to challenge`,
+					);
+					printCopyPaste(
+						'Proceed to implementation anyway',
+						`pnpm workflow dev ${inputIdentifier} --skip-to review`,
+					);
+					process.exit(0);
+				}
+				log('✓', `Challenge verdict: ${verdict ?? 'unknown (check challenge.md)'}`);
+			}
+		}
+
+		// Pre-implementation complete
+		divider('Pre-Implementation Complete');
+		log('✓', 'Scope → Plan → Challenge done. Ready to implement.');
+		notify('Workflow', 'Pre-implementation pipeline complete — ready to code', globalOpts.silent);
+
+		console.log(`  Artifacts:`);
+		console.log(`    ${devFolder}/goals.md`);
+		console.log(`    ${devFolder}/plan.md`);
+		console.log(`    ${devFolder}/challenge.md\n`);
+		console.log(`  Implement the changes, then run reviews:\n`);
+		printCopyPaste('Run post-implementation reviews', `pnpm workflow dev ${inputIdentifier} --skip-to review`);
+	} else {
+		// ── Post-implementation stages ───────────────────────────
+
+		// Verify goals.md exists for review context
+		if (!globalOpts.dryRun && !(await fileExists(join(devFolder, 'goals.md')))) {
+			log('⚠', `No goals.md found in ${devFolder}. Reviews will run without scope context.`);
+		}
+
+		// Stage 4: /deep-review
+		if (startPostIdx <= 0) {
+			divider('Stage 4: Deep Review');
+			const reviewPrompt = `/deep-review branch ${scopeFlag}`;
+			if (duck) {
+				const reviewPath = join(devFolder, 'review.md');
+				if (!main.runToFile(reviewPrompt, reviewPath, globalOpts)) {
+					log('✗', 'Deep review stage failed');
+					notify('Workflow', 'Deep review failed', globalOpts.silent);
+					process.exit(1);
+				}
+				await runRubberDuck('review', reviewPath, [join(devFolder, 'goals.md')], {
+					main,
+					duck,
+					scopeFlag,
+					dryRun: globalOpts.dryRun,
+				});
+			} else {
+				if (!main.run(reviewPrompt, globalOpts)) {
+					log('✗', 'Deep review stage failed');
+					notify('Workflow', 'Deep review failed', globalOpts.silent);
+					process.exit(1);
+				}
+			}
+		}
+
+		// Stage 5: /ux-review
+		if (startPostIdx <= 1) {
+			divider('Stage 5: UX Review');
+			const uxReviewPrompt = `/ux-review branch ${scopeFlag}`;
+			if (duck) {
+				const uxReviewPath = join(devFolder, 'ux-review.md');
+				if (!main.runToFile(uxReviewPrompt, uxReviewPath, globalOpts)) {
+					log('✗', 'UX review stage failed');
+					notify('Workflow', 'UX review failed', globalOpts.silent);
+					process.exit(1);
+				}
+				await runRubberDuck('ux-review', uxReviewPath, [join(devFolder, 'goals.md')], {
+					main,
+					duck,
+					scopeFlag,
+					dryRun: globalOpts.dryRun,
+				});
+			} else {
+				if (!main.run(uxReviewPrompt, globalOpts)) {
+					log('✗', 'UX review stage failed');
+					notify('Workflow', 'UX review failed', globalOpts.silent);
+					process.exit(1);
+				}
+			}
+		}
+
+		// Done — print commit/audit commands
+		divider('Reviews Complete');
+		log('✓', 'Deep review and UX review finished.');
+		notify('Workflow', 'Reviews complete — ready to commit', globalOpts.silent);
+
+		printCopyPaste('Commit changes', '/commit');
+		printCopyPaste('Audit commits for issues + CHANGELOG', '/audit-commits');
+	}
+}
+
+// ── Main ─────────────────────────────────────────────────────────────
+
+interface GlobalOpts {
+	silent: boolean;
+	agent: AgentType;
+	model?: string;
+	duckModel?: string;
+	dryRun: boolean;
+	rubberDuck: boolean;
+}
+
+function printUsage(): void {
+	console.log(`
+Usage: pnpm workflow <pipeline> [options]
+
+Pipelines:
+  triage <recent|audit|single> [options]    Run triage pipeline
+  dev <issue|"description"> [options]       Run dev pipeline
+
+Global Options:
+  --silent                 Suppress macOS notifications
+  --agent <claude|auggie>  Primary agent CLI (default: claude)
+  --model <model>          Model override for primary agent
+  --duck-model <model>     Override the auto-selected duck model
+  --dry-run                Show what would run without executing
+  --rubber-duck, --rd      Run a second-opinion pass on evaluative stages.
+                           Triage: investigate, prioritize. Dev: challenge, review, ux-review.
+                           The duck uses a different model family than the primary.
+
+Triage Options:
+  --since <duration>       Lookback window for recent (default: 7d)
+  --older-than <duration>  Age threshold for audit (default: 180d)
+  --batch-size <n>         Issues per batch for audit (default: 50)
+  --skip-to <stage>        Resume from stage: triage, investigate, prioritize
+
+Dev Options:
+  --skip-to <stage>        Resume from stage: scope, plan, challenge, review, ux-review, commit
+
+Examples:
+  pnpm workflow triage recent
+  pnpm workflow triage recent --rubber-duck
+  pnpm workflow triage recent --agent auggie --model gemini-3.1-pro-preview --rubber-duck
+  pnpm workflow triage audit --older-than 365d
+  pnpm workflow triage single 5096 5084
+  pnpm workflow dev 5096
+  pnpm workflow dev 5096 --skip-to plan
+  pnpm workflow dev 5096 --skip-to review
+  pnpm workflow dev "refactor-caching"
+  pnpm workflow dev 5096 --rubber-duck
+  pnpm workflow dev 5096 --rubber-duck --duck-model gpt5.4
+`);
+}
+
+async function main(): Promise<void> {
+	const pipeline = process.argv[2];
+	if (!pipeline || !['triage', 'dev'].includes(pipeline)) {
+		printUsage();
+		process.exit(1);
+	}
+
+	// Extract global options before passing to sub-pipeline
+	const allArgs = process.argv.slice(3);
+
+	// Pull global flags out manually (parseArgs doesn't handle mixed positional + flag well across sub-commands)
+	const silent = allArgs.includes('--silent');
+	const dryRun = allArgs.includes('--dry-run');
+	const rubberDuck = allArgs.includes('--rubber-duck') || allArgs.includes('--rd');
+
+	let model: string | undefined;
+	const modelIdx = allArgs.indexOf('--model');
+	if (modelIdx !== -1 && allArgs[modelIdx + 1]) {
+		model = allArgs[modelIdx + 1];
+	}
+
+	let agent: AgentType = 'claude';
+	const agentIdx = allArgs.indexOf('--agent');
+	if (agentIdx !== -1 && allArgs[agentIdx + 1]) {
+		const val = allArgs[agentIdx + 1];
+		if (val !== 'claude' && val !== 'auggie') {
+			console.error(`Invalid --agent value: ${val}. Valid: claude, auggie`);
+			process.exit(1);
+		}
+		agent = val;
+	}
+
+	let duckModel: string | undefined;
+	const duckModelIdx = allArgs.indexOf('--duck-model');
+	if (duckModelIdx !== -1 && allArgs[duckModelIdx + 1]) {
+		duckModel = allArgs[duckModelIdx + 1];
+	}
+
+	// Remove global flags from args passed to sub-pipelines
+	const subArgs = allArgs.filter((arg: string, idx: number) => {
+		if (arg === '--silent' || arg === '--dry-run' || arg === '--rubber-duck' || arg === '--rd') return false;
+		if (arg === '--model') return false;
+		if (modelIdx !== -1 && idx === modelIdx + 1) return false;
+		if (arg === '--agent') return false;
+		if (agentIdx !== -1 && idx === agentIdx + 1) return false;
+		if (arg === '--duck-model') return false;
+		if (duckModelIdx !== -1 && idx === duckModelIdx + 1) return false;
+		return true;
+	});
+
+	const globalOpts: GlobalOpts = { silent, agent, model, duckModel, dryRun, rubberDuck };
+
+	// Create runners
+	const mainRunner = createRunner(globalOpts.agent, { model: globalOpts.model });
+	const duckRunner = globalOpts.rubberDuck
+		? createRunner('auggie', {
+				model: resolveDuckModel(globalOpts.agent, globalOpts.model, globalOpts.duckModel),
+				capture: true,
+			})
+		: undefined;
+
+	if (pipeline === 'triage') {
+		await runTriagePipeline(subArgs, globalOpts, mainRunner, duckRunner);
+	} else {
+		await runDevPipeline(subArgs, globalOpts, mainRunner, duckRunner);
+	}
+}
+
+main().catch(err => {
+	console.error('Fatal error:', err);
+	process.exit(1);
+});


### PR DESCRIPTION
## Summary

- Adds agent skills for a full issue-to-delivery workflow: triage → investigate → prioritize → update GitHub issues → scope → plan → challenge → review
- Adds `scripts/issues/` tooling that fetches GitHub issues, builds evidence packs (labels, team, changelog, related issues), and orchestrates multi-stage pipelines via CLI
- Includes a workflow script (`pnpm workflow`) that chains pipeline stages as sequential AI CLI invocations with rubber-duck second-opinion mode

## Skills added/updated

**Triage pipeline** (read-only analysis → optional GitHub update):
- `/triage` — first-pass categorization with verdicts and confidence levels
- `/investigate` — single-issue deep root cause analysis or batch investigation
- `/prioritize` — recommends shortlist, backlog, won't fix, or community contribution
- `/update-issues` — applies recommendations to GitHub (labels, comments, milestones)

**Dev pipeline** (scope → plan → review):
- `/dev-scope` — defines what and why, bridging triage output to planning
- `/deep-planning`, `/challenge-plan` — design and stress-test implementation approach
- `/deep-review`, `/ux-review` — post-implementation review against goals

## Test plan

- [ ] Run `pnpm workflow triage single <issue-number>` end-to-end
- [ ] Run `pnpm workflow dev <issue-number>` end-to-end
- [ ] Invoke individual skills (`/triage`, `/investigate`, `/prioritize`) and verify report output
- [ ] Verify `--rubber-duck` mode spawns a second-opinion pass
- [ ] Verify `--dry-run` shows planned actions without executing