### PR TITLE
Add agent status to Home view

### DIFF
--- a/contributions.json
+++ b/contributions.json
@@ -32,6 +32,10 @@
 			"icon": "$(hubot)",
 			"commandPalette": "gitlens:enabled && !gitlens:hasVirtualFolders"
 		},
+		"gitlens.agents.uninstallClaudeHook": {
+			"label": "Uninstall Claude Hook",
+			"commandPalette": "gitlens:enabled && !gitlens:hasVirtualFolders"
+		},
 		"gitlens.ai.enable": {
 			"label": "Enable AI Features...",
 			"commandPalette": "gitlens:enabled && !gitlens:readonly && !gitlens:untrusted && !gitlens:gk:organization:ai:enabled"

--- a/contributions.json
+++ b/contributions.json
@@ -23,6 +23,15 @@
 				]
 			}
 		},
+		"gitlens.agents.installClaudeHook": {
+			"label": "Install Claude Hook",
+			"commandPalette": "gitlens:enabled && !gitlens:hasVirtualFolders"
+		},
+		"gitlens.agents.openSession": {
+			"label": "Open AI Agent Session",
+			"icon": "$(hubot)",
+			"commandPalette": "gitlens:enabled && !gitlens:hasVirtualFolders"
+		},
 		"gitlens.ai.enable": {
 			"label": "Enable AI Features...",
 			"commandPalette": "gitlens:enabled && !gitlens:readonly && !gitlens:untrusted && !gitlens:gk:organization:ai:enabled"

--- a/docs/telemetry-events.md
+++ b/docs/telemetry-events.md
@@ -118,6 +118,16 @@
 }
 ```
 
+### agents/hookUninstalled
+
+> Sent when an agent hook is uninstalled
+
+```typescript
+{
+  'agent.provider': string
+}
+```
+
 ### agents/permission/resolved
 
 > Sent when a permission request is resolved

--- a/docs/telemetry-events.md
+++ b/docs/telemetry-events.md
@@ -108,6 +108,48 @@
 }
 ```
 
+### agents/hookInstalled
+
+> Sent when an agent hook is installed
+
+```typescript
+{
+  'agent.provider': string
+}
+```
+
+### agents/permission/resolved
+
+> Sent when a permission request is resolved
+
+```typescript
+{
+  'agent.provider': string,
+  'permission.decision': string,
+  'permission.tool': string
+}
+```
+
+### agents/session/ended
+
+> Sent when an agent session ends
+
+```typescript
+{
+  'agent.provider': string
+}
+```
+
+### agents/session/started
+
+> Sent when an agent session starts
+
+```typescript
+{
+  'agent.provider': string
+}
+```
+
 ### ai/enabled
 
 > Sent when AI is enabled

--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -35,6 +35,7 @@ const filePatterns = {
 		'packages/git-cli/src/**/*',
 		'packages/plus/git-github/src/**/*',
 		'packages/plus/ai/src/**/*',
+		'packages/plus/agents/src/**/*',
 	],
 	src: ['src/**/*'],
 	envNode: ['src/env/node/**/*'],

--- a/package.json
+++ b/package.json
@@ -4207,6 +4207,19 @@
 							"experimental"
 						]
 					},
+					"gitlens.gitkraken.cli.localPath": {
+						"type": [
+							"string",
+							"null"
+						],
+						"default": null,
+						"markdownDescription": "Specifies the path to a local GitKraken CLI binary for development. When set in development mode, auto-install and auto-update of the CLI are disabled. _Only applies when running in development mode._",
+						"scope": "machine",
+						"order": 25,
+						"tags": [
+							"experimental"
+						]
+					},
 					"gitlens.gitkraken.cli.insiders.enabled": {
 						"type": "boolean",
 						"default": false,

--- a/package.json
+++ b/package.json
@@ -6404,6 +6404,11 @@
 				"icon": "$(hubot)"
 			},
 			{
+				"command": "gitlens.agents.uninstallClaudeHook",
+				"title": "Uninstall Claude Hook",
+				"category": "GitLens"
+			},
+			{
 				"command": "gitlens.ai.enable",
 				"title": "Enable AI Features...",
 				"category": "GitLens"
@@ -12024,6 +12029,10 @@
 				},
 				{
 					"command": "gitlens.agents.openSession",
+					"when": "gitlens:enabled && !gitlens:hasVirtualFolders"
+				},
+				{
+					"command": "gitlens.agents.uninstallClaudeHook",
 					"when": "gitlens:enabled && !gitlens:hasVirtualFolders"
 				},
 				{

--- a/package.json
+++ b/package.json
@@ -6393,6 +6393,17 @@
 				"icon": "$(person-add)"
 			},
 			{
+				"command": "gitlens.agents.installClaudeHook",
+				"title": "Install Claude Hook",
+				"category": "GitLens"
+			},
+			{
+				"command": "gitlens.agents.openSession",
+				"title": "Open AI Agent Session",
+				"category": "GitLens",
+				"icon": "$(hubot)"
+			},
+			{
 				"command": "gitlens.ai.enable",
 				"title": "Enable AI Features...",
 				"category": "GitLens"
@@ -12006,6 +12017,14 @@
 				{
 					"command": "gitlens.addAuthors",
 					"when": "gitlens:enabled && !gitlens:readonly && !gitlens:untrusted && !gitlens:hasVirtualFolders"
+				},
+				{
+					"command": "gitlens.agents.installClaudeHook",
+					"when": "gitlens:enabled && !gitlens:hasVirtualFolders"
+				},
+				{
+					"command": "gitlens.agents.openSession",
+					"when": "gitlens:enabled && !gitlens:hasVirtualFolders"
 				},
 				{
 					"command": "gitlens.ai.enable",

--- a/packages/git-cli/src/exec/__tests__/exec.test.ts
+++ b/packages/git-cli/src/exec/__tests__/exec.test.ts
@@ -1,5 +1,5 @@
 import * as assert from 'assert';
-import * as process from 'process';
+import { execPath } from 'process';
 import * as sinon from 'sinon';
 import { CancelledRunError, RunError } from '../exec.errors.js';
 import { run, runSpawn } from '../exec.js';
@@ -13,7 +13,7 @@ function bufferLiteral(bytes: readonly number[]): string {
 }
 
 suite('Shell Test Suite', () => {
-	const nodeExecutable = process.execPath;
+	const nodeExecutable = execPath;
 
 	suite('run()', () => {
 		test('returns stdout and skips decode for utf8 output', async () => {

--- a/packages/git-cli/src/providers/branches.ts
+++ b/packages/git-cli/src/providers/branches.ts
@@ -1386,6 +1386,16 @@ export class BranchesGitSubProvider implements GitBranchesSubProvider {
 		await this.storeBranchMetadata(repoPath, 'gk-last-modified', branch.name, now);
 	}
 
+	/** Updates the agent last activity timestamp for the current branch */
+	@debounce(2.5 * 60 * 1000)
+	@debug()
+	async onCurrentBranchAgentActivity(repoPath: string): Promise<void> {
+		const branch = await this.getBranch(repoPath);
+		if (branch == null || branch.remote || branch.detached) return;
+
+		await this.storeBranchMetadata(repoPath, 'gk-agent-last-activity', branch.name, new Date());
+	}
+
 	@debug()
 	async renameBranch(repoPath: string, oldName: string, newName: string): Promise<void> {
 		const args = ['branch', '-m', oldName, newName];
@@ -1465,7 +1475,7 @@ export class BranchesGitSubProvider implements GitBranchesSubProvider {
 				// Use git config --get-regexp to load all gk-* branch metadata in one call
 				const configMap = await this.provider.config.getGkConfigRegex(
 					commonPath,
-					'^branch\\..*\\.gk-(last-(accessed|modified)|disposition)$',
+					'^branch\\..*\\.gk-(last-(accessed|modified)|disposition|agent-last-activity)$',
 				);
 				if (!configMap.size) return metadataMap;
 
@@ -1490,6 +1500,8 @@ export class BranchesGitSubProvider implements GitBranchesSubProvider {
 						metadata.lastAccessedAt = value;
 					} else if (metaKey === 'gk-last-modified') {
 						metadata.lastModifiedAt = value;
+					} else if (metaKey === 'gk-agent-last-activity') {
+						metadata.agentLastActivityAt = value;
 					} else if (metaKey === 'gk-disposition') {
 						if (value === 'starred' || value === 'archived') {
 							metadata.disposition = value;
@@ -1507,7 +1519,7 @@ export class BranchesGitSubProvider implements GitBranchesSubProvider {
 
 	private async storeBranchMetadata(
 		repoPath: string,
-		key: 'gk-last-accessed' | 'gk-last-modified',
+		key: 'gk-last-accessed' | 'gk-last-modified' | 'gk-agent-last-activity',
 		ref: string,
 		date: Date,
 	): Promise<void> {

--- a/packages/git/docs/api-surface.md
+++ b/packages/git/docs/api-surface.md
@@ -248,6 +248,7 @@ Each sub-provider interface is defined in its own file under `providers/`:
 | `getStoredUserMergeTargetBranchName?(repoPath, ref)`                                 | `string \| undefined`                      |
 | `onCurrentBranchAccessed?(repoPath)`                                                 | `void`                                     |
 | `onCurrentBranchModified?(repoPath)`                                                 | `void`                                     |
+| `onCurrentBranchAgentActivity?(repoPath)`                                            | `void`                                     |
 | `renameBranch?(repoPath, oldName, newName)`                                          | `void`                                     |
 | `setUpstreamBranch?(repoPath, name, upstream)`                                       | `void`                                     |
 | `setBranchDisposition?(repoPath, branchName, disposition)`                           | `void`                                     |

--- a/packages/git/src/models/branch.ts
+++ b/packages/git/src/models/branch.ts
@@ -21,6 +21,7 @@ export type BranchDisposition = 'starred' | 'archived';
 export interface BranchMetadata {
 	lastAccessedAt?: string;
 	lastModifiedAt?: string;
+	agentLastActivityAt?: string;
 	disposition?: BranchDisposition;
 }
 

--- a/packages/git/src/providers/branches.ts
+++ b/packages/git/src/providers/branches.ts
@@ -100,6 +100,7 @@ export interface GitBranchesSubProvider {
 	getStoredUserMergeTargetBranchName?(repoPath: string, ref: string): Promise<string | undefined>;
 	onCurrentBranchAccessed?(repoPath: string): Promise<void>;
 	onCurrentBranchModified?(repoPath: string): Promise<void>;
+	onCurrentBranchAgentActivity?(repoPath: string): Promise<void>;
 	renameBranch?(repoPath: string, oldName: string, newName: string): Promise<void>;
 	setUpstreamBranch?(repoPath: string, name: string, upstream: string | undefined): Promise<void>;
 	setBranchDisposition?(

--- a/packages/git/src/providers/config.ts
+++ b/packages/git/src/providers/config.ts
@@ -36,6 +36,8 @@ export type GkConfigKeys =
 	| `branch.${string}.gk-last-accessed`
 	/** `gk-last-modified` — ISO 8601 timestamp of when the branch last received a commit */
 	| `branch.${string}.gk-last-modified`
+	/** `gk-agent-last-activity` — ISO 8601 timestamp of when an AI agent was last active on this branch */
+	| `branch.${string}.gk-agent-last-activity`
 	/** `gk-disposition` — user-assigned branch disposition: 'starred' or 'archived' */
 	| `branch.${string}.gk-disposition`
 	/** `gk.defaultRemote` — the user-designated default remote for the repository */

--- a/packages/plus/agents/package.json
+++ b/packages/plus/agents/package.json
@@ -1,0 +1,39 @@
+{
+	"name": "@gitlens/agents",
+	"description": "GitLens Agents package",
+	"version": "0.0.1",
+	"license": "SEE LICENSE IN LICENSE",
+	"private": true,
+	"type": "module",
+	"sideEffects": false,
+	"exports": {
+		"./*.js": {
+			"types": "./dist/*.d.ts",
+			"default": "./dist/*.js"
+		},
+		"./providers/*.js": {
+			"types": "./dist/providers/*.d.ts",
+			"default": "./dist/providers/*.js"
+		}
+	},
+	"files": [
+		"dist"
+	],
+	"scripts": {
+		"build": "tsc -b",
+		"clean": "pnpx rimraf --glob dist out **/.eslintcache* **/tsconfig*.tsbuildinfo",
+		"clean:all": "pnpm run clean && pnpm run clean:deps",
+		"clean:deps": "pnpx rimraf --glob **/node_modules",
+		"clean:lint": "pnpx rimraf --glob **/.eslintcache* **/tsconfig*.tsbuildinfo",
+		"test": "mocha --require tsx --ui tdd --timeout 30000 --no-error-on-unmatched-pattern 'src/**/__tests__/**/*.test.ts'"
+	},
+	"dependencies": {
+		"@gitlens/utils": "workspace:*"
+	},
+	"devDependencies": {
+		"@types/mocha": "catalog:",
+		"mocha": "catalog:",
+		"tsx": "catalog:",
+		"typescript": "catalog:"
+	}
+}

--- a/packages/plus/agents/src/__tests__/stateMachine.test.ts
+++ b/packages/plus/agents/src/__tests__/stateMachine.test.ts
@@ -1,0 +1,79 @@
+import * as assert from 'assert';
+import { deriveStatusFromEvent, describeToolInput, rehydrateSubagents } from '../stateMachine.js';
+
+suite('stateMachine', () => {
+	suite('deriveStatusFromEvent', () => {
+		test('maps lifecycle events to idle', () => {
+			assert.strictEqual(deriveStatusFromEvent('SessionStart'), 'idle');
+			assert.strictEqual(deriveStatusFromEvent('Stop'), 'idle');
+			assert.strictEqual(deriveStatusFromEvent('StopFailure'), 'idle');
+		});
+
+		test('maps tool and compact events to their working states', () => {
+			assert.strictEqual(deriveStatusFromEvent('PreToolUse'), 'tool_use');
+			assert.strictEqual(deriveStatusFromEvent('PreCompact'), 'compacting');
+		});
+
+		test('maps permission events to permission_requested', () => {
+			assert.strictEqual(deriveStatusFromEvent('PermissionRequest'), 'permission_requested');
+			assert.strictEqual(deriveStatusFromEvent('Elicitation'), 'permission_requested');
+		});
+
+		test('maps post-activity events to thinking', () => {
+			assert.strictEqual(deriveStatusFromEvent('UserPromptSubmit'), 'thinking');
+			assert.strictEqual(deriveStatusFromEvent('PostToolUse'), 'thinking');
+			assert.strictEqual(deriveStatusFromEvent('PermissionDenied'), 'thinking');
+		});
+
+		test('falls back to idle for unknown events', () => {
+			assert.strictEqual(deriveStatusFromEvent('NotAnEvent'), 'idle');
+		});
+	});
+
+	suite('describeToolInput', () => {
+		test('includes command for Bash', () => {
+			assert.strictEqual(describeToolInput('Bash', { command: 'ls -la' }), 'Bash(ls -la)');
+		});
+
+		test('includes file_path for file tools', () => {
+			assert.strictEqual(describeToolInput('Read', { file_path: '/tmp/foo' }), 'Read(/tmp/foo)');
+			assert.strictEqual(describeToolInput('Edit', { file_path: '/tmp/foo' }), 'Edit(/tmp/foo)');
+			assert.strictEqual(describeToolInput('Write', { file_path: '/tmp/foo' }), 'Write(/tmp/foo)');
+		});
+
+		test('returns bare tool name when detail is missing', () => {
+			assert.strictEqual(describeToolInput('Bash', {}), 'Bash');
+			assert.strictEqual(describeToolInput('UnknownTool', { foo: 'bar' }), 'UnknownTool');
+		});
+	});
+
+	suite('rehydrateSubagents', () => {
+		test('returns undefined for missing or empty input', () => {
+			assert.strictEqual(rehydrateSubagents(undefined), undefined);
+			assert.strictEqual(rehydrateSubagents([]), undefined);
+		});
+
+		test('rehydrates ISO strings into Date instances', () => {
+			const lastActivity = '2026-01-01T00:00:00.000Z';
+			const phaseSince = '2026-01-01T00:00:01.000Z';
+			const [sub] = rehydrateSubagents([
+				{
+					id: 'sub-1',
+					providerId: 'claudeCode',
+					name: 'Subagent',
+					status: 'thinking',
+					phase: 'working',
+					isSubagent: true,
+					isInWorkspace: true,
+					parentId: 'parent',
+					lastActivity: lastActivity,
+					phaseSince: phaseSince,
+				},
+			])!;
+			assert.ok(sub.lastActivity instanceof Date);
+			assert.ok(sub.phaseSince instanceof Date);
+			assert.strictEqual(sub.lastActivity.toISOString(), lastActivity);
+			assert.strictEqual(sub.phaseSince.toISOString(), phaseSince);
+		});
+	});
+});

--- a/packages/plus/agents/src/agentIpcServer.ts
+++ b/packages/plus/agents/src/agentIpcServer.ts
@@ -1,0 +1,98 @@
+import { mkdir, unlink, writeFile } from 'fs/promises';
+import { tmpdir } from 'os';
+import { join } from 'path';
+import { ppid } from 'process';
+import type { UnifiedDisposable } from '@gitlens/utils/disposable.js';
+import { Logger } from '@gitlens/utils/logger.js';
+import type { IpcHandler, IpcServer } from './ipcServer.js';
+import { createIpcServer } from './ipcServer.js';
+
+export const agentDiscoveryDir = join(tmpdir(), 'gitkraken', 'gitlens', 'agents');
+
+export interface AgentIpcServerOptions {
+	workspacePaths: string[];
+}
+
+export class AgentIpcServer implements UnifiedDisposable {
+	private _server: IpcServer<unknown, unknown> | undefined;
+	private _discoveryFilePath: string | undefined;
+	private _workspacePaths: string[] = [];
+
+	async start(options: AgentIpcServerOptions): Promise<void> {
+		if (this._server != null) return;
+
+		this._workspacePaths = options.workspacePaths;
+
+		try {
+			this._server = await createIpcServer<unknown, unknown>();
+			await this.writeDiscoveryFile();
+			Logger.debug(`AgentIpcServer listening on ${this._server.ipcAddress}`);
+		} catch (ex) {
+			Logger.error(ex, 'AgentIpcServer.start');
+			this._server?.dispose();
+			this._server = undefined;
+		}
+	}
+
+	get port(): number | undefined {
+		return this._server?.ipcPort;
+	}
+
+	async updateWorkspacePaths(paths: string[]): Promise<void> {
+		this._workspacePaths = paths;
+		if (this._server == null) return;
+		await this.writeDiscoveryFile();
+	}
+
+	registerHandler(name: string, handler: IpcHandler<unknown, unknown>): UnifiedDisposable | undefined {
+		return this._server?.registerHandler(name, handler);
+	}
+
+	dispose(): void {
+		this._server?.dispose();
+		this._server = undefined;
+		void this.cleanupDiscoveryFile();
+	}
+
+	[Symbol.dispose](): void {
+		this.dispose();
+	}
+
+	private getDiscoveryFileName(): string {
+		return `gitlens-ipc-server-${ppid}-${this._server?.ipcPort ?? 'none'}.json`;
+	}
+
+	private async writeDiscoveryFile(): Promise<void> {
+		if (this._server == null) return;
+
+		const filePath = join(agentDiscoveryDir, this.getDiscoveryFileName());
+
+		try {
+			await mkdir(agentDiscoveryDir, { recursive: true, mode: 0o700 });
+
+			const discoveryData = {
+				token: this._server.ipcToken,
+				address: this._server.ipcAddress,
+				port: this._server.ipcPort,
+				workspacePaths: this._workspacePaths,
+				createdAt: new Date().toISOString(),
+			};
+
+			await writeFile(filePath, JSON.stringify(discoveryData, null, 2), { mode: 0o600 });
+			this._discoveryFilePath = filePath;
+		} catch (ex) {
+			Logger.error(ex, 'AgentIpcServer.writeDiscoveryFile');
+		}
+	}
+
+	private async cleanupDiscoveryFile(): Promise<void> {
+		if (this._discoveryFilePath == null) return;
+
+		try {
+			await unlink(this._discoveryFilePath);
+		} catch {
+			// Ignore cleanup errors
+		}
+		this._discoveryFilePath = undefined;
+	}
+}

--- a/packages/plus/agents/src/ipcServer.ts
+++ b/packages/plus/agents/src/ipcServer.ts
@@ -1,14 +1,14 @@
 import type { IncomingMessage, Server, ServerResponse } from 'http';
 import { createServer } from 'http';
-import type { Disposable } from 'vscode';
 import { uuid } from '@gitlens/utils/crypto.js';
 import { debug } from '@gitlens/utils/decorators/log.js';
+import type { UnifiedDisposable } from '@gitlens/utils/disposable.js';
 import { createDisposable } from '@gitlens/utils/disposable.js';
 import { Logger } from '@gitlens/utils/logger.js';
 import { getScopedLogger } from '@gitlens/utils/logger.scoped.js';
 
 export interface IpcHandler<Request = unknown, Response = void> {
-	(request: Request | undefined): Promise<Response>;
+	(request: Request | undefined, searchParams: URLSearchParams): Promise<Response>;
 }
 
 export async function createIpcServer<Request = unknown, Response = void>(): Promise<IpcServer<Request, Response>> {
@@ -18,8 +18,7 @@ export async function createIpcServer<Request = unknown, Response = void>(): Pro
 	return new Promise<IpcServer<Request, Response>>((resolve, reject) => {
 		try {
 			server.on('error', ex => {
-				debugger;
-				Logger.error(ex, 'Cli Integration IPC server error');
+				Logger.error(ex, 'IPC server error');
 				reject(ex);
 			});
 
@@ -42,7 +41,7 @@ export async function createIpcServer<Request = unknown, Response = void>(): Pro
 	});
 }
 
-export class IpcServer<Request = unknown, Response = void> implements Disposable {
+export class IpcServer<Request = unknown, Response = void> implements UnifiedDisposable {
 	private readonly handlers = new Map<string | undefined, IpcHandler<Request, Response>>();
 
 	constructor(
@@ -53,7 +52,7 @@ export class IpcServer<Request = unknown, Response = void> implements Disposable
 	) {
 		server
 			.on('listening', () => {
-				Logger.trace(`Cli Integration IPC server listening on ${this.ipcAddress}`);
+				Logger.trace(`IPC server listening on ${this.ipcAddress}`);
 			})
 			.on('request', this.onRequest.bind(this));
 	}
@@ -63,7 +62,11 @@ export class IpcServer<Request = unknown, Response = void> implements Disposable
 		this.server.close();
 	}
 
-	registerHandler(name: string, handler: IpcHandler<Request, Response>): Disposable {
+	[Symbol.dispose](): void {
+		this.dispose();
+	}
+
+	registerHandler(name: string, handler: IpcHandler<Request, Response>): UnifiedDisposable {
 		this.handlers.set(`/${name}`, handler);
 		return createDisposable(() => this.handlers.delete(`/${name}`));
 	}
@@ -72,10 +75,13 @@ export class IpcServer<Request = unknown, Response = void> implements Disposable
 	private onRequest(req: IncomingMessage, res: ServerResponse): void {
 		const scope = getScopedLogger();
 
-		// Parse URL to extract pathname for routing, separating from query parameters
+		// Parse URL to extract pathname for routing and query parameters
 		let pathname: string | undefined;
+		let searchParams = new URLSearchParams();
 		try {
-			pathname = new URL(req.url ?? '', this.ipcAddress).pathname;
+			const url = new URL(req.url ?? '', this.ipcAddress);
+			pathname = url.pathname;
+			searchParams = url.searchParams;
 		} catch {
 			pathname = req.url;
 		}
@@ -97,9 +103,22 @@ export class IpcServer<Request = unknown, Response = void> implements Disposable
 			return;
 		}
 
+		const maxBodySize = 10_485_760; // 10 MB
+		let bodySize = 0;
 		const chunks: Uint8Array[] = [];
-		req.on('data', d => chunks.push(d));
+		req.on('data', (d: Uint8Array) => {
+			bodySize += d.length;
+			if (bodySize > maxBodySize) {
+				res.writeHead(413);
+				res.end();
+				req.destroy();
+				return;
+			}
+			chunks.push(d);
+		});
 		req.on('end', async () => {
+			if (bodySize > maxBodySize) return;
+
 			const body = Buffer.concat(chunks).toString('utf8');
 
 			let data: Request | undefined;
@@ -113,7 +132,7 @@ export class IpcServer<Request = unknown, Response = void> implements Disposable
 			}
 
 			try {
-				const result = await handler(data);
+				const result = await handler(data, searchParams);
 				if (result == null) {
 					res.writeHead(200);
 					res.end();

--- a/packages/plus/agents/src/providers/claudeCodeProvider.ts
+++ b/packages/plus/agents/src/providers/claudeCodeProvider.ts
@@ -1,0 +1,962 @@
+import { readdir, readFile } from 'fs/promises';
+import { join, sep } from 'path';
+import { gate } from '@gitlens/utils/decorators/gate.js';
+import type { UnifiedDisposable } from '@gitlens/utils/disposable.js';
+import { disposableInterval } from '@gitlens/utils/disposable.js';
+import { Emitter } from '@gitlens/utils/event.js';
+import { Logger } from '@gitlens/utils/logger.js';
+import { truncate } from '@gitlens/utils/string.js';
+import { agentDiscoveryDir, AgentIpcServer } from '../agentIpcServer.js';
+import { deriveStatusFromEvent, describeToolInput, isProcessAlive, rehydrateSubagents } from '../stateMachine.js';
+import type {
+	AgentProviderCallbacks,
+	AgentSession,
+	AgentSessionProvider,
+	AgentSessionStatus,
+	ClaudeCodeHookEvent,
+	PendingPermission,
+	PermissionDecision,
+	PermissionSuggestion,
+} from '../types.js';
+import { getPhaseForStatus } from '../types.js';
+
+interface AgentSessionEvent {
+	event: ClaudeCodeHookEvent;
+	sessionId: string;
+	cwd: string;
+	pid?: number;
+	source?: string;
+	model?: string;
+	reason?: string;
+	toolName?: string;
+	agentId?: string;
+	agentType?: string;
+	planFile?: string;
+	notificationType?: string;
+	sessionName?: string;
+	prompt?: string;
+	toolInput?: Record<string, unknown>;
+	permissionSuggestions?: PermissionSuggestion[];
+	hookInput?: Record<string, unknown>;
+}
+
+interface PermissionResponse {
+	hookSpecificOutput: {
+		hookEventName: 'PermissionRequest';
+		decision: {
+			behavior: PermissionDecision;
+			updatedPermissions?: PermissionSuggestion[];
+		};
+	};
+}
+
+interface PendingPermissionEntry {
+	resolve(response: PermissionResponse): void;
+	reject(reason: Error): void;
+	toolName: string;
+	toolDescription: string;
+}
+
+interface SessionBookkeeping {
+	activeToolCount: number;
+	pendingPermission?: PendingPermission;
+}
+
+const staleCheckIntervalMs = 60 * 1000; // 1 minute
+
+interface SessionFileData {
+	sessionId: string;
+	event: string;
+	cwd: string;
+	pid: number;
+	toolName?: string | null;
+	agentId?: string | null;
+	agentType?: string | null;
+	source?: string | null;
+	model?: string | null;
+	updatedAt: string;
+	subagents?: { agentId: string; agentType: string }[];
+	planFile?: string | null;
+	sessionName?: string | null;
+	prompt?: string | null;
+}
+
+interface DiscoveryFile {
+	token: string;
+	address: string;
+	port?: number;
+	workspacePaths?: string[];
+}
+
+interface SessionContext {
+	pid?: number;
+	workspacePath?: string;
+	isInWorkspace?: boolean;
+	cwd?: string;
+	planFile?: string;
+	sessionName?: string;
+}
+
+type SerializedAgentSession = Omit<AgentSession, 'lastActivity' | 'phaseSince' | 'subagents'> & {
+	lastActivity: string;
+	phaseSince: string;
+	subagents?: (Omit<AgentSession, 'lastActivity' | 'phaseSince'> & {
+		lastActivity: string;
+		phaseSince: string;
+	})[];
+};
+
+function normalizeWorkspacePath(value: string | null | undefined): string | undefined {
+	return value ? value : undefined;
+}
+
+export class ClaudeCodeProvider implements AgentSessionProvider {
+	readonly id = 'claudeCode';
+	readonly name = 'Claude Code';
+	readonly icon = 'hubot';
+
+	private readonly _onDidChangeSessions = new Emitter<void>();
+	readonly onDidChangeSessions = this._onDidChangeSessions.event;
+
+	private _sessions: AgentSession[] = [];
+	private _ipcServer: AgentIpcServer | undefined;
+	private _handlerDisposables: UnifiedDisposable[] = [];
+	private readonly _pendingPermissions = new Map<string, PendingPermissionEntry>();
+	private readonly _sessionBookkeeping = new Map<string, SessionBookkeeping>();
+	private _workspacePaths: string[] = [];
+	private _staleCheckTimer: UnifiedDisposable | undefined;
+
+	constructor(private readonly callbacks: AgentProviderCallbacks) {}
+
+	get sessions(): readonly AgentSession[] {
+		return this._sessions;
+	}
+
+	start(workspacePaths: string[]): void {
+		this._workspacePaths = workspacePaths;
+		void this.ensureIpcServer(workspacePaths);
+	}
+
+	stop(): void {
+		// IPC server stays up intentionally — hooks fire even when the window is unfocused
+	}
+
+	updateWorkspacePaths(workspacePaths: string[]): void {
+		this._workspacePaths = workspacePaths;
+
+		let changed = false;
+		for (let i = 0; i < this._sessions.length; i++) {
+			const s = this._sessions[i];
+			const nextIsInWorkspace = this.matchesWorkspace(s.workspacePath);
+			const subagents = s.subagents?.map(sub =>
+				sub.isInWorkspace === nextIsInWorkspace ? sub : { ...sub, isInWorkspace: nextIsInWorkspace },
+			);
+			if (s.isInWorkspace !== nextIsInWorkspace || subagents !== s.subagents) {
+				this._sessions[i] = { ...s, isInWorkspace: nextIsInWorkspace, subagents: subagents };
+				changed = true;
+			}
+		}
+		if (changed) {
+			this._onDidChangeSessions.fire();
+		}
+
+		if (this._ipcServer == null) {
+			// Server wasn't started yet — bootstrap. The `.then` re-issues the
+			// path update after the (gated) `ensureIpcServer` completes, in
+			// case it deduped with an in-flight `start()` that used stale paths.
+			void this.ensureIpcServer(workspacePaths).then(() => this._ipcServer?.updateWorkspacePaths(workspacePaths));
+		} else {
+			void this._ipcServer.updateWorkspacePaths(workspacePaths);
+		}
+	}
+
+	dispose(): void {
+		this.stop();
+		this._staleCheckTimer?.dispose();
+		this._staleCheckTimer = undefined;
+		for (const d of this._handlerDisposables) {
+			d.dispose();
+		}
+		this._handlerDisposables = [];
+		for (const pending of this._pendingPermissions.values()) {
+			pending.reject(new Error('Provider disposed'));
+		}
+		this._pendingPermissions.clear();
+		this._sessionBookkeeping.clear();
+		this._ipcServer?.dispose();
+		this._ipcServer = undefined;
+		this._onDidChangeSessions.dispose();
+	}
+
+	[Symbol.dispose](): void {
+		this.dispose();
+	}
+
+	@gate<typeof ClaudeCodeProvider.prototype.ensureIpcServer>()
+	private async ensureIpcServer(workspacePaths: string[]): Promise<void> {
+		if (this._ipcServer != null) return;
+
+		try {
+			const server = new AgentIpcServer();
+			await server.start({ workspacePaths: workspacePaths });
+
+			// Register handlers before any async work so blocking permission requests aren't delayed.
+			this._handlerDisposables = [
+				server.registerHandler('agents/session', (request, searchParams) => {
+					if (request != null) {
+						const isBlocking = searchParams.get('blocking') === 'true';
+						return this.handleSessionEvent(request as AgentSessionEvent, isBlocking);
+					}
+					return Promise.resolve();
+				}),
+				server.registerHandler('agents/sessions/list', () =>
+					Promise.resolve(
+						this._sessions.map(s => ({
+							...s,
+							lastActivity: s.lastActivity.toISOString(),
+							phaseSince: s.phaseSince.toISOString(),
+							subagents: s.subagents?.map(sub => ({
+								...sub,
+								lastActivity: sub.lastActivity.toISOString(),
+								phaseSince: sub.phaseSince.toISOString(),
+							})),
+						})),
+					),
+				),
+			].filter((d): d is UnifiedDisposable => d != null);
+
+			this._ipcServer = server;
+
+			await this.syncSessions();
+			void this.querySiblingWindowSessions();
+
+			this._staleCheckTimer?.dispose();
+			this._staleCheckTimer = disposableInterval(() => void this.syncSessions(), staleCheckIntervalMs);
+		} catch (ex) {
+			Logger.error(ex, 'ClaudeCodeProvider.ensureIpcServer');
+		}
+	}
+
+	private handleSessionEvent(event: AgentSessionEvent, isBlocking: boolean): Promise<PermissionResponse | void> {
+		const workspacePath = this.resolveWorkspacePath(event.cwd);
+		const eventContext: SessionContext = {
+			pid: event.pid,
+			workspacePath: workspacePath,
+			isInWorkspace: workspacePath != null,
+			cwd: event.cwd,
+			planFile: event.planFile,
+			sessionName: event.sessionName,
+		};
+		const tag = this.sessionTag(event.sessionId, event.sessionName ?? 'unnamed');
+
+		if (event.event === 'SessionStart' || event.event === 'SessionEnd') {
+			Logger.info(`ClaudeCodeProvider.handleSessionEvent: ${event.event} ${tag}`);
+		} else {
+			Logger.debug(
+				`ClaudeCodeProvider.handleSessionEvent: ${event.event} ${tag}${event.toolName ? ` tool=${event.toolName}` : ''}${event.agentId ? ` agent=${event.agentId}` : ''}${event.notificationType ? ` type=${event.notificationType}` : ''}`,
+			);
+		}
+
+		switch (event.event) {
+			case 'SessionStart': {
+				const { index } = this.ensureSession(event.sessionId, eventContext);
+				this.resetBookkeeping(event.sessionId);
+				const prev = this._sessions[index];
+				const newPhase = getPhaseForStatus('idle');
+				this._sessions[index] = {
+					...prev,
+					pid: event.pid ?? prev.pid,
+					status: 'idle',
+					phase: newPhase,
+					phaseSince: prev.phase !== newPhase ? new Date() : prev.phaseSince,
+					statusDetail: undefined,
+					pendingPermission: undefined,
+					lastActivity: new Date(),
+				};
+				this._onDidChangeSessions.fire();
+				this.callbacks.onSessionStarted?.(this.id);
+				break;
+			}
+
+			case 'SessionEnd': {
+				const pending = this._pendingPermissions.get(event.sessionId);
+				if (pending != null) {
+					pending.reject(new Error('Session ended'));
+					this._pendingPermissions.delete(event.sessionId);
+				}
+
+				const index = this._sessions.findIndex(s => s.id === event.sessionId);
+				if (index >= 0) {
+					this._sessions.splice(index, 1);
+					this._onDidChangeSessions.fire();
+				}
+				this._sessionBookkeeping.delete(event.sessionId);
+				this.callbacks.onSessionEnded?.(this.id);
+				break;
+			}
+
+			case 'UserPromptSubmit': {
+				const { index } = this.ensureSession(event.sessionId, eventContext);
+				if (event.prompt) {
+					this._sessions[index] = {
+						...this._sessions[index],
+						lastPrompt: truncate(event.prompt, 500),
+					};
+				}
+				this.clearStalePermission(event.sessionId, 'UserPromptSubmit');
+				this.updateSessionStatus(event.sessionId, 'thinking', eventContext);
+				break;
+			}
+
+			case 'PreToolUse': {
+				const bk = this.getBookkeeping(event.sessionId);
+				bk.activeToolCount++;
+				this.updateSessionStatus(event.sessionId, 'tool_use', {
+					...eventContext,
+					statusDetail: event.toolName,
+				});
+				break;
+			}
+
+			case 'PostToolUse':
+			case 'PostToolUseFailure': {
+				this.clearStalePermission(event.sessionId, event.event);
+				const bk = this.getBookkeeping(event.sessionId);
+				bk.activeToolCount = Math.max(0, bk.activeToolCount - 1);
+				if (bk.activeToolCount === 0) {
+					this.updateSessionStatus(event.sessionId, 'thinking', eventContext);
+				}
+				break;
+			}
+
+			case 'Stop':
+			case 'StopFailure': {
+				const pending = this._pendingPermissions.get(event.sessionId);
+				if (pending != null) {
+					pending.reject(new Error('Session stopped'));
+					this._pendingPermissions.delete(event.sessionId);
+				}
+				this.resetBookkeeping(event.sessionId);
+				this.updateSessionStatus(event.sessionId, 'idle', eventContext);
+				break;
+			}
+
+			case 'PreCompact':
+				this.updateSessionStatus(event.sessionId, 'compacting', eventContext);
+				break;
+
+			case 'PostCompact':
+				this.updateSessionStatus(event.sessionId, 'thinking', eventContext);
+				break;
+
+			case 'Notification':
+				switch (event.notificationType) {
+					case 'idle_prompt':
+						// No-op — session is already idle from the preceding stop/session-start event
+						break;
+					case 'permission_prompt':
+					case 'elicitation_dialog':
+						this.updateSessionStatus(event.sessionId, 'permission_requested', {
+							...eventContext,
+							statusDetail: event.toolName,
+						});
+						break;
+					default:
+						// auth_success, unknown, or missing: no status change, just update timestamp
+						break;
+				}
+				break;
+
+			case 'PermissionRequest': {
+				// hookInput is the raw passthrough; fall back to top-level fields for older CLI versions.
+				const hookInput = event.hookInput;
+				const toolInput = (hookInput?.tool_input as Record<string, unknown> | undefined) ?? event.toolInput;
+				if (isBlocking && toolInput != null) {
+					const toolName = (hookInput?.tool_name as string | undefined) ?? event.toolName ?? '';
+					const toolDescription = describeToolInput(toolName, toolInput);
+					const toolInputDescription = (toolInput.description as string | undefined) || undefined;
+
+					return new Promise<PermissionResponse>((resolve, reject) => {
+						const existing = this._pendingPermissions.get(event.sessionId);
+						if (existing != null) {
+							Logger.debug(
+								`ClaudeCodeProvider.handleSessionEvent: auto-denying stale permission ${tag} tool=${existing.toolName}`,
+							);
+							existing.resolve({
+								hookSpecificOutput: {
+									hookEventName: 'PermissionRequest',
+									decision: { behavior: 'deny' },
+								},
+							});
+						}
+
+						this._pendingPermissions.set(event.sessionId, {
+							resolve: resolve,
+							reject: reject,
+							toolName: toolName,
+							toolDescription: toolDescription,
+						});
+
+						const permission: PendingPermission = {
+							toolName: toolName,
+							toolDescription: toolDescription,
+							toolInputDescription: toolInputDescription,
+							suggestions:
+								(hookInput?.permission_suggestions as PermissionSuggestion[] | undefined) ??
+								event.permissionSuggestions,
+						};
+						this.updateSessionWithPermission(event.sessionId, permission, event.pid);
+					});
+				}
+
+				this.updateSessionStatus(event.sessionId, 'permission_requested', {
+					...eventContext,
+					statusDetail: event.toolName,
+				});
+				break;
+			}
+
+			case 'PermissionDenied': {
+				this.clearStalePermission(event.sessionId, 'PermissionDenied');
+				const bk = this.getBookkeeping(event.sessionId);
+				bk.activeToolCount = Math.max(0, bk.activeToolCount - 1);
+				this.updateSessionStatus(
+					event.sessionId,
+					bk.activeToolCount > 0 ? 'tool_use' : 'thinking',
+					eventContext,
+				);
+				break;
+			}
+
+			case 'Elicitation': {
+				const bk = this.getBookkeeping(event.sessionId);
+				bk.pendingPermission = {
+					toolName: event.toolName ?? 'Input Required',
+					toolDescription: event.toolName ?? 'Waiting for input',
+				};
+				this.updateSessionStatus(event.sessionId, 'permission_requested', {
+					...eventContext,
+					statusDetail: event.toolName,
+				});
+				break;
+			}
+
+			case 'ElicitationResult': {
+				const bk = this.getBookkeeping(event.sessionId);
+				bk.pendingPermission = undefined;
+				this.updateSessionStatus(
+					event.sessionId,
+					bk.activeToolCount > 0 ? 'tool_use' : 'thinking',
+					eventContext,
+				);
+				break;
+			}
+
+			case 'CwdChanged':
+				if (event.cwd) {
+					const index = this._sessions.findIndex(s => s.id === event.sessionId);
+					if (index >= 0 && this._sessions[index].cwd !== event.cwd) {
+						this._sessions[index] = { ...this._sessions[index], cwd: event.cwd };
+						this._onDidChangeSessions.fire();
+					}
+					void this.resolveGitInfo(event.sessionId, event.cwd);
+				}
+				break;
+
+			case 'SubagentStart': {
+				const { index: parentIdx } = this.ensureSession(event.sessionId, eventContext);
+				const parent = this._sessions[parentIdx];
+				if (event.agentId) {
+					const now = new Date();
+					const subagent: AgentSession = {
+						id: event.agentId,
+						providerId: this.id,
+						name: event.agentType ?? 'Subagent',
+						status: 'thinking',
+						phase: 'working',
+						phaseSince: now,
+						lastActivity: now,
+						isSubagent: true,
+						parentId: event.sessionId,
+						isInWorkspace: workspacePath != null,
+					};
+					const existingSubs = parent.subagents ? [...parent.subagents] : [];
+					existingSubs.push(subagent);
+					this._sessions[parentIdx] = { ...parent, subagents: existingSubs };
+					this._onDidChangeSessions.fire();
+				}
+				break;
+			}
+
+			case 'SubagentStop': {
+				const { index: parentIdx } = this.ensureSession(event.sessionId, eventContext);
+				const parentSession = this._sessions[parentIdx];
+				if (parentSession.subagents != null && event.agentId) {
+					const filtered = parentSession.subagents.filter(s => s.id !== event.agentId);
+					if (filtered.length !== parentSession.subagents.length) {
+						this._sessions[parentIdx] = {
+							...parentSession,
+							subagents: filtered.length > 0 ? filtered : undefined,
+						};
+						this._onDidChangeSessions.fire();
+					}
+				}
+				break;
+			}
+
+			case 'TeammateIdle':
+			case 'TaskCompleted':
+			case 'InstructionsLoaded':
+			case 'ConfigChange':
+			case 'WorktreeCreate':
+			case 'WorktreeRemove':
+				// Not yet handled — intentional no-op.
+				break;
+		}
+
+		return Promise.resolve();
+	}
+
+	private sessionTag(sessionId: string, name?: string): string {
+		return name != null
+			? `[session=${sessionId.substring(0, 8)}(${name})]`
+			: `[session=${sessionId.substring(0, 8)}]`;
+	}
+
+	private getBookkeeping(sessionId: string): SessionBookkeeping {
+		let bk = this._sessionBookkeeping.get(sessionId);
+		if (bk == null) {
+			bk = { activeToolCount: 0 };
+			this._sessionBookkeeping.set(sessionId, bk);
+		}
+		return bk;
+	}
+
+	private resetBookkeeping(sessionId: string): void {
+		const bk = this.getBookkeeping(sessionId);
+		bk.activeToolCount = 0;
+		bk.pendingPermission = undefined;
+	}
+
+	// Called when a pending permission was resolved outside GitLens (e.g. via the CLI terminal).
+	// The 'deny' response is a safe no-op since the tool has already run or been denied upstream.
+	private clearStalePermission(sessionId: string, reason: string): void {
+		const bk = this.getBookkeeping(sessionId);
+		if (bk.pendingPermission == null) return;
+
+		Logger.debug(`ClaudeCodeProvider.clearStalePermission: ${reason} ${this.sessionTag(sessionId)}`);
+
+		const pending = this._pendingPermissions.get(sessionId);
+		if (pending != null) {
+			pending.resolve({
+				hookSpecificOutput: { hookEventName: 'PermissionRequest', decision: { behavior: 'deny' } },
+			});
+			this._pendingPermissions.delete(sessionId);
+		}
+
+		bk.pendingPermission = undefined;
+	}
+
+	resolvePermission(
+		sessionId: string,
+		decision: PermissionDecision,
+		updatedPermissions?: PermissionSuggestion[],
+	): void {
+		const pending = this._pendingPermissions.get(sessionId);
+		if (pending == null) return;
+
+		Logger.debug(
+			`ClaudeCodeProvider.resolvePermission: ${decision} ${this.sessionTag(sessionId)} tool=${pending.toolName}`,
+		);
+		pending.resolve({
+			hookSpecificOutput: {
+				hookEventName: 'PermissionRequest',
+				decision: { behavior: decision, updatedPermissions: updatedPermissions },
+			},
+		});
+		this.callbacks.onPermissionResolved?.({
+			provider: this.id,
+			tool: pending.toolName,
+			decision: decision,
+		});
+		this._pendingPermissions.delete(sessionId);
+
+		const bk = this.getBookkeeping(sessionId);
+		bk.pendingPermission = undefined;
+
+		const nextStatus = bk.activeToolCount > 0 ? 'tool_use' : 'thinking';
+		this.updateSessionStatus(sessionId, nextStatus);
+	}
+
+	private matchesWorkspace(workspacePath: string | undefined): boolean {
+		if (!workspacePath) return false;
+		return this._workspacePaths.some(
+			p =>
+				workspacePath === p || workspacePath.startsWith(`${p}${sep}`) || p.startsWith(`${workspacePath}${sep}`),
+		);
+	}
+
+	private resolveWorkspacePath(cwd: string | undefined): string | undefined {
+		if (!cwd) return undefined;
+		return this._workspacePaths.find(
+			p => cwd === p || cwd.startsWith(`${p}${sep}`) || p.startsWith(`${cwd}${sep}`),
+		);
+	}
+
+	private updateSessionWithPermission(sessionId: string, permission: PendingPermission, pid?: number): void {
+		const { index } = this.ensureSession(sessionId, { pid: pid });
+
+		const prev = this._sessions[index];
+		const newPhase = getPhaseForStatus('permission_requested');
+		this.getBookkeeping(sessionId).pendingPermission = permission;
+		this._sessions[index] = {
+			...prev,
+			status: 'permission_requested',
+			phase: newPhase,
+			phaseSince: prev.phase !== newPhase ? new Date() : prev.phaseSince,
+			statusDetail: permission.toolDescription,
+			pendingPermission: permission,
+			lastActivity: new Date(),
+		};
+		this._onDidChangeSessions.fire();
+	}
+
+	private updateSessionStatus(
+		sessionId: string,
+		status: AgentSessionStatus,
+		options?: SessionContext & { statusDetail?: string },
+	): void {
+		const { index, changed: metadataChanged } = this.ensureSession(sessionId, options);
+
+		const prev = this._sessions[index];
+		const bk = this.getBookkeeping(sessionId);
+
+		// If a permission/elicitation is pending, preserve permission_requested state.
+		// Tool counts and other bookkeeping are still updated by callers before this
+		// method, but the visible status remains locked until the wait is explicitly
+		// resolved.
+		if (bk.pendingPermission != null && status !== 'permission_requested') {
+			this._sessions[index] = { ...prev, lastActivity: new Date() };
+			if (metadataChanged) {
+				this._onDidChangeSessions.fire();
+			}
+			return;
+		}
+
+		const statusDetail = options?.statusDetail;
+		if (prev.status === status && prev.statusDetail === statusDetail) {
+			if (metadataChanged) {
+				this._onDidChangeSessions.fire();
+			}
+			return;
+		}
+
+		const newPhase = getPhaseForStatus(status);
+		this._sessions[index] = {
+			...prev,
+			status: status,
+			phase: newPhase,
+			phaseSince: prev.phase !== newPhase ? new Date() : prev.phaseSince,
+			statusDetail: statusDetail,
+			pendingPermission: status === 'permission_requested' ? bk.pendingPermission : undefined,
+			lastActivity: new Date(),
+		};
+		this._onDidChangeSessions.fire();
+
+		if (status === 'thinking' || status === 'tool_use' || status === 'compacting') {
+			const sessionCwd = this._sessions[index].cwd;
+			if (sessionCwd != null) {
+				this.callbacks.onBranchAgentActivity?.(sessionCwd);
+			}
+		}
+	}
+
+	private ensureSession(sessionId: string, context?: SessionContext): { index: number; changed: boolean } {
+		const { pid, workspacePath, isInWorkspace, cwd, planFile, sessionName } = context ?? {};
+
+		let index = this._sessions.findIndex(s => s.id === sessionId);
+		if (index < 0) {
+			const now = new Date();
+			index = this._sessions.length;
+			this._sessions.push({
+				id: sessionId,
+				providerId: this.id,
+				name: sessionName || this.name,
+				status: 'idle',
+				phase: getPhaseForStatus('idle'),
+				phaseSince: now,
+				pid: pid,
+				lastActivity: now,
+				isSubagent: false,
+				workspacePath: workspacePath,
+				cwd: cwd,
+				planFile: planFile,
+				isInWorkspace: isInWorkspace ?? false,
+			});
+			Logger.debug(
+				`ClaudeCodeProvider.ensureSession: implicitly created ${this.sessionTag(sessionId, sessionName ?? 'unnamed')}`,
+			);
+			this._onDidChangeSessions.fire();
+
+			if (cwd != null) {
+				void this.resolveGitInfo(sessionId, cwd);
+			}
+			return { index: index, changed: true };
+		}
+
+		const existing = this._sessions[index];
+		const updatedPid = pid != null && existing.pid == null ? pid : existing.pid;
+		const updatedWorkspacePath = workspacePath || existing.workspacePath;
+		const updatedIsInWorkspace = workspacePath ? (isInWorkspace ?? existing.isInWorkspace) : existing.isInWorkspace;
+		const updatedPlanFile = planFile ?? existing.planFile;
+		const updatedName = sessionName || existing.name;
+		const updatedCwd = cwd ?? existing.cwd;
+
+		let changed = false;
+		if (
+			updatedPid !== existing.pid ||
+			updatedWorkspacePath !== existing.workspacePath ||
+			updatedIsInWorkspace !== existing.isInWorkspace ||
+			updatedPlanFile !== existing.planFile ||
+			updatedName !== existing.name ||
+			updatedCwd !== existing.cwd
+		) {
+			this._sessions[index] = {
+				...existing,
+				name: updatedName,
+				pid: updatedPid,
+				workspacePath: updatedWorkspacePath,
+				cwd: updatedCwd,
+				planFile: updatedPlanFile,
+				isInWorkspace: updatedIsInWorkspace,
+			};
+			changed = true;
+		}
+
+		if (cwd != null && existing.branch == null) {
+			void this.resolveGitInfo(sessionId, cwd);
+		}
+		return { index: index, changed: changed };
+	}
+
+	private async resolveGitInfo(sessionId: string, cwd: string): Promise<void> {
+		const resolveGitInfo = this.callbacks.resolveGitInfo;
+		if (resolveGitInfo == null) return;
+
+		try {
+			const info = await resolveGitInfo(cwd);
+			if (info == null) return;
+
+			const index = this._sessions.findIndex(s => s.id === sessionId);
+			if (index < 0) return;
+
+			const session = this._sessions[index];
+
+			// If the session has no workspacePath (CLI didn't match a workspace),
+			// use the resolved repository root so pills can match branch cards.
+			const resolvedWorkspacePath = !session.workspacePath ? info.repoRoot : session.workspacePath;
+			const resolvedIsInWorkspace =
+				resolvedWorkspacePath !== session.workspacePath
+					? this.matchesWorkspace(resolvedWorkspacePath)
+					: session.isInWorkspace;
+
+			if (
+				cwd !== session.cwd ||
+				info.branch !== session.branch ||
+				info.worktreeName !== session.worktreeName ||
+				resolvedWorkspacePath !== session.workspacePath
+			) {
+				this._sessions[index] = {
+					...session,
+					cwd: cwd,
+					branch: info.branch,
+					worktreeName: info.worktreeName,
+					workspacePath: resolvedWorkspacePath,
+					isInWorkspace: resolvedIsInWorkspace,
+				};
+				this._onDidChangeSessions.fire();
+			}
+		} catch {
+			// Git not available or not a git repo — leave branch/worktree undefined
+		}
+	}
+
+	private pruneDeadSessions(): boolean {
+		const kept: AgentSession[] = [];
+		const removedIds: string[] = [];
+		for (const s of this._sessions) {
+			if (s.pid == null || isProcessAlive(s.pid)) {
+				kept.push(s);
+			} else {
+				removedIds.push(s.id);
+			}
+		}
+		if (removedIds.length === 0) return false;
+
+		this._sessions = kept;
+		for (const id of removedIds) {
+			this._sessionBookkeeping.delete(id);
+		}
+		Logger.debug(
+			`ClaudeCodeProvider.syncSessions: removed ${removedIds.length} stale session(s): ${removedIds.map(id => id.substring(0, 8)).join(', ')}`,
+		);
+		return true;
+	}
+
+	private async syncSessions(): Promise<void> {
+		let sessions: SessionFileData[];
+		try {
+			const output = await this.callbacks.runCLICommand(['ai', 'hook', 'list-sessions', '--json']);
+			sessions = JSON.parse(output) as SessionFileData[];
+		} catch {
+			if (this.pruneDeadSessions()) {
+				this._onDidChangeSessions.fire();
+			}
+			return;
+		}
+
+		let changed = false;
+
+		for (const data of sessions) {
+			if (!data.sessionId || !data.pid || !isProcessAlive(data.pid)) {
+				continue;
+			}
+
+			if (this._sessions.some(s => s.id === data.sessionId)) continue;
+
+			const workspacePath = this.resolveWorkspacePath(data.cwd);
+			const isInWorkspace = workspacePath != null;
+			const status = deriveStatusFromEvent(data.event);
+			const phase = getPhaseForStatus(status);
+			const activityDate = new Date(data.updatedAt);
+
+			const subagents: AgentSession[] | undefined = data.subagents?.map(sub => ({
+				id: sub.agentId,
+				providerId: this.id,
+				name: sub.agentType ?? 'Subagent',
+				status: 'thinking',
+				phase: 'working' as const,
+				phaseSince: activityDate,
+				lastActivity: activityDate,
+				isSubagent: true,
+				parentId: data.sessionId,
+				isInWorkspace: isInWorkspace,
+			}));
+
+			this._sessions.push({
+				id: data.sessionId,
+				providerId: this.id,
+				name: data.sessionName || this.name,
+				status: status,
+				phase: phase,
+				phaseSince: activityDate,
+				pid: data.pid,
+				lastActivity: activityDate,
+				isSubagent: false,
+				workspacePath: workspacePath,
+				cwd: data.cwd,
+				planFile: data.planFile ?? undefined,
+				isInWorkspace: isInWorkspace,
+				lastPrompt: data.prompt ?? undefined,
+				subagents: subagents,
+			});
+			changed = true;
+
+			if (data.cwd) {
+				void this.resolveGitInfo(data.sessionId, data.cwd);
+			}
+		}
+
+		if (this.pruneDeadSessions()) {
+			changed = true;
+		}
+
+		if (changed) {
+			this._onDidChangeSessions.fire();
+		}
+	}
+
+	private async querySiblingWindowSessions(): Promise<void> {
+		let files: string[];
+		try {
+			files = await readdir(agentDiscoveryDir);
+		} catch {
+			return;
+		}
+
+		const ownPort = this._ipcServer?.port;
+
+		const peerBatches = await Promise.all(
+			files
+				.filter(f => f.startsWith('gitlens-ipc-server-') && f.endsWith('.json'))
+				.map(async f => this.fetchPeerSessions(join(agentDiscoveryDir, f), ownPort)),
+		);
+
+		let changed = false;
+		for (const peerSessions of peerBatches) {
+			if (peerSessions == null) continue;
+
+			for (const peerSession of peerSessions) {
+				const peerActivity = new Date(peerSession.lastActivity);
+				const peerPhaseSince = new Date(peerSession.phaseSince);
+
+				const existing = this._sessions.find(s => s.id === peerSession.id);
+				if (existing != null) {
+					if (peerActivity > existing.lastActivity) {
+						const idx = this._sessions.indexOf(existing);
+						this._sessions[idx] = {
+							...existing,
+							status: peerSession.status,
+							phase: peerSession.phase,
+							phaseSince: peerPhaseSince,
+							statusDetail: peerSession.statusDetail,
+							lastActivity: peerActivity,
+							subagents: rehydrateSubagents(peerSession.subagents),
+						};
+						changed = true;
+					}
+				} else {
+					this._sessions.push({
+						...peerSession,
+						lastActivity: peerActivity,
+						phaseSince: peerPhaseSince,
+						workspacePath: normalizeWorkspacePath(peerSession.workspacePath),
+						isInWorkspace: this.matchesWorkspace(peerSession.workspacePath),
+						subagents: rehydrateSubagents(peerSession.subagents),
+					});
+					changed = true;
+				}
+			}
+		}
+
+		if (changed) {
+			this._onDidChangeSessions.fire();
+		}
+	}
+
+	private async fetchPeerSessions(
+		path: string,
+		ownPort: number | undefined,
+	): Promise<SerializedAgentSession[] | undefined> {
+		let discovery: DiscoveryFile;
+		try {
+			discovery = JSON.parse(await readFile(path, 'utf8')) as DiscoveryFile;
+		} catch {
+			return undefined;
+		}
+		if (ownPort != null && discovery.port === ownPort) return undefined;
+
+		try {
+			const response = await fetch(`${discovery.address}/agents/sessions/list`, {
+				method: 'POST',
+				headers: { Authorization: `Bearer ${discovery.token}`, 'Content-Type': 'application/json' },
+				body: '{}',
+				signal: AbortSignal.timeout(2000),
+			});
+			if (!response.ok) return undefined;
+			return (await response.json()) as SerializedAgentSession[];
+		} catch {
+			return undefined;
+		}
+	}
+}

--- a/packages/plus/agents/src/stateMachine.ts
+++ b/packages/plus/agents/src/stateMachine.ts
@@ -1,0 +1,80 @@
+import { kill } from 'process';
+import type { AgentSession, AgentSessionStatus } from './types.js';
+
+export function deriveStatusFromEvent(event: string): AgentSessionStatus {
+	switch (event) {
+		case 'SessionStart':
+		case 'Stop':
+		case 'StopFailure':
+			return 'idle';
+		case 'PreToolUse':
+			return 'tool_use';
+		case 'PreCompact':
+			return 'compacting';
+		case 'PermissionRequest':
+		case 'Elicitation':
+			return 'permission_requested';
+		case 'UserPromptSubmit':
+		case 'PostToolUse':
+		case 'PostToolUseFailure':
+		case 'PostCompact':
+		case 'PermissionDenied':
+		case 'ElicitationResult':
+		case 'SubagentStart':
+		case 'SubagentStop':
+			return 'thinking';
+		default:
+			return 'idle';
+	}
+}
+
+export function isProcessAlive(pid: number): boolean {
+	try {
+		kill(pid, 0);
+		return true;
+	} catch {
+		return false;
+	}
+}
+
+export function rehydrateSubagents(
+	subagents:
+		| (Omit<AgentSession, 'lastActivity' | 'phaseSince'> & { lastActivity: string; phaseSince: string })[]
+		| undefined,
+): AgentSession[] | undefined {
+	if (subagents == null || subagents.length === 0) return undefined;
+	return subagents.map(s => ({
+		...s,
+		lastActivity: new Date(s.lastActivity),
+		phaseSince: new Date(s.phaseSince),
+	}));
+}
+
+export function describeToolInput(toolName: string, toolInput: Record<string, unknown>): string {
+	let detail: string | undefined;
+	switch (toolName) {
+		case 'Bash':
+			detail = toolInput.command as string | undefined;
+			break;
+		case 'Edit':
+		case 'Write':
+		case 'Read':
+			detail = toolInput.file_path as string | undefined;
+			break;
+		case 'Grep':
+		case 'Glob':
+			detail = toolInput.pattern as string | undefined;
+			break;
+		case 'WebFetch':
+			detail = toolInput.url as string | undefined;
+			break;
+		case 'WebSearch':
+			detail = toolInput.query as string | undefined;
+			break;
+		case 'NotebookEdit':
+			detail = toolInput.notebook_path as string | undefined;
+			break;
+	}
+
+	return detail != null ? `${toolName}(${detail})` : toolName;
+}

--- a/packages/plus/agents/src/types.ts
+++ b/packages/plus/agents/src/types.ts
@@ -1,0 +1,156 @@
+import type { UnifiedDisposable } from '@gitlens/utils/disposable.js';
+import type { Event } from '@gitlens/utils/event.js';
+
+export const claudeCodeNonBlockingHookEvents = [
+	'SessionStart',
+	'SessionEnd',
+	'UserPromptSubmit',
+	'PreToolUse',
+	'PostToolUse',
+	'PostToolUseFailure',
+	'Notification',
+	'Stop',
+	'StopFailure',
+	'SubagentStart',
+	'SubagentStop',
+	'TeammateIdle',
+	'TaskCompleted',
+	'InstructionsLoaded',
+	'ConfigChange',
+	'WorktreeCreate',
+	'WorktreeRemove',
+	'PreCompact',
+	'PostCompact',
+	'Elicitation',
+	'ElicitationResult',
+	'PermissionDenied',
+	'CwdChanged',
+] as const;
+
+export const claudeCodeBlockingHookEvents = ['PermissionRequest'] as const;
+
+export type ClaudeCodeHookEvent =
+	| (typeof claudeCodeNonBlockingHookEvents)[number]
+	| (typeof claudeCodeBlockingHookEvents)[number];
+
+export type PermissionDecision = 'allow' | 'deny';
+
+export type AgentSessionStatus =
+	| 'thinking'
+	| 'tool_use'
+	| 'responding'
+	| 'waiting'
+	| 'idle'
+	| 'compacting'
+	| 'permission_requested';
+
+export type AgentSessionPhase = 'idle' | 'working' | 'waiting';
+
+export function getPhaseForStatus(status: AgentSessionStatus): AgentSessionPhase {
+	switch (status) {
+		case 'thinking':
+		case 'tool_use':
+		case 'responding':
+		case 'compacting':
+			return 'working';
+		case 'waiting':
+		case 'permission_requested':
+			return 'waiting';
+		case 'idle':
+			return 'idle';
+	}
+}
+
+export interface PermissionSuggestion {
+	readonly type: string;
+	readonly tool?: string;
+	readonly rules?: readonly { readonly toolName: string; readonly ruleContent?: string }[];
+	readonly destination?: string;
+}
+
+export interface PendingPermission {
+	readonly toolName: string;
+	readonly toolDescription: string;
+	readonly toolInputDescription?: string;
+	readonly suggestions?: readonly PermissionSuggestion[];
+}
+
+export interface AgentSession {
+	readonly id: string;
+	readonly providerId: string;
+	readonly name: string;
+	readonly status: AgentSessionStatus;
+	readonly phase: AgentSessionPhase;
+	readonly statusDetail?: string;
+	readonly branch?: string;
+	readonly worktreeName?: string;
+	readonly pid?: number;
+	readonly lastActivity: Date;
+	readonly phaseSince: Date;
+	readonly isSubagent: boolean;
+	readonly parentId?: string;
+	readonly subagents?: readonly AgentSession[];
+	readonly pendingPermission?: PendingPermission;
+	readonly workspacePath?: string;
+	readonly cwd?: string;
+	readonly planFile?: string;
+	readonly isInWorkspace: boolean;
+	readonly lastPrompt?: string;
+}
+
+export interface AgentSessionProvider extends UnifiedDisposable {
+	readonly id: string;
+	readonly name: string;
+	readonly icon: string;
+
+	readonly onDidChangeSessions: Event<void>;
+	readonly sessions: readonly AgentSession[];
+
+	start(workspacePaths: string[]): void;
+	stop(): void;
+	updateWorkspacePaths?(workspacePaths: string[]): void;
+
+	resolvePermission?(
+		sessionId: string,
+		decision: PermissionDecision,
+		updatedPermissions?: PermissionSuggestion[],
+	): void;
+}
+
+export interface AgentProviderCallbacks {
+	/** Report that an agent session started. No-op if the host has no telemetry. */
+	onSessionStarted?(provider: string): void;
+
+	/** Report that an agent session ended. No-op if the host has no telemetry. */
+	onSessionEnded?(provider: string): void;
+
+	/** Report that a permission request was resolved. No-op if the host has no telemetry. */
+	onPermissionResolved?(info: { provider: string; tool: string; decision: PermissionDecision }): void;
+
+	/** Notify the host that a branch has agent activity. */
+	onBranchAgentActivity?(cwd: string): void;
+
+	/**
+	 * Run the GK CLI with the given args. Returns stdout.
+	 *
+	 * Host responsibilities:
+	 * - Resolve the CLI executable path (e.g. via `resolveCLIExecutable`)
+	 * - Provide the default `cwd` if `options.cwd` is not set (e.g. `globalStorageUri.fsPath` in VS Code)
+	 * - Inject any environment-specific flags (e.g. `--insiders` when the host has insiders mode enabled)
+	 */
+	runCLICommand(args: string[], options?: { cwd?: string }): Promise<string>;
+
+	/**
+	 * Resolve git metadata (branch, worktree, repo root) for a session's cwd.
+	 * Optional — if omitted, sessions won't have branch/worktree metadata.
+	 */
+	resolveGitInfo?(cwd: string): Promise<
+		| {
+				branch?: string;
+				repoRoot: string;
+				isWorktree: boolean;
+				worktreeName?: string;
+		  }
+		| undefined
+	>;
+}

--- a/packages/plus/agents/tsconfig.json
+++ b/packages/plus/agents/tsconfig.json
@@ -1,0 +1,10 @@
+{
+	"extends": "../../../tsconfig.package.json",
+	"compilerOptions": {
+		"rootDir": "src",
+		"outDir": "dist",
+		"tsBuildInfoFile": "tsconfig.tsbuildinfo"
+	},
+	"references": [{ "path": "../../utils" }],
+	"include": ["src/**/*"]
+}

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -474,6 +474,25 @@ importers:
         specifier: 'catalog:'
         version: 6.0.3
 
+  packages/plus/agents:
+    dependencies:
+      '@gitlens/utils':
+        specifier: workspace:*
+        version: link:../../utils
+    devDependencies:
+      '@types/mocha':
+        specifier: 'catalog:'
+        version: 10.0.10
+      mocha:
+        specifier: 'catalog:'
+        version: 11.7.5
+      tsx:
+        specifier: 'catalog:'
+        version: 4.21.0
+      typescript:
+        specifier: 'catalog:'
+        version: 6.0.3
+
   packages/plus/ai:
     dependencies:
       '@gitlens/git':

--- a/src/agents/agentStatusService.ts
+++ b/src/agents/agentStatusService.ts
@@ -1,0 +1,264 @@
+import type { Disposable, QuickPickItem } from 'vscode';
+import { commands, EventEmitter, Uri, window, workspace } from 'vscode';
+import type { Container } from '../container.js';
+import { createQuickPickSeparator } from '../quickpicks/items/common.js';
+import { registerCommand } from '../system/-webview/command.js';
+import type { AgentSession, AgentSessionProvider, PermissionDecision, PermissionSuggestion } from './provider.js';
+
+export class AgentStatusService implements Disposable {
+	private readonly _onDidChange = new EventEmitter<void>();
+	readonly onDidChange = this._onDidChange.event;
+
+	private readonly _disposables: Disposable[] = [];
+	private readonly _providers: AgentSessionProvider[];
+
+	constructor(
+		private readonly container: Container,
+		providers: AgentSessionProvider[],
+	) {
+		this._providers = providers;
+
+		for (const provider of this._providers) {
+			this._disposables.push(provider.onDidChangeSessions(() => this._onDidChange.fire()));
+		}
+
+		this._disposables.push(
+			window.onDidChangeWindowState(e => {
+				if (e.focused) {
+					this.startProviders();
+				} else {
+					this.stopProviders();
+				}
+			}),
+			workspace.onDidChangeWorkspaceFolders(() => this.onWorkspaceFoldersChanged()),
+			...this.registerCommands(),
+		);
+
+		this.startProviders();
+	}
+
+	dispose(): void {
+		this.stopProviders();
+		for (const provider of this._providers) {
+			provider.dispose();
+		}
+		for (const d of this._disposables) {
+			d.dispose();
+		}
+		this._onDidChange.dispose();
+	}
+
+	get sessions(): readonly AgentSession[] {
+		return this._providers.flatMap(p => p.sessions);
+	}
+
+	resolvePermission(
+		sessionId: string,
+		decision: PermissionDecision,
+		updatedPermissions?: PermissionSuggestion[],
+	): void {
+		for (const provider of this._providers) {
+			const session = provider.sessions.find(s => s.id === sessionId);
+			if (session != null) {
+				// Sessions outside this workspace are owned by another GitLens instance; let it resolve them.
+				if (!session.isInWorkspace) return;
+				provider.resolvePermission?.(sessionId, decision, updatedPermissions);
+				return;
+			}
+		}
+	}
+
+	private registerCommands(): Disposable[] {
+		return [
+			registerCommand('gitlens.agents.installClaudeHook', async () => {
+				try {
+					const { installClaudeHook } = await import('@env/agents/installClaudeHook.js');
+					await installClaudeHook();
+					this.container.telemetry.sendEvent('agents/hookInstalled', { 'agent.provider': 'claudeCode' });
+				} catch (ex) {
+					void window.showErrorMessage(
+						`Failed to install Claude hook: ${ex instanceof Error ? ex.message : String(ex)}`,
+					);
+				}
+			}),
+			registerCommand('gitlens.agents.openSession', (sessionId?: string) => this.openSession(sessionId)),
+			registerCommand(
+				'gitlens.agents.resolvePermission',
+				(args?: { sessionId: string; decision: PermissionDecision; alwaysAllow?: boolean }) => {
+					if (args?.sessionId == null || args.decision == null) return;
+
+					let updatedPermissions: PermissionSuggestion[] | undefined;
+					if (args.alwaysAllow) {
+						const session = this.sessions.find(s => s.id === args.sessionId);
+						const suggestions = session?.pendingPermission?.suggestions;
+						if (suggestions != null && suggestions.length > 0) {
+							updatedPermissions = [...suggestions];
+						}
+					}
+
+					this.resolvePermission(args.sessionId, args.decision, updatedPermissions);
+				},
+			),
+		];
+	}
+
+	private async openSession(sessionId?: string): Promise<void> {
+		const sessions = [...this.sessions];
+		if (sessions.length === 0) return;
+
+		let session: AgentSession | undefined;
+
+		if (sessionId != null) {
+			session = sessions.find(s => s.id === sessionId);
+		} else if (sessions.length === 1) {
+			session = sessions[0];
+		} else {
+			const workspaceSessions = sessions.filter(s => s.isInWorkspace);
+			const externalSessions = sessions.filter(s => !s.isInWorkspace);
+
+			interface SessionPickItem extends QuickPickItem {
+				session: AgentSession;
+			}
+
+			const items: (SessionPickItem | QuickPickItem)[] = [];
+
+			if (workspaceSessions.length > 0) {
+				items.push(createQuickPickSeparator('This workspace'));
+				for (const s of workspaceSessions) {
+					items.push({
+						label: `$(hubot) ${s.name}`,
+						description: s.status,
+						detail: s.branch ? `on ${s.branch}` : undefined,
+						session: s,
+					} satisfies SessionPickItem);
+				}
+			}
+
+			if (externalSessions.length > 0) {
+				items.push(createQuickPickSeparator('Other workspaces'));
+				for (const s of externalSessions) {
+					items.push({
+						label: `$(hubot) ${s.name}`,
+						description: s.status,
+						detail: s.workspacePath ?? undefined,
+						session: s,
+					} satisfies SessionPickItem);
+				}
+			}
+
+			const pick = await window.showQuickPick<SessionPickItem | QuickPickItem>(items, {
+				placeHolder: 'Select an agent session',
+			});
+			if (pick == null || !('session' in pick)) return;
+
+			session = pick.session;
+		}
+
+		if (session == null) return;
+
+		interface ActionPickItem extends QuickPickItem {
+			action: string;
+		}
+
+		const actions: ActionPickItem[] = [];
+
+		if (session.pid != null) {
+			actions.push({
+				label: '$(window) Focus Agent Window',
+				description: 'Bring the terminal running the agent to the foreground',
+				action: 'focus',
+			});
+		}
+
+		if (session.isInWorkspace) {
+			actions.push({
+				label: '$(edit) Open in Claude Code Extension',
+				description: 'Open session in the Claude Code VS Code extension',
+				action: 'open-extension',
+			});
+		}
+
+		if (!session.isInWorkspace && session.workspacePath != null) {
+			actions.push({
+				label: '$(folder-opened) Switch to Workspace',
+				description: session.workspacePath,
+				action: 'switch-workspace',
+			});
+		}
+
+		if (actions.length === 0) return;
+
+		let action: string;
+		if (actions.length === 1) {
+			action = actions[0].action;
+		} else {
+			const actionPick = await window.showQuickPick(actions, {
+				placeHolder: `Action for ${session.name}`,
+			});
+			if (actionPick == null) return;
+			action = actionPick.action;
+		}
+
+		switch (action) {
+			case 'focus':
+				if (session.pid != null) {
+					const { focusProcessWindow } = await import('@env/focusWindow.js');
+					await focusProcessWindow(session.pid);
+				}
+				break;
+			case 'open-extension':
+				try {
+					await commands.executeCommand('claude-vscode.editor.open', session.id);
+				} catch {
+					try {
+						await commands.executeCommand('claude-vscode.sidebar.open');
+					} catch {
+						void window.showWarningMessage(
+							'Unable to open session. Is the Claude Code extension installed?',
+						);
+					}
+				}
+				break;
+			case 'switch-workspace':
+				if (session.workspacePath != null) {
+					void commands.executeCommand('vscode.openFolder', Uri.file(session.workspacePath), {
+						forceNewWindow: false,
+					});
+				}
+				break;
+		}
+	}
+
+	private getWorkspacePaths(): string[] {
+		return workspace.workspaceFolders?.map(f => f.uri.fsPath) ?? [];
+	}
+
+	private startProviders(): void {
+		const paths = this.getWorkspacePaths();
+		if (paths.length === 0) return;
+
+		for (const provider of this._providers) {
+			provider.start(paths);
+		}
+	}
+
+	private stopProviders(): void {
+		for (const provider of this._providers) {
+			provider.stop();
+		}
+	}
+
+	private onWorkspaceFoldersChanged(): void {
+		// Do NOT early-return on an empty list — providers need to reclassify
+		// existing sessions' `isInWorkspace` when the last folder is removed.
+		const paths = this.getWorkspacePaths();
+
+		for (const provider of this._providers) {
+			if (provider.updateWorkspacePaths != null) {
+				provider.updateWorkspacePaths(paths);
+			} else if (paths.length > 0) {
+				provider.start(paths);
+			}
+		}
+	}
+}

--- a/src/agents/agentStatusService.ts
+++ b/src/agents/agentStatusService.ts
@@ -81,6 +81,17 @@ export class AgentStatusService implements Disposable {
 					);
 				}
 			}),
+			registerCommand('gitlens.agents.uninstallClaudeHook', async () => {
+				try {
+					const { uninstallClaudeHook } = await import('@env/agents/uninstallClaudeHook.js');
+					await uninstallClaudeHook();
+					this.container.telemetry.sendEvent('agents/hookUninstalled', { 'agent.provider': 'claudeCode' });
+				} catch (ex) {
+					void window.showErrorMessage(
+						`Failed to uninstall Claude hook: ${ex instanceof Error ? ex.message : String(ex)}`,
+					);
+				}
+			}),
 			registerCommand('gitlens.agents.openSession', (sessionId?: string) => this.openSession(sessionId)),
 			registerCommand(
 				'gitlens.agents.resolvePermission',

--- a/src/agents/provider.ts
+++ b/src/agents/provider.ts
@@ -1,0 +1,11 @@
+export {
+	type AgentProviderCallbacks,
+	type AgentSession,
+	type AgentSessionPhase,
+	type AgentSessionProvider,
+	type AgentSessionStatus,
+	getPhaseForStatus,
+	type PendingPermission,
+	type PermissionDecision,
+	type PermissionSuggestion,
+} from '@gitlens/agents/types.js';

--- a/src/config.ts
+++ b/src/config.ts
@@ -401,6 +401,7 @@ interface GitKrakenConfig {
 }
 
 interface GitKrakenCliConfig {
+	readonly localPath: string | null;
 	readonly integration: {
 		readonly enabled: boolean;
 	};

--- a/src/constants.commands.generated.ts
+++ b/src/constants.commands.generated.ts
@@ -859,6 +859,7 @@ export type ContributedPaletteCommands =
 	| 'gitlens.addAuthors'
 	| 'gitlens.agents.installClaudeHook'
 	| 'gitlens.agents.openSession'
+	| 'gitlens.agents.uninstallClaudeHook'
 	| 'gitlens.ai.enable'
 	| 'gitlens.ai.explainBranch'
 	| 'gitlens.ai.explainCommit'

--- a/src/constants.commands.generated.ts
+++ b/src/constants.commands.generated.ts
@@ -857,6 +857,8 @@ export type ContributedCommands =
 
 export type ContributedPaletteCommands =
 	| 'gitlens.addAuthors'
+	| 'gitlens.agents.installClaudeHook'
+	| 'gitlens.agents.openSession'
 	| 'gitlens.ai.enable'
 	| 'gitlens.ai.explainBranch'
 	| 'gitlens.ai.explainCommit'

--- a/src/constants.commands.ts
+++ b/src/constants.commands.ts
@@ -80,6 +80,8 @@ type InternalHomeWebviewCommands =
 	| 'gitlens.visualizeHistory.repo:home'
 	| 'gitlens.visualizeHistory.branch:home';
 
+type InternalAgentCommands = 'gitlens.agents.installClaudeHook' | 'gitlens.agents.resolvePermission';
+
 type InternalLaunchPadCommands = 'gitlens.launchpad.indicator.action';
 
 type InternalPlusCommands =
@@ -171,6 +173,7 @@ type InternalGlCommands =
 	| 'gitlens.toggleFileHeatmap:mode'
 	| 'gitlens.toggleFileHeatmap:statusbar'
 	| 'gitlens.visualizeHistory'
+	| InternalAgentCommands
 	| InternalGraphWebviewCommands
 	| InternalHomeWebviewCommands
 	| InternalLaunchPadCommands

--- a/src/constants.commands.ts
+++ b/src/constants.commands.ts
@@ -80,7 +80,10 @@ type InternalHomeWebviewCommands =
 	| 'gitlens.visualizeHistory.repo:home'
 	| 'gitlens.visualizeHistory.branch:home';
 
-type InternalAgentCommands = 'gitlens.agents.installClaudeHook' | 'gitlens.agents.resolvePermission';
+type InternalAgentCommands =
+	| 'gitlens.agents.installClaudeHook'
+	| 'gitlens.agents.uninstallClaudeHook'
+	| 'gitlens.agents.resolvePermission';
 
 type InternalLaunchPadCommands = 'gitlens.launchpad.indicator.action';
 

--- a/src/constants.telemetry.ts
+++ b/src/constants.telemetry.ts
@@ -92,6 +92,15 @@ export interface TelemetryEvents extends WebviewShowAbortedEvents, WebviewShownE
 	/** Sent when user opts in to AI All Access */
 	'aiAllAccess/optedIn': void;
 
+	/** Sent when an agent hook is installed */
+	'agents/hookInstalled': AgentProviderEvent;
+	/** Sent when an agent session starts */
+	'agents/session/started': AgentProviderEvent;
+	/** Sent when an agent session ends */
+	'agents/session/ended': AgentProviderEvent;
+	/** Sent when a permission request is resolved */
+	'agents/permission/resolved': AgentPermissionResolvedEvent;
+
 	/** Sent when a CLI install attempt is started */
 	'cli/install/started': CLIInstallStartedEvent;
 	/** Sent when a CLI install attempt succeeds */
@@ -486,6 +495,16 @@ interface AccountValidationFailedEvent {
 	exception: string;
 	code: string | undefined;
 	statusCode: number | undefined;
+}
+
+interface AgentProviderEvent {
+	'agent.provider': string;
+}
+
+interface AgentPermissionResolvedEvent {
+	'agent.provider': string;
+	'permission.tool': string;
+	'permission.decision': string;
 }
 
 interface ActivateEvent extends ConfigEventData {

--- a/src/constants.telemetry.ts
+++ b/src/constants.telemetry.ts
@@ -94,6 +94,8 @@ export interface TelemetryEvents extends WebviewShowAbortedEvents, WebviewShownE
 
 	/** Sent when an agent hook is installed */
 	'agents/hookInstalled': AgentProviderEvent;
+	/** Sent when an agent hook is uninstalled */
+	'agents/hookUninstalled': AgentProviderEvent;
 	/** Sent when an agent session starts */
 	'agents/session/started': AgentProviderEvent;
 	/** Sent when an agent session ends */

--- a/src/container.ts
+++ b/src/container.ts
@@ -1,6 +1,7 @@
 import type { ConfigurationChangeEvent, Disposable, Event, ExtensionContext } from 'vscode';
 import { EventEmitter, ExtensionMode } from 'vscode';
 import {
+	getAgentSessionProviders,
 	getGkCliIntegrationProvider,
 	getMcpProviders,
 	getSharedGKStorageLocationProvider,
@@ -11,6 +12,7 @@ import {
 import { debug } from '@gitlens/utils/decorators/log.js';
 import { memoize } from '@gitlens/utils/decorators/memoize.js';
 import { Logger } from '@gitlens/utils/logger.js';
+import { AgentStatusService } from './agents/agentStatusService.js';
 import { FileAnnotationController } from './annotations/fileAnnotationController.js';
 import { LineAnnotationController } from './annotations/lineAnnotationController.js';
 import { ActionRunners } from './api/actionRunners.js';
@@ -188,6 +190,11 @@ export class Container {
 		},
 	};
 
+	private _agentStatusService: AgentStatusService | undefined;
+
+	get agentStatus(): AgentStatusService | undefined {
+		return this._agentStatusService;
+	}
 	private readonly _connection: ServerConnection;
 	private _disposables: Disposable[];
 	private _terminalLinks: GitTerminalLinkProvider | undefined;
@@ -282,6 +289,11 @@ export class Container {
 
 		if (configuration.get('launchpad.indicator.enabled')) {
 			this._disposables.push((this._launchpadIndicator = new LaunchpadIndicator(this, this._launchpadProvider)));
+		}
+
+		const agentProviders = getAgentSessionProviders(this);
+		if (agentProviders.length > 0) {
+			this._disposables.push((this._agentStatusService = new AgentStatusService(this, agentProviders)));
 		}
 
 		if (configuration.get('terminalLinks.enabled')) {

--- a/src/env/browser/agents/installClaudeHook.ts
+++ b/src/env/browser/agents/installClaudeHook.ts
@@ -1,0 +1,1 @@
+export async function installClaudeHook(): Promise<void> {}

--- a/src/env/browser/agents/uninstallClaudeHook.ts
+++ b/src/env/browser/agents/uninstallClaudeHook.ts
@@ -1,0 +1,1 @@
+export async function uninstallClaudeHook(): Promise<void> {}

--- a/src/env/browser/focusWindow.ts
+++ b/src/env/browser/focusWindow.ts
@@ -1,0 +1,3 @@
+export function focusProcessWindow(_pid: number): Promise<boolean> {
+	return Promise.resolve(false);
+}

--- a/src/env/browser/providers.ts
+++ b/src/env/browser/providers.ts
@@ -3,6 +3,7 @@ import type { Cache } from '@gitlens/git/cache.js';
 import type { GitExecOptions, GitResult } from '@gitlens/git/exec.types.js';
 import type { GitProvider } from '@gitlens/git/providers/provider.js';
 import type { UnifiedDisposable } from '@gitlens/utils/disposable.js';
+import type { AgentSessionProvider } from '../../agents/provider.js';
 import type { Container } from '../../container.js';
 // Force import of GitHub since dynamic imports are not supported in the WebWorker ExtensionHost
 // eslint-disable-next-line @typescript-eslint/consistent-type-imports
@@ -49,6 +50,10 @@ export function getSupportedWorkspacesStorageProvider(
 
 export function getGkCliIntegrationProvider(_container: Container): undefined {
 	return undefined;
+}
+
+export function getAgentSessionProviders(_container: Container): AgentSessionProvider[] {
+	return [];
 }
 
 export function getMcpProviders(_container: Container): Promise<Disposable[] | undefined> {

--- a/src/env/node/agents/installClaudeHook.ts
+++ b/src/env/node/agents/installClaudeHook.ts
@@ -1,0 +1,7 @@
+import { window } from 'vscode';
+import { runCLICommand } from '../gk/cli/utils.js';
+
+export async function installClaudeHook(): Promise<void> {
+	await runCLICommand(['ai', 'hook', 'install', 'claude-code']);
+	void window.showInformationMessage('Claude hook installed successfully.');
+}

--- a/src/env/node/agents/installClaudeHook.ts
+++ b/src/env/node/agents/installClaudeHook.ts
@@ -1,7 +1,15 @@
 import { window } from 'vscode';
+import { claudeCodeBlockingHookEvents, claudeCodeNonBlockingHookEvents } from '@gitlens/agents/types.js';
 import { runCLICommand } from '../gk/cli/utils.js';
 
 export async function installClaudeHook(): Promise<void> {
-	await runCLICommand(['ai', 'hook', 'install', 'claude-code']);
+	const args = ['ai', 'hook', 'install', 'claude-code'];
+	for (const event of claudeCodeNonBlockingHookEvents) {
+		args.push('--event', event);
+	}
+	for (const event of claudeCodeBlockingHookEvents) {
+		args.push('--blocking-event', event);
+	}
+	await runCLICommand(args);
 	void window.showInformationMessage('Claude hook installed successfully.');
 }

--- a/src/env/node/agents/uninstallClaudeHook.ts
+++ b/src/env/node/agents/uninstallClaudeHook.ts
@@ -1,0 +1,7 @@
+import { window } from 'vscode';
+import { runCLICommand } from '../gk/cli/utils.js';
+
+export async function uninstallClaudeHook(): Promise<void> {
+	await runCLICommand(['ai', 'hook', 'uninstall', 'claude-code']);
+	void window.showInformationMessage('Claude hook uninstalled successfully.');
+}

--- a/src/env/node/focusWindow.ts
+++ b/src/env/node/focusWindow.ts
@@ -1,0 +1,136 @@
+import type { ExecFileException } from 'child_process';
+import { execFile } from 'child_process';
+import { platform, env as processEnv } from 'process';
+import { Logger } from '@gitlens/utils/logger.js';
+
+const maxParentWalkDepth = 10;
+
+export async function focusProcessWindow(pid: number): Promise<boolean> {
+	try {
+		const strategy = getStrategy();
+		if (strategy == null) return false;
+
+		// Try the given PID first, then walk up parent PIDs
+		// (the agent process runs inside a terminal, and the terminal owns the window)
+		// This will not always work (e.g. when running Claude from `foot tmux`,
+		// the process tree stops at tmux)
+		let currentPid: number | undefined = pid;
+		for (let depth = 0; depth < maxParentWalkDepth && currentPid != null; depth++) {
+			if (await strategy(currentPid)) return true;
+			currentPid = await getParentPid(currentPid);
+		}
+
+		return false;
+	} catch (ex) {
+		Logger.warn(`focusProcessWindow: failed to focus window for PID ${pid}: ${ex}`);
+		return false;
+	}
+}
+
+type FocusStrategy = (pid: number) => Promise<boolean>;
+
+function getStrategy(): FocusStrategy | undefined {
+	switch (platform) {
+		case 'linux':
+			return getLinuxStrategy();
+		case 'darwin':
+			return focusMacOS;
+		case 'win32':
+			return focusWindows;
+		default:
+			return undefined;
+	}
+}
+
+function getLinuxStrategy(): FocusStrategy {
+	const sessionType = processEnv.XDG_SESSION_TYPE;
+	const desktop = processEnv.XDG_CURRENT_DESKTOP?.toLowerCase() ?? '';
+
+	// Wayland compositors (check before X11 since Wayland sessions may also set DISPLAY for XWayland)
+	if (sessionType === 'wayland' || processEnv.WAYLAND_DISPLAY != null) {
+		if (processEnv.HYPRLAND_INSTANCE_SIGNATURE != null) {
+			return focusHyprland;
+		}
+		if (processEnv.SWAYSOCK != null || desktop.includes('sway')) {
+			return focusSway;
+		}
+		if (desktop.includes('kde')) {
+			return focusKde;
+		}
+	}
+
+	// X11 or fallback — xdotool works on X11 and sometimes under XWayland
+	return focusX11;
+}
+
+async function focusX11(pid: number): Promise<boolean> {
+	return run('xdotool', ['search', '--pid', String(pid), 'windowactivate']);
+}
+
+async function focusHyprland(pid: number): Promise<boolean> {
+	return run('hyprctl', ['dispatch', 'focuswindow', `pid:${pid}`]);
+}
+
+async function focusSway(pid: number): Promise<boolean> {
+	return run('swaymsg', [`[pid=${pid}]`, 'focus']);
+}
+
+async function focusKde(pid: number): Promise<boolean> {
+	return run('kdotool', ['windowactivate', '--pid', String(pid)]);
+}
+
+async function focusMacOS(pid: number): Promise<boolean> {
+	return run('osascript', [
+		'-e',
+		`tell application "System Events" to set frontmost of (first process whose unix id is ${pid}) to true`,
+	]);
+}
+
+async function focusWindows(pid: number): Promise<boolean> {
+	return run('powershell', [
+		'-NoProfile',
+		'-NonInteractive',
+		'-Command',
+		`(New-Object -ComObject WScript.Shell).AppActivate(${pid})`,
+	]);
+}
+
+async function getParentPid(pid: number): Promise<number | undefined> {
+	try {
+		let stdout: string;
+		if (platform === 'win32') {
+			stdout = await exec('wmic', ['process', 'where', `(ProcessId=${pid})`, 'get', 'ParentProcessId']);
+		} else {
+			stdout = await exec('ps', ['-o', 'ppid=', '-p', String(pid)]);
+		}
+
+		// wmic outputs a header line ("ParentProcessId") followed by the value;
+		// split on whitespace and parse the last non-empty token to skip the header.
+		const tokens = stdout.trim().split(/\s+/);
+		const parsed = parseInt(tokens.at(-1)!, 10);
+		if (isNaN(parsed) || parsed <= 1) return undefined;
+		return parsed;
+	} catch {
+		return undefined;
+	}
+}
+
+function run(command: string, args: string[]): Promise<boolean> {
+	return new Promise<boolean>(resolve => {
+		execFile(command, args, { timeout: 5000 }, (error: ExecFileException | null) => {
+			resolve(error == null);
+		});
+	});
+}
+
+function exec(command: string, args: string[]): Promise<string> {
+	return new Promise<string>((resolve, reject) => {
+		execFile(command, args, { timeout: 5000 }, (error: ExecFileException | null, stdout: string) => {
+			if (error != null) {
+				reject(error instanceof Error ? error : new Error(`exec failed: ${command}`));
+			} else {
+				resolve(stdout);
+			}
+		});
+	});
+}

--- a/src/env/node/gk/cli/integration.ts
+++ b/src/env/node/gk/cli/integration.ts
@@ -1,9 +1,11 @@
 import { mkdir, unlink, writeFile } from 'fs/promises';
 import { tmpdir } from 'os';
-import { join } from 'path';
+import { dirname, join } from 'path';
 import { arch, ppid } from 'process';
 import type { ConfigurationChangeEvent } from 'vscode';
 import { version as codeVersion, Disposable, env, ProgressLocation, Uri, window, workspace } from 'vscode';
+import type { IpcServer } from '@gitlens/agents/ipcServer.js';
+import { createIpcServer } from '@gitlens/agents/ipcServer.js';
 import { debug, trace } from '@gitlens/utils/decorators/log.js';
 import { Logger } from '@gitlens/utils/logger.js';
 import { formatLoggableScopeBlock, getScopedLogger } from '@gitlens/utils/logger.scoped.js';
@@ -22,14 +24,13 @@ import { getHostAppName, isHostVSCode } from '../../../../system/-webview/vscode
 import { gate } from '../../../../system/decorators/gate.js';
 import { getPlatform, isOffline, isWeb } from '../../platform.js';
 import { CliCommandHandlers } from './commands.js';
-import type { IpcServer } from './ipcServer.js';
-import { createIpcServer } from './ipcServer.js';
 import { showMcpAgentPicker } from './mcpAgentPicker.js';
 import type { McpAgent } from './mcpAgents.js';
 import {
 	extractZipFile,
 	getCLIExecutable,
 	getCLIVersions,
+	getDevCLILocalPath,
 	resolveCLIExecutable,
 	runCLICommand,
 	showManualMcpSetupPrompt,
@@ -121,8 +122,8 @@ export class GkCliIntegrationProvider implements Disposable {
 			}
 		}
 
-		// Reinstall CLI when insiders setting changes
-		if (e != null && configuration.changed(e, 'gitkraken.cli.insiders.enabled')) {
+		// Reinstall CLI when insiders setting changes (skip when using local CLI)
+		if (e != null && configuration.changed(e, 'gitkraken.cli.insiders.enabled') && getDevCLILocalPath() == null) {
 			const cliInstall = this.container.storage.getScoped('gk:cli:install');
 			if (cliInstall?.status === 'completed') {
 				// Force reinstall to switch between production and insiders
@@ -211,6 +212,12 @@ export class GkCliIntegrationProvider implements Disposable {
 	}
 
 	private async ensureUpdateOrInstall() {
+		if (getDevCLILocalPath() != null) {
+			Logger.info(`${formatLoggableScopeBlock('CLI')} Using local CLI binary — skipping auto-install/update`);
+			void setContext('gitlens:gk:cli:installed', true);
+			return;
+		}
+
 		let forceInstall = false;
 		const versionDidChange = this.container.version !== this.container.previousVersion;
 
@@ -499,6 +506,18 @@ export class GkCliIntegrationProvider implements Disposable {
 		force = false,
 	): Promise<{ cliVersion?: string; cliPath?: string; status: 'completed' | 'unsupported' | 'attempted' }> {
 		const scope = getScopedLogger();
+
+		const devLocalPath = getDevCLILocalPath();
+		if (devLocalPath != null) {
+			const resolved = await resolveCLIExecutable();
+			if (resolved != null) {
+				scope?.info(`Using local CLI binary: ${resolved.fsPath}`);
+				const versions = await getCLIVersions();
+				return { cliVersion: versions?.core, cliPath: dirname(resolved.fsPath), status: 'completed' };
+			}
+			scope?.warn(`Local CLI binary not found at: ${devLocalPath}`);
+			return { cliVersion: undefined, cliPath: undefined, status: 'attempted' };
+		}
 
 		const cliInstall = this.container.storage.getScoped('gk:cli:install');
 		let cliInstallAttempts = force ? 0 : (cliInstall?.attempts ?? 0);

--- a/src/env/node/gk/cli/utils.ts
+++ b/src/env/node/gk/cli/utils.ts
@@ -78,7 +78,17 @@ export async function extractZipFile(
 	}
 }
 
+export function getDevCLILocalPath(): string | undefined {
+	if (!Container.instance.debugging) return undefined;
+	return configuration.get('gitkraken.cli.localPath') ?? undefined;
+}
+
 export function getCLIExecutable(cliPath?: string | null): Uri {
+	const localPath = getDevCLILocalPath();
+	if (localPath != null) {
+		return Uri.file(localPath);
+	}
+
 	return joinUriPath(
 		Uri.file(cliPath ?? Container.instance.context.globalStorageUri.fsPath),
 		getPlatform() === 'windows' ? 'gk.exe' : 'gk',

--- a/src/env/node/providers.ts
+++ b/src/env/node/providers.ts
@@ -1,11 +1,14 @@
+import { basename, dirname, resolve } from 'path';
 import type { Disposable } from 'vscode';
 import { workspace } from 'vscode';
+import { ClaudeCodeProvider } from '@gitlens/agents/providers/claudeCodeProvider.js';
 import type { Cache } from '@gitlens/git/cache.js';
 import type { GitExecOptions, GitResult } from '@gitlens/git/exec.types.js';
 import type { GitProvider } from '@gitlens/git/providers/provider.js';
 import { Git } from '@gitlens/git-cli/exec/git.js';
 import { findGitPath } from '@gitlens/git-cli/exec/locator.js';
 import type { UnifiedDisposable } from '@gitlens/utils/disposable.js';
+import type { AgentSessionProvider } from '../../agents/provider.js';
 import type { Container } from '../../container.js';
 import type { GlGitProvider } from '../../git/gitProvider.js';
 import type { RepositoryLocationProvider } from '../../git/location/repositorylocationProvider.js';
@@ -22,6 +25,7 @@ import type { TelemetryService } from '../../telemetry/telemetry.js';
 import { GlCliGitProvider } from './git/cliGitProvider.js';
 import { VslsGitProvider } from './git/vslsGitProvider.js';
 import { GkCliIntegrationProvider } from './gk/cli/integration.js';
+import { runCLICommand } from './gk/cli/utils.js';
 import { LocalRepositoryLocationProvider } from './gk/localRepositoryLocationProvider.js';
 import { LocalSharedGkStorageLocationProvider } from './gk/localSharedGkStorageLocationProvider.js';
 import { LocalGkWorkspacesSharedStorageProvider } from './gk/localWorkspacesSharedStorageProvider.js';
@@ -107,6 +111,54 @@ export async function getMcpProviders(container: Container): Promise<Disposable[
 	}
 
 	return undefined;
+}
+
+export function getAgentSessionProviders(container: Container): AgentSessionProvider[] {
+	return [
+		new ClaudeCodeProvider({
+			onSessionStarted: provider =>
+				container.telemetry.sendEvent('agents/session/started', { 'agent.provider': provider }),
+			onSessionEnded: provider =>
+				container.telemetry.sendEvent('agents/session/ended', { 'agent.provider': provider }),
+			onPermissionResolved: info =>
+				container.telemetry.sendEvent('agents/permission/resolved', {
+					'agent.provider': info.provider,
+					'permission.tool': info.tool,
+					'permission.decision': info.decision,
+				}),
+			onBranchAgentActivity: cwd => {
+				const repo = container.git.getRepository(cwd);
+				if (repo != null) {
+					queueMicrotask(() => repo.git.branches.onCurrentBranchAgentActivity?.());
+				}
+			},
+			runCLICommand: (args, opts) => runCLICommand(args, opts),
+			resolveGitInfo: async cwd => {
+				const opts = { cwd: cwd, errors: 'ignore' as const, timeout: 5000 };
+				const [branchResult, toplevelResult, commonDirResult, gitDirResult] = await Promise.all([
+					git(container, opts, 'rev-parse', '--abbrev-ref', 'HEAD'),
+					git(container, opts, 'rev-parse', '--show-toplevel'),
+					git(container, opts, 'rev-parse', '--git-common-dir'),
+					git(container, opts, 'rev-parse', '--git-dir'),
+				]);
+
+				const branch = String(branchResult.stdout).trim() || undefined;
+				const toplevel = String(toplevelResult.stdout).trim() || undefined;
+				const commonDir = String(commonDirResult.stdout).trim() || undefined;
+				const gitDir = String(gitDirResult.stdout).trim() || undefined;
+
+				if (toplevel == null) return undefined;
+
+				const isWorktree = commonDir != null && gitDir != null && commonDir !== gitDir;
+				return {
+					branch: branch,
+					repoRoot: isWorktree && commonDir ? dirname(resolve(cwd, commonDir)) : toplevel,
+					isWorktree: isWorktree,
+					worktreeName: isWorktree ? basename(toplevel) : undefined,
+				};
+			},
+		}),
+	];
 }
 
 let _telemetryService: TelemetryService | undefined;

--- a/src/webviews/apps/home/__tests__/actions.test.ts
+++ b/src/webviews/apps/home/__tests__/actions.test.ts
@@ -84,6 +84,7 @@ suite('home actions', () => {
 				getWalkthroughProgress: async () => undefined,
 				getOverviewFilterState: async () => persisted,
 				setOverviewFilter: async () => filterRestore,
+				getAgentSessions: async () => [],
 			} as any,
 			{} as any,
 			{ getIntegrationStates: async () => [] } as any,

--- a/src/webviews/apps/home/__tests__/events.test.ts
+++ b/src/webviews/apps/home/__tests__/events.test.ts
@@ -33,6 +33,7 @@ suite('setupSubscriptions Test Suite', () => {
 					return () => {};
 				},
 				onFocusAccount: () => () => {},
+				onAgentSessionsChanged: () => () => {},
 			},
 			launchpad: {
 				onLaunchpadChanged: () => () => {},
@@ -79,6 +80,7 @@ suite('setupSubscriptions Test Suite', () => {
 			onFocusAccount: () => {},
 			onSubscriptionChanged: () => {},
 			refreshLaunchpad: () => {},
+			refreshAgentOverview: () => {},
 		} satisfies SubscriptionActions;
 
 		const unsubscribe = await setupSubscriptions(state, services, actions);
@@ -121,6 +123,7 @@ suite('setupSubscriptions Test Suite', () => {
 				},
 				onOverviewFilterChanged: () => () => {},
 				onFocusAccount: () => () => {},
+				onAgentSessionsChanged: () => () => {},
 			},
 			launchpad: {
 				onLaunchpadChanged: () => () => {},
@@ -159,6 +162,7 @@ suite('setupSubscriptions Test Suite', () => {
 			onFocusAccount: () => {},
 			onSubscriptionChanged: () => {},
 			refreshLaunchpad: () => {},
+			refreshAgentOverview: () => {},
 		} satisfies SubscriptionActions;
 
 		const unsubscribe = await setupSubscriptions(state, services, actions);

--- a/src/webviews/apps/home/actions.ts
+++ b/src/webviews/apps/home/actions.ts
@@ -111,6 +111,7 @@ export function populateInitialState(
 	// Secondary data: banners, filters, and content
 	// Note: repositories already set from getInitialContext() above; event-driven updates keep it fresh
 	void home.getWalkthroughProgress().then(w => state.onboarding.walkthroughProgress.set(w), noop);
+	void home.getAgentSessions().then(s => state.home.agentSessions.set(s), noop);
 	void ai.getState().then(s => state.ai.state.set(s), noop);
 	// Launchpad summary is deferred — fetched when GlLaunchpad mounts (connectedCallback)
 

--- a/src/webviews/apps/home/events.ts
+++ b/src/webviews/apps/home/events.ts
@@ -21,7 +21,7 @@
 import type { Remote } from '@eamodio/supertalk';
 import { Logger } from '@gitlens/utils/logger.js';
 import type { HomeServices, WalkthroughProgressState } from '../../home/homeService.js';
-import type { OverviewFilters } from '../../home/protocol.js';
+import type { AgentSessionState, OverviewFilters } from '../../home/protocol.js';
 import type {
 	AiModelInfo,
 	AIState,
@@ -66,6 +66,8 @@ export interface SubscriptionActions {
 	onSubscriptionChanged(): void;
 	/** Called when launchpad data should be refreshed. */
 	refreshLaunchpad(): void;
+	/** Called when agent overview branches should be refreshed. */
+	refreshAgentOverview(): void;
 }
 
 /**
@@ -195,6 +197,16 @@ export function setupSubscriptions(
 		() =>
 			services.launchpad.onLaunchpadChanged(() => {
 				actions.refreshLaunchpad();
+			}),
+
+		// ============================================================
+		// Agent sessions — from HomeViewService
+		// ============================================================
+
+		() =>
+			services.home.onAgentSessionsChanged((sessions: AgentSessionState[]) => {
+				state.home.agentSessions.set(sessions);
+				actions.refreshAgentOverview();
 			}),
 	]);
 }

--- a/src/webviews/apps/home/home.ts
+++ b/src/webviews/apps/home/home.ts
@@ -18,7 +18,11 @@ import type {
 	OverviewBranch,
 	OverviewFilters,
 } from '../../home/protocol.js';
-import { activeOverviewStateContext, inactiveOverviewStateContext } from '../plus/home/components/overviewState.js';
+import {
+	activeOverviewStateContext,
+	agentOverviewStateContext,
+	inactiveOverviewStateContext,
+} from '../plus/home/components/overviewState.js';
 import type { GlHomeHeader } from '../plus/shared/components/home-header.js';
 import { SignalWatcherWebviewApp } from '../shared/appBase.js';
 import { scrollableBase } from '../shared/components/styles/lit/base.css.js';
@@ -110,12 +114,14 @@ export class GlHomeApp extends SignalWatcherWebviewApp {
 	private _homeStateCtx?: ContextProvider<typeof homeStateContext>;
 	private _activeOverviewCtxProvider?: ContextProvider<typeof activeOverviewStateContext>;
 	private _inactiveOverviewCtxProvider?: ContextProvider<typeof inactiveOverviewStateContext>;
+	private _agentOverviewCtxProvider?: ContextProvider<typeof agentOverviewStateContext>;
 
 	/**
 	 * Resource-backed overview states (created in _onRpcReady).
 	 */
 	private _activeResource?: Resource<GetActiveOverviewResponse>;
 	private _inactiveResource?: Resource<GetInactiveOverviewResponse>;
+	private _agentResource?: Resource<GetInactiveOverviewResponse>;
 	private _inactiveFilter?: Partial<OverviewFilters>;
 	private readonly _refreshOverviewDebounced = debounce(() => {
 		void this._activeResource?.fetch();
@@ -179,6 +185,9 @@ export class GlHomeApp extends SignalWatcherWebviewApp {
 		this._inactiveOverviewCtxProvider = new ContextProvider(this, {
 			context: inactiveOverviewStateContext,
 		});
+		this._agentOverviewCtxProvider = new ContextProvider(this, {
+			context: agentOverviewStateContext,
+		});
 	}
 
 	override disconnectedCallback(): void {
@@ -200,8 +209,10 @@ export class GlHomeApp extends SignalWatcherWebviewApp {
 		this._refreshOverviewDebounced.cancel();
 		this._activeResource?.dispose();
 		this._inactiveResource?.dispose();
+		this._agentResource?.dispose();
 		this._activeResource = undefined;
 		this._inactiveResource = undefined;
+		this._agentResource = undefined;
 		this._inactiveFilter = undefined;
 
 		// Reset all domain states
@@ -388,8 +399,27 @@ export class GlHomeApp extends SignalWatcherWebviewApp {
 		});
 		const inactiveFilter = signalObject<Partial<OverviewFilters>>({});
 
+		const agentResource = createResource<GetInactiveOverviewResponse>(async signal => {
+			const branches = await home.getOverviewBranches('agents', signal);
+			if (branches == null) return undefined;
+			syncOverviewRepositoryPath(branches.repository.path);
+
+			const allIds = branches.recent.map(b => b.id);
+			const wipIds = branches.recent.filter(b => b.worktree != null).map(b => b.id);
+
+			const emptyWip = Promise.resolve<GetOverviewWipResponse>({});
+			const wipPromise = wipIds.length > 0 ? home.getOverviewWip(wipIds, signal) : emptyWip;
+			const enrichmentPromise = home.getOverviewEnrichment(allIds, signal);
+
+			return {
+				repository: branches.repository,
+				recent: branches.recent.map(s => buildBranchProgressive(s, wipPromise, enrichmentPromise)),
+			};
+		});
+
 		this._activeResource = activeResource;
 		this._inactiveResource = inactiveResource;
+		this._agentResource = agentResource;
 		this._inactiveFilter = inactiveFilter;
 
 		this._activeOverviewCtxProvider?.setValue(
@@ -409,6 +439,15 @@ export class GlHomeApp extends SignalWatcherWebviewApp {
 				error: inactiveResource.error,
 				filter: inactiveFilter,
 				fetch: () => void inactiveResource.fetch(),
+			},
+			true,
+		);
+		this._agentOverviewCtxProvider?.setValue(
+			{
+				value: agentResource.value,
+				loading: agentResource.loading,
+				error: agentResource.error,
+				fetch: () => void agentResource.fetch(),
 			},
 			true,
 		);
@@ -461,8 +500,10 @@ export class GlHomeApp extends SignalWatcherWebviewApp {
 			this._refreshOverviewDebounced.cancel();
 			this._activeResource?.cancel();
 			this._inactiveResource?.cancel();
+			this._agentResource?.cancel();
 			void this._activeResource?.fetch();
 			void this._inactiveResource?.fetch();
+			void this._agentResource?.fetch();
 			// Re-subscribe FS watcher for the (possibly new) overview repo
 			watchWipForRepo(this._homeState.overviewRepositoryPath.get());
 		};
@@ -488,6 +529,9 @@ export class GlHomeApp extends SignalWatcherWebviewApp {
 				if (launchpad != null) {
 					void fetchLaunchpadSummary(root.launchpad, launchpad);
 				}
+			},
+			refreshAgentOverview: () => {
+				void this._agentResource?.fetch();
 			},
 		};
 		this._unsubscribeEvents = await phaseTimeout(
@@ -519,11 +563,13 @@ export class GlHomeApp extends SignalWatcherWebviewApp {
 				this._refreshOverviewDebounced.cancel();
 				this._activeResource?.cancel();
 				this._inactiveResource?.cancel();
+				this._agentResource?.cancel();
 				return;
 			}
 
 			// Visibility restored — refresh overview and launchpad
 			this._refreshOverviewDebounced();
+			void this._agentResource?.fetch();
 			if (launchpad != null) {
 				void fetchLaunchpadSummary(root.launchpad, launchpad);
 			}

--- a/src/webviews/apps/home/state.ts
+++ b/src/webviews/apps/home/state.ts
@@ -20,7 +20,7 @@
 import type { Remote } from '@eamodio/supertalk';
 import { createContext } from '@lit/context';
 import type { HomeServices } from '../../home/homeService.js';
-import type { OverviewFilters } from '../../home/protocol.js';
+import type { AgentSessionState, OverviewFilters } from '../../home/protocol.js';
 import type { RepositoriesState } from '../../rpc/services/types.js';
 import type { AIContextState } from '../shared/contexts/ai.js';
 import type { CommandsState } from '../shared/contexts/commands.js';
@@ -78,6 +78,8 @@ export function createHomeState(storage?: HostStorage) {
 		newInstall: signal(false),
 		/** Host application name. */
 		hostAppName: signal(''),
+		/** Active agent sessions. */
+		agentSessions: signal<AgentSessionState[]>([]),
 
 		/** Resolved `home` sub-service from RPC. Available after RPC connection. Set once, not reactive. */
 		homeService: undefined as ResolvedHome | undefined,

--- a/src/webviews/apps/plus/home/components/agent-session-card.ts
+++ b/src/webviews/apps/plus/home/components/agent-session-card.ts
@@ -1,0 +1,176 @@
+import { css, html, LitElement, nothing } from 'lit';
+import { customElement, property } from 'lit/decorators.js';
+import type { AgentSessionState } from '../../../../home/protocol.js';
+import '../../../shared/components/card/card.js';
+import '../../../shared/components/code-icon.js';
+import '../../../shared/components/pills/agent-status-pill.js';
+
+export const agentSessionCardTagName = 'gl-agent-session-card';
+
+@customElement(agentSessionCardTagName)
+export class GlAgentSessionCard extends LitElement {
+	static override styles = [
+		css`
+			:host {
+				display: block;
+			}
+
+			.content {
+				display: flex;
+				flex-direction: column;
+				gap: 0.4rem;
+				padding: 0.4rem 0;
+			}
+
+			.header {
+				display: inline-flex;
+				align-items: center;
+				gap: 0.6rem;
+				max-width: 100%;
+				margin-block: 0;
+			}
+
+			.header__icon {
+				color: var(--vscode-descriptionForeground);
+				flex: none;
+			}
+
+			.header__name {
+				flex: 1;
+				min-width: 0;
+				white-space: nowrap;
+				overflow: hidden;
+				text-overflow: ellipsis;
+				font-weight: bold;
+			}
+
+			.details {
+				display: flex;
+				flex-direction: column;
+				gap: 0.2rem;
+				font-size: 0.9em;
+				color: var(--vscode-descriptionForeground);
+			}
+
+			.detail {
+				display: inline-flex;
+				align-items: center;
+				gap: 0.4rem;
+			}
+
+			.sessions {
+				display: flex;
+				flex-direction: column;
+				gap: 0.4rem;
+			}
+
+			.session {
+				display: flex;
+				flex-direction: row;
+				align-items: center;
+				gap: 0.4rem;
+				flex-wrap: wrap;
+			}
+
+			.session code-icon {
+				color: var(--vscode-descriptionForeground);
+			}
+
+			.session__name {
+				color: var(--vscode-descriptionForeground);
+				font-size: 0.9em;
+			}
+
+			.session__subagents {
+				color: var(--vscode-descriptionForeground);
+			}
+		`,
+	];
+
+	@property()
+	label!: string;
+
+	@property()
+	labelTitle = '';
+
+	@property()
+	labelType: 'workspace' | 'cwd' = 'workspace';
+
+	@property({ type: Array })
+	sessions!: AgentSessionState[];
+
+	override render(): unknown {
+		if (this.sessions.length === 0) return nothing;
+
+		return html`
+			<gl-card>
+				<div class="content">
+					<p class="header">
+						<span class="header__icon"
+							><code-icon
+								icon=${this.labelType === 'workspace' ? 'folder-library' : 'folder'}
+								title=${this.labelType === 'workspace' ? 'Workspace' : 'Working Directory'}
+							></code-icon
+						></span>
+						<span class="header__name" title=${this.labelTitle}>${this.label}</span>
+					</p>
+					${this.renderDetails()}
+					<div class="sessions">${this.sessions.map(s => this.renderSession(s))}</div>
+				</div>
+			</gl-card>
+		`;
+	}
+
+	private renderDetails(): unknown {
+		const branches = new Set<string>();
+		const worktrees = new Map<string, string | undefined>();
+		for (const s of this.sessions) {
+			if (s.branch != null) {
+				branches.add(s.branch);
+			}
+			if (s.worktreeName != null && !worktrees.has(s.worktreeName)) {
+				worktrees.set(s.worktreeName, s.cwd);
+			}
+		}
+
+		if (branches.size === 0 && worktrees.size === 0) return nothing;
+
+		return html`
+			<div class="details">
+				${Array.from(
+					branches,
+					b => html`<span class="detail"><code-icon icon="git-branch" title="Branch"></code-icon>${b}</span>`,
+				)}
+				${Array.from(
+					worktrees,
+					([w, cwd]) =>
+						html`<span class="detail" title=${cwd ?? w}
+							><code-icon icon="folder-opened" title="Worktree"></code-icon>${w}</span
+						>`,
+				)}
+			</div>
+		`;
+	}
+
+	private renderSession(session: AgentSessionState): unknown {
+		return html`
+			<div class="session">
+				<code-icon icon="hubot" title="Agent"></code-icon>
+				<gl-agent-status-pill .session=${session}></gl-agent-status-pill>
+				<span class="session__name">${session.name}</span>
+				${session.subagentCount > 0
+					? html`<span class="session__subagents">
+							<code-icon icon="organization" title="Subagents"></code-icon>
+							${session.subagentCount}
+						</span>`
+					: nothing}
+			</div>
+		`;
+	}
+}
+
+declare global {
+	interface HTMLElementTagNameMap {
+		[agentSessionCardTagName]: GlAgentSessionCard;
+	}
+}

--- a/src/webviews/apps/plus/home/components/agent-status.ts
+++ b/src/webviews/apps/plus/home/components/agent-status.ts
@@ -1,0 +1,147 @@
+import { consume } from '@lit/context';
+import { SignalWatcher } from '@lit-labs/signals';
+import { css, html, LitElement, nothing } from 'lit';
+import { customElement, state } from 'lit/decorators.js';
+import { basename } from '@gitlens/utils/path.js';
+import type { AgentSessionState } from '../../../../home/protocol.js';
+import type { HomeState } from '../../../home/state.js';
+import { homeStateContext } from '../../../home/state.js';
+import '../../../shared/components/code-icon.js';
+import '../../../shared/components/pills/agent-status-pill.js';
+import './branch-section.js';
+
+@customElement('gl-agent-status')
+export class GlAgentStatus extends SignalWatcher(LitElement) {
+	static override styles = [
+		css`
+			:host {
+				display: block;
+				margin-bottom: 2.4rem;
+			}
+
+			.workspace-group {
+				margin-block-start: 0.4rem;
+			}
+
+			.workspace-group__label {
+				margin-block: 0 0.2rem;
+				font-size: 0.9em;
+				font-weight: 600;
+				color: var(--vscode-descriptionForeground);
+			}
+
+			.sessions {
+				display: flex;
+				flex-direction: column;
+				gap: 0.2rem;
+			}
+
+			.session {
+				display: flex;
+				align-items: center;
+				gap: 0.6rem;
+				margin-block: 0;
+			}
+
+			.session__name {
+				flex: 1;
+				min-width: 0;
+				white-space: nowrap;
+				overflow: hidden;
+				text-overflow: ellipsis;
+				color: var(--vscode-foreground);
+			}
+
+			.session__subagents {
+				flex: none;
+				color: var(--vscode-descriptionForeground);
+			}
+
+			.session__context {
+				flex: none;
+				color: var(--vscode-descriptionForeground);
+				font-size: 0.9em;
+				white-space: nowrap;
+				overflow: hidden;
+				text-overflow: ellipsis;
+			}
+		`,
+	];
+
+	@consume({ context: homeStateContext })
+	@state()
+	private _homeState!: HomeState;
+
+	override render(): unknown {
+		const sessions = this._homeState.agentSessions.get();
+		if (sessions == null || sessions.length === 0) return nothing;
+
+		// Group sessions by full workspace path to avoid collisions between
+		// identically-named folders; display only the basename as the label.
+		const groups = new Map<string, AgentSessionState[]>();
+		for (const session of sessions) {
+			const key = session.workspacePath ?? 'unknown';
+			let group = groups.get(key);
+			if (group == null) {
+				group = [];
+				groups.set(key, group);
+			}
+			group.push(session);
+		}
+
+		return html`
+			<gl-section>
+				<span slot="heading">AI Agents</span>
+				${Array.from(
+					groups,
+					([key, sessions]) => html`
+						<div class="workspace-group">
+							<p class="workspace-group__label" title=${key !== 'unknown' ? key : ''}>
+								${key !== 'unknown' ? basename(key) : 'Unknown workspace'}
+							</p>
+							<div class="sessions">${sessions.map(s => this.renderSession(s))}</div>
+						</div>
+					`,
+				)}
+			</gl-section>
+		`;
+	}
+
+	private getSessionContext(session: AgentSessionState): { text: string; tooltip?: string } | undefined {
+		const parts: string[] = [];
+		if (session.branch != null) {
+			parts.push(session.branch);
+		}
+		if (session.worktreeName != null) {
+			parts.push(`worktree: ${session.worktreeName}`);
+		}
+		if (parts.length === 0) return undefined;
+
+		return {
+			text: parts.join(' · '),
+			tooltip: session.worktreeName != null ? session.cwd : undefined,
+		};
+	}
+
+	private renderSession(session: AgentSessionState): unknown {
+		const context = this.getSessionContext(session);
+
+		return html`
+			<div class="session">
+				<gl-agent-status-pill .session=${session}></gl-agent-status-pill>
+				<span class="session__name">${session.name}</span>
+				${context != null
+					? html`<span class="session__context" title=${context.tooltip ?? context.text}
+							>${context.text}</span
+						>`
+					: nothing}
+				${session.subagentCount > 0
+					? html`<span class="session__subagents">
+							<code-icon icon="organization"></code-icon>
+							${session.subagentCount}
+						</span>`
+					: nothing}
+			</div>
+		`;
+	}
+}

--- a/src/webviews/apps/plus/home/components/branch-card.ts
+++ b/src/webviews/apps/plus/home/components/branch-card.ts
@@ -16,6 +16,7 @@ import {
 } from '../../../../../plus/launchpad/models/launchpad.js';
 import { createCommandLink } from '../../../../../system/commands.js';
 import type {
+	AgentSessionState,
 	BranchRef,
 	CreatePullRequestCommandArgs,
 	GetOverviewBranch,
@@ -23,6 +24,8 @@ import type {
 	OpenInTimelineParams,
 	OpenWorktreeCommandArgs,
 } from '../../../../home/protocol.js';
+import type { HomeState } from '../../../home/state.js';
+import { homeStateContext } from '../../../home/state.js';
 import { renderBranchName } from '../../../shared/components/branch-name.js';
 import type { GlCard } from '../../../shared/components/card/card.js';
 import { GlElement, observe } from '../../../shared/components/element.js';
@@ -47,6 +50,7 @@ import '../../../shared/components/actions/action-item.js';
 import '../../../shared/components/actions/action-nav.js';
 import '../../../shared/components/branch-icon.js';
 import '../../shared/components/merge-target-status.js';
+import '../../../shared/components/pills/agent-status-pill.js';
 
 export const branchCardStyles = css`
 	* {
@@ -127,6 +131,18 @@ export const branchCardStyles = css`
 		gap: 0.6rem;
 		max-width: 100%;
 		margin-block: 0;
+	}
+
+	.branch-item__agents {
+		display: flex;
+		flex-direction: row;
+		align-items: center;
+		gap: 0.4rem;
+		flex-wrap: wrap;
+	}
+
+	.branch-item__agents code-icon {
+		color: var(--vscode-descriptionForeground);
 	}
 
 	.branch-item__changes {
@@ -272,6 +288,9 @@ export abstract class GlBranchCardBase extends SignalWatcherGlElement {
 
 	@consume({ context: webviewContext })
 	protected _webview!: WebviewContext;
+
+	@consume({ context: homeStateContext })
+	private _homeState!: HomeState;
 
 	@property()
 	repo!: string;
@@ -791,6 +810,7 @@ export abstract class GlBranchCardBase extends SignalWatcherGlElement {
 						</div>
 					`,
 				)}
+				${this.renderAgentPillsRow()}
 				${when(
 					// TODO: this doesn't work properly. nothing is true, empty html template is true
 					actionsSection || mergeTargetStatus,
@@ -816,6 +836,36 @@ export abstract class GlBranchCardBase extends SignalWatcherGlElement {
 			?worktree=${this.branch.worktree != null}
 			?is-default=${this.branch.worktree?.isDefault ?? false}
 		></gl-branch-icon>`;
+	}
+
+	private getMatchingAgentSessions(): AgentSessionState[] {
+		const sessions = this._homeState?.agentSessions?.get();
+		if (sessions == null || sessions.length === 0) return [];
+
+		const branchName = this.branch.name;
+		const repoPath = this.repo;
+		return sessions.filter(session => {
+			if (session.branch !== branchName) return false;
+			if (session.workspacePath !== repoPath) return false;
+			// If both the session and the branch card have worktree info, cross-check
+			if (session.worktreeName != null && this.branch.worktree != null) {
+				const worktreeBasename = this.branch.worktree.uri.split('/').pop() ?? '';
+				if (session.worktreeName !== worktreeBasename) return false;
+			}
+			return true;
+		});
+	}
+
+	private renderAgentPillsRow(): TemplateResult | NothingType {
+		const sessions = this.getMatchingAgentSessions();
+		if (sessions.length === 0) return nothing;
+
+		return html`
+			<div class="branch-item__agents">
+				<code-icon icon="hubot"></code-icon>
+				${sessions.map(s => html`<gl-agent-status-pill .session=${s}></gl-agent-status-pill>`)}
+			</div>
+		`;
 	}
 
 	protected renderPrItem(): TemplateResult | NothingType {

--- a/src/webviews/apps/plus/home/components/overview.ts
+++ b/src/webviews/apps/plus/home/components/overview.ts
@@ -1,27 +1,66 @@
 import { consume } from '@lit/context';
 import { SignalWatcher } from '@lit-labs/signals';
 import { css, html, LitElement, nothing } from 'lit';
-import { customElement } from 'lit/decorators.js';
+import { customElement, state } from 'lit/decorators.js';
 import { when } from 'lit/directives/when.js';
-import type { GetInactiveOverviewResponse, OverviewRecentThreshold } from '../../../../home/protocol.js';
+import { basename } from '@gitlens/utils/path.js';
+import type {
+	AgentSessionState,
+	GetInactiveOverviewResponse,
+	GetOverviewBranch,
+	OverviewRecentThreshold,
+} from '../../../../home/protocol.js';
 import type { HomeState } from '../../../home/state.js';
 import { homeStateContext } from '../../../home/state.js';
 import { linkStyles } from '../../shared/components/vscode.css.js';
-import type { InactiveOverviewState } from './overviewState.js';
-import { inactiveOverviewStateContext } from './overviewState.js';
+import { selectStyles } from './branch-threshold-filter.js';
+import type { AgentOverviewState, InactiveOverviewState } from './overviewState.js';
+import { agentOverviewStateContext, inactiveOverviewStateContext } from './overviewState.js';
 import '../../../shared/components/skeleton-loader.js';
-import './branch-threshold-filter.js';
+import './agent-session-card.js';
+import './branch-section.js';
 
 export const overviewTagName = 'gl-overview';
+
+type OverviewTab = 'recent' | 'agents';
+type AgentFilter = 'workspace' | 'all';
 
 @customElement(overviewTagName)
 export class GlOverview extends SignalWatcher(LitElement) {
 	static override styles = [
 		linkStyles,
+		selectStyles,
 		css`
 			:host {
 				display: block;
 				margin-bottom: 2.4rem;
+				color: var(--vscode-foreground);
+			}
+
+			.tabs {
+				display: inline-flex;
+				gap: 0.6rem;
+			}
+
+			.tab {
+				appearance: none;
+				background: none;
+				border: none;
+				padding: 0;
+				margin: 0;
+				cursor: pointer;
+				font-family: inherit;
+				font-size: inherit;
+				font-weight: normal;
+				text-transform: uppercase;
+				color: var(--vscode-descriptionForeground);
+			}
+
+			.tab:hover {
+				color: var(--vscode-foreground);
+			}
+
+			.tab[aria-selected='true'] {
 				color: var(--vscode-foreground);
 			}
 		`,
@@ -32,6 +71,15 @@ export class GlOverview extends SignalWatcher(LitElement) {
 
 	@consume({ context: inactiveOverviewStateContext })
 	private _inactiveOverviewState!: InactiveOverviewState;
+
+	@consume({ context: agentOverviewStateContext })
+	private _agentOverviewState!: AgentOverviewState;
+
+	@state()
+	private _activeTab: OverviewTab = 'recent';
+
+	@state()
+	private _agentFilter: AgentFilter = 'workspace';
 
 	override connectedCallback(): void {
 		super.connectedCallback?.();
@@ -50,6 +98,54 @@ export class GlOverview extends SignalWatcher(LitElement) {
 			return nothing;
 		}
 
+		const hasAgents = (this._homeCtx.agentSessions.get()?.length ?? 0) > 0;
+
+		// When no agents, render original behavior with gl-branch-section
+		if (!hasAgents) {
+			return this.renderRecentOnly();
+		}
+
+		if (this._activeTab === 'agents') {
+			return this.renderAgentsTab();
+		}
+
+		return this.renderRecentTab();
+	}
+
+	// ── Tab switching ──
+
+	private renderTabs() {
+		return html`<div class="tabs" slot="heading" role="tablist">
+			<button
+				class="tab"
+				role="tab"
+				aria-selected=${this._activeTab === 'recent'}
+				@click=${() => this.switchTab('recent')}
+			>
+				Recent
+			</button>
+			<button
+				class="tab"
+				role="tab"
+				aria-selected=${this._activeTab === 'agents'}
+				@click=${() => this.switchTab('agents')}
+			>
+				Agents
+			</button>
+		</div>`;
+	}
+
+	private switchTab(tab: OverviewTab): void {
+		if (this._activeTab === tab) return;
+		this._activeTab = tab;
+		if (tab === 'agents') {
+			this._agentOverviewState.fetch();
+		}
+	}
+
+	// ── Recent (no agents, original behavior) ──
+
+	private renderRecentOnly() {
 		if (this._inactiveOverviewState.error.get() != null) {
 			return html`
 				<gl-section>
@@ -74,29 +170,10 @@ export class GlOverview extends SignalWatcher(LitElement) {
 			return this.renderLoader();
 		}
 
-		return this.renderComplete(overview, this._inactiveOverviewState.loading.get());
+		return this.renderRecentOnlyComplete(overview, this._inactiveOverviewState.loading.get());
 	}
 
-	private renderLoader() {
-		return html`
-			<gl-section>
-				<skeleton-loader slot="heading" lines="1"></skeleton-loader>
-				<skeleton-loader lines="3"></skeleton-loader>
-			</gl-section>
-		`;
-	}
-
-	private readonly onChangeRecentThresholdFilter = (e: CustomEvent<{ threshold: OverviewRecentThreshold }>) => {
-		if (!this._inactiveOverviewState.filter.stale || !this._inactiveOverviewState.filter.recent) {
-			return;
-		}
-		void this._homeCtx.homeService?.setOverviewFilter({
-			stale: this._inactiveOverviewState.filter.stale,
-			recent: { ...this._inactiveOverviewState.filter.recent, threshold: e.detail.threshold },
-		});
-	};
-
-	private renderComplete(overview: GetInactiveOverviewResponse, isFetching = false) {
+	private renderRecentOnlyComplete(overview: GetInactiveOverviewResponse, isFetching = false) {
 		if (overview == null) return nothing;
 		const { repository } = overview;
 		return html`
@@ -131,6 +208,220 @@ export class GlOverview extends SignalWatcher(LitElement) {
 					></gl-branch-section>
 				`,
 			)}
+		`;
+	}
+
+	private readonly onChangeRecentThresholdFilter = (e: CustomEvent<{ threshold: OverviewRecentThreshold }>) => {
+		if (!this._inactiveOverviewState.filter.stale || !this._inactiveOverviewState.filter.recent) {
+			return;
+		}
+		void this._homeCtx.homeService?.setOverviewFilter({
+			stale: this._inactiveOverviewState.filter.stale,
+			recent: { ...this._inactiveOverviewState.filter.recent, threshold: e.detail.threshold },
+		});
+	};
+
+	// ── Recent tab (with agents dropdown) ──
+
+	private renderRecentTab() {
+		if (this._inactiveOverviewState.error.get() != null) {
+			return html`
+				<gl-section>
+					${this.renderTabs()}
+					<span
+						>Unable to load branch data.
+						<a
+							href="#"
+							@click=${(e: Event) => {
+								e.preventDefault();
+								this._inactiveOverviewState.fetch();
+							}}
+							>Retry</a
+						>
+					</span>
+				</gl-section>
+			`;
+		}
+
+		const overview = this._inactiveOverviewState.value.get();
+		if (overview == null) {
+			return this.renderLoader();
+		}
+
+		return this.renderRecentTabComplete(overview, this._inactiveOverviewState.loading.get());
+	}
+
+	private renderRecentTabComplete(overview: GetInactiveOverviewResponse, isFetching = false) {
+		if (overview == null) return nothing;
+		const { repository } = overview;
+		return html`
+			<gl-section ?loading=${isFetching}>
+				${this.renderTabs()}
+				<gl-branch-threshold-filter
+					slot="heading-actions"
+					@gl-change=${this.onChangeRecentThresholdFilter}
+					.options=${[
+						{ value: 'OneDay', label: '1 day' },
+						{ value: 'OneWeek', label: '1 week' },
+						{ value: 'OneMonth', label: '1 month' },
+					] satisfies {
+						value: OverviewRecentThreshold;
+						label: string;
+					}[]}
+					.disabled=${isFetching}
+					.value=${this._inactiveOverviewState.filter.recent?.threshold}
+				></gl-branch-threshold-filter>
+				${this.renderBranchCards(overview.recent, repository.path)}
+			</gl-section>
+			${when(
+				this._inactiveOverviewState.filter.stale?.show === true && overview.stale,
+				() => html`
+					<gl-branch-section
+						label="stale"
+						.repo=${repository.path}
+						.branches=${overview.stale!}
+					></gl-branch-section>
+				`,
+			)}
+		`;
+	}
+
+	// ── Agents tab ──
+
+	private renderAgentsTab() {
+		if (this._agentOverviewState.error.get() != null) {
+			return html`
+				<gl-section>
+					${this.renderTabs()}
+					<span
+						>Unable to load agent branch data.
+						<a
+							href="#"
+							@click=${(e: Event) => {
+								e.preventDefault();
+								this._agentOverviewState.fetch();
+							}}
+							>Retry</a
+						>
+					</span>
+				</gl-section>
+			`;
+		}
+
+		const overview = this._agentOverviewState.value.get();
+		if (overview == null) {
+			return this.renderLoader();
+		}
+
+		return this.renderAgentsTabComplete(overview, this._agentOverviewState.loading.get());
+	}
+
+	private renderAgentsTabComplete(overview: GetInactiveOverviewResponse, isFetching = false) {
+		if (overview == null) return nothing;
+		const { repository } = overview;
+		const branches = this.filterAgentBranches(overview.recent, repository.path);
+		const unrepresentedSessions =
+			this._agentFilter === 'all' ? this.getUnrepresentedAgentSessions(branches, repository.path) : [];
+
+		return html`
+			<gl-section ?loading=${isFetching}>
+				${this.renderTabs()}
+				<select
+					slot="heading-actions"
+					class="select"
+					.value=${this._agentFilter}
+					@change=${this.onAgentFilterChange}
+				>
+					<option value="workspace" ?selected=${this._agentFilter === 'workspace'}>workspace</option>
+					<option value="all" ?selected=${this._agentFilter === 'all'}>all</option>
+				</select>
+				${branches.length > 0 || unrepresentedSessions.length > 0
+					? html`${branches.length > 0
+							? this.renderBranchCards(branches, repository.path)
+							: nothing}${this.renderAgentSessionCards(unrepresentedSessions)}`
+					: html`<p>No agent sessions</p>`}
+			</gl-section>
+		`;
+	}
+
+	private readonly onAgentFilterChange = (e: Event) => {
+		this._agentFilter = (e.target as HTMLSelectElement).value as AgentFilter;
+	};
+
+	private filterAgentBranches(branches: GetOverviewBranch[], repoPath: string): GetOverviewBranch[] {
+		if (this._agentFilter === 'all') return branches;
+
+		const sessions = this._homeCtx.agentSessions.get() ?? [];
+		const workspaceBranches = new Set<string>();
+		for (const session of sessions) {
+			if (session.branch != null && session.workspacePath === repoPath) {
+				workspaceBranches.add(session.branch);
+			}
+		}
+
+		return branches.filter(b => workspaceBranches.has(b.name));
+	}
+
+	private getUnrepresentedAgentSessions(
+		renderedBranches: GetOverviewBranch[],
+		repoPath: string,
+	): AgentSessionState[] {
+		const sessions = this._homeCtx.agentSessions.get() ?? [];
+		if (sessions.length === 0) return [];
+
+		const renderedBranchNames = new Set(renderedBranches.map(b => b.name));
+		return sessions.filter(s => {
+			if (s.branch == null) return true;
+			if (s.workspacePath !== repoPath) return true;
+			return !renderedBranchNames.has(s.branch);
+		});
+	}
+
+	private renderAgentSessionCards(sessions: AgentSessionState[]): unknown {
+		if (sessions.length === 0) return nothing;
+
+		const groups = new Map<string, AgentSessionState[]>();
+		for (const session of sessions) {
+			const key = session.workspacePath || session.cwd || 'unknown';
+			let group = groups.get(key);
+			if (group == null) {
+				group = [];
+				groups.set(key, group);
+			}
+			group.push(session);
+		}
+
+		return html`${Array.from(
+			groups,
+			([key, groupSessions]) => html`
+				<gl-agent-session-card
+					.label=${key !== 'unknown' ? basename(key) : 'Unknown'}
+					.labelTitle=${key !== 'unknown' ? key : ''}
+					.labelType=${groupSessions[0].workspacePath ? 'workspace' : 'cwd'}
+					.sessions=${groupSessions}
+				></gl-agent-session-card>
+			`,
+		)}`;
+	}
+
+	// ── Shared ──
+
+	private renderBranchCards(branches: GetOverviewBranch[], repo: string) {
+		if (branches.length === 0) {
+			return html`<p>No branches</p>`;
+		}
+
+		return branches.map(
+			branch => html`<gl-branch-card expandable .repo=${repo} .branch=${branch}></gl-branch-card>`,
+		);
+	}
+
+	private renderLoader() {
+		return html`
+			<gl-section>
+				<skeleton-loader slot="heading" lines="1"></skeleton-loader>
+				<skeleton-loader lines="3"></skeleton-loader>
+			</gl-section>
 		`;
 	}
 }

--- a/src/webviews/apps/plus/home/components/overviewState.ts
+++ b/src/webviews/apps/plus/home/components/overviewState.ts
@@ -33,5 +33,17 @@ export interface InactiveOverviewState {
 	fetch(): void;
 }
 
+/**
+ * Interface for the agent overview state consumed by child components via Lit context.
+ * Backed by a Resource in home.ts. Shows branches with active agent sessions.
+ */
+export interface AgentOverviewState {
+	readonly value: ReadableSignal<InactiveOverview>;
+	readonly loading: ReadableSignal<boolean>;
+	readonly error: ReadableSignal<string | undefined>;
+	fetch(): void;
+}
+
 export const activeOverviewStateContext = createContext<ActiveOverviewState>('activeOverviewState');
 export const inactiveOverviewStateContext = createContext<InactiveOverviewState>('inactiveOverviewState');
+export const agentOverviewStateContext = createContext<AgentOverviewState>('agentOverviewState');

--- a/src/webviews/apps/shared/components/pills/agent-status-pill.ts
+++ b/src/webviews/apps/shared/components/pills/agent-status-pill.ts
@@ -1,0 +1,436 @@
+import { css, html, LitElement, nothing } from 'lit';
+import { customElement, property } from 'lit/decorators.js';
+import type { AgentSessionPhase } from '../../../../../agents/provider.js';
+import { createCommandLink } from '../../../../../system/commands.js';
+import type { AgentSessionState } from '../../../../home/protocol.js';
+import { elementBase, linkBase } from '../styles/lit/base.css.js';
+import '../button.js';
+import '../code-icon.js';
+import '../overlays/popover.js';
+
+type AgentPillCategory = 'working' | 'needs-input' | 'idle';
+
+const phaseCategories: Record<AgentSessionPhase, AgentPillCategory> = {
+	working: 'working',
+	waiting: 'needs-input',
+	idle: 'idle',
+};
+
+const categoryLabels: Record<AgentPillCategory, string> = {
+	working: 'Working',
+	'needs-input': 'Needs Input',
+	idle: 'Idle',
+};
+
+function formatElapsed(timestamp: number | undefined): string | undefined {
+	if (timestamp == null) return undefined;
+
+	const seconds = Math.floor((Date.now() - timestamp) / 1000);
+	if (seconds < 60) return `${seconds}s`;
+
+	const minutes = Math.floor(seconds / 60);
+	const remainingSeconds = seconds % 60;
+	if (minutes < 60) return `${minutes}m ${remainingSeconds}s`;
+
+	const hours = Math.floor(minutes / 60);
+	const remainingMinutes = minutes % 60;
+	return `${hours}h ${remainingMinutes}m`;
+}
+
+declare global {
+	interface HTMLElementTagNameMap {
+		'gl-agent-status-pill': GlAgentStatusPill;
+	}
+}
+
+@customElement('gl-agent-status-pill')
+export class GlAgentStatusPill extends LitElement {
+	static override styles = [
+		elementBase,
+		linkBase,
+		css`
+			:host {
+				display: inline-block;
+				--max-width: 30rem;
+
+				/* Working (blue) */
+				--gl-agent-pill-working-color: var(--vscode-progressBar-background);
+				--gl-agent-pill-working-bg: color-mix(in srgb, var(--gl-agent-pill-working-color) 10%, transparent);
+				--gl-agent-pill-working-border: color-mix(in srgb, var(--gl-agent-pill-working-color) 50%, transparent);
+
+				/* Needs Input (amber/warning) */
+				--gl-agent-pill-attention-color: var(--vscode-editorWarning-foreground);
+				--gl-agent-pill-attention-bg: color-mix(in srgb, var(--gl-agent-pill-attention-color) 10%, transparent);
+				--gl-agent-pill-attention-border: color-mix(
+					in srgb,
+					var(--gl-agent-pill-attention-color) 50%,
+					transparent
+				);
+
+				/* Idle (muted) */
+				--gl-agent-pill-idle-color: var(--vscode-descriptionForeground);
+				--gl-agent-pill-idle-bg: color-mix(in srgb, var(--gl-agent-pill-idle-color) 10%, transparent);
+				--gl-agent-pill-idle-border: color-mix(in srgb, var(--gl-agent-pill-idle-color) 35%, transparent);
+			}
+
+			/* Pill badge */
+			.pill {
+				display: inline-flex;
+				align-items: center;
+				gap: 0.4rem;
+				padding: 0.1rem 0.6rem;
+				border-radius: 50px;
+				border: 1px solid transparent;
+				font-size: 0.85em;
+				font-weight: 500;
+				line-height: normal;
+				white-space: nowrap;
+				cursor: default;
+			}
+
+			.pill__dot {
+				width: 5px;
+				height: 5px;
+				border-radius: 50%;
+				flex: none;
+			}
+
+			/* Working */
+			.pill--working {
+				background-color: var(--gl-agent-pill-working-bg);
+				border-color: var(--gl-agent-pill-working-border);
+				color: var(--gl-agent-pill-working-color);
+			}
+			.pill--working .pill__dot {
+				background-color: var(--gl-agent-pill-working-color);
+			}
+
+			/* Needs Input */
+			.pill--needs-input {
+				background-color: var(--gl-agent-pill-attention-bg);
+				border-color: var(--gl-agent-pill-attention-border);
+				color: var(--gl-agent-pill-attention-color);
+			}
+			.pill--needs-input .pill__dot {
+				background-color: var(--gl-agent-pill-attention-color);
+			}
+
+			/* Idle */
+			.pill--idle {
+				background-color: var(--gl-agent-pill-idle-bg);
+				border-color: var(--gl-agent-pill-idle-border);
+				color: var(--gl-agent-pill-idle-color);
+			}
+			.pill--idle .pill__dot {
+				background-color: var(--gl-agent-pill-idle-color);
+			}
+
+			/* Popover content */
+			.hover-card {
+				display: flex;
+				flex-direction: column;
+				gap: 0.6rem;
+				white-space: normal;
+				min-width: 16rem;
+			}
+
+			.hover-header {
+				display: flex;
+				align-items: center;
+				gap: 0.5rem;
+			}
+
+			.hover-header__dot {
+				width: 8px;
+				height: 8px;
+				border-radius: 50%;
+				flex: none;
+			}
+
+			.hover-header__dot--working {
+				background-color: var(--gl-agent-pill-working-color);
+			}
+			.hover-header__dot--needs-input {
+				background-color: var(--gl-agent-pill-attention-color);
+			}
+			.hover-header__dot--idle {
+				background-color: var(--gl-agent-pill-idle-color);
+			}
+
+			.hover-header__text {
+				flex: 1;
+				min-width: 0;
+				font-weight: 500;
+			}
+
+			.hover-header__elapsed {
+				flex: none;
+				color: var(--vscode-descriptionForeground);
+				font-size: 0.9em;
+			}
+
+			.hover-section {
+				display: flex;
+				flex-direction: column;
+				gap: 0.2rem;
+			}
+
+			.hover-section__label {
+				text-transform: uppercase;
+				font-size: 0.8em;
+				color: var(--vscode-descriptionForeground);
+				opacity: 0.7;
+			}
+
+			.hover-section__value {
+			}
+
+			.hover-code {
+				background-color: rgba(0, 0, 0, 0.3);
+				border-radius: 2px;
+				padding: 0.3rem 0.5rem;
+				font-family: var(--vscode-editor-font-family, monospace);
+				font-size: 0.9em;
+				word-break: break-all;
+			}
+
+			:host-context(.vscode-light) .hover-code,
+			:host-context(.vscode-high-contrast-light) .hover-code {
+				background-color: rgba(0, 0, 0, 0.06);
+			}
+
+			.hover-prompt {
+				font-size: 0.9em;
+				color: var(--vscode-descriptionForeground);
+				word-break: break-word;
+				display: -webkit-box;
+				-webkit-line-clamp: 3;
+				-webkit-box-orient: vertical;
+				overflow: hidden;
+			}
+
+			.hover-actions {
+				display: flex;
+				flex-direction: column;
+				gap: 0.4rem;
+				margin-top: 0.2rem;
+			}
+
+			.hover-actions__row {
+				display: flex;
+				flex-direction: row;
+				gap: 0.4rem;
+			}
+
+			.hover-actions__row gl-button {
+				flex: 1;
+				min-width: 0;
+			}
+		`,
+	];
+
+	@property({ type: Object })
+	session!: AgentSessionState;
+
+	private onActionMouseDown(e: MouseEvent): void {
+		// Stop mousedown from reaching the popover, which would hide it
+		// before the click event fires on the <a> tag
+		e.stopPropagation();
+	}
+
+	override render(): unknown {
+		const category = phaseCategories[this.session.phase];
+		const label = categoryLabels[category];
+
+		return html`
+			<gl-popover placement="bottom" hoist>
+				<span slot="anchor" class="pill pill--${category}" tabindex="0">
+					<span class="pill__dot"></span>
+					${label}
+				</span>
+				<div slot="content" class="hover-card" tabindex="-1">${this.renderHoverContent(category)}</div>
+			</gl-popover>
+		`;
+	}
+
+	private renderHoverContent(category: AgentPillCategory): unknown {
+		switch (category) {
+			case 'working':
+				return this.renderWorkingHover();
+			case 'needs-input':
+				return this.renderNeedsInputHover();
+			case 'idle':
+				return this.renderIdleHover();
+		}
+	}
+
+	private renderWorkingHover(): unknown {
+		const elapsed = formatElapsed(this.session.phaseSinceTimestamp);
+		const openHref = createCommandLink('gitlens.agents.openSession', JSON.stringify(this.session.id));
+
+		return html`
+			<div class="hover-header">
+				<span class="hover-header__dot hover-header__dot--working"></span>
+				<span class="hover-header__text">${this.session.name}</span>
+				${elapsed != null ? html`<span class="hover-header__elapsed">${elapsed}</span>` : nothing}
+			</div>
+			${this.session.lastPrompt
+				? html`
+						<div class="hover-section">
+							<span class="hover-section__label">Last Prompt</span>
+							<span class="hover-prompt">${this.session.lastPrompt}</span>
+						</div>
+					`
+				: nothing}
+			${this.session.status === 'tool_use' && this.session.statusDetail
+				? html`
+						<div class="hover-section">
+							<span class="hover-section__label">Current Tool</span>
+							<span class="hover-section__value">${this.session.statusDetail}</span>
+						</div>
+					`
+				: nothing}
+			<div class="hover-actions" @mousedown=${this.onActionMouseDown}>
+				<gl-button appearance="secondary" full density="compact" href=${openHref}>
+					<code-icon icon="link-external" slot="prefix"></code-icon>
+					Open Session
+				</gl-button>
+			</div>
+		`;
+	}
+
+	private renderNeedsInputHover(): unknown {
+		const elapsed = formatElapsed(this.session.phaseSinceTimestamp);
+		const detail = this.session.pendingPermissionDetail;
+		const openHref = createCommandLink('gitlens.agents.openSession', JSON.stringify(this.session.id));
+
+		const canResolve = this.session.isInWorkspace && detail != null;
+		const allowHref = canResolve
+			? createCommandLink('gitlens.agents.resolvePermission', {
+					sessionId: this.session.id,
+					decision: 'allow' as const,
+				})
+			: undefined;
+		const alwaysAllowHref =
+			canResolve && detail.hasSuggestions
+				? createCommandLink('gitlens.agents.resolvePermission', {
+						sessionId: this.session.id,
+						decision: 'allow' as const,
+						alwaysAllow: true,
+					})
+				: undefined;
+		const denyHref = canResolve
+			? createCommandLink('gitlens.agents.resolvePermission', {
+					sessionId: this.session.id,
+					decision: 'deny' as const,
+				})
+			: undefined;
+
+		return html`
+			<div class="hover-header">
+				<span class="hover-header__dot hover-header__dot--needs-input"></span>
+				<span class="hover-header__text">${this.session.name}</span>
+				${elapsed != null ? html`<span class="hover-header__elapsed">${elapsed}</span>` : nothing}
+			</div>
+			${this.session.lastPrompt
+				? html`
+						<div class="hover-section">
+							<span class="hover-section__label">Last Prompt</span>
+							<span class="hover-prompt">${this.session.lastPrompt}</span>
+						</div>
+					`
+				: nothing}
+			${detail != null
+				? html`
+						<div class="hover-section">
+							<span class="hover-section__label">Request</span>
+							<div class="hover-code">
+								${detail.toolName}${detail.toolDescription
+									? html` &mdash; ${detail.toolDescription}`
+									: nothing}
+							</div>
+						</div>
+						${detail.toolInputDescription
+							? html`
+									<div class="hover-section">
+										<span class="hover-section__label">Context</span>
+										<span class="hover-section__value">${detail.toolInputDescription}</span>
+									</div>
+								`
+							: nothing}
+					`
+				: nothing}
+			${canResolve
+				? html`
+						<div class="hover-actions" @mousedown=${this.onActionMouseDown}>
+							<div class="hover-actions__row">
+								<gl-button appearance="secondary" full density="compact" href=${allowHref!}>
+									<code-icon icon="check" slot="prefix"></code-icon>
+									Allow
+								</gl-button>
+								${alwaysAllowHref != null
+									? html`
+											<gl-button
+												appearance="secondary"
+												full
+												density="compact"
+												href=${alwaysAllowHref}
+											>
+												<code-icon icon="check-all" slot="prefix"></code-icon>
+												Always Allow
+											</gl-button>
+										`
+									: nothing}
+								<gl-button
+									appearance="secondary"
+									full
+									density="compact"
+									variant="danger"
+									href=${denyHref!}
+								>
+									<code-icon icon="x" slot="prefix"></code-icon>
+									Deny
+								</gl-button>
+							</div>
+							<gl-button appearance="secondary" full density="compact" href=${openHref}>
+								<code-icon icon="link-external" slot="prefix"></code-icon>
+								Open Session
+							</gl-button>
+						</div>
+					`
+				: html`
+						<div class="hover-actions" @mousedown=${this.onActionMouseDown}>
+							<gl-button appearance="secondary" full density="compact" href=${openHref}>
+								<code-icon icon="link-external" slot="prefix"></code-icon>
+								Open Session
+							</gl-button>
+						</div>
+					`}
+		`;
+	}
+
+	private renderIdleHover(): unknown {
+		const openHref = createCommandLink('gitlens.agents.openSession', JSON.stringify(this.session.id));
+
+		return html`
+			<div class="hover-header">
+				<span class="hover-header__dot hover-header__dot--idle"></span>
+				<span class="hover-header__text">${this.session.name}</span>
+			</div>
+			${this.session.lastPrompt
+				? html`
+						<div class="hover-section">
+							<span class="hover-section__label">Last Prompt</span>
+							<span class="hover-prompt">${this.session.lastPrompt}</span>
+						</div>
+					`
+				: nothing}
+			<div class="hover-actions" @mousedown=${this.onActionMouseDown}>
+				<gl-button appearance="secondary" full density="compact" href=${openHref}>
+					<code-icon icon="link-external" slot="prefix"></code-icon>
+					Open Session
+				</gl-button>
+			</div>
+		`;
+	}
+}

--- a/src/webviews/apps/tsconfig.json
+++ b/src/webviews/apps/tsconfig.json
@@ -11,7 +11,8 @@
 			"@gitlens/utils/*": ["../../../packages/utils/src/*"],
 			"@gitlens/git/*": ["../../../packages/git/src/*"],
 			"@gitlens/git-github/*": ["../../../packages/plus/git-github/src/*"],
-			"@gitlens/ai/*": ["../../../packages/plus/ai/src/*"]
+			"@gitlens/ai/*": ["../../../packages/plus/ai/src/*"],
+			"@gitlens/agents/*": ["../../../packages/plus/agents/src/*"]
 		},
 		"useDefineForClassFields": false // Needed for lit decorators https://github.com/lit/lit/issues/3278 https://lit.dev/docs/tools/publishing/#publishing-modern-javascript
 	},

--- a/src/webviews/home/homeService.ts
+++ b/src/webviews/home/homeService.ts
@@ -11,6 +11,7 @@ import type { LaunchpadService } from '../rpc/launchpadService.js';
 import type { SharedWebviewServices } from '../rpc/services/common.js';
 import type { OrgSettings, RepositoriesState, RpcEventSubscription } from '../rpc/services/types.js';
 import type {
+	AgentSessionState,
 	GetOverviewBranchesResponse,
 	GetOverviewEnrichmentResponse,
 	GetOverviewWipResponse,
@@ -66,7 +67,10 @@ export interface HomeViewService {
 	/** Get branch skeletons (sync fields only) classified as active/recent/stale. Fast — no enrichment.
 	 * @param type - If specified, only returns the requested category. Omit for all categories.
 	 */
-	getOverviewBranches(type?: 'active' | 'inactive', signal?: AbortSignal): Promise<GetOverviewBranchesResponse>;
+	getOverviewBranches(
+		type?: 'active' | 'inactive' | 'agents',
+		signal?: AbortSignal,
+	): Promise<GetOverviewBranchesResponse>;
 
 	/** Get WIP status for specified branches. Lightweight — local git status only. */
 	getOverviewWip(branchIds: string[], signal?: AbortSignal): Promise<GetOverviewWipResponse>;
@@ -113,6 +117,14 @@ export interface HomeViewService {
 
 	/** Fired when the extension requests account focus. */
 	onFocusAccount: RpcEventSubscription<undefined>;
+
+	// --- Agent Sessions ---
+
+	/** Get current agent sessions. */
+	getAgentSessions(): Promise<AgentSessionState[]>;
+
+	/** Fired when agent sessions change. */
+	onAgentSessionsChanged: RpcEventSubscription<AgentSessionState[]>;
 
 	// --- Initial Context ---
 

--- a/src/webviews/home/homeWebview.ts
+++ b/src/webviews/home/homeWebview.ts
@@ -85,6 +85,7 @@ import type { WebviewHost, WebviewProvider, WebviewShowingArgs } from '../webvie
 import type { WebviewShowOptions } from '../webviewsController.js';
 import type { HomeServices, HomeViewService, WalkthroughProgressState } from './homeService.js';
 import type {
+	AgentSessionState,
 	BranchAndTargetRefs,
 	BranchRef,
 	CreatePullRequestCommandArgs,
@@ -129,7 +130,12 @@ export class HomeWebviewProvider implements WebviewProvider<State, State, HomeWe
 			this.container.subscription.onDidChange(this.onSubscriptionChanged, this),
 			this.container.integrations.onDidChange(this.onIntegrationsChanged, this),
 			this.container.integrations.onDidChangeConnectionState(this.onIntegrationConnectionStateChanged, this),
+			...(this.container.agentStatus != null
+				? [this.container.agentStatus.onDidChange(() => this.updateAgentBadge())]
+				: []),
 		);
+
+		this.updateAgentBadge();
 	}
 
 	dispose(): void {
@@ -191,6 +197,28 @@ export class HomeWebviewProvider implements WebviewProvider<State, State, HomeWe
 			// --- UI Actions ---
 			openInGraph: params => this.showInCommitGraph(params),
 			onFocusAccount: this._focusAccountEvent.subscribe(buffer, tracker),
+
+			// --- Agent Sessions ---
+			getAgentSessions: () => Promise.resolve(this.getAgentSessionsState()),
+			onAgentSessionsChanged: createRpcEventSubscription<AgentSessionState[]>(
+				buffer,
+				'agentSessions',
+				'save-last',
+				buffered => {
+					if (this.container.agentStatus == null) return { dispose: () => {} };
+
+					let lastSerialized = '';
+					return this.container.agentStatus.onDidChange(() => {
+						const state = this.getAgentSessionsState();
+						const serialized = JSON.stringify(state);
+						if (serialized === lastSerialized) return;
+						lastSerialized = serialized;
+						buffered(state);
+					});
+				},
+				undefined,
+				tracker,
+			),
 
 			// --- Initial Context ---
 			getInitialContext: () =>
@@ -684,7 +712,7 @@ export class HomeWebviewProvider implements WebviewProvider<State, State, HomeWe
 	// ---- Progressive overview methods (skeleton → WIP → enrichment) ----
 
 	private async getOverviewBranches(
-		type?: 'active' | 'inactive',
+		type?: 'active' | 'inactive' | 'agents',
 		signal?: AbortSignal,
 	): Promise<GetOverviewBranchesResponse> {
 		if (this._discovering != null) {
@@ -704,6 +732,27 @@ export class HomeWebviewProvider implements WebviewProvider<State, State, HomeWe
 
 		const { branches, worktreesByBranch } = getSettledValue(branchesAndWorktreesResult)!;
 		const repository = getSettledValue(formatRepositoryResult)!;
+
+		// Agent branches: return only branches that have an active agent session
+		if (type === 'agents') {
+			const sessions = this.container.agentStatus?.sessions ?? [];
+			const repoPath = repo.path;
+			const agentBranchNames = new Set<string>();
+			for (const session of sessions) {
+				if (session.branch != null && session.workspacePath === repoPath) {
+					agentBranchNames.add(session.branch);
+				}
+			}
+
+			const agentBranches: OverviewBranch[] = [];
+			for (const branch of branches) {
+				if (agentBranchNames.has(branch.name)) {
+					agentBranches.push(toOverviewBranch(branch, worktreesByBranch, false));
+				}
+			}
+
+			return { repository: repository, active: [], recent: agentBranches, stale: undefined };
+		}
 
 		const active: OverviewBranch[] = [];
 		const recent: OverviewBranch[] = [];
@@ -975,6 +1024,60 @@ export class HomeWebviewProvider implements WebviewProvider<State, State, HomeWe
 			progress: this.container.walkthrough.progress,
 			state: state,
 		};
+	}
+
+	private getAgentSessionsState(): AgentSessionState[] {
+		const service = this.container.agentStatus;
+		if (service == null) return [];
+
+		return service.sessions.map(s => ({
+			id: s.id,
+			name: s.name,
+			status: s.status,
+			phase: s.phase,
+			statusDetail: s.statusDetail,
+			branch: s.branch,
+			worktreeName: s.worktreeName,
+			isInWorkspace: s.isInWorkspace,
+			hasPermissionRequest: s.pendingPermission != null,
+			subagentCount: s.subagents?.length ?? 0,
+			workspacePath: s.workspacePath,
+			cwd: s.cwd,
+			lastActivityTimestamp: s.lastActivity.getTime(),
+			phaseSinceTimestamp: s.phaseSince.getTime(),
+			pendingPermissionDetail:
+				s.pendingPermission != null
+					? {
+							toolName: s.pendingPermission.toolName,
+							toolDescription: s.pendingPermission.toolDescription,
+							toolInputDescription: s.pendingPermission.toolInputDescription,
+							hasSuggestions:
+								s.pendingPermission.suggestions != null && s.pendingPermission.suggestions.length > 0,
+						}
+					: undefined,
+			lastPrompt: s.lastPrompt,
+		}));
+	}
+
+	private _lastBadgeWaiting = -1;
+
+	private updateAgentBadge(): void {
+		const service = this.container.agentStatus;
+		if (service == null) {
+			if (this._lastBadgeWaiting !== 0) {
+				this._lastBadgeWaiting = 0;
+				this.host.badge = undefined;
+			}
+			return;
+		}
+
+		const waiting = service.sessions.filter(
+			s => !s.isSubagent && (s.status === 'waiting' || s.status === 'permission_requested'),
+		).length;
+
+		if (waiting === this._lastBadgeWaiting) return;
+		this._lastBadgeWaiting = waiting;
+		this.host.badge = waiting > 0 ? { tooltip: `${waiting} agent(s) need attention`, value: waiting } : undefined;
 	}
 
 	private async onIntegrationsChangedCore() {

--- a/src/webviews/home/protocol.ts
+++ b/src/webviews/home/protocol.ts
@@ -7,6 +7,7 @@ import type { GitPausedOperationStatus } from '@gitlens/git/models/pausedOperati
 import type { GitBranchReference } from '@gitlens/git/models/reference.js';
 import type { RemoteProviderSupportedFeatures } from '@gitlens/git/models/remoteProvider.js';
 import type { GitBranchMergedStatus } from '@gitlens/git/providers/branches.js';
+import type { AgentSessionPhase, AgentSessionStatus } from '../../agents/provider.js';
 import type { IntegrationDescriptor } from '../../constants.integrations.js';
 import type { WalkthroughContextKeys } from '../../constants.walkthroughs.js';
 import type { RepositoryShape } from '../../git/models/repositoryShape.js';
@@ -55,6 +56,31 @@ export interface State extends WebviewState<'gitlens.views.home'> {
 	previewEnabled: boolean;
 	newInstall: boolean;
 	hostAppName: string;
+	agentSessions?: AgentSessionState[];
+}
+
+export interface AgentSessionState {
+	readonly id: string;
+	readonly name: string;
+	readonly status: AgentSessionStatus;
+	readonly phase: AgentSessionPhase;
+	readonly statusDetail?: string;
+	readonly branch?: string;
+	readonly worktreeName?: string;
+	readonly isInWorkspace: boolean;
+	readonly hasPermissionRequest: boolean;
+	readonly subagentCount: number;
+	readonly workspacePath?: string;
+	readonly cwd?: string;
+	readonly lastActivityTimestamp?: number;
+	readonly phaseSinceTimestamp?: number;
+	readonly pendingPermissionDetail?: {
+		readonly toolName: string;
+		readonly toolDescription: string;
+		readonly toolInputDescription?: string;
+		readonly hasSuggestions?: boolean;
+	};
+	readonly lastPrompt?: string;
 }
 
 export interface SubscriptionState {

--- a/tsconfig.browser.json
+++ b/tsconfig.browser.json
@@ -10,7 +10,8 @@
 			"@gitlens/utils/*": ["./packages/utils/src/*"],
 			"@gitlens/git/*": ["./packages/git/src/*"],
 			"@gitlens/git-github/*": ["./packages/plus/git-github/src/*"],
-			"@gitlens/ai/*": ["./packages/plus/ai/src/*"]
+			"@gitlens/ai/*": ["./packages/plus/ai/src/*"],
+			"@gitlens/agents/*": ["./packages/plus/agents/src/*"]
 		},
 		"tsBuildInfoFile": "tsconfig.browser.tsbuildinfo"
 	},

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -9,6 +9,7 @@
 		{ "path": "./packages/git-cli" },
 		{ "path": "./packages/plus/git-github" },
 		{ "path": "./packages/plus/ai" },
+		{ "path": "./packages/plus/agents" },
 		{ "path": "./tsconfig.node.json" },
 		{ "path": "./tsconfig.browser.json" },
 		{ "path": "./src/webviews/apps/tsconfig.json" },

--- a/tsconfig.node.json
+++ b/tsconfig.node.json
@@ -9,7 +9,8 @@
 			"@gitlens/git/*": ["./packages/git/src/*"],
 			"@gitlens/git-cli/*": ["./packages/git-cli/src/*"],
 			"@gitlens/git-github/*": ["./packages/plus/git-github/src/*"],
-			"@gitlens/ai/*": ["./packages/plus/ai/src/*"]
+			"@gitlens/ai/*": ["./packages/plus/ai/src/*"],
+			"@gitlens/agents/*": ["./packages/plus/agents/src/*"]
 		},
 		"tsBuildInfoFile": "tsconfig.node.tsbuildinfo"
 	},

--- a/tsconfig.test.json
+++ b/tsconfig.test.json
@@ -9,7 +9,8 @@
 			"@gitlens/utils/*": ["./packages/utils/src/*"],
 			"@gitlens/git/*": ["./packages/git/src/*"],
 			"@gitlens/git-cli/*": ["./packages/git-cli/src/*"],
-			"@gitlens/git-github/*": ["./packages/plus/git-github/src/*"]
+			"@gitlens/git-github/*": ["./packages/plus/git-github/src/*"],
+			"@gitlens/agents/*": ["./packages/plus/agents/src/*"]
 		},
 		"tsBuildInfoFile": "tsconfig.test.tsbuildinfo"
 	},

--- a/webpack.config.mjs
+++ b/webpack.config.mjs
@@ -60,6 +60,7 @@ function getLibraryAliases() {
 		'@gitlens/git-cli': path.resolve(__dirname, 'packages', 'git-cli', 'src'),
 		'@gitlens/git-github': path.resolve(__dirname, 'packages', 'plus', 'git-github', 'src'),
 		'@gitlens/ai': path.resolve(__dirname, 'packages', 'plus', 'ai', 'src'),
+		'@gitlens/agents': path.resolve(__dirname, 'packages', 'plus', 'agents', 'src'),
 	};
 }
 
@@ -414,7 +415,14 @@ function getExtensionConfig(target, mode, env) {
 			fallback: {
 				'../../../product.json': false,
 				...(target === 'webworker'
-					? { path: require.resolve('path-browserify'), os: require.resolve('os-browserify/browser') }
+					? {
+							path: require.resolve('path-browserify'),
+							os: require.resolve('os-browserify/browser'),
+							child_process: false,
+							fs: false,
+							'fs/promises': false,
+							process: false,
+						}
 					: {}),
 			},
 			mainFields: target === 'webworker' ? ['browser', 'module', 'main'] : ['module', 'main'],


### PR DESCRIPTION
## Summary

Adds real-time AI agent status tracking to the Home view, starting with Claude Code as the first provider.

- Introduces an agent status provider framework (`AgentStatusService`, `AgentStatusProvider`) with a Claude Code implementation that discovers running sessions via process inspection and IPC
- Adds Home webview components (`agent-status`, `agent-session-card`, `agent-status-pill`) to display active agent sessions, their current state, and token usage
- Hardens the GK CLI IPC server and adds a dev-only local CLI path override

<img width="543" height="550" alt="image" src="https://github.com/user-attachments/assets/220d65e1-2db2-44cc-b884-d85b32e86a99" />
<img width="616" height="547" alt="image" src="https://github.com/user-attachments/assets/dac256e7-3fb1-459d-b14a-ab1f9e851aac" />
<img width="618" height="793" alt="image" src="https://github.com/user-attachments/assets/dfa2d4a8-d81c-405f-a8c4-495766e2a6af" />


Closes #5041

## Test plan

- [x] Verify agent status appears in Home view when Claude Code is running
- [x] Verify status updates in real-time as agent sessions change state (idle, working, waiting for input)
- [x] Verify graceful handling when no agents are running (no errors, clean empty state)
- [ ] Verify browser/web environment builds successfully (browser stubs in place)
- [x] Run `pnpm run build` — no new errors