### PR TITLE
Restores local AI provider URL precedence

### DIFF
--- a/src/plus/ai/aiProviderService.ts
+++ b/src/plus/ai/aiProviderService.ts
@@ -373,7 +373,11 @@ export class AIProviderService implements AIService, Disposable {
 				);
 			},
 			getProviderConfig: (type: string): { enabled: boolean; key?: string; url?: string } => {
-				return getOrgAIProviderOfType(type as AIProviders);
+				const provider = getOrgAIProviderOfType(type as AIProviders);
+				return {
+					...provider,
+					url: configuration.get(`ai.${type}.url` as any) ?? provider.url ?? undefined,
+				};
 			},
 			getOrPromptUrl: async (
 				providerId: string,


### PR DESCRIPTION
# Description

Closes #5147.

Restores local AI provider URL precedence for AI providers after the provider package refactor.

The regression appears to have been introduced in b60bf782e (\`Refactors AI providers into a dedicated package\`), where the new \`getProviderConfig()\` bridge returned only the organization-level provider config and no longer merged the local \`gitlens.ai.<provider>.url\` setting.

`getProviderConfig()` in `src/plus/ai/aiProviderService.ts` now merges the local `gitlens.ai.<provider>.url` setting back into the provider config and prefers the settings-defined URL before any organization/cloud URL. This fixes custom endpoint configuration for providers like OpenAI and OpenAI-compatible models.

Validation:
- `pnpm run build:extension`

# Checklist

- [x] My changes follow the coding style of this project
- [x] My changes build without any errors or warnings
- [x] My changes have been formatted and linted
- [x] My changes have been rebased and squashed to the minimal number (typically 1) of relevant commits