### PR TITLE
Adds conflict resolution actions to rebase editor conflict list

### DIFF
--- a/contributions.json
+++ b/contributions.json
@@ -5286,6 +5286,32 @@
 				]
 			}
 		},
+		"gitlens.rebase.stageCurrentChanges:rebase": {
+			"label": "Stage Current Changes",
+			"icon": "$(reply)",
+			"menus": {
+				"webview/context": [
+					{
+						"when": "webviewItem =~ /gitlens:rebase:conflict\\+file\\b(?=.*?\\+canStageCurrent\\b)/ && webview == gitlens.rebase",
+						"group": "1_conflict",
+						"order": 1
+					}
+				]
+			}
+		},
+		"gitlens.rebase.stageIncomingChanges:rebase": {
+			"label": "Stage Incoming Changes",
+			"icon": "$(forward)",
+			"menus": {
+				"webview/context": [
+					{
+						"when": "webviewItem =~ /gitlens:rebase:conflict\\+file\\b(?=.*?\\+canStageIncoming\\b)/ && webview == gitlens.rebase",
+						"group": "1_conflict",
+						"order": 2
+					}
+				]
+			}
+		},
 		"gitlens.recomposeBranch": {
 			"label": "Recompose Commits (Preview)...",
 			"commandPalette": "gitlens:enabled && !gitlens:readonly && !gitlens:untrusted && gitlens:gk:organization:ai:enabled"

--- a/docs/telemetry-events.md
+++ b/docs/telemetry-events.md
@@ -3601,6 +3601,64 @@ void
 }
 ```
 
+### rebaseEditor/action/resolveAllConflicts
+
+> Sent when the user resolves all conflict files by taking one side
+
+```typescript
+{
+  // Total number of conflicted files at the time of confirmation
+  'conflict.fileCount': number,
+  // Number of files whose resolution failed (checkout or staging error)
+  'conflict.fileCount.failed': number,
+  // Number of files successfully resolved (checked out or deleted, and then staged)
+  'conflict.fileCount.resolved': number,
+  // Number of files skipped because the requested side is unsupported for their status
+  'conflict.fileCount.skipped': number,
+  // Which side of the conflict was taken for all files
+  'conflict.resolution': 'current' | 'incoming',
+  'context.ascending': boolean,
+  'context.done.count': number,
+  'context.hasConflicts': boolean,
+  'context.isPaused': boolean,
+  'context.isRebasing': boolean,
+  'context.preservesMerges': boolean,
+  'context.session.start': string,
+  'context.todo.count': number,
+  'context.webview.host': 'view' | 'editor',
+  'context.webview.id': string,
+  'context.webview.instanceId': string,
+  'context.webview.type': string
+}
+```
+
+### rebaseEditor/action/resolveConflict
+
+> Sent when the user resolves a single conflict file by taking one side
+
+```typescript
+{
+  // File extension of the resolved conflict file (e.g. '.ts', '.json')
+  'conflict.fileExtension': string,
+  // Which side of the conflict was taken
+  'conflict.resolution': 'current' | 'incoming',
+  // Two-character conflict status (e.g. 'UU', 'AU')
+  'conflict.status': string,
+  'context.ascending': boolean,
+  'context.done.count': number,
+  'context.hasConflicts': boolean,
+  'context.isPaused': boolean,
+  'context.isRebasing': boolean,
+  'context.preservesMerges': boolean,
+  'context.session.start': string,
+  'context.todo.count': number,
+  'context.webview.host': 'view' | 'editor',
+  'context.webview.id': string,
+  'context.webview.instanceId': string,
+  'context.webview.type': string
+}
+```
+
 ### rebaseEditor/action/revealRef
 
 > Sent when the user reveals a ref (commit/branch) in graph or commit details
@@ -3653,6 +3711,31 @@ void
 
 ```typescript
 {
+  'context.ascending': boolean,
+  'context.done.count': number,
+  'context.hasConflicts': boolean,
+  'context.isPaused': boolean,
+  'context.isRebasing': boolean,
+  'context.preservesMerges': boolean,
+  'context.session.start': string,
+  'context.todo.count': number,
+  'context.webview.host': 'view' | 'editor',
+  'context.webview.id': string,
+  'context.webview.instanceId': string,
+  'context.webview.type': string
+}
+```
+
+### rebaseEditor/action/stageConflict
+
+> Sent when the user stages a single conflict file (marks as resolved)
+
+```typescript
+{
+  // File extension of the staged conflict file (e.g. '.ts', '.json')
+  'conflict.fileExtension': string,
+  // Two-character conflict status (e.g. 'UU', 'AU')
+  'conflict.status': string,
   'context.ascending': boolean,
   'context.done.count': number,
   'context.hasConflicts': boolean,

--- a/package.json
+++ b/package.json
@@ -8366,6 +8366,16 @@
 				"icon": "$(go-to-file)"
 			},
 			{
+				"command": "gitlens.rebase.stageCurrentChanges:rebase",
+				"title": "Stage Current Changes",
+				"icon": "$(reply)"
+			},
+			{
+				"command": "gitlens.rebase.stageIncomingChanges:rebase",
+				"title": "Stage Incoming Changes",
+				"icon": "$(forward)"
+			},
+			{
 				"command": "gitlens.recomposeBranch",
 				"title": "Recompose Commits (Preview)...",
 				"category": "GitLens"
@@ -13581,6 +13591,14 @@
 				},
 				{
 					"command": "gitlens.rebase.reopenAsTextEditor:editor/title",
+					"when": "false"
+				},
+				{
+					"command": "gitlens.rebase.stageCurrentChanges:rebase",
+					"when": "false"
+				},
+				{
+					"command": "gitlens.rebase.stageIncomingChanges:rebase",
 					"when": "false"
 				},
 				{
@@ -26549,6 +26567,16 @@
 					"command": "gitlens.openPullRequestComparison:graph",
 					"when": "webviewItem =~ /gitlens:pullrequest\\b(?=.*?\\b\\+refs\\b)/",
 					"group": "4_gitlens_compare@1"
+				},
+				{
+					"command": "gitlens.rebase.stageCurrentChanges:rebase",
+					"when": "webviewItem =~ /gitlens:rebase:conflict\\+file\\b(?=.*?\\+canStageCurrent\\b)/ && webview == gitlens.rebase",
+					"group": "1_conflict@1"
+				},
+				{
+					"command": "gitlens.rebase.stageIncomingChanges:rebase",
+					"when": "webviewItem =~ /gitlens:rebase:conflict\\+file\\b(?=.*?\\+canStageIncoming\\b)/ && webview == gitlens.rebase",
+					"group": "1_conflict@2"
 				},
 				{
 					"command": "gitlens.fetchRemote:graph",

--- a/packages/git-cli/src/providers/operations.ts
+++ b/packages/git-cli/src/providers/operations.ts
@@ -32,6 +32,7 @@ import {
 	gitConfigsPull,
 	GitErrors,
 	inferSigningFormatFromError,
+	maxGitCliLength,
 } from '../exec/git.js';
 
 export class OperationsGitSubProvider implements GitOperationsSubProvider {
@@ -86,6 +87,84 @@ export class OperationsGitSubProvider implements GitOperationsSubProvider {
 				reason =>
 					new CheckoutError(
 						{ reason: reason ?? 'other', ref: ref, gitCommand: { repoPath: repoPath, args: params } },
+						ex,
+					),
+			);
+		}
+	}
+
+	@debug()
+	async checkoutConflictedPath(repoPath: string, path: string, side: 'ours' | 'theirs'): Promise<void> {
+		const scope = getScopedLogger();
+
+		[path, repoPath] = splitPath(path, repoPath, true);
+		const params = ['checkout', `--${side}`, '--', path];
+
+		try {
+			await this.git.run({ cwd: repoPath }, ...params);
+			this.context.hooks?.cache?.onReset?.(repoPath, 'status');
+			this.context.hooks?.repository?.onChanged?.(repoPath, ['index']);
+		} catch (ex) {
+			scope?.error(ex);
+			throw getGitCommandError(
+				'checkout',
+				ex,
+				reason =>
+					new CheckoutError(
+						{ reason: reason ?? 'other', ref: side, gitCommand: { repoPath: repoPath, args: params } },
+						ex,
+					),
+			);
+		}
+	}
+
+	@debug()
+	async checkoutConflictedPaths(repoPath: string, paths: string[], side: 'ours' | 'theirs'): Promise<void> {
+		if (!paths.length) return;
+
+		const scope = getScopedLogger();
+		const normalized = paths.map(p => splitPath(p, repoPath, true)[0]);
+
+		// Build batches by accumulating the length of each path + a small per-arg overhead (separator +
+		// possible quoting), so a single long path — or just the overhead itself — can't push a batch
+		// past the CLI length limit. Always keep at least one path per batch, even if a lone path is
+		// longer than the limit (the OS may still accept it on some platforms).
+		const perArgOverhead = 3;
+		const batches: string[][] = [];
+		let current: string[] = [];
+		let currentLen = 0;
+		for (const p of normalized) {
+			const cost = p.length + perArgOverhead;
+			if (current.length > 0 && currentLen + cost > maxGitCliLength) {
+				batches.push(current);
+				current = [];
+				currentLen = 0;
+			}
+			current.push(p);
+			currentLen += cost;
+		}
+		if (current.length) {
+			batches.push(current);
+		}
+
+		try {
+			for (const batch of batches) {
+				await this.git.run({ cwd: repoPath }, 'checkout', `--${side}`, '--', ...batch);
+			}
+			this.context.hooks?.cache?.onReset?.(repoPath, 'status');
+			this.context.hooks?.repository?.onChanged?.(repoPath, ['index']);
+		} catch (ex) {
+			scope?.error(ex);
+			throw getGitCommandError(
+				'checkout',
+				ex,
+				reason =>
+					new CheckoutError(
+						{
+							reason: reason ?? 'other',
+							ref: side,
+							gitCommand: { repoPath: repoPath, args: ['checkout', `--${side}`, '--', ...normalized] },
+						},
 						ex,
 					),
 			);

--- a/packages/git-cli/src/providers/staging.ts
+++ b/packages/git-cli/src/providers/staging.ts
@@ -159,6 +159,38 @@ export class StagingGitSubProvider implements GitStagingSubProvider {
 	}
 
 	@debug()
+	async removeFile(repoPath: string, pathOrUri: string | Uri, options?: { force?: boolean }): Promise<void> {
+		const args = ['rm'];
+		if (options?.force) {
+			args.push('-f');
+		}
+		args.push('--', toFsPath(pathOrUri));
+		await this.git.run({ cwd: repoPath }, ...args);
+	}
+
+	@debug()
+	async removeFiles(repoPath: string, pathsOrUris: (string | Uri)[], options?: { force?: boolean }): Promise<void> {
+		const paths = pathsOrUris.map(toFsPath);
+		if (!paths.length) return;
+
+		const args: string[] = ['rm'];
+		if (options?.force) {
+			args.push('-f');
+		}
+		args.push('--');
+
+		// Calculate a safe batch size based on average path length
+		const avgPathLength = countStringLength(paths) / paths.length;
+		const batchSize = Math.max(1, Math.floor(maxGitCliLength / avgPathLength));
+
+		// Process files in batches (will be a single batch if under the limit)
+		const batches = chunk(paths, batchSize);
+		for (const batch of batches) {
+			await this.git.run({ cwd: repoPath }, ...args, ...batch);
+		}
+	}
+
+	@debug()
 	async stageAll(repoPath: string): Promise<void> {
 		await this.git.run({ cwd: repoPath }, 'add', '-A');
 	}

--- a/packages/git/src/providers/operations.ts
+++ b/packages/git/src/providers/operations.ts
@@ -13,6 +13,17 @@ export interface GitOperationsSubProvider {
 		ref: string,
 		options?: { createBranch?: string | undefined } | { path?: string | undefined },
 	): Promise<void>;
+	/**
+	 * Checks out one side of a conflicted path during a paused merge/rebase/cherry-pick.
+	 * Executes `git checkout --ours|--theirs -- <path>`, leaving the file unstaged.
+	 */
+	checkoutConflictedPath(repoPath: string, path: string, side: 'ours' | 'theirs'): Promise<void>;
+	/**
+	 * Checks out one side for multiple conflicted paths during a paused merge/rebase/cherry-pick.
+	 * Batches paths into `git checkout --ours|--theirs -- <paths...>`, chunked to stay under the
+	 * CLI length limit. Leaves files unstaged.
+	 */
+	checkoutConflictedPaths(repoPath: string, paths: string[], side: 'ours' | 'theirs'): Promise<void>;
 	cherryPick(
 		repoPath: string,
 		revs: string[],

--- a/packages/git/src/providers/staging.ts
+++ b/packages/git/src/providers/staging.ts
@@ -19,6 +19,18 @@ export interface GitStagingSubProvider {
 	unstageFile(repoPath: string, pathOrUri: string | Uri): Promise<void>;
 	unstageFiles(repoPath: string, pathsOrUris: (string | Uri)[]): Promise<void>;
 	unstageDirectory(repoPath: string, directoryOrUri: string | Uri): Promise<void>;
+	/**
+	 * Removes a file from both the working tree and the index in a single operation
+	 * (`git rm [-f] -- <path>`). Use during conflict resolution when the user has chosen a
+	 * side that is itself a deletion — atomic, so it can't leave a working-tree-modified
+	 * file accidentally staged with content. Pass `force: true` to discard local
+	 * modifications (required for conflicted files).
+	 */
+	removeFile(repoPath: string, pathOrUri: string | Uri, options?: { force?: boolean }): Promise<void>;
+	/**
+	 * Batched form of {@link removeFile}. Chunks paths to stay under the CLI length limit.
+	 */
+	removeFiles(repoPath: string, pathsOrUris: (string | Uri)[], options?: { force?: boolean }): Promise<void>;
 	stageAll(repoPath: string): Promise<void>;
 	unstageAll(repoPath: string): Promise<void>;
 }

--- a/src/constants.commands.generated.ts
+++ b/src/constants.commands.generated.ts
@@ -283,6 +283,8 @@ export type ContributedCommands =
 	| 'gitlens.rebase.refresh'
 	| 'gitlens.rebase.reopenAsInteractiveEditor:editor/title'
 	| 'gitlens.rebase.reopenAsTextEditor:editor/title'
+	| 'gitlens.rebase.stageCurrentChanges:rebase'
+	| 'gitlens.rebase.stageIncomingChanges:rebase'
 	| 'gitlens.recomposeBranch:graph'
 	| 'gitlens.recomposeBranch:views'
 	| 'gitlens.recomposeFromCommit:graph'

--- a/src/constants.telemetry.ts
+++ b/src/constants.telemetry.ts
@@ -354,6 +354,12 @@ export interface TelemetryEvents extends WebviewShowAbortedEvents, WebviewShownE
 	'rebaseEditor/action/openConflictFile': RebaseEditorOpenConflictFileEvent;
 	/** Sent when the user opens current or incoming changes for a conflict file */
 	'rebaseEditor/action/openConflictChanges': RebaseEditorOpenConflictChangesEvent;
+	/** Sent when the user resolves a single conflict file by taking one side */
+	'rebaseEditor/action/resolveConflict': RebaseEditorResolveConflictEvent;
+	/** Sent when the user stages a single conflict file (marks as resolved) */
+	'rebaseEditor/action/stageConflict': RebaseEditorStageConflictEvent;
+	/** Sent when the user resolves all conflict files by taking one side */
+	'rebaseEditor/action/resolveAllConflicts': RebaseEditorResolveAllConflictsEvent;
 	/** Sent when the user reveals a ref (commit/branch) in graph or commit details */
 	'rebaseEditor/action/revealRef': RebaseEditorRevealRefEvent;
 
@@ -1321,6 +1327,35 @@ interface RebaseEditorOpenConflictChangesEvent extends RebaseEditorContextEventD
 	side: 'current' | 'incoming';
 }
 
+interface RebaseEditorResolveConflictEvent extends RebaseEditorContextEventData {
+	/** Which side of the conflict was taken */
+	'conflict.resolution': 'current' | 'incoming';
+	/** File extension of the resolved conflict file (e.g. '.ts', '.json') */
+	'conflict.fileExtension': string;
+	/** Two-character conflict status (e.g. 'UU', 'AU') */
+	'conflict.status': string;
+}
+
+interface RebaseEditorStageConflictEvent extends RebaseEditorContextEventData {
+	/** File extension of the staged conflict file (e.g. '.ts', '.json') */
+	'conflict.fileExtension': string;
+	/** Two-character conflict status (e.g. 'UU', 'AU') */
+	'conflict.status': string;
+}
+
+interface RebaseEditorResolveAllConflictsEvent extends RebaseEditorContextEventData {
+	/** Which side of the conflict was taken for all files */
+	'conflict.resolution': 'current' | 'incoming';
+	/** Total number of conflicted files at the time of confirmation */
+	'conflict.fileCount': number;
+	/** Number of files successfully resolved (checked out or deleted, and then staged) */
+	'conflict.fileCount.resolved': number;
+	/** Number of files skipped because the requested side is unsupported for their status */
+	'conflict.fileCount.skipped': number;
+	/** Number of files whose resolution failed (checkout or staging error) */
+	'conflict.fileCount.failed': number;
+}
+
 interface RebaseEditorRevealRefEvent extends RebaseEditorContextEventData {
 	/** Type of ref being revealed */
 	'ref.type': 'commit' | 'branch';
@@ -1375,6 +1410,9 @@ export type RebaseEditorTelemetryEvent =
 	| 'rebaseEditor/action/showConflicts'
 	| 'rebaseEditor/action/openConflictFile'
 	| 'rebaseEditor/action/openConflictChanges'
+	| 'rebaseEditor/action/resolveConflict'
+	| 'rebaseEditor/action/stageConflict'
+	| 'rebaseEditor/action/resolveAllConflicts'
 	| 'rebaseEditor/action/revealRef'
 	| 'rebaseEditor/entries/changed'
 	| 'rebaseEditor/entries/moved'

--- a/src/webviews/apps/plus/graph/graph-app.ts
+++ b/src/webviews/apps/plus/graph/graph-app.ts
@@ -799,8 +799,9 @@ export class GraphApp extends SignalWatcher(LitElement) {
 		try {
 			// `services.branches` is a supertalk Remote — await once to resolve the proxy.
 			const branches = await services.branches;
-			const status = await branches.getMergeTargetStatus(branch.repoPath, branch.name);
-			this.graphState.mergeMergeTargetIntoEnrichment(branchId, status?.mergeTarget);
+			const enrichment = await branches.getBranchEnrichment(branch.repoPath, branch.name);
+			const mergeTarget = await enrichment?.mergeTargetStatus;
+			this.graphState.mergeMergeTargetIntoEnrichment(branchId, mergeTarget);
 		} catch {
 			// Swallow — the scope-anchor flow tolerates an absent tip SHA.
 		}

--- a/src/webviews/apps/plus/graph/overview/graph-overview-card.ts
+++ b/src/webviews/apps/plus/graph/overview/graph-overview-card.ts
@@ -710,8 +710,8 @@ export class GlGraphOverviewCard extends LitElement {
 				// `services.branches` is a supertalk Remote — `await` once to resolve the proxy,
 				// then invoke the method. Same shape detailsResolver uses (`detailsResolver.ts:39`).
 				const branches = await services.branches;
-				const status = await branches.getMergeTargetStatus(repoPath, branchName);
-				return status?.mergeTarget;
+				const enrichment = await branches.getBranchEnrichment(repoPath, branchName);
+				return await enrichment?.mergeTargetStatus;
 			} catch {
 				return undefined;
 			}

--- a/src/webviews/apps/rebase/__tests__/conflictStatus.utils.test.ts
+++ b/src/webviews/apps/rebase/__tests__/conflictStatus.utils.test.ts
@@ -1,0 +1,65 @@
+import * as assert from 'assert';
+import type { GitFileConflictStatus } from '@gitlens/git/models/fileStatus.js';
+import { getConflictFileActions, getConflictFileContextData } from '../conflictStatus.utils.js';
+
+const allStatuses: GitFileConflictStatus[] = ['UU', 'AA', 'DD', 'AU', 'UA', 'UD', 'DU'];
+
+suite('rebase/conflictStatus.utils', () => {
+	suite('getConflictFileActions', () => {
+		function actionNames(status: GitFileConflictStatus): string[] {
+			return getConflictFileActions(status).map(a => a.action);
+		}
+
+		test('returns current-changes, incoming-changes, and stage for every status', () => {
+			for (const status of allStatuses) {
+				assert.deepStrictEqual(
+					actionNames(status),
+					['current-changes', 'incoming-changes', 'stage'],
+					`inline actions wrong for ${status}`,
+				);
+			}
+		});
+	});
+
+	suite('getConflictFileContextData', () => {
+		function parseContext(status: GitFileConflictStatus) {
+			return JSON.parse(getConflictFileContextData('path/to/file.ts', status)) as {
+				webviewItem: string;
+				webviewItemValue: { type: string; path: string; conflictStatus: GitFileConflictStatus };
+			};
+		}
+
+		test('emits webviewItem and item value for every status', () => {
+			for (const status of allStatuses) {
+				const ctx = parseContext(status);
+				assert.strictEqual(ctx.webviewItemValue.type, 'rebaseConflict');
+				assert.strictEqual(ctx.webviewItemValue.path, 'path/to/file.ts');
+				assert.strictEqual(ctx.webviewItemValue.conflictStatus, status);
+				assert.ok(
+					ctx.webviewItem.startsWith('gitlens:rebase:conflict+file'),
+					`webviewItem prefix wrong for ${status}`,
+				);
+			}
+		});
+
+		test('+canStageCurrent is excluded for UA and DD only', () => {
+			for (const status of allStatuses) {
+				const has = parseContext(status).webviewItem.includes('+canStageCurrent');
+				const expected = status !== 'UA' && status !== 'DD';
+				assert.strictEqual(has, expected, `+canStageCurrent presence wrong for ${status}`);
+			}
+		});
+
+		test('+canStageIncoming is excluded for AU and DD only', () => {
+			for (const status of allStatuses) {
+				const has = parseContext(status).webviewItem.includes('+canStageIncoming');
+				const expected = status !== 'AU' && status !== 'DD';
+				assert.strictEqual(has, expected, `+canStageIncoming presence wrong for ${status}`);
+			}
+		});
+
+		test('DD has no stage modifiers', () => {
+			assert.strictEqual(parseContext('DD').webviewItem, 'gitlens:rebase:conflict+file');
+		});
+	});
+});

--- a/src/webviews/apps/rebase/conflictStatus.utils.ts
+++ b/src/webviews/apps/rebase/conflictStatus.utils.ts
@@ -1,0 +1,37 @@
+import type { GitFileConflictStatus } from '@gitlens/git/models/fileStatus.js';
+import type { ConflictFileWebviewContext } from '../../rebase/protocol.js';
+import type { TreeItemAction } from '../shared/components/tree/base.js';
+
+export function getConflictFileActions(_conflictStatus: GitFileConflictStatus): TreeItemAction[] {
+	return [
+		{ icon: 'gl-diff-left', label: 'Open Current Changes', action: 'current-changes' },
+		{ icon: 'gl-diff-right', label: 'Open Incoming Changes', action: 'incoming-changes' },
+		{ icon: 'add', label: 'Stage', action: 'stage' },
+	];
+}
+
+// Stage Current is invalid when the current side has no content to take (added/deleted only by them, or both deleted)
+export function canStageCurrent(conflictStatus: GitFileConflictStatus): boolean {
+	return conflictStatus !== 'UA' && conflictStatus !== 'DD';
+}
+
+// Stage Incoming is invalid when the incoming side has no content to take (added/deleted only by us, or both deleted)
+export function canStageIncoming(conflictStatus: GitFileConflictStatus): boolean {
+	return conflictStatus !== 'AU' && conflictStatus !== 'DD';
+}
+
+export function getConflictFileContextData(path: string, conflictStatus: GitFileConflictStatus): string {
+	const modifiers: string[] = [];
+	if (canStageCurrent(conflictStatus)) {
+		modifiers.push('+canStageCurrent');
+	}
+	if (canStageIncoming(conflictStatus)) {
+		modifiers.push('+canStageIncoming');
+	}
+
+	const context: ConflictFileWebviewContext = {
+		webviewItem: `gitlens:rebase:conflict+file${modifiers.join('')}`,
+		webviewItemValue: { type: 'rebaseConflict', path: path, conflictStatus: conflictStatus },
+	};
+	return JSON.stringify(context);
+}

--- a/src/webviews/apps/rebase/rebase.ts
+++ b/src/webviews/apps/rebase/rebase.ts
@@ -36,10 +36,12 @@ import {
 	OpenConflictFileCommand,
 	RecomposeCommand,
 	ReorderCommand,
+	ResolveAllConflictsCommand,
 	RevealRefCommand,
 	SearchCommand,
 	ShiftEntriesCommand,
 	SkipCommand,
+	StageConflictCommand,
 	StartCommand,
 	SwitchCommand,
 	UpdateSelectionCommand,
@@ -58,8 +60,10 @@ import {
 	getConflictTooltip as getSharedConflictTooltip,
 } from '../shared/components/tree/conflictRendering.js';
 import type { LoggerContext } from '../shared/contexts/logger.js';
+import { ContextMenuProxyController } from '../shared/controllers/context-menu-proxy.js';
 import type { HostIpc } from '../shared/ipc.js';
 import type { GlRebaseEntryElement } from './components/rebase-entry.js';
+import { getConflictFileActions, getConflictFileContextData } from './conflictStatus.utils.js';
 import { rebaseStyles } from './rebase.css.js';
 import { RebaseStateProvider } from './stateProvider.js';
 import '@lit-labs/virtualizer';
@@ -106,6 +110,11 @@ export class GlRebaseEditor extends GlAppHost<State, RebaseStateProvider> {
 	private readonly _virtualizer?: LitVirtualizer;
 	private readonly virtualizerKeyFn = (entry: RebaseEntry) => entry.id;
 	private readonly virtualizerRenderFn = (entry: RebaseEntry, index: number) => this.renderEntry(entry, index);
+
+	// Bridges `data-vscode-context` out of nested shadow DOM (gl-tree-view) onto this host so VS
+	// Code's native context-menu integration — which walks the light DOM from the event target —
+	// can resolve contributed `webview/context` items for conflicted file rows.
+	private readonly _contextMenuProxy = new ContextMenuProxyController(this);
 
 	/** Unified conflict detection state — single source of truth for both initial and dynamic checks */
 	@state() private _conflictResult: ConflictDetectionResult | undefined;
@@ -1523,7 +1532,28 @@ export class GlRebaseEditor extends GlAppHost<State, RebaseStateProvider> {
 				<gl-button
 					appearance="toolbar"
 					density="compact"
-					tooltip="${this._conflictFilesLayout === 'tree' ? 'View as List' : 'View as Tree'}"
+					tooltip="Stage Current for All Conflicts"
+					aria-label="Stage Current for All Conflicts"
+					@click=${this.onStageAllCurrent}
+					><code-icon icon="gl-accept-all-left"></code-icon
+				></gl-button>
+				<gl-button
+					appearance="toolbar"
+					density="compact"
+					tooltip="Stage Incoming for All Conflicts"
+					aria-label="Stage Incoming for All Conflicts"
+					@click=${this.onStageAllIncoming}
+					><code-icon icon="gl-accept-all-right"></code-icon
+				></gl-button>
+				<gl-button
+					appearance="toolbar"
+					density="compact"
+					tooltip="${this._conflictFilesLayout === 'tree'
+						? 'Switch to List Layout'
+						: 'Switch to Tree Layout'}"
+					aria-label="${this._conflictFilesLayout === 'tree'
+						? 'Switch to List Layout'
+						: 'Switch to Tree Layout'}"
 					@click=${this.onToggleConflictFilesLayout}
 					><code-icon icon="${this._conflictFilesLayout === 'tree' ? 'list-flat' : 'list-tree'}"></code-icon
 				></gl-button>
@@ -1562,10 +1592,8 @@ export class GlRebaseEditor extends GlAppHost<State, RebaseStateProvider> {
 				label: filename,
 				description: dir,
 				tooltip: this.getConflictTooltip(file.conflictStatus, file.conflictCount),
-				actions: [
-					{ icon: 'gl-diff-left', label: 'Open Current Changes', action: 'current-changes' },
-					{ icon: 'gl-diff-right', label: 'Open Incoming Changes', action: 'incoming-changes' },
-				],
+				actions: getConflictFileActions(file.conflictStatus),
+				contextData: getConflictFileContextData(file.path, file.conflictStatus),
 				decorations: this.getConflictDecorations(file.conflictStatus, file.conflictCount),
 			};
 		});
@@ -1596,14 +1624,8 @@ export class GlRebaseEditor extends GlAppHost<State, RebaseStateProvider> {
 						icon: { type: 'status', name: child.value.conflictStatus },
 						label: child.name,
 						tooltip: this.getConflictTooltip(child.value.conflictStatus, child.value.conflictCount),
-						actions: [
-							{ icon: 'gl-diff-left', label: 'Open Current Changes', action: 'current-changes' },
-							{
-								icon: 'gl-diff-right',
-								label: 'Open Incoming Changes',
-								action: 'incoming-changes',
-							},
-						],
+						actions: getConflictFileActions(child.value.conflictStatus),
+						contextData: getConflictFileContextData(child.value.path, child.value.conflictStatus),
 						decorations: this.getConflictDecorations(child.value.conflictStatus, child.value.conflictCount),
 					});
 				} else if (child.children != null && child.children.size > 0) {
@@ -1651,8 +1673,19 @@ export class GlRebaseEditor extends GlAppHost<State, RebaseStateProvider> {
 			case 'incoming-changes':
 				this._ipc.sendCommand(OpenConflictChangesCommand, { path: path, side: 'incoming' });
 				break;
+			case 'stage':
+				this._ipc.sendCommand(StageConflictCommand, { path: path });
+				break;
 		}
 	}
+
+	private onStageAllCurrent = () => {
+		this._ipc.sendCommand(ResolveAllConflictsCommand, { resolution: 'current' });
+	};
+
+	private onStageAllIncoming = () => {
+		this._ipc.sendCommand(ResolveAllConflictsCommand, { resolution: 'incoming' });
+	};
 
 	private onOpenConflictFile(path: string): void {
 		this._ipc.sendCommand(OpenConflictFileCommand, { path: path });

--- a/src/webviews/apps/shared/components/tree/__tests__/conflictRendering.test.ts
+++ b/src/webviews/apps/shared/components/tree/__tests__/conflictRendering.test.ts
@@ -1,0 +1,53 @@
+import * as assert from 'assert';
+import type { GitFileConflictStatus } from '@gitlens/git/models/fileStatus.js';
+import { getConflictStatusInfo } from '../conflictRendering.js';
+
+const allStatuses: GitFileConflictStatus[] = ['UU', 'AA', 'DD', 'AU', 'UA', 'UD', 'DU'];
+
+suite('tree/conflictRendering', () => {
+	suite('getConflictStatusInfo', () => {
+		test('returns an entry for every GitFileConflictStatus value', () => {
+			for (const status of allStatuses) {
+				const info = getConflictStatusInfo(status);
+				assert.ok(info != null, `expected info for ${status}`);
+				assert.ok(info.label.length > 0, `label should be non-empty for ${status}`);
+				assert.ok(info.description.length > 0, `description should be non-empty for ${status}`);
+				assert.ok(info.kind.length > 0, `kind should be non-empty for ${status}`);
+			}
+		});
+
+		test('uses modified kind for UU', () => {
+			assert.strictEqual(getConflictStatusInfo('UU')?.kind, 'modified');
+		});
+
+		test('uses added kind for AA/AU/UA', () => {
+			assert.strictEqual(getConflictStatusInfo('AA')?.kind, 'added');
+			assert.strictEqual(getConflictStatusInfo('AU')?.kind, 'added');
+			assert.strictEqual(getConflictStatusInfo('UA')?.kind, 'added');
+		});
+
+		test('uses deleted kind for DD/UD/DU', () => {
+			assert.strictEqual(getConflictStatusInfo('DD')?.kind, 'deleted');
+			assert.strictEqual(getConflictStatusInfo('UD')?.kind, 'deleted');
+			assert.strictEqual(getConflictStatusInfo('DU')?.kind, 'deleted');
+		});
+
+		test('distinguishes UA from AU labels', () => {
+			assert.notStrictEqual(getConflictStatusInfo('UA')?.label, getConflictStatusInfo('AU')?.label);
+		});
+
+		test('distinguishes UD from DU labels', () => {
+			assert.notStrictEqual(getConflictStatusInfo('UD')?.label, getConflictStatusInfo('DU')?.label);
+		});
+
+		test('includes branch name in description when provided', () => {
+			const info = getConflictStatusInfo('UU', 'feature/foo');
+			assert.ok(info?.description.includes('feature/foo'));
+		});
+
+		test('falls back to "incoming" when no branch name', () => {
+			const info = getConflictStatusInfo('UU');
+			assert.ok(info?.description.includes('incoming'));
+		});
+	});
+});

--- a/src/webviews/apps/shared/components/tree/conflictRendering.ts
+++ b/src/webviews/apps/shared/components/tree/conflictRendering.ts
@@ -2,37 +2,60 @@ import type { GitFileConflictStatus } from '@gitlens/git/models/fileStatus.js';
 import { pluralize } from '@gitlens/utils/string.js';
 import type { TreeItemDecoration, TreeItemDecorationKind } from './base.js';
 
-export const conflictActions: Record<string, { label: string; kind: TreeItemDecorationKind }> = {
-	A: { label: 'Added', kind: 'added' },
-	D: { label: 'Deleted', kind: 'deleted' },
-	U: { label: 'Modified', kind: 'modified' },
-};
-
+// Decodes Git's two-character unmerged status codes. The `U` placeholder is context-dependent:
+// in `UA`/`AU` it means the side is absent; in `UD`/`DU`/`UU` it means the side has a modified version.
 export function getConflictStatusInfo(
 	status: GitFileConflictStatus,
 	branchName?: string,
 ): { label: string; kind: TreeItemDecorationKind; description: string } | undefined {
-	// First char = current (ours in rebase = onto/target), second char = incoming (theirs in rebase = branch)
-	const currentAction = conflictActions[status[0]];
-	const incomingAction = conflictActions[status[1]];
-	if (currentAction == null || incomingAction == null) return undefined;
-
-	const kind = currentAction.kind === conflictActions.U.kind ? incomingAction.kind : currentAction.kind;
 	const branch = branchName ? `$(git-branch) ${branchName}` : 'incoming';
 
-	if (status[0] === status[1]) {
-		return {
-			label: `${currentAction.label} (Both)`,
-			kind: kind,
-			description: `${currentAction.label} on both ${branch} and the target`,
-		};
+	switch (status) {
+		case 'UU':
+			return {
+				label: 'Modified (Both)',
+				kind: 'modified',
+				description: `Modified on both ${branch} and the target`,
+			};
+		case 'AA':
+			return {
+				label: 'Added (Both)',
+				kind: 'added',
+				description: `Added on both ${branch} and the target`,
+			};
+		case 'DD':
+			return {
+				label: 'Deleted (Both)',
+				kind: 'deleted',
+				description: `Deleted on both ${branch} and the target`,
+			};
+		case 'AU':
+			return {
+				label: 'Added by Current',
+				kind: 'added',
+				description: `Added on the target (conflict with ${branch} — possible rename or directory/file clash)`,
+			};
+		case 'UA':
+			return {
+				label: 'Added by Incoming',
+				kind: 'added',
+				description: `Added on ${branch} (conflict with the target — possible rename or directory/file clash)`,
+			};
+		case 'UD':
+			return {
+				label: 'Modified (Current), Deleted (Incoming)',
+				kind: 'deleted',
+				description: `Deleted on ${branch}\nModified on the target`,
+			};
+		case 'DU':
+			return {
+				label: 'Deleted (Current), Modified (Incoming)',
+				kind: 'deleted',
+				description: `Modified on ${branch}\nDeleted on the target`,
+			};
+		default:
+			return undefined;
 	}
-
-	return {
-		label: `${currentAction.label} (Current), ${incomingAction.label} (Incoming)`,
-		kind: kind,
-		description: `${incomingAction.label} on ${branch}\n${currentAction.label} on the target`,
-	};
 }
 
 export function getConflictDecorations(
@@ -66,7 +89,7 @@ export function getConflictDecorations(
 			label: pluralize('conflict', conflictCount),
 			count: conflictCount,
 			tooltip: pluralize('conflict', conflictCount),
-			kind: info?.kind ?? conflictActions.U.kind,
+			kind: info?.kind ?? 'modified',
 			position: 'before',
 		});
 	}

--- a/src/webviews/rebase/__tests__/conflictResolution.utils.test.ts
+++ b/src/webviews/rebase/__tests__/conflictResolution.utils.test.ts
@@ -1,0 +1,35 @@
+import * as assert from 'assert';
+import type { GitFileConflictStatus } from '@gitlens/git/models/fileStatus.js';
+import type { ConflictResolutionAction } from '../conflictResolution.utils.js';
+import { classifyConflictAction } from '../conflictResolution.utils.js';
+
+const cases: {
+	status: GitFileConflictStatus;
+	resolution: 'current' | 'incoming';
+	expected: ConflictResolutionAction;
+}[] = [
+	{ status: 'UU', resolution: 'current', expected: 'take-ours' },
+	{ status: 'UU', resolution: 'incoming', expected: 'take-theirs' },
+	{ status: 'AA', resolution: 'current', expected: 'take-ours' },
+	{ status: 'AA', resolution: 'incoming', expected: 'take-theirs' },
+	{ status: 'DD', resolution: 'current', expected: 'delete' },
+	{ status: 'DD', resolution: 'incoming', expected: 'delete' },
+	{ status: 'UD', resolution: 'current', expected: 'take-ours' },
+	{ status: 'UD', resolution: 'incoming', expected: 'delete' },
+	{ status: 'DU', resolution: 'current', expected: 'delete' },
+	{ status: 'DU', resolution: 'incoming', expected: 'take-theirs' },
+	{ status: 'AU', resolution: 'current', expected: 'take-ours' },
+	{ status: 'AU', resolution: 'incoming', expected: 'unsupported' },
+	{ status: 'UA', resolution: 'current', expected: 'unsupported' },
+	{ status: 'UA', resolution: 'incoming', expected: 'take-theirs' },
+];
+
+suite('rebase/conflictResolution.utils', () => {
+	suite('classifyConflictAction', () => {
+		for (const { status, resolution, expected } of cases) {
+			test(`${status} + take-${resolution} → ${expected}`, () => {
+				assert.strictEqual(classifyConflictAction(status, resolution), expected);
+			});
+		}
+	});
+});

--- a/src/webviews/rebase/conflictResolution.utils.ts
+++ b/src/webviews/rebase/conflictResolution.utils.ts
@@ -1,0 +1,21 @@
+import type { GitFileConflictStatus } from '@gitlens/git/models/fileStatus.js';
+
+export type ConflictResolutionAction = 'take-ours' | 'take-theirs' | 'delete' | 'unsupported';
+
+export function classifyConflictAction(
+	status: GitFileConflictStatus,
+	resolution: 'current' | 'incoming',
+): ConflictResolutionAction {
+	const takeCurrent = resolution === 'current';
+
+	if (status === 'DD') return 'delete';
+	if (status === 'UD' && !takeCurrent) return 'delete';
+	if (status === 'DU' && takeCurrent) return 'delete';
+
+	// `git checkout --{ours,theirs}` fails when the requested stage is absent.
+	// Single-file UI filters these out; bulk resolve surfaces them as failures.
+	if (status === 'UA' && takeCurrent) return 'unsupported';
+	if (status === 'AU' && !takeCurrent) return 'unsupported';
+
+	return takeCurrent ? 'take-ours' : 'take-theirs';
+}

--- a/src/webviews/rebase/protocol.ts
+++ b/src/webviews/rebase/protocol.ts
@@ -8,6 +8,7 @@ import type {
 } from '@gitlens/git/models/rebase.js';
 import type { Config } from '../../config.js';
 import type { Subscription } from '../../plus/gk/models/subscription.js';
+import type { WebviewItemContext } from '../../system/webview.js';
 import type { IpcScope } from '../ipc/models/ipc.js';
 import { IpcCommand, IpcNotification, IpcRequest } from '../ipc/models/ipc.js';
 import type { WebviewState } from '../protocol.js';
@@ -64,6 +65,14 @@ export interface ConflictFileInfo {
 	/** Number of conflict markers in the file */
 	conflictCount?: number;
 }
+
+export interface ConflictFileContextValue {
+	type: 'rebaseConflict';
+	path: string;
+	conflictStatus: GitFileConflictStatus;
+}
+
+export type ConflictFileWebviewContext = WebviewItemContext<ConflictFileContextValue>;
 
 /** Reason the rebase is paused */
 export type RebasePauseReason = 'edit' | 'reword' | 'break' | 'conflict' | 'exec';
@@ -204,6 +213,22 @@ export interface OpenConflictChangesParams {
 	side: 'current' | 'incoming';
 }
 export const OpenConflictChangesCommand = new IpcCommand<OpenConflictChangesParams>(scope, 'conflicts/openChanges');
+
+export interface ResolveConflictParams {
+	path: string;
+	resolution: 'current' | 'incoming';
+}
+export const ResolveConflictCommand = new IpcCommand<ResolveConflictParams>(scope, 'conflicts/resolve');
+
+export interface StageConflictParams {
+	path: string;
+}
+export const StageConflictCommand = new IpcCommand<StageConflictParams>(scope, 'conflicts/stage');
+
+export interface ResolveAllConflictsParams {
+	resolution: 'current' | 'incoming';
+}
+export const ResolveAllConflictsCommand = new IpcCommand<ResolveAllConflictsParams>(scope, 'conflicts/resolveAll');
 
 // REQUESTS
 

--- a/src/webviews/rebase/rebaseWebviewProvider.ts
+++ b/src/webviews/rebase/rebaseWebviewProvider.ts
@@ -1,6 +1,7 @@
 import type { Disposable, TextDocument } from 'vscode';
 import { Uri, ViewColumn, window, workspace } from 'vscode';
 import type { GitCommit } from '@gitlens/git/models/commit.js';
+import type { GitFileConflictStatus } from '@gitlens/git/models/fileStatus.js';
 import type { ProcessedRebaseTodo, RebaseTodoAction } from '@gitlens/git/models/rebase.js';
 import { getConflictIncomingRef, resolveConflictFilePaths } from '@gitlens/git/utils/pausedOperationStatus.utils.js';
 import { createReference } from '@gitlens/git/utils/reference.utils.js';
@@ -11,6 +12,7 @@ import { concat, filterMap, find, first, join, last, map } from '@gitlens/utils/
 import { Logger } from '@gitlens/utils/logger.js';
 import { extname, normalizePath } from '@gitlens/utils/path.js';
 import { getSettledValue } from '@gitlens/utils/promise.js';
+import { pluralize } from '@gitlens/utils/string.js';
 import { getAvatarUri, getAvatarUriFromGravatarEmail } from '../../avatars.js';
 import type { DiffWithCommandArgs } from '../../commands/diffWith.js';
 import type { GlWebviewCommandsOrCommandsWithSuffix } from '../../constants.commands.js';
@@ -32,6 +34,7 @@ import {
 import { countConflictMarkers } from '../../git/utils/-webview/mergeConflicts.utils.js';
 import { processRebaseEntries, readAndParseRebaseDoneFile } from '../../git/utils/-webview/rebase.parsing.utils.js';
 import { reopenRebaseTodoEditor } from '../../git/utils/-webview/rebase.utils.js';
+import { showGitErrorMessage } from '../../messages.js';
 import type { Subscription } from '../../plus/gk/models/subscription.js';
 import { isSubscriptionTrialOrPaidFromState } from '../../plus/gk/utils/subscription.utils.js';
 import { executeCommand, executeCoreCommand } from '../../system/-webview/command.js';
@@ -45,10 +48,12 @@ import type { ComposerWebviewShowingArgs } from '../plus/composer/registration.j
 import type { ShowInCommitGraphCommandArgs } from '../plus/graph/registration.js';
 import type { WebviewHost } from '../webviewProvider.js';
 import type { WebviewPanelShowCommandArgs } from '../webviewsController.js';
+import { classifyConflictAction } from './conflictResolution.utils.js';
 import type {
 	Author,
 	Commit,
 	ConflictFileInfo,
+	ConflictFileWebviewContext,
 	RebaseActiveStatus,
 	RebaseEntry,
 	RebasePauseReason,
@@ -74,10 +79,13 @@ import {
 	OpenConflictFileCommand,
 	RecomposeCommand,
 	ReorderCommand,
+	ResolveAllConflictsCommand,
+	ResolveConflictCommand,
 	RevealRefCommand,
 	SearchCommand,
 	ShiftEntriesCommand,
 	SkipCommand,
+	StageConflictCommand,
 	StartCommand,
 	SwitchCommand,
 	UpdateSelectionCommand,
@@ -333,6 +341,239 @@ export class RebaseWebviewProvider implements Disposable {
 	private getConflictFileViewColumn(): ViewColumn {
 		const rebaseColumn = this.host.viewColumn;
 		return window.tabGroups.all.find(g => g.viewColumn !== rebaseColumn)?.viewColumn ?? ViewColumn.Beside;
+	}
+
+	@ipcCommand(ResolveConflictCommand)
+	@debug()
+	private async onResolveConflict(params: IpcParams<typeof ResolveConflictCommand>): Promise<void> {
+		await this.stageConflictResolution(params.path, params.resolution);
+	}
+
+	@command('gitlens.rebase.stageCurrentChanges:')
+	@debug()
+	private async onStageCurrentChangesFromContext(item: ConflictFileWebviewContext | undefined): Promise<void> {
+		const path = item?.webviewItemValue?.path;
+		if (path == null) return;
+		await this.stageConflictResolution(path, 'current');
+	}
+
+	@command('gitlens.rebase.stageIncomingChanges:')
+	@debug()
+	private async onStageIncomingChangesFromContext(item: ConflictFileWebviewContext | undefined): Promise<void> {
+		const path = item?.webviewItemValue?.path;
+		if (path == null) return;
+		await this.stageConflictResolution(path, 'incoming');
+	}
+
+	private async stageConflictResolution(path: string, resolution: 'current' | 'incoming'): Promise<void> {
+		const normalizedPath = normalizePath(path);
+
+		const svc = this.container.git.getRepositoryService(this.repoPath);
+		const pausedStatus = await svc.pausedOps?.getPausedOperationStatus?.();
+		if (pausedStatus?.type !== 'rebase') {
+			Logger.warn('stageConflictResolution: unable to resolve — missing rebase status');
+			void window.showWarningMessage('Unable to resolve conflict — rebase status is no longer available');
+			return;
+		}
+
+		const conflictFiles = await svc.status.getConflictingFiles();
+		const conflictFile = conflictFiles.find(f => f.path === normalizedPath);
+		if (conflictFile == null) {
+			Logger.warn(`stageConflictResolution: file is no longer conflicted: ${normalizedPath}`);
+			return;
+		}
+
+		this.host.sendTelemetryEvent('rebaseEditor/action/resolveConflict', {
+			'conflict.resolution': resolution,
+			'conflict.fileExtension': extname(normalizedPath),
+			'conflict.status': conflictFile.conflictStatus,
+		});
+
+		try {
+			await this.applyConflictResolution(svc, normalizedPath, conflictFile.conflictStatus, resolution);
+		} catch (ex) {
+			void showGitErrorMessage(ex);
+		}
+	}
+
+	@ipcCommand(StageConflictCommand)
+	@debug()
+	private async onStageConflict(params: IpcParams<typeof StageConflictCommand>): Promise<void> {
+		const normalizedPath = normalizePath(params.path);
+
+		const svc = this.container.git.getRepositoryService(this.repoPath);
+		const pausedStatus = await svc.pausedOps?.getPausedOperationStatus?.();
+		if (pausedStatus?.type !== 'rebase') {
+			Logger.warn('onStageConflict: unable to stage — missing rebase status');
+			return;
+		}
+
+		const conflictFiles = await svc.status.getConflictingFiles();
+		const conflictFile = conflictFiles.find(f => f.path === normalizedPath);
+		if (conflictFile == null) {
+			Logger.warn(`onStageConflict: file is no longer conflicted: ${normalizedPath}`);
+			return;
+		}
+
+		const uri = Uri.joinPath(Uri.file(this.repoPath), normalizedPath);
+		const markerCount = await this.countConflictMarkers(uri);
+		if (markerCount > 0) {
+			const proceed = await window.showWarningMessage(
+				`${normalizedPath} still contains ${pluralize('unresolved conflict marker', markerCount)}.\n\nStage anyway?`,
+				{ modal: true },
+				{ title: 'Stage Anyway' },
+			);
+			if (proceed == null) return;
+		}
+
+		this.host.sendTelemetryEvent('rebaseEditor/action/stageConflict', {
+			'conflict.fileExtension': extname(normalizedPath),
+			'conflict.status': conflictFile.conflictStatus,
+		});
+
+		try {
+			await svc.staging?.stageFile(normalizedPath);
+		} catch (ex) {
+			void showGitErrorMessage(ex);
+		}
+	}
+
+	@ipcCommand(ResolveAllConflictsCommand)
+	@debug()
+	private async onResolveAllConflicts(params: IpcParams<typeof ResolveAllConflictsCommand>): Promise<void> {
+		const svc = this.container.git.getRepositoryService(this.repoPath);
+		const pausedStatus = await svc.pausedOps?.getPausedOperationStatus?.();
+		if (pausedStatus?.type !== 'rebase') {
+			Logger.warn('onResolveAllConflicts: unable to resolve — missing rebase status');
+			return;
+		}
+
+		const conflictFiles = await svc.status.getConflictingFiles();
+		if (!conflictFiles.length) return;
+
+		const confirmTitle = params.resolution === 'current' ? 'Stage All Current' : 'Stage All Incoming';
+		const discardedSide = params.resolution === 'current' ? 'incoming' : 'current';
+		const result = await window.showWarningMessage(
+			`Resolve all ${conflictFiles.length} conflicted files by staging the ${params.resolution} side?\n\nThis will discard the ${discardedSide} changes for every conflicted file.`,
+			{ modal: true },
+			{ title: confirmTitle },
+		);
+		if (result == null) return;
+
+		const toCheckoutOurs: string[] = [];
+		const toCheckoutTheirs: string[] = [];
+		const toDelete: string[] = [];
+		let skippedCount = 0;
+
+		for (const f of conflictFiles) {
+			const action = classifyConflictAction(f.conflictStatus, params.resolution);
+			switch (action) {
+				case 'delete':
+					toDelete.push(f.path);
+					break;
+				case 'take-ours':
+					toCheckoutOurs.push(f.path);
+					break;
+				case 'take-theirs':
+					toCheckoutTheirs.push(f.path);
+					break;
+				case 'unsupported':
+					// No content on the requested side (e.g., UA + take-current) — leave conflicted
+					skippedCount++;
+					break;
+			}
+		}
+
+		const failures: { paths: string[]; reason: unknown }[] = [];
+
+		if (toCheckoutOurs.length) {
+			try {
+				await svc.ops?.checkoutConflictedPaths?.(toCheckoutOurs, 'ours');
+			} catch (ex) {
+				failures.push({ paths: toCheckoutOurs, reason: ex });
+				toCheckoutOurs.length = 0;
+			}
+		}
+		if (toCheckoutTheirs.length) {
+			try {
+				await svc.ops?.checkoutConflictedPaths?.(toCheckoutTheirs, 'theirs');
+			} catch (ex) {
+				failures.push({ paths: toCheckoutTheirs, reason: ex });
+				toCheckoutTheirs.length = 0;
+			}
+		}
+
+		if (toDelete.length) {
+			// `git rm -f` removes the working-tree file and stages the deletion atomically,
+			// so a locked/permission-denied file fails loudly instead of silently leaving
+			// conflict markers staged via a follow-up `git add -A`.
+			try {
+				await svc.staging?.removeFiles(toDelete, { force: true });
+			} catch (ex) {
+				failures.push({ paths: toDelete, reason: ex });
+				toDelete.length = 0;
+			}
+		}
+
+		const toStage = [...toCheckoutOurs, ...toCheckoutTheirs];
+		if (toStage.length) {
+			try {
+				await svc.staging?.stageFiles(toStage);
+			} catch (ex) {
+				failures.push({ paths: toStage, reason: ex });
+			}
+		}
+
+		const failedCount = failures.reduce((n, f) => n + f.paths.length, 0);
+		const attempted = conflictFiles.length - skippedCount;
+		const resolvedCount = Math.max(0, attempted - failedCount);
+
+		this.host.sendTelemetryEvent('rebaseEditor/action/resolveAllConflicts', {
+			'conflict.resolution': params.resolution,
+			'conflict.fileCount': conflictFiles.length,
+			'conflict.fileCount.resolved': resolvedCount,
+			'conflict.fileCount.skipped': skippedCount,
+			'conflict.fileCount.failed': failedCount,
+		});
+
+		if (failedCount) {
+			void window.showErrorMessage(
+				`Failed to resolve ${failedCount} of ${attempted} conflicted ${failedCount === 1 ? 'file' : 'files'}. See logs for details.`,
+			);
+			for (const f of failures) {
+				const error = f.reason instanceof Error ? f.reason : new Error(String(f.reason));
+				for (const path of f.paths) {
+					Logger.error(error, `onResolveAllConflicts: ${path}`);
+				}
+			}
+		}
+	}
+
+	private async applyConflictResolution(
+		svc: ReturnType<Container['git']['getRepositoryService']>,
+		path: string,
+		status: GitFileConflictStatus,
+		resolution: 'current' | 'incoming',
+	): Promise<void> {
+		const action = classifyConflictAction(status, resolution);
+		switch (action) {
+			case 'delete':
+				// `git rm -f` removes the working-tree file and stages the deletion atomically,
+				// so a locked/permission-denied file fails loudly instead of silently leaving
+				// conflict markers staged via a follow-up `git add -A`.
+				await svc.staging?.removeFile(path, { force: true });
+				return;
+			case 'take-ours':
+				await svc.ops?.checkoutConflictedPath?.(path, 'ours');
+				break;
+			case 'take-theirs':
+				await svc.ops?.checkoutConflictedPath?.(path, 'theirs');
+				break;
+			case 'unsupported':
+				throw new Error(`Cannot take ${resolution} side for conflict status ${status}`);
+		}
+
+		await svc.staging?.stageFile(path);
 	}
 
 	@ipcCommand(AbortCommand)


### PR DESCRIPTION
## Summary

- Adds per-file **Take Current**, **Take Incoming**, and **Stage** actions to each conflicted file in the rebase editor's conflict panel, plus panel-header **Take All Current** / **Take All Incoming** actions (with modal confirmation) for bulk resolution
- Wraps `git checkout --ours|--theirs -- <path>` as a new `checkoutConflictedPath` operation on the git provider, filters actions to those valid for each conflict status, and warns before staging a file that still contains conflict markers
- Fixes misleading conflict status labels by decoding Git's unmerged two-char status codes explicitly — `UA` / `AU` now read as `Added by Incoming` / `Added by Current` instead of mixing in a bogus `Modified` side, while `UD` / `DU` keep their correct modified/deleted wording

Closes #5127

<img width="495" height="418" alt="image" src="https://github.com/user-attachments/assets/f1d10d9c-817a-4d80-a0a0-0605d4bb0243" />


## Test plan

- [x] Start a rebase that produces conflicts with a mix of statuses (`UU`, `UA`, `AU`, `UD`, `DU`, `AA`, `DD`)
- [x] In the rebase editor conflict panel, verify each file shows only the actions valid for its status
- [x] Use **Take Current** / **Take Incoming** / **Stage** per-file and confirm the working tree + index update correctly
- [x] Use the header **Take All Current** / **Take All Incoming** and verify the confirmation modal + bulk resolution
- [x] Stage a file that still contains conflict markers and confirm the warning prompt appears
- [x] Verify conflict status labels read correctly for `UA` / `AU` / `UD` / `DU`