### PR TITLE
Adds custom avatar URL for custom remotes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,7 +9,7 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/) and this p
 ### Added
 
 - Adds ConfigCat-based feature flag service for A/B testing and experimentation support ([#5092](https://github.com/gitkraken/vscode-gitlens/issues/5092))
-- Adds an optional `avatar` URL template to custom remotes in the `gitlens.remotes` setting &mdash; enables corporate and self-hosted setups to resolve commit-author avatars via a templated URL with `${email}`, `${name}`, `${domain}`, and `${size}` tokens ([#302](https://github.com/gitkraken/vscode-gitlens/issues/302)) &mdash; thanks to [PR #1636](https://github.com/gitkraken/vscode-gitlens/pull/1636) by Tmk ([@tmkx](https://github.com/tmkx))
+- Adds an optional `avatar` URL template to custom remotes in the `gitlens.remotes` setting &mdash; enables corporate and self-hosted setups to resolve commit-author avatars via a templated URL with `${email}`, `${emailName}`, `${domain}`, and `${size}` tokens; identity values are component-encoded before interpolation to keep attacker-controllable commit emails from injecting URL-structural characters, and templates configured via workspace settings require explicit user approval on first use in a trusted workspace (revocable via _GitLens: Reset > Approved Avatar URL Templates..._) ([#302](https://github.com/gitkraken/vscode-gitlens/issues/302), [#5155](https://github.com/gitkraken/vscode-gitlens/pull/5155)) &mdash; thanks to [PR #1636](https://github.com/gitkraken/vscode-gitlens/pull/1636) by Tmk ([@tmkx](https://github.com/tmkx))
 
 ## [18.2.0] - 2026-06-15
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/) and this p
 ### Added
 
 - Adds ConfigCat-based feature flag service for A/B testing and experimentation support ([#5092](https://github.com/gitkraken/vscode-gitlens/issues/5092))
+- Adds an optional `avatar` URL template to custom remotes in the `gitlens.remotes` setting &mdash; enables corporate and self-hosted setups to resolve commit-author avatars via a templated URL with `${email}`, `${name}`, `${domain}`, and `${size}` tokens ([#302](https://github.com/gitkraken/vscode-gitlens/issues/302)) &mdash; thanks to [PR #1636](https://github.com/gitkraken/vscode-gitlens/pull/1636) by Tmk ([@tmkx](https://github.com/tmkx))
 
 ## [18.2.0] - 2026-06-15
 

--- a/package.json
+++ b/package.json
@@ -4224,7 +4224,7 @@
 										},
 										"avatar": {
 											"type": "string",
-											"markdownDescription": "Specifies the format of an avatar URL for the custom remote service\n\nAvailable tokens\\\n`${email}` &mdash; contributor email\\\n`${name}` &mdash; email local-part\\\n`${domain}` &mdash; email domain\\\n`${size}` &mdash; avatar size"
+											"markdownDescription": "Specifies the format of an avatar URL for the custom remote service\n\nAvailable tokens\\\n`${email}` &mdash; contributor email\\\n`${emailName}` &mdash; email local-part\\\n`${domain}` &mdash; email domain\\\n`${size}` &mdash; avatar size"
 										}
 									},
 									"additionalProperties": false

--- a/package.json
+++ b/package.json
@@ -4224,7 +4224,7 @@
 										},
 										"avatar": {
 											"type": "string",
-											"markdownDescription": "Specifies the format of a avatar url for the custom remote service\n\nAvailable tokens\\\n`${email}` &mdash; contributor email\\\n`${name}` &mdash; email local-part\\\n`${domain}` &mdash; email domain\\\n`${size}` &mdash; avatar size"
+											"markdownDescription": "Specifies the format of an avatar URL for the custom remote service\n\nAvailable tokens\\\n`${email}` &mdash; contributor email\\\n`${name}` &mdash; email local-part\\\n`${domain}` &mdash; email domain\\\n`${size}` &mdash; avatar size"
 										}
 									},
 									"additionalProperties": false

--- a/package.json
+++ b/package.json
@@ -4221,6 +4221,10 @@
 										"fileRange": {
 											"type": "string",
 											"markdownDescription": "Specifies the format of a range in a file URL for the custom remote service\n\nAvailable tokens\\\n`${start}` &mdash; starting line\\\n`${end}` &mdash; ending line"
+										},
+										"avatar": {
+											"type": "string",
+											"markdownDescription": "Specifies the format of a avatar url for the custom remote service\n\nAvailable tokens\\\n`${email}` &mdash; contributor email\\\n`${name}` &mdash; email local-part\\\n`${domain}` &mdash; email domain\\\n`${size}` &mdash; avatar size"
 										}
 									},
 									"additionalProperties": false

--- a/packages/git/src/models/remoteProvider.ts
+++ b/packages/git/src/models/remoteProvider.ts
@@ -74,6 +74,7 @@ export interface RemotesUrlsConfig {
 	readonly fileInCommit: string;
 	readonly fileLine: string;
 	readonly fileRange: string;
+	readonly avatar?: string;
 }
 
 export abstract class RemoteProvider<T extends ResourceDescriptor = ResourceDescriptor> implements ProviderReference {

--- a/packages/git/src/remotes/__tests__/custom.test.ts
+++ b/packages/git/src/remotes/__tests__/custom.test.ts
@@ -1,0 +1,112 @@
+/* eslint-disable no-template-curly-in-string */
+import * as assert from 'assert';
+import type { RemotesUrlsConfig } from '../../models/remoteProvider.js';
+import { CustomRemoteProvider } from '../custom.js';
+
+const stubUrls: RemotesUrlsConfig = {
+	repository: '',
+	branches: '',
+	branch: '',
+	commit: '',
+	file: '',
+	fileInBranch: '',
+	fileInCommit: '',
+	fileLine: '',
+	fileRange: '',
+};
+
+function createProvider(avatarTemplate: string): CustomRemoteProvider {
+	return new CustomRemoteProvider('git.corp.com', 'org/repo', { ...stubUrls, avatar: avatarTemplate });
+}
+
+suite('CustomRemoteProvider.getUrlForAvatar', () => {
+	suite('basic interpolation', () => {
+		test('interpolates all tokens', () => {
+			const provider = createProvider('https://avatars.corp.com/${email}/${emailName}/${domain}?s=${size}');
+			const url = provider.getUrlForAvatar('alice@corp.com', 32);
+			assert.strictEqual(url, 'https://avatars.corp.com/alice%40corp.com/alice/corp.com?s=32');
+		});
+
+		test('returns undefined when no avatar template is configured', () => {
+			const provider = new CustomRemoteProvider('git.corp.com', 'org/repo', stubUrls);
+			assert.strictEqual(provider.getUrlForAvatar('alice@corp.com', 32), undefined);
+			assert.strictEqual(provider.avatarUrlTemplate, undefined);
+		});
+
+		test('handles email-only template', () => {
+			const provider = createProvider('https://avatars.corp.com/${email}');
+			assert.strictEqual(
+				provider.getUrlForAvatar('alice@corp.com', 16),
+				'https://avatars.corp.com/alice%40corp.com',
+			);
+		});
+
+		test('handles size-only template', () => {
+			const provider = createProvider('https://avatars.corp.com/default?s=${size}');
+			assert.strictEqual(provider.getUrlForAvatar('alice@corp.com', 64), 'https://avatars.corp.com/default?s=64');
+		});
+	});
+
+	suite('email parsing', () => {
+		test('splits on last @ for standard email', () => {
+			const provider = createProvider('${emailName}---${domain}');
+			assert.strictEqual(provider.getUrlForAvatar('alice@corp.com', 16), 'alice---corp.com');
+		});
+
+		test('preserves local-part containing @ (RFC 5322)', () => {
+			const provider = createProvider('${emailName}---${domain}');
+			assert.strictEqual(
+				provider.getUrlForAvatar('"user@internal"@corp.com', 16),
+				'%22user%40internal%22---corp.com',
+			);
+		});
+
+		test('handles email with no @', () => {
+			const provider = createProvider('${emailName}---${domain}');
+			assert.strictEqual(provider.getUrlForAvatar('localonly', 16), 'localonly---');
+		});
+
+		test('handles email with multiple @ signs', () => {
+			const provider = createProvider('${emailName}---${domain}');
+			assert.strictEqual(provider.getUrlForAvatar('a@b@c.com', 16), 'a%40b---c.com');
+		});
+	});
+
+	suite('URI encoding of special characters', () => {
+		test('encodes slash in email', () => {
+			const provider = createProvider('https://avatars.corp.com/${email}');
+			const url = provider.getUrlForAvatar('user/admin@corp.com', 16);
+			assert.ok(url!.includes('user%2Fadmin%40corp.com'));
+		});
+
+		test('encodes question mark in email', () => {
+			const provider = createProvider('https://avatars.corp.com/${email}');
+			const url = provider.getUrlForAvatar('user?q=1@corp.com', 16);
+			assert.ok(url!.includes('user%3Fq%3D1%40corp.com'));
+		});
+
+		test('encodes hash in email', () => {
+			const provider = createProvider('https://avatars.corp.com/${email}');
+			const url = provider.getUrlForAvatar('user#tag@corp.com', 16);
+			assert.ok(url!.includes('user%23tag%40corp.com'));
+		});
+
+		test('encodes spaces', () => {
+			const provider = createProvider('https://avatars.corp.com/${emailName}');
+			const url = provider.getUrlForAvatar('first last@corp.com', 16);
+			assert.ok(url!.includes('first%20last'));
+		});
+
+		test('encodes unicode characters', () => {
+			const provider = createProvider('https://avatars.corp.com/${emailName}');
+			const url = provider.getUrlForAvatar('ünïcödé@corp.com', 16);
+			assert.strictEqual(url, 'https://avatars.corp.com/%C3%BCn%C3%AFc%C3%B6d%C3%A9');
+		});
+
+		test('encodes colon and at-sign to prevent authority injection', () => {
+			const provider = createProvider('https://avatars.corp.com/${email}');
+			const url = provider.getUrlForAvatar('evil:pass@attacker.com', 16);
+			assert.ok(url!.includes('evil%3Apass%40attacker.com'));
+		});
+	});
+});

--- a/packages/git/src/remotes/custom.ts
+++ b/packages/git/src/remotes/custom.ts
@@ -36,16 +36,22 @@ export class CustomRemoteProvider extends RemoteProvider {
 	}
 
 	getUrlForAvatar(email: string, size: number): string | undefined {
-		if (this.urls.avatar != null) {
-			const [emailName, domain] = email.split('@');
-			return this.encodeUrl(
-				interpolate(
-					this.urls.avatar,
-					this.getContext({ emailName: emailName, domain: domain, email: email, size: String(size) }),
-				),
-			);
-		}
-		return undefined;
+		if (this.urls.avatar == null) return undefined;
+
+		// Split on the last `@` so local-parts that contain `@` are preserved (per RFC 5322)
+		const at = email.lastIndexOf('@');
+		const emailName = at === -1 ? email : email.slice(0, at);
+		const domain = at === -1 ? '' : email.slice(at + 1);
+
+		// Component-encode identity values — commit emails are attacker-controllable and
+		// must never be able to inject URL-structural characters (`/`, `?`, `#`, ...) into the
+		// resulting URL
+		return interpolate(this.urls.avatar, {
+			email: encodeURIComponent(email),
+			emailName: encodeURIComponent(emailName),
+			domain: encodeURIComponent(domain),
+			size: String(size),
+		});
 	}
 
 	protected override getUrlForRepository(): string {

--- a/packages/git/src/remotes/custom.ts
+++ b/packages/git/src/remotes/custom.ts
@@ -37,11 +37,11 @@ export class CustomRemoteProvider extends RemoteProvider {
 
 	getUrlForAvatar(email: string, size: number): string | undefined {
 		if (this.urls.avatar != null) {
-			const [name, domain] = email.split('@');
+			const [emailName, domain] = email.split('@');
 			return this.encodeUrl(
 				interpolate(
 					this.urls.avatar,
-					this.getContext({ name: name, domain: domain, email: email, size: String(size) }),
+					this.getContext({ emailName: emailName, domain: domain, email: email, size: String(size) }),
 				),
 			);
 		}

--- a/packages/git/src/remotes/custom.ts
+++ b/packages/git/src/remotes/custom.ts
@@ -35,6 +35,10 @@ export class CustomRemoteProvider extends RemoteProvider {
 		return [];
 	}
 
+	get avatarUrlTemplate(): string | undefined {
+		return this.urls.avatar;
+	}
+
 	getUrlForAvatar(email: string, size: number): string | undefined {
 		if (this.urls.avatar == null) return undefined;
 

--- a/packages/git/src/remotes/custom.ts
+++ b/packages/git/src/remotes/custom.ts
@@ -35,6 +35,19 @@ export class CustomRemoteProvider extends RemoteProvider {
 		return [];
 	}
 
+	getUrlForAvatar(email: string, size: number): string | undefined {
+		if (this.urls.avatar != null) {
+			const [name, domain] = email.split('@');
+			return this.encodeUrl(
+				interpolate(
+					this.urls.avatar,
+					this.getContext({ name: name, domain: domain, email: email, size: String(size) }),
+				),
+			);
+		}
+		return undefined;
+	}
+
 	protected override getUrlForRepository(): string {
 		return this.getUrl(this.urls.repository, this.getContext());
 	}

--- a/src/avatars.ts
+++ b/src/avatars.ts
@@ -21,8 +21,6 @@ import { configuration } from './system/-webview/configuration.js';
 import { getContext } from './system/-webview/context.js';
 import type { ContactPresenceStatus } from './vsls/vsls.js';
 
-const maxSmallIntegerV8 = 2 ** 30 - 1; // Max number that can be stored in V8's smis (small integers)
-
 let avatarCache: Map<string, Avatar> | undefined;
 const avatarQueue = new Map<string, Promise<Uri>>();
 
@@ -271,7 +269,7 @@ async function getAvatarUriFromRemoteProvider(
 		if (account?.avatarUrl == null) {
 			// If we have no account assume that won't change (without a reset), so set the timestamp to "never expire"
 			avatar.uri = undefined;
-			avatar.timestamp = maxSmallIntegerV8;
+			avatar.timestamp = Infinity;
 			avatar.retries = 0;
 
 			return undefined;

--- a/src/avatars.ts
+++ b/src/avatars.ts
@@ -233,6 +233,7 @@ async function getAvatarUriFromRemoteProvider(
 
 	try {
 		let account: CommitAuthor | undefined;
+		let hasAvatarSource = false;
 		// if (typeof repoPathOrCommit === 'string') {
 		// 	const remote = await Container.instance.git.getRichRemoteProvider(repoPathOrCommit);
 		// 	account = await remote?.provider.getAccountForEmail(email, { avatarSize: size });
@@ -240,6 +241,7 @@ async function getAvatarUriFromRemoteProvider(
 		if (typeof repoPathOrCommit !== 'string') {
 			const remote = await getBestRemoteWithIntegration(repoPathOrCommit.repoPath);
 			if (remote != null && remoteSupportsIntegration(remote)) {
+				hasAvatarSource = true;
 				account = await (
 					await getRemoteIntegration(remote)
 				)?.getAccountForCommit(remote.provider.repoDesc, repoPathOrCommit.ref, {
@@ -267,10 +269,12 @@ async function getAvatarUriFromRemoteProvider(
 		}
 
 		if (account?.avatarUrl == null) {
-			// If we have no account assume that won't change (without a reset), so set the timestamp to "never expire"
-			avatar.uri = undefined;
-			avatar.timestamp = Infinity;
-			avatar.retries = 0;
+			if (hasAvatarSource) {
+				// A provider was consulted but returned no avatar — permanently cache "no result"
+				avatar.uri = undefined;
+				avatar.timestamp = Infinity;
+				avatar.retries = 0;
+			}
 
 			return undefined;
 		}

--- a/src/avatars.ts
+++ b/src/avatars.ts
@@ -1,6 +1,7 @@
 import { EventEmitter, Uri } from 'vscode';
 import { fetch } from '@env/fetch.js';
 import type { CommitAuthor } from '@gitlens/git/models/author.js';
+import { CustomRemoteProvider } from '@gitlens/git/remotes/custom.js';
 import { getGitHubNoReplyAddressParts } from '@gitlens/git/remotes/github.js';
 import { base64 } from '@gitlens/utils/base64.js';
 import { md5 } from '@gitlens/utils/crypto.js';
@@ -136,7 +137,7 @@ function getAvatarUriCore(
 	if (
 		!options?.cached &&
 		repoPathOrCommit != null &&
-		getContext('gitlens:repos:withHostingIntegrationsConnected')?.includes(
+		getContext('gitlens:repos:withRemotes')?.includes(
 			typeof repoPathOrCommit === 'string' ? repoPathOrCommit : repoPathOrCommit.repoPath,
 		)
 	) {
@@ -245,6 +246,23 @@ async function getAvatarUriFromRemoteProvider(
 				)?.getAccountForCommit(remote.provider.repoDesc, repoPathOrCommit.ref, {
 					avatarSize: size,
 				});
+			}
+
+			if (!account) {
+				const remoteWithProvider = await Container.instance.git
+					.getRepositoryService(repoPathOrCommit.repoPath)
+					.remotes.getBestRemoteWithProvider();
+
+				if (remoteWithProvider?.provider instanceof CustomRemoteProvider) {
+					const avatarUrl = remoteWithProvider.provider.getUrlForAvatar(email, size);
+					if (avatarUrl != null) {
+						avatar.uri = Uri.parse(avatarUrl);
+						avatar.timestamp = Date.now();
+						avatar.retries = 0;
+						avatarCache.set(`${md5(email.trim().toLowerCase())}:${size}`, { ...avatar });
+						return avatar.uri;
+					}
+				}
 			}
 		}
 

--- a/src/avatars.ts
+++ b/src/avatars.ts
@@ -1,4 +1,5 @@
-import { EventEmitter, Uri } from 'vscode';
+import type { MessageItem } from 'vscode';
+import { EventEmitter, Uri, window, workspace } from 'vscode';
 import { fetch } from '@env/fetch.js';
 import type { CommitAuthor } from '@gitlens/git/models/author.js';
 import { CustomRemoteProvider } from '@gitlens/git/remotes/custom.js';
@@ -248,18 +249,19 @@ async function getAvatarUriFromRemoteProvider(
 				});
 			}
 
-			if (!account) {
+			if (!account?.avatarUrl) {
 				const remoteWithProvider = await Container.instance.git
 					.getRepositoryService(repoPathOrCommit.repoPath)
 					.remotes.getBestRemoteWithProvider();
 
 				if (remoteWithProvider?.provider instanceof CustomRemoteProvider) {
-					const avatarUrl = remoteWithProvider.provider.getUrlForAvatar(email, size);
+					const avatarUrl = getApprovedCustomRemoteAvatarUrl(remoteWithProvider.provider, email, size);
 					if (avatarUrl != null) {
 						avatar.uri = Uri.parse(avatarUrl);
 						avatar.timestamp = Date.now();
 						avatar.retries = 0;
 						avatarCache.set(`${md5(email.trim().toLowerCase())}:${size}`, { ...avatar });
+						_onDidFetchAvatar.fire({ email: email });
 						return avatar.uri;
 					}
 				}
@@ -354,6 +356,76 @@ export function getPresenceDataUri(status: ContactPresenceStatus): string {
 	}
 
 	return dataUri;
+}
+
+const promptedAvatarTemplates = new Set<string>();
+
+function getApprovedCustomRemoteAvatarUrl(
+	provider: CustomRemoteProvider,
+	email: string,
+	size: number,
+): string | undefined {
+	// Avatar templates from `gitlens.remotes` may originate from workspace settings
+	// — only honor them in a trusted workspace
+	if (!workspace.isTrusted) return undefined;
+
+	const template = provider.avatarUrlTemplate;
+	if (template == null) return undefined;
+
+	const approval = getAvatarTemplateApproval(template);
+	if (approval === 'allow') {
+		return provider.getUrlForAvatar(email, size);
+	}
+	if (approval === 'deny') {
+		return undefined;
+	}
+
+	// Unknown template — prompt the user (non-blocking) and fall through to fallback avatar
+	void promptForAvatarTemplateApproval(template);
+	return undefined;
+}
+
+function getAvatarTemplateApproval(template: string): 'allow' | 'deny' | undefined {
+	const approvals = Container.instance.storage.get('avatars:approvedRemoteTemplates');
+	if (approvals == null) return undefined;
+	return Object.hasOwn(approvals, template) ? approvals[template] : undefined;
+}
+
+async function setAvatarTemplateApproval(template: string, decision: 'allow' | 'deny'): Promise<void> {
+	const approvals: Record<string, 'allow' | 'deny'> = Object.create(null);
+	Object.assign(approvals, Container.instance.storage.get('avatars:approvedRemoteTemplates'));
+	approvals[template] = decision;
+	await Container.instance.storage.store('avatars:approvedRemoteTemplates', approvals);
+}
+
+async function promptForAvatarTemplateApproval(template: string): Promise<void> {
+	if (promptedAvatarTemplates.has(template)) return;
+
+	promptedAvatarTemplates.add(template);
+
+	const allow: MessageItem = { title: 'Allow' };
+	const deny: MessageItem = { title: 'Deny' };
+	const notNow: MessageItem = { title: 'Not Now', isCloseAffordance: true };
+
+	const result = await window.showInformationMessage(
+		`The \`gitlens.remotes\` setting in this workspace includes an avatar URL template that will be requested for every commit author.\n\nTemplate: ${template}\n\nDo you trust this workspace to make these requests?`,
+		allow,
+		deny,
+		notNow,
+	);
+
+	if (result === allow) {
+		await setAvatarTemplateApproval(template, 'allow');
+		resetAvatarCache('failed');
+	} else if (result === deny) {
+		await setAvatarTemplateApproval(template, 'deny');
+	}
+}
+
+export function resetApprovedAvatarTemplates(): Promise<void> {
+	promptedAvatarTemplates.clear();
+	resetAvatarCache('failed');
+	return Container.instance.storage.delete('avatars:approvedRemoteTemplates');
 }
 
 export function resetAvatarCache(reset: 'all' | 'failed' | 'fallback'): void {

--- a/src/commands/resets.ts
+++ b/src/commands/resets.ts
@@ -1,6 +1,6 @@
 import type { MessageItem } from 'vscode';
 import { ConfigurationTarget, window } from 'vscode';
-import { resetAvatarCache } from '../avatars.js';
+import { resetApprovedAvatarTemplates, resetAvatarCache } from '../avatars.js';
 import type { Container } from '../container.js';
 import type { QuickPickItemOfT } from '../quickpicks/items/common.js';
 import { createQuickPickSeparator } from '../quickpicks/items/common.js';
@@ -12,6 +12,7 @@ const resetTypes = [
 	'ai',
 	'ai:confirmations',
 	'avatars',
+	'avatars:approvedTemplates',
 	'integrations',
 	'onboarding',
 	'previews',
@@ -46,6 +47,11 @@ export class ResetCommand extends GlCommandBase {
 				label: 'Avatars...',
 				detail: 'Clears the stored avatar cache',
 				item: 'avatars',
+			},
+			{
+				label: 'Approved Avatar URL Templates...',
+				detail: 'Clears approvals granted to custom remote avatar URL templates',
+				item: 'avatars:approvedTemplates',
 			},
 			{
 				label: 'Integrations (Authentication)...',
@@ -131,6 +137,11 @@ export class ResetCommand extends GlCommandBase {
 				confirmationMessage = 'Are you sure you want to reset the avatar cache?';
 				confirm.title = 'Reset Avatars';
 				break;
+			case 'avatars:approvedTemplates':
+				confirmationMessage =
+					'Are you sure you want to reset all approvals for custom remote avatar URL templates?';
+				confirm.title = 'Reset Approved Avatar URL Templates';
+				break;
 			case 'integrations':
 				confirmationMessage = 'Are you sure you want to reset all of the stored integrations?';
 				confirm.title = 'Reset Integrations';
@@ -203,6 +214,10 @@ export class ResetCommand extends GlCommandBase {
 
 			case 'avatars':
 				resetAvatarCache('all');
+				break;
+
+			case 'avatars:approvedTemplates':
+				await resetApprovedAvatarTemplates();
 				break;
 
 			case 'integrations':

--- a/src/config.ts
+++ b/src/config.ts
@@ -718,6 +718,7 @@ export interface RemotesUrlsConfig {
 	readonly fileInCommit: string;
 	readonly fileLine: string;
 	readonly fileRange: string;
+	readonly avatar?: string;
 }
 
 interface SigningConfig {

--- a/src/constants.storage.ts
+++ b/src/constants.storage.ts
@@ -35,6 +35,7 @@ export type IntegrationAuthenticationKeys =
 export const enum SyncedStorageKeys {
 	Version = 'gitlens:synced:version',
 	PreReleaseVersion = 'gitlens:synced:preVersion',
+	ApprovedAvatarRemoteTemplates = 'gitlens:avatars:approvedRemoteTemplates',
 }
 
 export type DeprecatedGlobalStorage = {
@@ -88,6 +89,7 @@ interface GlobalStorageCore {
 	avatars: [string, StoredAvatar][];
 	'ai:scope:compose:model': AIProviderAndModel;
 	'ai:scope:review:model': AIProviderAndModel;
+	'avatars:approvedRemoteTemplates': Record<string, 'allow' | 'deny'>;
 	'confirm:ai:generateCommits': boolean;
 	'confirm:ai:tos': boolean;
 	repoVisibility: [string, StoredRepoVisibilityInfo][];

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -312,7 +312,12 @@ export function deactivate(): void {
 // }
 
 function setKeysForSync(context: ExtensionContext, ...keys: (SyncedStorageKeys | string)[]) {
-	context.globalState?.setKeysForSync([...keys, SyncedStorageKeys.Version, SyncedStorageKeys.PreReleaseVersion]);
+	context.globalState?.setKeysForSync([
+		...keys,
+		SyncedStorageKeys.ApprovedAvatarRemoteTemplates,
+		SyncedStorageKeys.Version,
+		SyncedStorageKeys.PreReleaseVersion,
+	]);
 }
 
 function setFeatureFlagTelemetryGlobalAttributes(container: Container): void {


### PR DESCRIPTION
Rebases and integrates #1636 (by @tmkx) on top of the current `main` after the `@gitlens/git` package split.

## Summary

Adds an optional `avatar` URL template to `gitlens.remotes[].urls`, enabling corporate / self-hosted setups to resolve commit-author avatars through a custom URL.

```diff
 "gitlens.remotes": [
   {
     "domain": "gitlab.intranet.com",
     "type": "Custom",
     "urls": {
       "repository": "https://gitlab.intranet.com/${repo}",
       ...
+      "avatar": "https://avatar.intranet.com/employee?username=${emailName}&size=${size}"
     }
   }
 ]
```

Available tokens: `${email}`, `${emailName}` (email local-part), `${domain}`, `${size}`.

When no hosting integration resolves the commit author, `getAvatarUriFromRemoteProvider` now falls back to the best remote-with-provider; if that provider is a `CustomRemoteProvider` with `avatar` configured, its interpolated URL is cached and returned.

## Differences vs. original PR #1636

- **Rebased onto the `@gitlens/git` package split** — `CustomRemote` was renamed to `CustomRemoteProvider` and moved to `packages/git/src/remotes/custom.ts`; the `RemotesUrlsConfig` interface in the package needed the same `avatar?: string` addition as `src/config.ts`.
- **`${name}` token renamed to `${emailName}`** — disambiguates from the commit-author display name. The schema description already labels it as "email local-part", but the variable name itself was potentially confusing.
- **Hardened against email-driven URL injection.** Commit emails are attacker-controllable, and the original interpolation ran through `encodeUrl` (= `encodeURI`), which leaves `/`, `?`, `#`, `@`, and `:` intact — so a crafted email could bend the resulting avatar URL's path, query, or fragment. `getUrlForAvatar` now component-encodes `${email}`, `${emailName}`, and `${domain}` before interpolation, splits the email on the last `@` (so RFC 5322 local-parts containing `@` aren't truncated), and drops the now-redundant outer `encodeUrl`.
- **CHANGELOG entry added** — credits @tmkx for the original PR.
- **Grammar fix** in the `markdownDescription` for the `avatar` field (`"a avatar url"` → `"an avatar URL"`).
- **Scope of closed issues narrowed.** The original PR description had `close #302` and `close #1036`. This PR closes **#302 only**. Issue **#1036** asks for a standalone `gitlens.avatars` setting (map of `email` → file URI, or a folder of images) so that users without a custom remote — e.g., regular github.com users who just want local employee photos — can configure avatars. That specific mechanism is **not** delivered here: this PR requires a `gitlens.remotes` entry with `"type": "Custom"` and an `avatar` template, so #1036 should remain open.

Refs #1036 · Closes #302

## Test plan

- [ ] With a `gitlens.remotes` entry of `"type": "Custom"` and an `avatar` template, commit-author avatars in the blame hover, commit details, and views resolve to the templated URL.
- [ ] Without an `avatar` template, behavior is unchanged (Gravatar / hosting-integration path).
- [ ] No regression on repos with only standard remotes (github/gitlab.com).
- [ ] Verify `${emailName}`, `${email}`, `${domain}`, `${size}` tokens all interpolate.
- [ ] Settings IntelliSense shows the `avatar` field with the correct description.
- [ ] Email with URL-structural characters (e.g., `a/b@host`) produces a URL that preserves the email verbatim via component-encoding, without bending the template's path/query.
