### PR TITLE
Centralize signing-error classification across git-cli operations

### DIFF
--- a/packages/git-cli/src/exec/__tests__/gitErrors.test.ts
+++ b/packages/git-cli/src/exec/__tests__/gitErrors.test.ts
@@ -1,6 +1,13 @@
 import * as assert from 'assert';
 import { RunError } from '../exec.errors.js';
-import { getGitCommandError, GitError, GitErrors, GitWarnings } from '../git.js';
+import {
+	classifySigningError,
+	getGitCommandError,
+	GitError,
+	GitErrors,
+	GitWarnings,
+	inferSigningFormatFromError,
+} from '../git.js';
 
 /**
  * Helper: creates a GitError wrapping a RunError with the given stderr.
@@ -436,5 +443,172 @@ suite('getGitCommandError() Test Suite', () => {
 	test('maps fetch stderr to "remoteConnectionFailed" reason', () => {
 		const ex = makeGitError('fatal: Could not read from remote repository.');
 		assert.strictEqual(captureReason('fetch', ex), 'remoteConnectionFailed');
+	});
+});
+
+suite('Signing Errors Test Suite', () => {
+	suite('GitErrors signing regexes', () => {
+		test('gpgSignFailed matches standard gpg sign failure', () => {
+			const stderr = 'error: gpg failed to sign the data\nfatal: failed to write commit object';
+			assert.ok(GitErrors.gpgSignFailed.test(stderr));
+		});
+
+		test('gpgSignFailed matches with CRLF line endings', () => {
+			const stderr = 'error: gpg failed to sign the data\r\nfatal: failed to write commit object\r\n';
+			assert.ok(GitErrors.gpgSignFailed.test(stderr));
+		});
+
+		test('gpgSignFailed does NOT match unrelated gpg config error', () => {
+			// Intentional narrowing vs. the old patch.ts substring check which matched
+			// any "error: gpg" prefix and falsely classified config errors as passphrase failures.
+			const stderr = 'error: gpg.format is set to an invalid value';
+			assert.ok(!GitErrors.gpgSignFailed.test(stderr));
+		});
+
+		test('signingKeyNotAvailable matches "No secret key"', () => {
+			const stderr = 'gpg: skipped "ABC123": No secret key';
+			assert.ok(GitErrors.signingKeyNotAvailable.test(stderr));
+		});
+
+		test('signingKeyNotAvailable matches "signing failed: No secret key"', () => {
+			const stderr = 'gpg: signing failed: No secret key';
+			assert.ok(GitErrors.signingKeyNotAvailable.test(stderr));
+		});
+
+		test('signingKeyNotAvailable matches "no signing key"', () => {
+			const stderr = 'error: no signing key found';
+			assert.ok(GitErrors.signingKeyNotAvailable.test(stderr));
+		});
+
+		test('gpgNotFound matches POSIX shell "not found"', () => {
+			const stderr = 'sh: 1: gpg: not found';
+			assert.ok(GitErrors.gpgNotFound.test(stderr));
+		});
+
+		test('gpgNotFound matches Windows "not recognized as"', () => {
+			const stderr = "'gpg' is not recognized as an internal or external command";
+			assert.ok(GitErrors.gpgNotFound.test(stderr));
+		});
+
+		test('gpgNotFound matches "cannot run gpg"', () => {
+			const stderr = 'error: cannot run gpg: No such file or directory';
+			assert.ok(GitErrors.gpgNotFound.test(stderr));
+		});
+
+		test('gpgNotFound does NOT match "gpg-agent: signing failed"', () => {
+			const stderr = 'gpg-agent: signing failed: Operation cancelled';
+			assert.ok(!GitErrors.gpgNotFound.test(stderr));
+		});
+
+		test('sshNotFound matches "unable to start ssh-keygen"', () => {
+			const stderr = 'error: unable to start ssh-keygen: No such file or directory';
+			assert.ok(GitErrors.sshNotFound.test(stderr));
+		});
+
+		test('sshNotFound matches Windows "not recognized"', () => {
+			const stderr = "'ssh-keygen' is not recognized as an internal or external command";
+			assert.ok(GitErrors.sshNotFound.test(stderr));
+		});
+
+		test('sshNotFound does NOT match unrelated ssh connection error', () => {
+			const stderr = 'ssh: connect to host example.com port 22: Connection refused';
+			assert.ok(!GitErrors.sshNotFound.test(stderr));
+		});
+	});
+
+	suite('classifySigningError', () => {
+		test('returns "passphraseFailed" for gpg sign failure stderr', () => {
+			const ex = new GitError(
+				new RunError({ message: '', cmd: 'git commit', code: 1 }, '', 'error: gpg failed to sign the data'),
+			);
+			assert.strictEqual(classifySigningError(ex), 'passphraseFailed');
+		});
+
+		test('returns "noKey" for "No secret key" stderr', () => {
+			const ex = new GitError(
+				new RunError({ message: '', cmd: 'git commit', code: 1 }, '', 'gpg: signing failed: No secret key'),
+			);
+			assert.strictEqual(classifySigningError(ex), 'noKey');
+		});
+
+		test('returns "gpgNotFound" for POSIX shell not-found', () => {
+			const ex = new GitError(
+				new RunError({ message: '', cmd: 'git commit', code: 1 }, '', 'sh: 1: gpg: not found'),
+			);
+			assert.strictEqual(classifySigningError(ex), 'gpgNotFound');
+		});
+
+		test('returns "sshNotFound" for ssh-keygen unavailable', () => {
+			const ex = new GitError(
+				new RunError(
+					{ message: '', cmd: 'git commit', code: 1 },
+					'',
+					'error: unable to start ssh-keygen: No such file or directory',
+				),
+			);
+			assert.strictEqual(classifySigningError(ex), 'sshNotFound');
+		});
+
+		test('returns undefined when stderr is not signing-related', () => {
+			const ex = new GitError(
+				new RunError(
+					{ message: '', cmd: 'git commit', code: 1 },
+					'',
+					'error: pathspec "foo" did not match any files',
+				),
+			);
+			assert.strictEqual(classifySigningError(ex), undefined);
+		});
+
+		test('precedence: "passphraseFailed" wins over "noKey" when both appear', () => {
+			// Preserves the ordering from patch.ts's original classifier: the outer
+			// "gpg failed to sign" cause takes precedence over the inner "No secret key".
+			const ex = new GitError(
+				new RunError(
+					{ message: '', cmd: 'git commit', code: 1 },
+					'',
+					'error: gpg failed to sign the data\ngpg: signing failed: No secret key',
+				),
+			);
+			assert.strictEqual(classifySigningError(ex), 'passphraseFailed');
+		});
+
+		test('reads Error.message when passed a plain Error (non-GitError)', () => {
+			const ex = new Error('error: gpg failed to sign the data');
+			assert.strictEqual(classifySigningError(ex), 'passphraseFailed');
+		});
+
+		test('returns undefined for null/undefined/empty input', () => {
+			assert.strictEqual(classifySigningError(undefined), undefined);
+			assert.strictEqual(classifySigningError(null), undefined);
+			assert.strictEqual(classifySigningError(''), undefined);
+		});
+	});
+
+	suite('inferSigningFormatFromError', () => {
+		test('returns "ssh" when stderr mentions ssh-keygen', () => {
+			const ex = new Error('error: unable to start ssh-keygen');
+			assert.strictEqual(inferSigningFormatFromError(ex), 'ssh');
+		});
+
+		test('returns "ssh" when stderr mentions gpg.ssh.* config', () => {
+			const ex = new Error('error: gpg.ssh.allowedSignersFile is unset');
+			assert.strictEqual(inferSigningFormatFromError(ex), 'ssh');
+		});
+
+		test('returns "gpg" when stderr mentions gpg but not ssh', () => {
+			const ex = new Error('error: gpg failed to sign the data');
+			assert.strictEqual(inferSigningFormatFromError(ex), 'gpg');
+		});
+
+		test('returns "ssh" when both ssh-keygen and gpg appear (ssh wins)', () => {
+			const ex = new Error('error: unable to start ssh-keygen\ngpg: fallback not attempted');
+			assert.strictEqual(inferSigningFormatFromError(ex), 'ssh');
+		});
+
+		test('returns undefined for unrelated stderr', () => {
+			const ex = new Error('fatal: not a git repository');
+			assert.strictEqual(inferSigningFormatFromError(ex), undefined);
+		});
 	});
 });

--- a/packages/git-cli/src/exec/git.ts
+++ b/packages/git-cli/src/exec/git.ts
@@ -17,6 +17,7 @@ import type {
 	ResetErrorReason,
 	RevertErrorReason,
 	ShowErrorReason,
+	SigningErrorReason,
 	StashApplyErrorReason,
 	StashPushErrorReason,
 	TagErrorReason,
@@ -24,6 +25,7 @@ import type {
 	WorktreeDeleteErrorReason,
 } from '@gitlens/git/errors.js';
 import { WorkspaceUntrustedError } from '@gitlens/git/errors.js';
+import type { SigningFormat } from '@gitlens/git/models/signature.js';
 import { CancellationError, getAbortSignalId, isCancellationError } from '@gitlens/utils/cancellation.js';
 import { getScopedCounter } from '@gitlens/utils/counter.js';
 import { getDurationMilliseconds, hrtime } from '@gitlens/utils/hrtime.js';
@@ -74,6 +76,8 @@ export const GitErrors = {
 	detachedHead: /You are in 'detached HEAD' state/i,
 	entryNotUpToDate: /error:\s*Entry ['"].+['"] not uptodate\. Cannot merge\./i,
 	failedToDeleteDirectoryNotEmpty: /failed to delete '(.*?)': Directory not empty/i,
+	gpgNotFound: /gpg:?\s*(?:command\s+)?not found|'gpg' is not recognized as|cannot run gpg:/i,
+	gpgSignFailed: /^error:\s*gpg failed to sign the data/im,
 	invalidName: /fatal:\s*'.+?' is not a valid branch name/i,
 	invalidLineCount: /file .+? has only (\d+) lines/i,
 	invalidObjectName: /invalid object name: (.*)\s/i,
@@ -106,6 +110,8 @@ export const GitErrors = {
 	remoteAhead: /rejected because the remote contains work/i,
 	remoteConnectionFailed: /Could not read from remote repository/i,
 	remoteRejected: /rejected because the remote contains work/i,
+	signingKeyNotAvailable: /secret key not available|no secret key|no signing key/i,
+	sshNotFound: /ssh-keygen[^\n]*(?:not found|No such file or directory|is not recognized)/i,
 	stashConflictingStagedAndUnstagedLines: /Cannot remove worktree changes/i,
 	stashNothingToSave: /No local changes to save/i,
 	stashSavedWorkingDirAndIndexState: /Saved working directory and index state/i,
@@ -411,6 +417,52 @@ export function getGitCommandError<T extends GitCommand, TReturn extends GitComm
 	}
 
 	return creator(undefined);
+}
+
+function extractSigningErrorText(ex: unknown): string {
+	if (ex == null) return '';
+	if (ex instanceof GitError) return ex.stderr || ex.stdout || ex.message || '';
+	if (ex instanceof Error) return ex.message || '';
+	if (typeof ex === 'string') return ex;
+	if (typeof ex === 'number' || typeof ex === 'boolean' || typeof ex === 'bigint') return String(ex);
+	if (typeof ex === 'object' && 'message' in ex && typeof ex.message === 'string') return ex.message;
+	return '';
+}
+
+/**
+ * Classifies a Git error as a signing-related failure using the {@link GitErrors}
+ * signing regexes. Returns the matched {@link SigningErrorReason}, or `undefined`
+ * when the error is not a recognized signing failure.
+ *
+ * Precedence is significant: `passphraseFailed` (gpg sign failure) is checked
+ * before `noKey`, matching the ordering used historically in patch.ts — a
+ * combined stderr like "error: gpg failed to sign … gpg: No secret key"
+ * resolves to `passphraseFailed`, the outer cause.
+ */
+export function classifySigningError(ex: unknown): SigningErrorReason | undefined {
+	const text = extractSigningErrorText(ex);
+	if (!text) return undefined;
+	if (GitErrors.gpgSignFailed.test(text)) return 'passphraseFailed';
+	if (GitErrors.signingKeyNotAvailable.test(text)) return 'noKey';
+	if (GitErrors.gpgNotFound.test(text)) return 'gpgNotFound';
+	if (GitErrors.sshNotFound.test(text)) return 'sshNotFound';
+	return undefined;
+}
+
+/**
+ * Infers the {@link SigningFormat} from stderr hints (e.g., mentions of
+ * `ssh-keygen` or `gpg.ssh.*` config keys). Returns `undefined` when no hints
+ * are present so callers can supply their own default (typically `'gpg'`).
+ *
+ * Used as a fallback when `config.getSigningConfig` is unavailable or rejects
+ * on the error path.
+ */
+export function inferSigningFormatFromError(ex: unknown): SigningFormat | undefined {
+	const text = extractSigningErrorText(ex);
+	if (!text) return undefined;
+	if (/\bssh-keygen\b|gpg\.ssh\.(?:program|allowedsignersfile)/i.test(text)) return 'ssh';
+	if (/\bgpg\b/i.test(text)) return 'gpg';
+	return undefined;
 }
 
 export interface GitOptions {

--- a/packages/git-cli/src/providers/__tests__/integration/helpers.ts
+++ b/packages/git-cli/src/providers/__tests__/integration/helpers.ts
@@ -10,7 +10,7 @@ import { mkdirSync, mkdtempSync, readdirSync, readFileSync, rmSync, statSync, wr
 import { readFile } from 'node:fs/promises';
 import { tmpdir } from 'node:os';
 import { join } from 'node:path';
-import type { FileSystemProvider, GitServiceContext } from '@gitlens/git/context.js';
+import type { FileSystemProvider, GitServiceContext, GitServiceHooks } from '@gitlens/git/context.js';
 import { Logger } from '@gitlens/utils/logger.js';
 import { toFsPath } from '@gitlens/utils/uri.js';
 import { CliGitProvider } from '../../../cliGitProvider.js';
@@ -59,9 +59,10 @@ function ensureLogger() {
 	});
 }
 
-function createMinimalContext(): GitServiceContext {
+function createMinimalContext(hooks?: GitServiceHooks): GitServiceContext {
 	return {
 		fs: createNodeFs(),
+		hooks: hooks,
 	};
 }
 
@@ -96,7 +97,7 @@ function createNodeFs(): FileSystemProvider {
  *
  * Call `cleanup()` in your `teardown()` / `suiteTeardown()`.
  */
-export function createTestRepo(): TestRepo {
+export function createTestRepo(options?: { hooks?: GitServiceHooks }): TestRepo {
 	ensureLogger();
 
 	const dir = mkdtempSync(join(tmpdir(), 'gitlens-test-'));
@@ -120,7 +121,7 @@ export function createTestRepo(): TestRepo {
 		env: { ...process.env, GIT_COMMITTER_DATE: '2024-01-01T00:00:00Z', GIT_AUTHOR_DATE: '2024-01-01T00:00:00Z' },
 	});
 
-	const context = createMinimalContext();
+	const context = createMinimalContext(options?.hooks);
 	const provider = new CliGitProvider({
 		context: context,
 		locator: getGitLocation,

--- a/packages/git-cli/src/providers/__tests__/integration/operations.test.ts
+++ b/packages/git-cli/src/providers/__tests__/integration/operations.test.ts
@@ -2,7 +2,9 @@ import * as assert from 'assert';
 import { execFileSync } from 'node:child_process';
 import { writeFileSync } from 'node:fs';
 import { join } from 'node:path';
-import { CommitError, MergeError } from '@gitlens/git/errors.js';
+import type { SigningErrorReason } from '@gitlens/git/errors.js';
+import { CommitError, MergeError, SigningError } from '@gitlens/git/errors.js';
+import type { SigningFormat } from '@gitlens/git/models/signature.js';
 import { addCommit, createBranch, createTestRepo } from './helpers.js';
 
 suite('OperationsGitSubProvider.merge', () => {
@@ -178,6 +180,75 @@ suite('OperationsGitSubProvider.commit', () => {
 			assert.strictEqual(log[0], 'amended');
 			// The original commit was amended, not appended — check that only one commit exists after initial
 			assert.strictEqual(log.length, 2, 'Expected 2 commits total (initial + amended)');
+		} finally {
+			r.cleanup();
+		}
+	});
+});
+
+suite('OperationsGitSubProvider signing', () => {
+	test('commit throws SigningError and fires onSigningFailed when gpg program fails', async () => {
+		const calls: Array<{ reason: SigningErrorReason; format: SigningFormat; source: unknown }> = [];
+		const r = createTestRepo({
+			hooks: {
+				commits: {
+					onSigningFailed: (reason, format, source) =>
+						calls.push({ reason: reason, format: format, source: source }),
+				},
+			},
+		});
+		try {
+			execFileSync('git', ['config', 'commit.gpgsign', 'true'], { cwd: r.path, stdio: 'pipe' });
+			execFileSync('git', ['config', 'gpg.format', 'openpgp'], { cwd: r.path, stdio: 'pipe' });
+			execFileSync('git', ['config', 'gpg.program', 'node --eval process.exit(1)'], {
+				cwd: r.path,
+				stdio: 'pipe',
+			});
+
+			writeFileSync(join(r.path, 'signed.txt'), 'content\n');
+			execFileSync('git', ['add', 'signed.txt'], { cwd: r.path, stdio: 'pipe' });
+
+			const sentinel = { caller: 'test-sentinel' };
+			await assert.rejects(
+				() => r.provider.ops.commit(r.path, 'should fail to sign', { source: sentinel }),
+				ex =>
+					SigningError.is(ex) &&
+					// Any real signing reason is acceptable — different git versions emit different stderr.
+					['passphraseFailed', 'noKey', 'gpgNotFound'].includes(ex.details.reason ?? 'unknown'),
+				'Expected a SigningError (not CommitError) when gpg sign fails',
+			);
+
+			assert.strictEqual(calls.length, 1, 'Expected onSigningFailed hook to fire exactly once');
+			assert.ok(
+				['passphraseFailed', 'noKey', 'gpgNotFound'].includes(calls[0].reason),
+				`Unexpected hook reason: ${calls[0].reason}`,
+			);
+			// getSigningConfig reads gpg.format from the repo config we set above.
+			assert.strictEqual(calls[0].format, 'openpgp');
+			assert.strictEqual(calls[0].source, sentinel, 'Expected `source` to be threaded to the hook');
+		} finally {
+			r.cleanup();
+		}
+	});
+
+	test('non-signing commit failures still throw CommitError (baseline)', async () => {
+		const calls: unknown[] = [];
+		const r = createTestRepo({
+			hooks: {
+				commits: {
+					onSigningFailed: (...args) => calls.push(args),
+				},
+			},
+		});
+		try {
+			// No signing configured; a clean-tree commit should yield CommitError('nothingToCommit'),
+			// not SigningError, and the hook must not fire.
+			await assert.rejects(
+				() => r.provider.ops.commit(r.path, 'empty commit'),
+				ex => CommitError.is(ex, 'nothingToCommit'),
+				'Expected CommitError with reason nothingToCommit',
+			);
+			assert.strictEqual(calls.length, 0, 'onSigningFailed must not fire for non-signing failures');
 		} finally {
 			r.cleanup();
 		}

--- a/packages/git-cli/src/providers/operations.ts
+++ b/packages/git-cli/src/providers/operations.ts
@@ -11,8 +11,10 @@ import {
 	RebaseError,
 	ResetError,
 	RevertError,
+	SigningError,
 } from '@gitlens/git/errors.js';
 import type { GitBranchReference, GitReference } from '@gitlens/git/models/reference.js';
+import type { SigningFormat } from '@gitlens/git/models/signature.js';
 import type { GitConflictFile } from '@gitlens/git/models/staging.js';
 import type { GitOperationResult, GitOperationsSubProvider } from '@gitlens/git/providers/operations.js';
 import { getBranchNameAndRemote, getBranchTrackingWithoutRemote } from '@gitlens/git/utils/branch.utils.js';
@@ -24,7 +26,13 @@ import { getScopedLogger } from '@gitlens/utils/logger.scoped.js';
 import { normalizePath, splitPath } from '@gitlens/utils/path.js';
 import type { CliGitProviderInternal } from '../cliGitProvider.js';
 import type { Git, PushForceOptions } from '../exec/git.js';
-import { getGitCommandError, gitConfigsPull, GitErrors } from '../exec/git.js';
+import {
+	classifySigningError,
+	getGitCommandError,
+	gitConfigsPull,
+	GitErrors,
+	inferSigningFormatFromError,
+} from '../exec/git.js';
 
 export class OperationsGitSubProvider implements GitOperationsSubProvider {
 	constructor(
@@ -89,7 +97,7 @@ export class OperationsGitSubProvider implements GitOperationsSubProvider {
 	async cherryPick(
 		repoPath: string,
 		revs: string[],
-		options?: { edit?: boolean; noCommit?: boolean },
+		options?: { edit?: boolean; noCommit?: boolean; source?: unknown },
 	): Promise<GitOperationResult> {
 		const scope = getScopedLogger();
 
@@ -129,6 +137,7 @@ export class OperationsGitSubProvider implements GitOperationsSubProvider {
 			return { conflicted: false };
 		} catch (ex) {
 			scope?.error(ex);
+			await this.throwIfSigningError(repoPath, args, ex, options?.source);
 			const mapped = getGitCommandError(
 				'cherry-pick',
 				ex,
@@ -157,6 +166,7 @@ export class OperationsGitSubProvider implements GitOperationsSubProvider {
 			author?: string;
 			date?: string;
 			signoff?: boolean;
+			source?: unknown;
 		},
 	): Promise<void> {
 		const scope = getScopedLogger();
@@ -189,6 +199,7 @@ export class OperationsGitSubProvider implements GitOperationsSubProvider {
 			this.context.hooks?.repository?.onChanged?.(repoPath, ['head', 'heads', 'index']);
 		} catch (ex) {
 			scope?.error(ex);
+			await this.throwIfSigningError(repoPath, params, ex, options?.source);
 			throw getGitCommandError(
 				'commit',
 				ex,
@@ -289,7 +300,7 @@ export class OperationsGitSubProvider implements GitOperationsSubProvider {
 	async merge(
 		repoPath: string,
 		ref: string,
-		options?: { fastForward?: boolean | 'only'; noCommit?: boolean; squash?: boolean },
+		options?: { fastForward?: boolean | 'only'; noCommit?: boolean; squash?: boolean; source?: unknown },
 	): Promise<GitOperationResult> {
 		const scope = getScopedLogger();
 
@@ -323,6 +334,7 @@ export class OperationsGitSubProvider implements GitOperationsSubProvider {
 			return { conflicted: false };
 		} catch (ex) {
 			scope?.error(ex);
+			await this.throwIfSigningError(repoPath, args, ex, options?.source);
 			const mapped = getGitCommandError(
 				'merge',
 				ex,
@@ -343,7 +355,7 @@ export class OperationsGitSubProvider implements GitOperationsSubProvider {
 	@debug()
 	async pull(
 		repoPath: string,
-		options?: { branch?: GitBranchReference; rebase?: boolean; tags?: boolean },
+		options?: { branch?: GitBranchReference; rebase?: boolean; tags?: boolean; source?: unknown },
 	): Promise<void> {
 		const scope = getScopedLogger();
 
@@ -360,6 +372,7 @@ export class OperationsGitSubProvider implements GitOperationsSubProvider {
 					await this.pullCore(normalizePath(worktree.uri.fsPath), {
 						rebase: options?.rebase,
 						tags: options?.tags,
+						source: options?.source,
 					});
 					this.context.hooks?.cache?.onReset?.(repoPath, 'branches', 'status', 'tags');
 					this.context.hooks?.repository?.onChanged?.(repoPath, ['head', 'heads', 'remotes', 'index']);
@@ -373,6 +386,7 @@ export class OperationsGitSubProvider implements GitOperationsSubProvider {
 			await this.pullCore(repoPath, {
 				rebase: options?.rebase,
 				tags: options?.tags,
+				source: options?.source,
 			});
 
 			this.context.hooks?.cache?.onReset?.(repoPath, 'branches', 'status', 'tags');
@@ -383,7 +397,10 @@ export class OperationsGitSubProvider implements GitOperationsSubProvider {
 		}
 	}
 
-	private async pullCore(repoPath: string, options: { rebase?: boolean; tags?: boolean }): Promise<void> {
+	private async pullCore(
+		repoPath: string,
+		options: { rebase?: boolean; tags?: boolean; source?: unknown },
+	): Promise<void> {
 		const params = ['pull'];
 
 		if (options.tags) {
@@ -397,6 +414,7 @@ export class OperationsGitSubProvider implements GitOperationsSubProvider {
 		try {
 			await this.git.exec({ cwd: repoPath, configs: gitConfigsPull }, ...params);
 		} catch (ex) {
+			await this.throwIfSigningError(repoPath, params, ex, options.source);
 			throw getGitCommandError(
 				'pull',
 				ex,
@@ -609,6 +627,7 @@ export class OperationsGitSubProvider implements GitOperationsSubProvider {
 			interactive?: boolean;
 			onto?: string;
 			updateRefs?: boolean;
+			source?: unknown;
 		},
 	): Promise<GitOperationResult> {
 		const scope = getScopedLogger();
@@ -653,6 +672,7 @@ export class OperationsGitSubProvider implements GitOperationsSubProvider {
 			return { conflicted: false };
 		} catch (ex) {
 			scope?.error(ex);
+			await this.throwIfSigningError(repoPath, args, ex, options?.source);
 			const mapped = getGitCommandError(
 				'rebase',
 				ex,
@@ -716,7 +736,11 @@ export class OperationsGitSubProvider implements GitOperationsSubProvider {
 
 	@sequentialize({ getQueueKey: rp => rp })
 	@debug()
-	async revert(repoPath: string, refs: string[], options?: { editMessage?: boolean }): Promise<GitOperationResult> {
+	async revert(
+		repoPath: string,
+		refs: string[],
+		options?: { editMessage?: boolean; source?: unknown },
+	): Promise<GitOperationResult> {
 		const scope = getScopedLogger();
 
 		const args = ['revert'];
@@ -741,6 +765,7 @@ export class OperationsGitSubProvider implements GitOperationsSubProvider {
 			return { conflicted: false };
 		} catch (ex) {
 			scope?.error(ex);
+			await this.throwIfSigningError(repoPath, args, ex, options?.source);
 
 			const mapped = getGitCommandError(
 				'revert',
@@ -756,6 +781,40 @@ export class OperationsGitSubProvider implements GitOperationsSubProvider {
 			}
 			throw mapped;
 		}
+	}
+
+	/**
+	 * Classifies `ex` as a signing failure; if so, fires the `commits.onSigningFailed`
+	 * hook and throws a typed {@link SigningError}. Callers should invoke this first
+	 * in their catch blocks, before falling through to command-specific error mapping
+	 * via {@link getGitCommandError}.
+	 *
+	 * `SigningFormat` is read opportunistically from `config.getSigningConfig`, with
+	 * {@link inferSigningFormatFromError} as a stderr-based fallback and `'gpg'` as
+	 * the final default.
+	 */
+	private async throwIfSigningError(
+		repoPath: string,
+		args: readonly (string | undefined)[],
+		ex: unknown,
+		source?: unknown,
+	): Promise<void> {
+		const reason = classifySigningError(ex);
+		if (reason == null) return;
+
+		let format: SigningFormat | undefined;
+		try {
+			format = (await this.provider.config.getSigningConfig?.(repoPath))?.format;
+		} catch {
+			// Fall through — config read failed; use stderr-inferred format or gpg default
+		}
+		format ??= inferSigningFormatFromError(ex) ?? 'gpg';
+
+		this.context.hooks?.commits?.onSigningFailed?.(reason, format, source);
+		throw new SigningError(
+			{ reason: reason, gitCommand: { repoPath: repoPath, args: args } },
+			ex instanceof Error ? ex : undefined,
+		);
 	}
 
 	private async createConflictResult(repoPath: string, command: GitConflictCommand): Promise<GitOperationResult> {

--- a/packages/git-cli/src/providers/patch.ts
+++ b/packages/git-cli/src/providers/patch.ts
@@ -11,7 +11,7 @@ import { getSettledValue } from '@gitlens/utils/promise.js';
 import type { CliGitProviderInternal } from '../cliGitProvider.js';
 import { RunError } from '../exec/exec.errors.js';
 import type { Git } from '../exec/git.js';
-import { gitConfigsLog, GitError } from '../exec/git.js';
+import { classifySigningError, gitConfigsLog, GitError } from '../exec/git.js';
 
 export class PatchGitSubProvider implements GitPatchSubProvider {
 	constructor(
@@ -260,33 +260,11 @@ export class PatchGitSubProvider implements GitPatchSubProvider {
 
 			// Handle signing-specific errors
 			if (shouldSign && ex instanceof Error) {
-				const errorMessage = ex.message.toLowerCase();
-				const gitCommand: GitCommandContext = { repoPath: repoPath, args: ['commit-tree'] };
-				let signingError: SigningError | undefined;
-
-				if (errorMessage.includes('gpg failed to sign') || errorMessage.includes('error: gpg')) {
-					signingError = new SigningError({ reason: 'passphraseFailed', gitCommand: gitCommand }, ex);
-				} else if (
-					errorMessage.includes('secret key not available') ||
-					errorMessage.includes('no secret key') ||
-					errorMessage.includes('no signing key')
-				) {
-					signingError = new SigningError({ reason: 'noKey', gitCommand: gitCommand }, ex);
-				} else if (
-					errorMessage.includes('gpg: command not found') ||
-					(errorMessage.includes('gpg') && errorMessage.includes('not found'))
-				) {
-					signingError = new SigningError({ reason: 'gpgNotFound', gitCommand: gitCommand }, ex);
-				} else if (errorMessage.includes('ssh-keygen') && errorMessage.includes('not found')) {
-					signingError = new SigningError({ reason: 'sshNotFound', gitCommand: gitCommand }, ex);
-				}
-
-				if (signingError != null) {
-					this.context.hooks?.commits?.onSigningFailed?.(
-						signingError.details.reason ?? 'unknown',
-						_signingFormat,
-						options?.source,
-					);
+				const reason = classifySigningError(ex);
+				if (reason != null) {
+					const gitCommand: GitCommandContext = { repoPath: repoPath, args: ['commit-tree'] };
+					const signingError = new SigningError({ reason: reason, gitCommand: gitCommand }, ex);
+					this.context.hooks?.commits?.onSigningFailed?.(reason, _signingFormat, options?.source);
 					throw signingError;
 				}
 			}

--- a/packages/git/src/context.ts
+++ b/packages/git/src/context.ts
@@ -113,9 +113,18 @@ export interface GitServiceHooks {
 	};
 	/** Commit lifecycle hooks */
 	readonly commits?: {
-		/** Called when a commit is signed successfully */
+		/**
+		 * Called when a commit is signed successfully.
+		 *
+		 * Note: currently fired only from explicit-sign paths in the patch provider
+		 * (where signing is requested via `-S` and confirmed up front). Operations
+		 * that sign implicitly via `commit.gpgsign=true` (`commit`, `merge`, `pull`,
+		 * `rebase`, `revert`, `cherryPick`) do not fire this hook because the
+		 * library cannot cheaply confirm that signing actually occurred without an
+		 * extra `git config`/`log --show-signature` call.
+		 */
 		onSigned?(format: SigningFormat, source?: unknown): void;
-		/** Called when commit signing fails */
+		/** Called when commit signing fails — fired from all signing-capable paths. */
 		onSigningFailed?(reason: SigningErrorReason, format: SigningFormat, source?: unknown): void;
 	};
 	/** Git operation hooks */

--- a/packages/git/src/providers/operations.ts
+++ b/packages/git/src/providers/operations.ts
@@ -16,7 +16,7 @@ export interface GitOperationsSubProvider {
 	cherryPick(
 		repoPath: string,
 		revs: string[],
-		options?: { edit?: boolean; noCommit?: boolean },
+		options?: { edit?: boolean; noCommit?: boolean; source?: unknown },
 	): Promise<GitOperationResult>;
 	commit(
 		repoPath: string,
@@ -28,6 +28,7 @@ export interface GitOperationsSubProvider {
 			author?: string;
 			date?: string;
 			signoff?: boolean;
+			source?: unknown;
 		},
 	): Promise<void>;
 	fetch(
@@ -43,7 +44,7 @@ export interface GitOperationsSubProvider {
 	merge(
 		repoPath: string,
 		ref: string,
-		options?: { fastForward?: boolean | 'only'; noCommit?: boolean; squash?: boolean },
+		options?: { fastForward?: boolean | 'only'; noCommit?: boolean; squash?: boolean; source?: unknown },
 	): Promise<GitOperationResult>;
 	pull(
 		repoPath: string,
@@ -51,6 +52,7 @@ export interface GitOperationsSubProvider {
 			branch?: GitBranchReference | undefined;
 			rebase?: boolean | undefined;
 			tags?: boolean | undefined;
+			source?: unknown;
 		},
 	): Promise<void>;
 	push(
@@ -71,6 +73,7 @@ export interface GitOperationsSubProvider {
 			interactive?: boolean;
 			onto?: string;
 			updateRefs?: boolean;
+			source?: unknown;
 		},
 	): Promise<GitOperationResult>;
 	reset(
@@ -78,5 +81,9 @@ export interface GitOperationsSubProvider {
 		rev: string,
 		options?: { mode?: 'hard' | 'keep' | 'merge' | 'mixed' | 'soft' },
 	): Promise<void>;
-	revert(repoPath: string, refs: string[], options?: { editMessage?: boolean }): Promise<GitOperationResult>;
+	revert(
+		repoPath: string,
+		refs: string[],
+		options?: { editMessage?: boolean; source?: unknown },
+	): Promise<GitOperationResult>;
 }

--- a/src/commands/git/cherry-pick.ts
+++ b/src/commands/git/cherry-pick.ts
@@ -1,5 +1,5 @@
 import { ThemeIcon, window } from 'vscode';
-import { CherryPickError } from '@gitlens/git/errors.js';
+import { CherryPickError, SigningError } from '@gitlens/git/errors.js';
 import type { GitBranch } from '@gitlens/git/models/branch.js';
 import type { GitLog } from '@gitlens/git/models/log.js';
 import type { ConflictDetectionResult } from '@gitlens/git/models/mergeConflicts.js';
@@ -153,7 +153,10 @@ export class CherryPickGitCommand extends QuickCommand<State> {
 				return;
 			}
 
-			void showGitErrorMessage(ex, CherryPickError.is(ex) ? undefined : 'Unable to cherry-pick');
+			void showGitErrorMessage(
+				ex,
+				CherryPickError.is(ex) || SigningError.is(ex) ? undefined : 'Unable to cherry-pick',
+			);
 		}
 	}
 

--- a/src/commands/git/merge.ts
+++ b/src/commands/git/merge.ts
@@ -1,5 +1,5 @@
 import { ThemeIcon, window } from 'vscode';
-import { MergeError } from '@gitlens/git/errors.js';
+import { MergeError, SigningError } from '@gitlens/git/errors.js';
 import type { GitBranch } from '@gitlens/git/models/branch.js';
 import type { GitLog } from '@gitlens/git/models/log.js';
 import type { ConflictDetectionResult } from '@gitlens/git/models/mergeConflicts.js';
@@ -132,7 +132,7 @@ export class MergeGitCommand extends QuickCommand<State> {
 				return;
 			}
 
-			void showGitErrorMessage(ex, MergeError.is(ex) ? undefined : 'Unable to merge');
+			void showGitErrorMessage(ex, MergeError.is(ex) || SigningError.is(ex) ? undefined : 'Unable to merge');
 		}
 	}
 

--- a/src/commands/git/rebase.ts
+++ b/src/commands/git/rebase.ts
@@ -1,5 +1,5 @@
 import { ThemeIcon, window } from 'vscode';
-import { RebaseError } from '@gitlens/git/errors.js';
+import { RebaseError, SigningError } from '@gitlens/git/errors.js';
 import type { GitBranch } from '@gitlens/git/models/branch.js';
 import type { GitLog } from '@gitlens/git/models/log.js';
 import type { ConflictDetectionResult } from '@gitlens/git/models/mergeConflicts.js';
@@ -161,7 +161,7 @@ export class RebaseGitCommand extends QuickCommand<State> {
 				return;
 			}
 
-			void showGitErrorMessage(ex, RebaseError.is(ex) ? undefined : 'Unable to rebase');
+			void showGitErrorMessage(ex, RebaseError.is(ex) || SigningError.is(ex) ? undefined : 'Unable to rebase');
 		}
 	}
 

--- a/src/commands/git/revert.ts
+++ b/src/commands/git/revert.ts
@@ -1,5 +1,5 @@
 import { window } from 'vscode';
-import { RevertError } from '@gitlens/git/errors.js';
+import { RevertError, SigningError } from '@gitlens/git/errors.js';
 import type { GitBranch } from '@gitlens/git/models/branch.js';
 import type { GitLog } from '@gitlens/git/models/log.js';
 import type { GitRevisionReference } from '@gitlens/git/models/reference.js';
@@ -114,7 +114,7 @@ export class RevertGitCommand extends QuickCommand<State> {
 				return;
 			}
 
-			void showGitErrorMessage(ex, RevertError.is(ex) ? undefined : 'Unable to revert');
+			void showGitErrorMessage(ex, RevertError.is(ex) || SigningError.is(ex) ? undefined : 'Unable to revert');
 		}
 	}
 

--- a/src/git/gitRepositoryService.ts
+++ b/src/git/gitRepositoryService.ts
@@ -1,6 +1,6 @@
 import type { Uri } from 'vscode';
 import { ProgressLocation, window } from 'vscode';
-import { CheckoutError, FetchError, PullError, PushError } from '@gitlens/git/errors.js';
+import { CheckoutError, FetchError, PullError, PushError, SigningError } from '@gitlens/git/errors.js';
 import type { GitFile } from '@gitlens/git/models/file.js';
 import type { GitBranchReference, GitReference } from '@gitlens/git/models/reference.js';
 import { deletedOrMissing } from '@gitlens/git/models/revision.js';
@@ -366,7 +366,7 @@ export class GitRepositoryService {
 		} catch (ex) {
 			Logger.error(ex);
 
-			if (PullError.is(ex)) {
+			if (PullError.is(ex) || SigningError.is(ex)) {
 				void showGitErrorMessage(ex);
 			} else {
 				void showGitErrorMessage(ex, 'Unable to pull');


### PR DESCRIPTION
Closes #5166.

## Summary

- Adds signing stderr regexes to `GitErrors` and exports pure `classifySigningError` / `inferSigningFormatFromError` helpers from `exec/git.ts` as the single source of truth — replaces the inline ladder in `patch.ts` and tightens the previously over-broad `error: gpg` substring to an anchored `/^error:\s*gpg failed to sign the data/im`
- Adds `throwIfSigningError` to `OperationsGitSubProvider` and wires it into every signing-capable catch (`commit`, `merge`, `pull`, `rebase`, `revert`, `cherryPick`), firing `hooks.commits.onSigningFailed(reason, format, source)` and throwing a typed `SigningError` so those operations no longer collapse signing failures into `CommitError { reason: 'other' }` / `MergeError { reason: 'other' }` / etc.

## Test plan

- [x] Manual end-to-end smoke: extension host with `commit.gpgsign=true` and an invalid `user.signingkey`, run **Git: Commit** — expect `SigningError` surface + `commit/signing/failed` telemetry event, not a generic "Unable to commit"