### PR TITLE
Updates merge-mate-action to v0.3.0

### DIFF
--- a/.github/workflows/merge-mate-review.yml
+++ b/.github/workflows/merge-mate-review.yml
@@ -1,7 +1,7 @@
 name: Merge Mate Review
 on:
     issue_comment:
-        types: [edited]
+        types: [created]
     workflow_dispatch:
         inputs:
             pr-number:
@@ -15,9 +15,15 @@ on:
                 options:
                     - apply
                     - undo
+            trigger-mode:
+                description: 'Trigger source'
+                required: false
+                default: workflow_dispatch
+                type: string
 permissions:
     contents: write
     pull-requests: write
+    issues: write
     id-token: write
 concurrency:
     group: merge-mate-review-${{ github.event.issue.number || inputs.pr-number }}
@@ -28,12 +34,13 @@ jobs:
             github.event_name == 'workflow_dispatch' ||
             (
                 github.event.issue.pull_request &&
-                github.event.comment.user.login == 'github-actions[bot]' &&
+                github.event.sender.type != 'Bot' &&
                 contains(fromJSON('["eamodio", "d13", "ramin-t", "sergeibbb", "justinrobots", "ianhattendorf"]'), github.event.sender.login)
             )
         runs-on: ubuntu-latest
         steps:
-            - uses: gitkraken/merge-mate-action/review@v0.2
+            - uses: gitkraken/merge-mate-action/review@v0.3.0
               with:
-                  pr-number: ${{ inputs.pr-number }}
+                  pr-number: ${{ github.event.issue.number || inputs.pr-number }}
                   action: ${{ inputs.action }}
+                  trigger-mode: ${{ inputs.trigger-mode }}

--- a/.github/workflows/merge-mate.yml
+++ b/.github/workflows/merge-mate.yml
@@ -11,9 +11,9 @@ on:
                 options:
                     - resolved-only
                     - auto
-                    - hidden-only
+                    - review
                     - dry-run
-                default: hidden-only
+                default: review
 permissions:
     contents: write
     pull-requests: write
@@ -22,11 +22,11 @@ jobs:
     sync:
         runs-on: ubuntu-latest
         steps:
-            - uses: gitkraken/merge-mate-action/sync@v0.2
+            - uses: gitkraken/merge-mate-action/sync@v0.3.0
               with:
                   ai-provider: gitkraken
                   ai-api-key: ${{ secrets.GK_AI_PROVISIONER_TOKEN }}
-                  apply-policy: ${{ inputs.apply-policy || 'hidden-only' }}
+                  apply-policy: ${{ inputs.apply-policy || 'review' }}
                   pr-filter: |
                       target-branches:
                           - "main"


### PR DESCRIPTION
## Summary

Migrates `gitkraken/merge-mate-action` from `v0.2` to `v0.3.0` per the [v0.3.0 release notes](https://github.com/gitkraken/merge-mate-action/releases/tag/v0.3.0).

- Bumps both `sync` and `review` action refs to `@v0.3.0`
- Renames deprecated `apply-policy: hidden-only` → `review` (semantically equivalent — verified in the merge-mate source via the `DEPRECATED_POLICY_ALIASES` map; the action emits a deprecation warning when the old name is used)
- Updates `merge-mate-review.yml` for the new image-button + `@`-mention apply/undo UX:
  - `issue_comment` trigger switched to `types: [created]` (was `[edited]`)
  - Added `trigger-mode` `workflow_dispatch` input
  - Added `issues: write` permission (used by v0.3 for comment reactions)
  - Replaced the bot-comment-author guard with `sender.type != 'Bot'` (the user now authors the mention comment, not the bot); kept the existing user allowlist for defense-in-depth
  - `pr-number` falls back to `github.event.issue.number` when invoked from a PR comment, and `trigger-mode` is forwarded to the action

Closes #5168

## Test plan

These workflows can only be exercised on GitHub:

- [ ] After merge, confirm `Merge Mate Sync` runs on the next push to `main`
- [ ] Manually trigger `Merge Mate Review` via the Actions tab (`workflow_dispatch` with a PR number) and confirm it runs to completion
- [ ] After v0.3.0 posts a PR comment with image buttons, click apply/undo and confirm `Merge Mate Review` is triggered and succeeds
- [ ] Comment `@gitkraken apply` (or the v0.3 bot mention) on a test PR from an allowlisted user and confirm the review workflow runs
- [ ] Confirm a comment from a non-allowlisted user or a bot is filtered out by the `if:` guard