### PR TITLE
Remove broken "Inspect Details" context menu from Graph view

### DIFF
--- a/contributions.json
+++ b/contributions.json
@@ -3662,19 +3662,6 @@
 				]
 			}
 		},
-		"gitlens.graph.showInDetailsView": {
-			"label": "Inspect Details",
-			"icon": "$(eye)",
-			"menus": {
-				"webview/context": [
-					{
-						"when": "webviewItem =~ /gitlens:(commit|stash|wip)\\b/ && !listMultiSelection",
-						"group": "3_gitlens_explore",
-						"order": 0
-					}
-				]
-			}
-		},
 		"gitlens.graph.soloBranch": {
 			"label": "Solo Branch",
 			"commandPalette": "gitlens:enabled",

--- a/docs/telemetry-events.md
+++ b/docs/telemetry-events.md
@@ -2814,7 +2814,7 @@ or
   // Whether the active selection is the WIP / uncommitted row
   'selection.uncommitted': boolean,
   // What caused the panel to be shown
-  'trigger': 'toggle' | 'request-inspect' | 'auto-restore'
+  'trigger': 'toggle' | 'auto-restore'
 }
 ```
 

--- a/package.json
+++ b/package.json
@@ -7798,11 +7798,6 @@
 				"title": "Share as Cloud Patch..."
 			},
 			{
-				"command": "gitlens.graph.showInDetailsView",
-				"title": "Inspect Details",
-				"icon": "$(eye)"
-			},
-			{
 				"command": "gitlens.graph.soloBranch",
 				"title": "Solo Branch",
 				"category": "GitLens"
@@ -13144,10 +13139,6 @@
 				},
 				{
 					"command": "gitlens.graph.shareAsCloudPatch",
-					"when": "false"
-				},
-				{
-					"command": "gitlens.graph.showInDetailsView",
 					"when": "false"
 				},
 				{
@@ -25999,11 +25990,6 @@
 					"submenu": "gitlens/graph/commit/changes",
 					"when": "webviewItem =~ /gitlens:(commit|stash|wip)\\b/ && !listMultiSelection",
 					"group": "2_gitlens_quickopen@1"
-				},
-				{
-					"command": "gitlens.graph.showInDetailsView",
-					"when": "webviewItem =~ /gitlens:(commit|stash|wip)\\b/ && !listMultiSelection",
-					"group": "3_gitlens_explore@0"
 				},
 				{
 					"command": "gitlens.graph.openCommitOnRemote",

--- a/src/constants.commands.generated.ts
+++ b/src/constants.commands.generated.ts
@@ -210,7 +210,6 @@ export type ContributedCommands =
 	| 'gitlens.graph.scrollMarkerWipOff'
 	| 'gitlens.graph.scrollMarkerWipOn'
 	| 'gitlens.graph.shareAsCloudPatch'
-	| 'gitlens.graph.showInDetailsView'
 	| 'gitlens.graph.soloBranch'
 	| 'gitlens.graph.soloBranch:views'
 	| 'gitlens.graph.soloTag'

--- a/src/constants.telemetry.ts
+++ b/src/constants.telemetry.ts
@@ -836,7 +836,7 @@ type GraphDetailsMode = 'commit' | 'wip' | 'multicommit' | 'review' | 'compose' 
 
 interface GraphDetailsShownEvent {
 	/** What caused the panel to be shown */
-	trigger: 'toggle' | 'request-inspect' | 'auto-restore';
+	trigger: 'toggle' | 'auto-restore';
 	/** Which graph host the panel is in: editor area or bottom panel */
 	host: 'editor' | 'panel';
 	/** Active panel mode at time of show */

--- a/src/webviews/apps/plus/graph/graph-app.ts
+++ b/src/webviews/apps/plus/graph/graph-app.ts
@@ -276,7 +276,7 @@ export class GraphApp extends SignalWatcher(LitElement) {
 					@toggle-minimap=${this.handleToggleMinimap}
 					@gl-graph-scope-to-branch=${this.handleScopeToBranchFromHeader}
 				></gl-graph-header>
-				<div class="graph__workspace" @gl-graph-request-inspect=${this.handleRequestInspect}>
+				<div class="graph__workspace">
 					${when(!this.graphState.allowed, () => html`<gl-graph-gate class="graph__gate"></gl-graph-gate>`)}
 					<gl-graph-hover id="commit-hover" distance=${0} skidding=${15}></gl-graph-hover>
 					<main id="main" class="graph__panes">${this.renderDetailsPanel()}</main>
@@ -557,7 +557,7 @@ export class GraphApp extends SignalWatcher(LitElement) {
 		this.persistState();
 	}
 
-	private setDetailsVisible(visible: boolean, trigger?: 'toggle' | 'request-inspect' | 'auto-restore'): void {
+	private setDetailsVisible(visible: boolean, trigger?: 'toggle' | 'auto-restore'): void {
 		const gs = this.graphState;
 		if (gs.detailsVisible === visible) return;
 		gs.detailsVisible = visible;
@@ -565,10 +565,7 @@ export class GraphApp extends SignalWatcher(LitElement) {
 		this.emitDetailsVisibilityTelemetry(visible, trigger ?? 'toggle');
 	}
 
-	private emitDetailsVisibilityTelemetry(
-		visible: boolean,
-		trigger: 'toggle' | 'request-inspect' | 'auto-restore',
-	): void {
+	private emitDetailsVisibilityTelemetry(visible: boolean, trigger: 'toggle' | 'auto-restore'): void {
 		if (visible) {
 			this._detailsShownAt = performance.now();
 			const selectionCount =
@@ -620,18 +617,6 @@ export class GraphApp extends SignalWatcher(LitElement) {
 			this.setDetailsVisible(true, 'toggle');
 		}
 	};
-
-	private handleRequestInspect(e: CustomEvent<{ sha: string; repoPath: string }>) {
-		const { sha, repoPath } = e.detail;
-
-		this._selectedCommit = { sha: sha, repoPath: repoPath };
-		this._selectedCommits = undefined;
-		this.setDetailsVisible(true, 'request-inspect');
-		this.ensureDetailsPosition();
-
-		// Let the graph component handle row highlighting natively
-		this.graph?.selectCommits([sha], { ensureVisible: true });
-	}
 
 	private handleToggleDetails(e: CustomEvent<{ altKey?: boolean } | void>) {
 		if (e.detail?.altKey) {

--- a/src/webviews/apps/plus/graph/stateProvider.ts
+++ b/src/webviews/apps/plus/graph/stateProvider.ts
@@ -30,7 +30,6 @@ import {
 	DidChangeWipStaleNotification,
 	DidChangeWorkingTreeNotification,
 	DidFetchNotification,
-	DidRequestInspectNotification,
 	DidSearchNotification,
 	DidStartFeaturePreviewNotification,
 	GetOverviewEnrichmentRequest,
@@ -607,15 +606,6 @@ export class GraphStateProvider extends StateProviderBase<State['webviewId'], Ap
 				break;
 			case DidChangeSelectionNotification.is(msg):
 				this.updateState({ selectedRows: msg.params.selection });
-				break;
-
-			case DidRequestInspectNotification.is(msg):
-				this.host.dispatchEvent(
-					new CustomEvent('gl-graph-request-inspect', {
-						detail: { sha: msg.params.sha, repoPath: msg.params.repoPath },
-						bubbles: true,
-					}),
-				);
 				break;
 
 			case DidChangeGraphConfigurationNotification.is(msg):

--- a/src/webviews/plus/graph/graphWebview.ts
+++ b/src/webviews/plus/graph/graphWebview.ts
@@ -296,7 +296,6 @@ import {
 	DidChangeWipStaleNotification,
 	DidChangeWorkingTreeNotification,
 	DidFetchNotification,
-	DidRequestInspectNotification,
 	DidSearchNotification,
 	DidStartFeaturePreviewNotification,
 	DoubleClickedCommand,
@@ -6093,16 +6092,6 @@ export class GraphWebviewProvider implements WebviewProvider<State, State, Graph
 		return executeCommand<CopyShaToClipboardCommandArgs, void>('gitlens.copyShaToClipboard', {
 			sha: sha,
 		});
-	}
-
-	@command('gitlens.graph.showInDetailsView')
-	@debug()
-	private openInDetailsView(item?: GraphItemContext) {
-		const ref = this.getGraphItemRef(item, 'revision');
-		if (ref == null) return Promise.resolve();
-
-		// Open in the embedded details panel
-		return this.host.notify(DidRequestInspectNotification, { sha: ref.ref, repoPath: ref.repoPath });
 	}
 
 	@command('gitlens.graph.commitViaSCM')

--- a/src/webviews/plus/graph/protocol.ts
+++ b/src/webviews/plus/graph/protocol.ts
@@ -837,12 +837,6 @@ export const DidChangeSelectionNotification = new IpcNotification<DidChangeSelec
 	'selection/didChange',
 );
 
-export interface DidRequestInspectParams {
-	sha: string;
-	repoPath: string;
-}
-export const DidRequestInspectNotification = new IpcNotification<DidRequestInspectParams>(scope, 'inspect/didRequest');
-
 export interface DidChangeWorkingTreeParams {
 	stats: WorkDirStats;
 	wipMetadataBySha?: GraphWipMetadataBySha;


### PR DESCRIPTION
## Summary

- Removes the **"Inspect Details"** context menu item from the Graph view commit rows
- The menu item never worked — the `gl-graph-request-inspect` DOM event was dispatched on `gl-graph-apphost` (ancestor) but the listener was on `div.graph__workspace` (descendant). Since events bubble up, the event never reached the listener
- The embedded details panel is already accessible via **double-click**, making this entry redundant

## Likely source

Broken since 0ebf629cf1 ("Embeds details panel directly into the graph").

## What's removed

- `gitlens.graph.showInDetailsView` command definition and menu entry from `contributions.json`
- `openInDetailsView` command handler from `graphWebview.ts`
- `DidRequestInspectNotification` IPC notification from `protocol.ts`
- Notification handler from `stateProvider.ts`
- `handleRequestInspect` method and template listener from `graph-app.ts`

## Related issues

- Closes #5183
- Part of #5143


