### PR TITLE
Fixes #4977 terminal relaunch prompt by removing env-var injection

### DIFF
--- a/package.json
+++ b/package.json
@@ -4219,16 +4219,6 @@
 						"scope": "window",
 						"order": 20
 					},
-					"gitlens.gitkraken.cli.integration.enabled": {
-						"type": "boolean",
-						"default": false,
-						"markdownDescription": "Specifies whether to enable experimental integration with the GitKraken CLI",
-						"scope": "window",
-						"order": 30,
-						"tags": [
-							"experimental"
-						]
-					},
 					"gitlens.gitkraken.cli.localPath": {
 						"type": [
 							"string",

--- a/src/config.ts
+++ b/src/config.ts
@@ -403,9 +403,6 @@ interface GitKrakenConfig {
 
 interface GitKrakenCliConfig {
 	readonly localPath: string | null;
-	readonly integration: {
-		readonly enabled: boolean;
-	};
 	readonly insiders: {
 		readonly enabled: boolean;
 	};

--- a/src/env/node/gk/cli/integration.ts
+++ b/src/env/node/gk/cli/integration.ts
@@ -117,7 +117,7 @@ export class GkCliIntegrationProvider implements Disposable {
 	}
 
 	private onConfigurationChanged(e?: ConfigurationChangeEvent): void {
-		if (e == null || configuration.changed(e, 'gitkraken.cli.integration.enabled')) {
+		if (e == null || configuration.changed(e, 'gitkraken.mcp.autoEnabled')) {
 			if (!this.supportsCliIntegration()) {
 				this.stop();
 			} else {
@@ -139,10 +139,7 @@ export class GkCliIntegrationProvider implements Disposable {
 	}
 
 	private supportsCliIntegration(): boolean {
-		return (
-			this.container.ai.enabled &&
-			(configuration.get('gitkraken.mcp.autoEnabled') || configuration.get('gitkraken.cli.integration.enabled'))
-		);
+		return this.container.ai.enabled && configuration.get('gitkraken.mcp.autoEnabled');
 	}
 
 	private async start() {

--- a/src/env/node/gk/cli/integration.ts
+++ b/src/env/node/gk/cli/integration.ts
@@ -166,21 +166,12 @@ export class GkCliIntegrationProvider implements Disposable {
 			Promise.resolve({ stdout: JSON.stringify({ version: this.container.version }) }),
 		);
 
-		const { environmentVariableCollection: envVars } = this.container.context;
-
-		envVars.clear();
-		envVars.persistent = false;
-		envVars.replace('GK_GL_ADDR', server.ipcAddress);
-		envVars.description = 'Enables GK CLI integration';
-
 		// Create discovery file for external terminal support
 		try {
 			const workspaceFolders = workspace.workspaceFolders;
 			if (workspaceFolders != null && workspaceFolders.length > 0) {
 				const workspacePaths = workspaceFolders.map(folder => folder.uri.fsPath);
 				this._discoveryFilePath = await createDiscoveryFile(server, workspacePaths);
-
-				envVars.replace('GK_GL_PATH', this._discoveryFilePath);
 			}
 		} catch (error) {
 			// Discovery file creation failure should not prevent IPC server startup
@@ -195,7 +186,7 @@ export class GkCliIntegrationProvider implements Disposable {
 		this._runningDisposable = Disposable.from(new CliCommandHandlers(this.container, server), server);
 
 		// Notify that the IPC server is ready so MCP providers can refresh
-		this.container.events.fire('gk:cli:ipc:started', undefined);
+		this.container.events.fire('gk:cli:ipc:started', { discoveryFilePath: this._discoveryFilePath });
 		Logger.info(`${formatLoggableScopeBlock('IPC')} Server started on ${server.ipcAddress}`);
 	}
 
@@ -206,7 +197,6 @@ export class GkCliIntegrationProvider implements Disposable {
 			this._discoveryFilePath = undefined;
 		}
 
-		this.container.context.environmentVariableCollection.clear();
 		if (this._runningDisposable != null) {
 			this._runningDisposable.dispose();
 			this._runningDisposable = undefined;

--- a/src/env/node/gk/mcp/cursorIntegration.ts
+++ b/src/env/node/gk/mcp/cursorIntegration.ts
@@ -26,10 +26,9 @@ export class CursorGkMcpProvider extends GkMcpProviderBase {
 	private async tryRegister(): Promise<void> {
 		const scope = getScopedLogger();
 
-		const { environmentVariableCollection: envVars } = this.container.context;
-		const discoveryFilePath = envVars.get('GK_GL_PATH')?.value;
+		const discoveryFilePath = this._discoveryFilePath;
 
-		// Gives time for the IPC server to start and set the environment variables
+		// Gives time for the IPC server to start and emit the discovery path
 		if (discoveryFilePath != null) {
 			this.clearIpcTimeout();
 		} else if (this._waitingForIPC) {

--- a/src/env/node/gk/mcp/integrationBase.ts
+++ b/src/env/node/gk/mcp/integrationBase.ts
@@ -25,11 +25,12 @@ export abstract class GkMcpProviderBase implements Disposable {
 	protected _getMcpConfigurationFromCLIPromise: Promise<McpConfiguration | undefined> | undefined;
 	protected _ipcTimeoutId: NodeJS.Timeout | undefined;
 	protected _waitingForIPC: boolean = true;
+	protected _discoveryFilePath: string | undefined;
 
 	constructor(protected readonly container: Container) {
 		this._disposable = Disposable.from(
 			container.storage.onDidChange(e => this.onStorageChanged(e)),
-			container.events.on('gk:cli:ipc:started', () => this.onIpcServerStarted()),
+			container.events.on('gk:cli:ipc:started', e => this.onIpcServerStarted(e.data)),
 			container.events.on('gk:cli:mcp:setup:completed', () => this.onMcpSetupCompleted()),
 			configuration.onDidChange(e => this.onConfigurationChanged(e)),
 		);
@@ -65,7 +66,8 @@ export abstract class GkMcpProviderBase implements Disposable {
 		this.fireChange();
 	}
 
-	protected onIpcServerStarted(): void {
+	protected onIpcServerStarted(data: { discoveryFilePath: string | undefined }): void {
+		this._discoveryFilePath = data.discoveryFilePath;
 		this.clearIpcTimeout();
 		this.fireChange();
 	}

--- a/src/env/node/gk/mcp/vscodeIntegration.ts
+++ b/src/env/node/gk/mcp/vscodeIntegration.ts
@@ -33,10 +33,9 @@ export class VSCodeGkMcpProvider extends GkMcpProviderBase implements McpServerD
 
 	@debug({ exit: true })
 	async provideMcpServerDefinitions(): Promise<McpServerDefinition[]> {
-		const { environmentVariableCollection: envVars } = this.container.context;
-		const discoveryFilePath = envVars.get('GK_GL_PATH')?.value;
+		const discoveryFilePath = this._discoveryFilePath;
 
-		// Gives time for the IPC server to start and set the environment variables
+		// Gives time for the IPC server to start and emit the discovery path
 		if (discoveryFilePath != null) {
 			this.clearIpcTimeout();
 		} else if (this._waitingForIPC) {

--- a/src/eventBus.ts
+++ b/src/eventBus.ts
@@ -88,7 +88,7 @@ type EventsMapping = {
 	/**
 	 * Event fired when the CLI integration IPC server is started
 	 */
-	'gk:cli:ipc:started': undefined;
+	'gk:cli:ipc:started': { discoveryFilePath: string | undefined };
 	/**
 	 * Event fired when MCP setup via CLI has completed successfully with extension-based registration
 	 */


### PR DESCRIPTION
## Summary

- Drops `GK_GL_ADDR` and `GK_GL_PATH` writes to `EnvironmentVariableCollection` in `GkCliIntegrationProvider.start()` / `stop()`. The writes were registered after `container.onReady()` resolved, so VS Code saw them as a late change against already-restored persistent terminals and surfaced the "Relaunch terminal" prompt. Since `gitkraken.mcp.autoEnabled` defaults to `true`, this fired for nearly every AI-enabled user.
- Carries the discovery file path on the existing `gk:cli:ipc:started` event payload instead, and caches it on `GkMcpProviderBase` so the VS Code and Cursor MCP providers no longer round-trip through `envVars.get('GK_GL_PATH')`. MCP behavior is unchanged: the path is still forwarded to the spawned `gk mcp` server via `McpStdioServerDefinition.env` / `cursor.mcp.registerServer({ env })`.
- Removes the now-redundant experimental `gitlens.gitkraken.cli.integration.enabled` setting; the integration's only remaining job is to power MCP, so the gate collapses to `mcp.autoEnabled` alone.

**Trade-off:** a `gk` CLI invoked from a terminal no longer auto-discovers this VS Code window via env vars. The discovery file still exists at the well-known tmp path, so file-based discovery in the CLI is unaffected — only `GK_GL_ADDR`-style env discovery is dropped. Per discussion, this terminal-side handoff is rarely used.

## Test plan

- [x] `pnpm run build` is clean (already verified locally)
- [x] Reproduce relaunch prompt on `main` (persistent terminal open across a window reload, AI-enabled account) — confirm it appears
- [x] On this branch with the same setup, confirm the prompt no longer appears
- [x] Deterministic check: toggle `gitlens.gitkraken.mcp.autoEnabled` mid-session with a terminal already open — confirm no relaunch banner on this branch
- [x] VS Code 1.101+: GitKraken MCP server still registers via `lm.registerMcpServerDefinitionProvider` and tools respond
- [x] Cursor: GitKraken MCP server still registers via `cursor.mcp.registerServer` and tools respond
- [x] Output → "GitLens" channel still shows `[IPC] Server started on ...` when the gate is satisfied