### PR TITLE
Fixes terminal commit links in multi-repository workspaces

### DIFF
--- a/src/terminal/linkProvider.ts
+++ b/src/terminal/linkProvider.ts
@@ -44,7 +44,7 @@ export class GitTerminalLinkProvider implements Disposable, TerminalLinkProvider
 	async provideTerminalLinks(context: TerminalLinkContext, token: CancellationToken): Promise<GitTerminalLink[]> {
 		if (context.line.trim().length === 0) return [];
 
-		const repoPath = this.container.git.highlander?.path;
+		const repoPath = await this.getTerminalRepositoryPath(context);
 		if (!repoPath) return [];
 
 		const showDetailsView = configuration.get('terminalLinks.showDetailsView');
@@ -100,6 +100,25 @@ export class GitTerminalLinkProvider implements Disposable, TerminalLinkProvider
 				continue;
 			}
 
+			if (shaRegex.test(ref)) {
+				const link: GitTerminalLink<ShowQuickCommitCommandArgs | InspectCommandArgs> = {
+					startIndex: match.index,
+					length: ref.length,
+					tooltip: 'Show Commit',
+					command: showDetailsView
+						? createTerminalLinkCommand<InspectCommandArgs>('gitlens.showInDetailsView', {
+								ref: createReference(ref, repoPath, { refType: 'revision' }),
+							})
+						: createTerminalLinkCommand<ShowQuickCommitCommandArgs>('gitlens.showQuickCommitDetails', {
+								repoPath: repoPath,
+								sha: ref,
+							}),
+				};
+				links.push(link);
+
+				continue;
+			}
+
 			const svc = this.container.git.getRepositoryService(repoPath);
 			// TODO@eamodio handle paging
 			branchResults ??= await svc.branches.getBranches(undefined, toAbortSignal(token)).catch(() => undefined);
@@ -142,45 +161,39 @@ export class GitTerminalLinkProvider implements Disposable, TerminalLinkProvider
 				continue;
 			}
 
-			if (!shaRegex.test(ref)) {
-				if (rangeRegex.test(ref)) {
-					const link: GitTerminalLink<GitWizardCommandArgs> = {
-						startIndex: match.index,
-						length: ref.length,
-						tooltip: 'Show Commits',
-						command: createTerminalLinkCommand<GitWizardCommandArgs>('gitlens.gitCommands', {
-							command: 'log',
-							state: {
-								repo: repoPath,
-								reference: createReference(ref, repoPath, { refType: 'revision' }),
-							},
-						}),
-					};
-					links.push(link);
-				}
-
-				continue;
-			}
-
-			if (await svc.refs.isValidReference(ref, undefined, toAbortSignal(token)).catch(() => false)) {
-				const link: GitTerminalLink<ShowQuickCommitCommandArgs | InspectCommandArgs> = {
+			if (rangeRegex.test(ref)) {
+				const link: GitTerminalLink<GitWizardCommandArgs> = {
 					startIndex: match.index,
 					length: ref.length,
-					tooltip: 'Show Commit',
-					command: showDetailsView
-						? createTerminalLinkCommand<InspectCommandArgs>('gitlens.showInDetailsView', {
-								ref: createReference(ref, repoPath, { refType: 'revision' }),
-							})
-						: createTerminalLinkCommand<ShowQuickCommitCommandArgs>('gitlens.showQuickCommitDetails', {
-								repoPath: repoPath,
-								sha: ref,
-							}),
+					tooltip: 'Show Commits',
+					command: createTerminalLinkCommand<GitWizardCommandArgs>('gitlens.gitCommands', {
+						command: 'log',
+						state: {
+							repo: repoPath,
+							reference: createReference(ref, repoPath, { refType: 'revision' }),
+						},
+					}),
 				};
 				links.push(link);
 			}
+
+			continue;
 		} while (true);
 
 		return links;
+	}
+
+	private async getTerminalRepositoryPath(context: TerminalLinkContext): Promise<string | undefined> {
+		const repo = this.container.git.highlander;
+		if (repo != null) return repo.path;
+
+		const cwd = context.terminal.shellIntegration?.cwd;
+		if (cwd != null) {
+			return (await this.container.git.getOrOpenRepository(cwd, { detectNested: true }).catch(() => undefined))
+				?.path;
+		}
+
+		return this.container.git.getBestRepositoryOrFirst()?.path;
 	}
 
 	handleTerminalLink(link: GitTerminalLink): void {


### PR DESCRIPTION
# Description

## Problem

In workspaces with multiple Git repositories, such as projects with nested repositories or submodules, terminal commit links can fail to resolve through GitLens.

When this happens, commit SHAs printed in terminal output are not handled by GitLens and VS Code can fall back to other link providers, such as file search results.

## Root Cause

`GitTerminalLinkProvider` currently relies on `container.git.highlander` to determine the repository for terminal links. In multi-repository workspaces, `highlander` is undefined, so terminal links cannot be created even when the terminal has a clear working directory.

Commit SHA links are also validated asynchronously before being returned. If that validation is cancelled, a valid commit SHA can be dropped before GitLens creates a terminal link.

## Fix

This change resolves the repository for terminal links by:

- keeping the existing `highlander` behavior when there is a single repository
- falling back to the terminal shell integration cwd via `getOrOpenRepository(..., { detectNested: true })`
- falling back to the best available repository when no terminal cwd is available

It also creates commit SHA terminal links once a repository path has been resolved, avoiding cancellation-prone validation before returning the link.

Branch, tag, and range link behavior is preserved.

## Testing

- `pnpm exec eslint src/terminal/linkProvider.ts`
- `pnpm exec tsc --noEmit --project tsconfig.json`
- Manually verified in a workspace with nested repositories/submodules that terminal `git log --oneline` commit SHAs open through GitLens instead of falling back to VS Code file search.

# Checklist

- [x] I have followed the guidelines in the Contributing document
- [x] My changes follow the coding style of this project
- [x] My changes have been formatted and linted
- [x] My changes include any required corresponding changes to the documentation (including CHANGELOG.md and README.md)
- [x] My changes have been rebased and squashed to the minimal number (typically 1) of relevant commits
- [x] My changes build without any errors or warnings
- [ ] My changes have a descriptive commit message with a short title, including a `Fixes $XXX -` or `Closes #XXX -` prefix to auto-close the issue that your PR addresses
