### PR TITLE
Adds conflict resolution actions to the graph WIP panel

### DIFF
--- a/contributions.json
+++ b/contributions.json
@@ -3925,6 +3925,32 @@
 				]
 			}
 		},
+		"gitlens.graph.stageConflictCurrentChanges:graph": {
+			"label": "Stage Current Changes",
+			"icon": "$(reply)",
+			"menus": {
+				"webview/context": [
+					{
+						"when": "webviewItem =~ /gitlens:file\\b(?=.*?\\+conflict\\b)(?=.*?\\+canStageCurrent\\b)/ && (webview == gitlens.graph || webview == gitlens.views.graph)",
+						"group": "1_conflict",
+						"order": 1
+					}
+				]
+			}
+		},
+		"gitlens.graph.stageConflictIncomingChanges:graph": {
+			"label": "Stage Incoming Changes",
+			"icon": "$(forward)",
+			"menus": {
+				"webview/context": [
+					{
+						"when": "webviewItem =~ /gitlens:file\\b(?=.*?\\+conflict\\b)(?=.*?\\+canStageIncoming\\b)/ && (webview == gitlens.graph || webview == gitlens.views.graph)",
+						"group": "1_conflict",
+						"order": 2
+					}
+				]
+			}
+		},
 		"gitlens.graph.switchToCommit": {
 			"label": "Switch to Commit...",
 			"icon": "$(gitlens-switch)",

--- a/package.json
+++ b/package.json
@@ -7868,6 +7868,16 @@
 				"icon": "$(split-horizontal)"
 			},
 			{
+				"command": "gitlens.graph.stageConflictCurrentChanges:graph",
+				"title": "Stage Current Changes",
+				"icon": "$(reply)"
+			},
+			{
+				"command": "gitlens.graph.stageConflictIncomingChanges:graph",
+				"title": "Stage Incoming Changes",
+				"icon": "$(forward)"
+			},
+			{
 				"command": "gitlens.graph.switchToCommit",
 				"title": "Switch to Commit...",
 				"icon": "$(gitlens-switch)",
@@ -13222,6 +13232,14 @@
 				{
 					"command": "gitlens.graph.split",
 					"when": "gitlens:enabled && config.gitlens.graph.allowMultiple"
+				},
+				{
+					"command": "gitlens.graph.stageConflictCurrentChanges:graph",
+					"when": "false"
+				},
+				{
+					"command": "gitlens.graph.stageConflictIncomingChanges:graph",
+					"when": "false"
 				},
 				{
 					"command": "gitlens.graph.switchToCommit",
@@ -26267,6 +26285,16 @@
 					"command": "gitlens.graph.addAuthor",
 					"when": "webviewItem =~ /gitlens:contributor\\b(?!.*?\\b\\+current\\b)/ && !gitlens:readonly && !gitlens:untrusted && !gitlens:hasVirtualFolders",
 					"group": "1_gitlens_actions@2"
+				},
+				{
+					"command": "gitlens.graph.stageConflictCurrentChanges:graph",
+					"when": "webviewItem =~ /gitlens:file\\b(?=.*?\\+conflict\\b)(?=.*?\\+canStageCurrent\\b)/ && (webview == gitlens.graph || webview == gitlens.views.graph)",
+					"group": "1_conflict@1"
+				},
+				{
+					"command": "gitlens.graph.stageConflictIncomingChanges:graph",
+					"when": "webviewItem =~ /gitlens:file\\b(?=.*?\\+conflict\\b)(?=.*?\\+canStageIncoming\\b)/ && (webview == gitlens.graph || webview == gitlens.views.graph)",
+					"group": "1_conflict@2"
 				},
 				{
 					"command": "gitlens.views.applyChanges:commitDetails",

--- a/packages/git/src/utils/conflictResolution.utils.ts
+++ b/packages/git/src/utils/conflictResolution.utils.ts
@@ -1,4 +1,4 @@
-import type { GitFileConflictStatus } from '@gitlens/git/models/fileStatus.js';
+import type { GitFileConflictStatus } from '../models/fileStatus.js';
 
 export type ConflictResolutionAction = 'take-ours' | 'take-theirs' | 'delete' | 'unsupported';
 
@@ -18,4 +18,14 @@ export function classifyConflictAction(
 	if (status === 'AU' && !takeCurrent) return 'unsupported';
 
 	return takeCurrent ? 'take-ours' : 'take-theirs';
+}
+
+// Stage Current is invalid when the current side has no content to take (added/deleted only by them, or both deleted)
+export function canStageCurrent(status: GitFileConflictStatus): boolean {
+	return status !== 'UA' && status !== 'DD';
+}
+
+// Stage Incoming is invalid when the incoming side has no content to take (added/deleted only by us, or both deleted)
+export function canStageIncoming(status: GitFileConflictStatus): boolean {
+	return status !== 'AU' && status !== 'DD';
 }

--- a/src/constants.commands.generated.ts
+++ b/src/constants.commands.generated.ts
@@ -217,6 +217,8 @@ export type ContributedCommands =
 	| 'gitlens.graph.soloTag'
 	| 'gitlens.graph.soloTag:views'
 	| 'gitlens.graph.split'
+	| 'gitlens.graph.stageConflictCurrentChanges:graph'
+	| 'gitlens.graph.stageConflictIncomingChanges:graph'
 	| 'gitlens.graph.switchToCommit'
 	| 'gitlens.graph.switchToEditorLayout'
 	| 'gitlens.graph.switchToPanelLayout'

--- a/src/git/utils/-webview/conflictResolution.utils.ts
+++ b/src/git/utils/-webview/conflictResolution.utils.ts
@@ -1,0 +1,186 @@
+import { window } from 'vscode';
+import type { GitFileConflictStatus } from '@gitlens/git/models/fileStatus.js';
+import { classifyConflictAction } from '@gitlens/git/utils/conflictResolution.utils.js';
+import { Logger } from '@gitlens/utils/logger.js';
+import { normalizePath } from '@gitlens/utils/path.js';
+import type { Container } from '../../../container.js';
+import { showGitErrorMessage } from '../../../messages.js';
+
+/**
+ * Resolve a single conflicted file by taking either the current (HEAD/ours) or incoming
+ * (theirs) side, then stage it. Operation-agnostic — works for any paused operation type
+ * (rebase, merge, cherry-pick, revert).
+ */
+export async function stageConflictResolution(
+	container: Container,
+	file: { path: string; repoPath: string; status: GitFileConflictStatus },
+	resolution: 'current' | 'incoming',
+): Promise<void> {
+	const normalizedPath = normalizePath(file.path);
+	const svc = container.git.getRepositoryService(file.repoPath);
+
+	const conflictFiles = await svc.status.getConflictingFiles();
+	const conflictFile = conflictFiles.find(f => f.path === normalizedPath);
+	if (conflictFile == null) {
+		Logger.warn(`stageConflictResolution: file is no longer conflicted: ${normalizedPath}`);
+		return;
+	}
+
+	try {
+		const action = classifyConflictAction(conflictFile.conflictStatus, resolution);
+		switch (action) {
+			case 'delete':
+				// `git rm -f` removes the working-tree file and stages the deletion atomically,
+				// so a locked/permission-denied file fails loudly instead of silently leaving
+				// conflict markers staged via a follow-up `git add -A`.
+				await svc.staging?.removeFile(normalizedPath, { force: true });
+				return;
+			case 'take-ours':
+				await svc.ops?.checkoutConflictedPath?.(normalizedPath, 'ours');
+				break;
+			case 'take-theirs':
+				await svc.ops?.checkoutConflictedPath?.(normalizedPath, 'theirs');
+				break;
+			case 'unsupported':
+				throw new Error(`Cannot take ${resolution} side for conflict status ${conflictFile.conflictStatus}`);
+		}
+
+		await svc.staging?.stageFile(normalizedPath);
+	} catch (ex) {
+		void showGitErrorMessage(ex);
+	}
+}
+
+/**
+ * Resolve every conflicted file at once by staging the requested side. Prompts for
+ * confirmation, partitions files by `classifyConflictAction`, and reports failures. Scoped
+ * to paused rebases for now — bulk resolution during merge/cherry-pick/revert can follow
+ * once telemetry confirms safe usage.
+ */
+export async function resolveAllConflicts(
+	container: Container,
+	repoPath: string,
+	resolution: 'current' | 'incoming',
+): Promise<void> {
+	const svc = container.git.getRepositoryService(repoPath);
+	const pausedStatus = await svc.pausedOps?.getPausedOperationStatus?.();
+	if (pausedStatus?.type !== 'rebase') {
+		Logger.warn('resolveAllConflicts: unable to resolve — paused rebase status unavailable');
+		return;
+	}
+
+	const conflictFiles = await svc.status.getConflictingFiles();
+	if (!conflictFiles.length) return;
+
+	// Classify upfront so the confirmation can call out files that can't be resolved by
+	// taking the requested side (e.g. UA when staging current, AU when staging incoming —
+	// `git checkout --{ours,theirs}` fails when the requested stage is absent). Surfacing
+	// the skip count avoids the misleading "all N files" copy when some will be left alone.
+	const toCheckoutOurs: string[] = [];
+	const toCheckoutTheirs: string[] = [];
+	const toDelete: string[] = [];
+	let skippedCount = 0;
+
+	for (const f of conflictFiles) {
+		const action = classifyConflictAction(f.conflictStatus, resolution);
+		switch (action) {
+			case 'delete':
+				toDelete.push(f.path);
+				break;
+			case 'take-ours':
+				toCheckoutOurs.push(f.path);
+				break;
+			case 'take-theirs':
+				toCheckoutTheirs.push(f.path);
+				break;
+			case 'unsupported':
+				skippedCount++;
+				break;
+		}
+	}
+
+	const resolvableCount = conflictFiles.length - skippedCount;
+	if (resolvableCount === 0) {
+		void window.showWarningMessage(
+			`None of the ${conflictFiles.length} conflicted ${
+				conflictFiles.length === 1 ? 'file' : 'files'
+			} can be resolved by staging the ${resolution} side.`,
+			{ modal: true },
+		);
+		return;
+	}
+
+	const confirmTitle = resolution === 'current' ? 'Stage All Current' : 'Stage All Incoming';
+	const discardedSide = resolution === 'current' ? 'incoming' : 'current';
+	const skipNote = skippedCount
+		? `\n\n${skippedCount} ${
+				skippedCount === 1 ? 'file has' : 'files have'
+			} no ${resolution} side to take and will be skipped — resolve ${
+				skippedCount === 1 ? 'it' : 'them'
+			} manually.`
+		: '';
+	const result = await window.showWarningMessage(
+		`Resolve ${resolvableCount} of ${conflictFiles.length} conflicted ${
+			conflictFiles.length === 1 ? 'file' : 'files'
+		} by staging the ${resolution} side?\n\nThis will discard the ${discardedSide} changes for ${
+			resolvableCount === 1 ? 'that file' : 'those files'
+		}.${skipNote}`,
+		{ modal: true },
+		{ title: confirmTitle },
+	);
+	if (result == null) return;
+
+	const failures: { paths: string[]; reason: unknown }[] = [];
+
+	if (toCheckoutOurs.length) {
+		try {
+			await svc.ops?.checkoutConflictedPaths?.(toCheckoutOurs, 'ours');
+		} catch (ex) {
+			failures.push({ paths: toCheckoutOurs, reason: ex });
+			toCheckoutOurs.length = 0;
+		}
+	}
+	if (toCheckoutTheirs.length) {
+		try {
+			await svc.ops?.checkoutConflictedPaths?.(toCheckoutTheirs, 'theirs');
+		} catch (ex) {
+			failures.push({ paths: toCheckoutTheirs, reason: ex });
+			toCheckoutTheirs.length = 0;
+		}
+	}
+
+	if (toDelete.length) {
+		// `git rm -f` removes the working-tree file and stages the deletion atomically,
+		// so a locked/permission-denied file fails loudly instead of silently leaving
+		// conflict markers staged via a follow-up `git add -A`.
+		try {
+			await svc.staging?.removeFiles(toDelete, { force: true });
+		} catch (ex) {
+			failures.push({ paths: toDelete, reason: ex });
+			toDelete.length = 0;
+		}
+	}
+
+	const toStage = [...toCheckoutOurs, ...toCheckoutTheirs];
+	if (toStage.length) {
+		try {
+			await svc.staging?.stageFiles(toStage);
+		} catch (ex) {
+			failures.push({ paths: toStage, reason: ex });
+		}
+	}
+
+	const failedCount = failures.reduce((n, f) => n + f.paths.length, 0);
+
+	if (failedCount) {
+		void window.showErrorMessage(
+			`Failed to resolve ${failedCount} of ${resolvableCount} conflicted ${failedCount === 1 ? 'file' : 'files'}. See logs for details.`,
+		);
+		for (const f of failures) {
+			const error = f.reason instanceof Error ? f.reason : new Error(String(f.reason));
+			for (const path of f.paths) {
+				Logger.error(error, `resolveAllConflicts: ${path}`);
+			}
+		}
+	}
+}

--- a/src/webviews/apps/commitDetails/components/gl-details-wip-panel.ts
+++ b/src/webviews/apps/commitDetails/components/gl-details-wip-panel.ts
@@ -5,6 +5,7 @@ import { repeat } from 'lit/directives/repeat.js';
 import { when } from 'lit/directives/when.js';
 import type { PullRequestShape } from '@gitlens/git/models/pullRequest.js';
 import { uncommitted } from '@gitlens/git/models/revision.js';
+import { canStageCurrent, canStageIncoming } from '@gitlens/git/utils/conflictResolution.utils.js';
 import { isConflictStatus } from '@gitlens/git/utils/fileStatus.utils.js';
 import { equalsIgnoreCase } from '@gitlens/utils/string.js';
 import type { Draft } from '../../../../plus/drafts/models/drafts.js';
@@ -67,6 +68,12 @@ export class GlDetailsWipPanel extends GlDetailsBase {
 
 	@property({ type: Boolean, attribute: 'checkbox-mode' })
 	checkboxMode = false;
+
+	/** Opt-in for the bulk "Stage Current/Incoming for All Conflicts" toolbar buttons.
+	 * Set true only by hosts that wire the `resolve-all-current/incoming` events AND can
+	 * vouch that bulk resolve is supported (currently graph WIP + paused rebase). */
+	@property({ type: Boolean, attribute: 'bulk-conflict-actions' })
+	bulkConflictActions = false;
 
 	@state()
 	get inReview(): boolean {
@@ -455,6 +462,7 @@ export class GlDetailsWipPanel extends GlDetailsBase {
 				.collapsable=${this.filesCollapsable}
 				?show-file-icons=${this.fileIcons}
 				?checkable=${this.checkboxMode}
+				?bulk-conflict-actions=${this.bulkConflictActions}
 				.fileActions=${this._getFileActions}
 				.fileContext=${this._getFileContext}
 				.searchContext=${this.searchContext}
@@ -545,12 +553,15 @@ export class GlDetailsWipPanel extends GlDetailsBase {
 	}
 
 	override getFileActions(file: File, options?: Partial<TreeItemBase>): TreeItemAction[] {
-		// Conflicted files get rebase-editor-style "Open Current/Incoming Changes" — these
-		// replace the generic Open File button (the row click already opens the file).
+		// Conflicted files get rebase-editor-style "Open Current/Incoming Changes" + Stage —
+		// these replace the generic Open File button (the row click already opens the file).
+		// Stage routes through the existing `file-stage` event, which prompts when unresolved
+		// conflict markers remain.
 		if (isConflictStatus(file.status)) {
 			return [
 				{ icon: 'gl-diff-left', label: 'Open Current Changes', action: 'file-open-current' },
 				{ icon: 'gl-diff-right', label: 'Open Incoming Changes', action: 'file-open-incoming' },
+				{ icon: 'add', label: 'Stage', action: 'file-stage' },
 			];
 		}
 
@@ -573,8 +584,28 @@ export class GlDetailsWipPanel extends GlDetailsBase {
 	override getFileContext(file: File): string | undefined {
 		if (!this.wip?.repo?.path) return undefined;
 
+		// Two-char `XY` conflict statuses (UU/AA/UD/DU/AU/UA/DD) carry the side semantics
+		// the stage-current/incoming commands need; the generic single-char 'U' from
+		// `isConflictStatus` doesn't, so we treat it as a regular unstaged file and skip
+		// the conflict modifiers. Without this guard, the host's runStageConflictResolution
+		// would silently no-op on 'U' files clicked through the new context-menu items.
+		let webviewItem: string;
+		if (isConflictStatus(file.status) && file.status !== 'U') {
+			const conflictStatus = file.status;
+			const modifiers: string[] = ['+conflict'];
+			if (canStageCurrent(conflictStatus)) {
+				modifiers.push('+canStageCurrent');
+			}
+			if (canStageIncoming(conflictStatus)) {
+				modifiers.push('+canStageIncoming');
+			}
+			webviewItem = `gitlens:file${modifiers.join('')}`;
+		} else {
+			webviewItem = file.staged ? 'gitlens:file+staged' : 'gitlens:file+unstaged';
+		}
+
 		const context: DetailsItemTypedContext = {
-			webviewItem: file.staged ? 'gitlens:file+staged' : 'gitlens:file+unstaged',
+			webviewItem: webviewItem,
 			webviewItemValue: {
 				type: 'file',
 				path: file.path,

--- a/src/webviews/apps/plus/graph/components/detailsActions.ts
+++ b/src/webviews/apps/plus/graph/components/detailsActions.ts
@@ -1831,6 +1831,11 @@ export class DetailsActions {
 		void this.services.repository.openConflictChanges(detail, side);
 	}
 
+	resolveAllConflicts(repoPath: string | undefined, resolution: 'current' | 'incoming'): void {
+		if (!repoPath) return;
+		void this.services.repository.resolveAllConflicts(repoPath, resolution);
+	}
+
 	unstageFile(detail: FileChangeListItemDetail): void {
 		this.optimisticallyUpdateFileStaged(detail.path, false);
 		this._pendingStagingOp = this.runStagingOp(this.services.repository.unstageFile(detail));

--- a/src/webviews/apps/plus/graph/components/detailsActions.ts
+++ b/src/webviews/apps/plus/graph/components/detailsActions.ts
@@ -1833,7 +1833,7 @@ export class DetailsActions {
 
 	resolveAllConflicts(repoPath: string | undefined, resolution: 'current' | 'incoming'): void {
 		if (!repoPath) return;
-		void this.services.repository.resolveAllConflicts(repoPath, resolution);
+		this._pendingStagingOp = this.runStagingOp(this.services.repository.resolveAllConflicts(repoPath, resolution));
 	}
 
 	unstageFile(detail: FileChangeListItemDetail): void {

--- a/src/webviews/apps/plus/graph/components/gl-graph-details-panel.ts
+++ b/src/webviews/apps/plus/graph/components/gl-graph-details-panel.ts
@@ -539,6 +539,7 @@ export class GlGraphDetailsPanel extends SignalWatcher(LitElement) {
 											variant="embedded"
 											file-icons
 											checkbox-mode
+											?bulk-conflict-actions=${wip.changes?.pausedOpStatus?.type === 'rebase'}
 											.wip=${wip}
 											.files=${wip.changes?.files}
 											.preferences=${this._state.preferences.get()}
@@ -556,6 +557,8 @@ export class GlGraphDetailsPanel extends SignalWatcher(LitElement) {
 											@stage-all=${this.handleStageAll}
 											@unstage-all=${this.handleUnstageAll}
 											@stash-save=${this.handleStashSave}
+											@resolve-all-current=${this.handleResolveAllCurrent}
+											@resolve-all-incoming=${this.handleResolveAllIncoming}
 											@change-files-layout=${this.handleChangeFilesLayout}
 											@open-multiple-changes=${this.handleOpenMultipleChanges}
 										></gl-details-wip-panel>
@@ -1237,6 +1240,14 @@ export class GlGraphDetailsPanel extends SignalWatcher(LitElement) {
 
 	private handleUnstageAll = () => {
 		this._actions.unstageAll(this.effectiveRepoPath);
+	};
+
+	private handleResolveAllCurrent = () => {
+		this._actions.resolveAllConflicts(this.effectiveRepoPath, 'current');
+	};
+
+	private handleResolveAllIncoming = () => {
+		this._actions.resolveAllConflicts(this.effectiveRepoPath, 'incoming');
 	};
 
 	private handleChangeFilesLayout = (e: CustomEvent<{ layout: ViewFilesLayout }>) => {

--- a/src/webviews/apps/plus/graph/stateProvider.ts
+++ b/src/webviews/apps/plus/graph/stateProvider.ts
@@ -34,6 +34,7 @@ import {
 	DidChangeWorkingTreeNotification,
 	DidFetchNotification,
 	DidRequestOpenCompareModeNotification,
+	DidRequestWipRefetchNotification,
 	DidSearchNotification,
 	DidStartFeaturePreviewNotification,
 	GetAgentSessionsRequest,
@@ -692,6 +693,19 @@ export class GraphStateProvider extends StateProviderBase<State['webviewId'], Ap
 					wipMetadataBySha: mergeWipMetadata(this._state.wipMetadataBySha, msg.params.wipMetadataBySha),
 				});
 				break;
+
+			case DidRequestWipRefetchNotification.is(msg): {
+				// Bump the working-tree-stats reference so the panel's willUpdate observer
+				// treats it as changed and force-runs `refetchWipQuiet(effectiveRepoPath)`.
+				// We don't have a direct path from stateProvider to actions, so we ride the
+				// existing wts-driven refresh hook. Stats values are unchanged — only the
+				// reference identity matters for the dedup at the panel side.
+				const stats = this._state.workingTreeStats;
+				if (stats != null) {
+					this.updateState({ workingTreeStats: { ...stats } });
+				}
+				break;
+			}
 
 			case DidChangeWipStaleNotification.is(msg): {
 				const current = this._state.wipMetadataBySha;

--- a/src/webviews/apps/rebase/conflictStatus.utils.ts
+++ b/src/webviews/apps/rebase/conflictStatus.utils.ts
@@ -1,4 +1,5 @@
 import type { GitFileConflictStatus } from '@gitlens/git/models/fileStatus.js';
+import { canStageCurrent, canStageIncoming } from '@gitlens/git/utils/conflictResolution.utils.js';
 import type { ConflictFileWebviewContext } from '../../rebase/protocol.js';
 import type { TreeItemAction } from '../shared/components/tree/base.js';
 
@@ -8,16 +9,6 @@ export function getConflictFileActions(_conflictStatus: GitFileConflictStatus): 
 		{ icon: 'gl-diff-right', label: 'Open Incoming Changes', action: 'incoming-changes' },
 		{ icon: 'add', label: 'Stage', action: 'stage' },
 	];
-}
-
-// Stage Current is invalid when the current side has no content to take (added/deleted only by them, or both deleted)
-export function canStageCurrent(conflictStatus: GitFileConflictStatus): boolean {
-	return conflictStatus !== 'UA' && conflictStatus !== 'DD';
-}
-
-// Stage Incoming is invalid when the incoming side has no content to take (added/deleted only by us, or both deleted)
-export function canStageIncoming(conflictStatus: GitFileConflictStatus): boolean {
-	return conflictStatus !== 'AU' && conflictStatus !== 'DD';
 }
 
 export function getConflictFileContextData(path: string, conflictStatus: GitFileConflictStatus): string {

--- a/src/webviews/apps/shared/components/tree/gl-wip-tree-pane.ts
+++ b/src/webviews/apps/shared/components/tree/gl-wip-tree-pane.ts
@@ -105,6 +105,14 @@ export class GlWipTreePane extends LitElement {
 	@property({ attribute: false })
 	multiDiff?: { repoPath: string; lhs: string; rhs: string; title?: string };
 
+	/** Opt-in for the bulk "Stage Current/Incoming for All Conflicts" toolbar buttons.
+	 * Off by default — only the graph WIP panel wires the resolve-all events and only enables
+	 * this when the paused operation is a rebase (the host bulk resolver bails otherwise),
+	 * so leaving it false keeps the buttons hidden in the inspect view and during merge/
+	 * cherry-pick/revert pauses where clicks would silently no-op. */
+	@property({ type: Boolean, attribute: 'bulk-conflict-actions' })
+	bulkConflictActions = false;
+
 	private _effectiveFiles: Files = [];
 	private _effectiveStates?: Map<
 		string,
@@ -223,6 +231,7 @@ export class GlWipTreePane extends LitElement {
 			@gl-file-tree-pane-open-multi-diff=${multiDiff ? () => this.onOpenMultiDiff(multiDiff) : null}
 		>
 			<span slot="subtitle" style="opacity: 1">${this.renderStats()}</span>
+			${this.renderConflictBulkActions(files)}
 			${files.length > 0
 				? html`<gl-button
 						slot="leading-actions"
@@ -237,6 +246,39 @@ export class GlWipTreePane extends LitElement {
 			<slot name="before-tree" slot="before-tree"></slot>
 		</gl-file-tree-pane>`;
 	}
+
+	private renderConflictBulkActions(files: Files) {
+		if (!this.bulkConflictActions || !files.some(f => isConflictStatus(f.status))) return nothing;
+
+		return html`<gl-button
+				slot="leading-actions"
+				appearance="toolbar"
+				density="compact"
+				tooltip="Stage Current for All Conflicts"
+				aria-label="Stage Current for All Conflicts"
+				@click=${this.onResolveAllCurrent}
+			>
+				<code-icon icon="gl-accept-all-left"></code-icon>
+			</gl-button>
+			<gl-button
+				slot="leading-actions"
+				appearance="toolbar"
+				density="compact"
+				tooltip="Stage Incoming for All Conflicts"
+				aria-label="Stage Incoming for All Conflicts"
+				@click=${this.onResolveAllIncoming}
+			>
+				<code-icon icon="gl-accept-all-right"></code-icon>
+			</gl-button>`;
+	}
+
+	private onResolveAllCurrent = () => {
+		this.dispatchEvent(new CustomEvent('resolve-all-current', { bubbles: true, composed: true }));
+	};
+
+	private onResolveAllIncoming = () => {
+		this.dispatchEvent(new CustomEvent('resolve-all-incoming', { bubbles: true, composed: true }));
+	};
 
 	private onStashSave() {
 		this.dispatchEvent(new CustomEvent('stash-save', { bubbles: true, composed: true }));

--- a/src/webviews/plus/graph/graphWebview.ts
+++ b/src/webviews/plus/graph/graphWebview.ts
@@ -144,6 +144,7 @@ import {
 	getCommitEnrichedAutolinks,
 	isCommitSigned,
 } from '../../../git/utils/-webview/commit.utils.js';
+import { stageConflictResolution } from '../../../git/utils/-webview/conflictResolution.utils.js';
 import { getRemoteIconUri } from '../../../git/utils/-webview/icons.js';
 import { countConflictMarkers } from '../../../git/utils/-webview/mergeConflicts.utils.js';
 import { getReferenceFromBranch } from '../../../git/utils/-webview/reference.utils.js';
@@ -209,7 +210,14 @@ import type { ComposerCommandArgs } from '../composer/registration.js';
 import * as branchRefCommands from '../shared/branchRefCommands.js';
 import type { TimelineCommandArgs } from '../timeline/registration.js';
 import { checkForAbandonedComposeStashes, executeComposeCommit } from './composeCommitService.js';
-import type { CommitDetails, CompareDiff, DetailsItemContext, GitBranchShape, Wip } from './detailsProtocol.js';
+import type {
+	CommitDetails,
+	CompareDiff,
+	DetailsItemContext,
+	DetailsItemTypedContext,
+	GitBranchShape,
+	Wip,
+} from './detailsProtocol.js';
 import { messageHeadlineSplitterToken } from './detailsProtocol.js';
 import {
 	GraphComposeVirtualContentProvider,
@@ -6352,6 +6360,38 @@ export class GraphWebviewProvider implements WebviewProvider<State, State, Graph
 		await showPausedOperationStatus(this.container, pausedOpArgs.repoPath, {
 			openRebaseEditor: pausedOpArgs.type === 'rebase',
 		});
+	}
+
+	@command('gitlens.graph.stageConflictCurrentChanges:')
+	@debug()
+	private async stageConflictCurrentChanges(item?: DetailsItemTypedContext): Promise<void> {
+		await this.runStageConflictResolution(item, 'current');
+	}
+
+	@command('gitlens.graph.stageConflictIncomingChanges:')
+	@debug()
+	private async stageConflictIncomingChanges(item?: DetailsItemTypedContext): Promise<void> {
+		await this.runStageConflictResolution(item, 'incoming');
+	}
+
+	private async runStageConflictResolution(
+		item: DetailsItemTypedContext | undefined,
+		resolution: 'current' | 'incoming',
+	): Promise<void> {
+		const value = item?.webviewItemValue;
+		if (value?.type !== 'file' || !value.path || !value.repoPath) return;
+
+		const status = value.status;
+		// Conflict actions only apply to two-char `XY` conflict statuses (UU/AA/UD/DU/AU/UA/DD).
+		// The generic single-char 'U' from `isConflictStatus` doesn't carry the side semantics
+		// needed to take ours/theirs.
+		if (status == null || !isConflictStatus(status) || status === 'U') return;
+
+		await stageConflictResolution(
+			this.container,
+			{ path: value.path, repoPath: value.repoPath, status: status },
+			resolution,
+		);
 	}
 
 	@command('gitlens.graph.copyDeepLinkToBranch')

--- a/src/webviews/plus/graph/graphWebview.ts
+++ b/src/webviews/plus/graph/graphWebview.ts
@@ -315,6 +315,7 @@ import {
 	DidChangeWorkingTreeNotification,
 	DidFetchNotification,
 	DidRequestOpenCompareModeNotification,
+	DidRequestWipRefetchNotification,
 	DidSearchNotification,
 	DidStartFeaturePreviewNotification,
 	DoubleClickedCommand,
@@ -6392,6 +6393,10 @@ export class GraphWebviewProvider implements WebviewProvider<State, State, Graph
 			{ path: value.path, repoPath: value.repoPath, status: status },
 			resolution,
 		);
+
+		// Tell the panel to refetch — for non-active worktrees the active-repo working-tree
+		// watcher won't fire, so we'd otherwise leave the panel showing pre-mutation state.
+		void this.host.notify(DidRequestWipRefetchNotification, { repoPath: value.repoPath });
 	}
 
 	@command('gitlens.graph.copyDeepLinkToBranch')

--- a/src/webviews/plus/graph/protocol.ts
+++ b/src/webviews/plus/graph/protocol.ts
@@ -604,6 +604,18 @@ export interface DidChangeWipStaleParams {
 }
 export const DidChangeWipStaleNotification = new IpcNotification<DidChangeWipStaleParams>(scope, 'wip/stale/didChange');
 
+export interface DidRequestWipRefetchParams {
+	/** Repo path of the WIP that should be re-fetched. */
+	repoPath: string;
+}
+/** Host → panel: force the displayed WIP to re-fetch (used after host-side mutating actions whose
+ *  effects don't reach the panel via the active-repo working-tree watcher — e.g. context-menu
+ *  conflict-resolution commands on a non-active worktree's WIP row). */
+export const DidRequestWipRefetchNotification = new IpcNotification<DidRequestWipRefetchParams>(
+	scope,
+	'wip/refetch/request',
+);
+
 export interface GraphSidebarBranch {
 	name: string;
 	sha?: string;

--- a/src/webviews/rebase/__tests__/conflictResolution.utils.test.ts
+++ b/src/webviews/rebase/__tests__/conflictResolution.utils.test.ts
@@ -1,7 +1,7 @@
 import * as assert from 'assert';
 import type { GitFileConflictStatus } from '@gitlens/git/models/fileStatus.js';
-import type { ConflictResolutionAction } from '../conflictResolution.utils.js';
-import { classifyConflictAction } from '../conflictResolution.utils.js';
+import type { ConflictResolutionAction } from '@gitlens/git/utils/conflictResolution.utils.js';
+import { classifyConflictAction } from '@gitlens/git/utils/conflictResolution.utils.js';
 
 const cases: {
 	status: GitFileConflictStatus;

--- a/src/webviews/rebase/rebaseWebviewProvider.ts
+++ b/src/webviews/rebase/rebaseWebviewProvider.ts
@@ -3,6 +3,7 @@ import { Uri, ViewColumn, window, workspace } from 'vscode';
 import type { GitCommit } from '@gitlens/git/models/commit.js';
 import type { GitFileConflictStatus } from '@gitlens/git/models/fileStatus.js';
 import type { ProcessedRebaseTodo, RebaseTodoAction } from '@gitlens/git/models/rebase.js';
+import { classifyConflictAction } from '@gitlens/git/utils/conflictResolution.utils.js';
 import { getConflictIncomingRef, resolveConflictFilePaths } from '@gitlens/git/utils/pausedOperationStatus.utils.js';
 import { createReference } from '@gitlens/git/utils/reference.utils.js';
 import type { Deferrable } from '@gitlens/utils/debounce.js';
@@ -48,7 +49,6 @@ import type { ComposerWebviewShowingArgs } from '../plus/composer/registration.j
 import type { ShowInCommitGraphCommandArgs } from '../plus/graph/registration.js';
 import type { WebviewHost } from '../webviewProvider.js';
 import type { WebviewPanelShowCommandArgs } from '../webviewsController.js';
-import { classifyConflictAction } from './conflictResolution.utils.js';
 import type {
 	Author,
 	Commit,

--- a/src/webviews/rpc/services/files.ts
+++ b/src/webviews/rpc/services/files.ts
@@ -12,6 +12,8 @@
 
 import type { GitCommit } from '@gitlens/git/models/commit.js';
 import type { GitFileChange, GitFileChangeShape } from '@gitlens/git/models/fileChange.js';
+import type { GitRevisionReference } from '@gitlens/git/models/reference.js';
+import { uncommitted } from '@gitlens/git/models/revision.js';
 import type { DiffRange } from '@gitlens/git/providers/types.js';
 import type { DiffWithCommandArgs } from '../../../commands/diffWith.js';
 import type { Container } from '../../../container.js';
@@ -31,6 +33,18 @@ import { openChangesEditor, openDiffEditor, openTextEditor } from '../../../syst
 import type { VirtualRef } from '../../../virtual/virtualContentProvider.js';
 import type { FileShowOptions, OpenMultipleChangesArgs } from './types.js';
 
+/**
+ * Synthesize a `GitRevisionReference` pointing at a repo's working tree.
+ *
+ * Used to bypass commit-resolution for WIP file actions: `getCommit(uncommitted)` is not
+ * reliably hydrated on every worktree's repo service (especially for non-active secondary
+ * worktrees in a multi-worktree workspace), but the underlying file actions only need a
+ * `GitRevisionReference`-shaped target — they don't require a fully-hydrated `GitCommit`.
+ */
+function makeWipRef(repoPath: string): GitRevisionReference {
+	return { refType: 'revision', name: 'Working Tree', ref: uncommitted, sha: uncommitted, repoPath: repoPath };
+}
+
 export class FilesService {
 	constructor(private readonly container: Container) {}
 
@@ -41,6 +55,11 @@ export class FilesService {
 	 * via the working-file command.
 	 */
 	async openFile(file: GitFileChangeShape, showOptions?: FileShowOptions, ref?: string): Promise<void> {
+		if (file.repoPath != null && ref === uncommitted) {
+			void openFile(file, makeWipRef(file.repoPath), { preserveFocus: true, preview: true, ...showOptions });
+			return;
+		}
+
 		const [commit, resolved] = await this.#getFileCommit(file, ref);
 		if (commit == null) return;
 
@@ -67,6 +86,15 @@ export class FilesService {
 	 * diff view comparing the committed version with working tree.
 	 */
 	async openFileCompareWorking(file: GitFileChangeShape, showOptions?: FileShowOptions, ref?: string): Promise<void> {
+		if (file.repoPath != null && ref === uncommitted) {
+			void openChangesWithWorking(file, makeWipRef(file.repoPath), {
+				preserveFocus: true,
+				preview: true,
+				...showOptions,
+			});
+			return;
+		}
+
 		const [commit, resolved] = await this.#getFileCommit(file, ref);
 		if (commit == null) return;
 
@@ -84,6 +112,17 @@ export class FilesService {
 		showOptions?: FileShowOptions,
 		ref?: string,
 	): Promise<void> {
+		if (file.repoPath != null && ref === uncommitted) {
+			// "Previous" for the working tree means HEAD vs working tree — `openChanges` with
+			// rhs='' and lhs='HEAD' delegates to `openChangesWithWorking` with the HEAD ref.
+			void openChanges(
+				file,
+				{ repoPath: file.repoPath, lhs: 'HEAD', rhs: '' },
+				{ preserveFocus: true, preview: true, ...showOptions },
+			);
+			return;
+		}
+
 		const [commit, resolved] = await this.#getFileCommit(file, ref);
 		if (commit == null) return;
 

--- a/src/webviews/rpc/services/repository.ts
+++ b/src/webviews/rpc/services/repository.ts
@@ -12,6 +12,7 @@ import { Disposable, Uri, window } from 'vscode';
 import type { GitBranch } from '@gitlens/git/models/branch.js';
 import { GitCommit } from '@gitlens/git/models/commit.js';
 import type { GitFileChange, GitFileChangeShape } from '@gitlens/git/models/fileChange.js';
+import type { GitFileConflictStatus } from '@gitlens/git/models/fileStatus.js';
 import type { RepositoryChange } from '@gitlens/git/models/repository.js';
 import { repositoryChanges } from '@gitlens/git/models/repository.js';
 import type { CommitSignature } from '@gitlens/git/models/signature.js';
@@ -30,6 +31,10 @@ import * as BranchActions from '../../../git/actions/branch.js';
 import * as RepoActions from '../../../git/actions/repository.js';
 import { GitUri } from '../../../git/gitUri.js';
 import { getCommitSignature } from '../../../git/utils/-webview/commit.utils.js';
+import {
+	resolveAllConflicts as resolveAllConflictsHelper,
+	stageConflictResolution as stageConflictResolutionHelper,
+} from '../../../git/utils/-webview/conflictResolution.utils.js';
 import { countConflictMarkers } from '../../../git/utils/-webview/mergeConflicts.utils.js';
 import { executeCommand, executeCoreCommand } from '../../../system/-webview/command.js';
 import { serialize } from '../../../system/serialize.js';
@@ -311,6 +316,26 @@ export class RepositoryService {
 			stage,
 		);
 		return choice === stage;
+	}
+
+	/**
+	 * Resolve a single conflicted file by taking either the current (HEAD/ours) or incoming
+	 * (theirs) side, then stage it. Operation-agnostic — works for any paused operation type
+	 * (rebase, merge, cherry-pick, revert).
+	 */
+	async stageConflictResolution(
+		file: GitFileChangeShape & { status: GitFileConflictStatus },
+		resolution: 'current' | 'incoming',
+	): Promise<void> {
+		await stageConflictResolutionHelper(this.container, file, resolution);
+	}
+
+	/**
+	 * Resolve every conflicted file at once by staging the requested side. Currently scoped to
+	 * paused rebases.
+	 */
+	async resolveAllConflicts(repoPath: string, resolution: 'current' | 'incoming'): Promise<void> {
+		await resolveAllConflictsHelper(this.container, repoPath, resolution);
 	}
 
 	/**


### PR DESCRIPTION
## Summary

Closes #5195 — brings the rebase editor's conflict file actions to the graph WIP panel.

Three commits, reviewable independently:

1. **`72bdad9e1` — `Adds conflict resolution actions to the graph WIP panel`**
   - Inline `Stage` button on conflict files (alongside existing Open Current/Incoming Changes)
   - Right-click `Stage Current Changes` / `Stage Incoming Changes` per file, gated by the file's conflict status via `canStageCurrent`/`canStageIncoming` predicates
   - Bulk `Stage Current/Incoming for All Conflicts` toolbar buttons that appear when conflicts exist (paused-rebase only in v1)

2. **`e7bfe71bc` — `Fixes file actions for non-active worktree WIPs`** (pre-existing bug)
   - Click-to-open and "Open Changes with Working" / "Open Changes with Previous" silently no-op'd on non-active worktree WIP rows because `getCommit(uncommitted)` isn't reliably hydrated on secondary worktrees' commits cache.

3. **`ec19af6e2` — `Fixes WIP refresh after conflict-resolution actions on non-active worktrees`** (pre-existing bug, surfaced while testing #1)
   - Bulk `resolveAllConflicts` and the host-side `gitlens.graph.stageConflict*` context-menu commands bypassed the post-RPC `runStagingOp → refetchWipQuiet` hook, so secondary-worktree WIPs kept showing pre-mutation state.

## Test plan

- [x] **#5195 inline + context-menu actions** (active worktree)
  - [x] Conflicted file shows three inline icons: Open Current, Open Incoming, **Stage** (new)
  - [x] Right-click on conflicted file shows **Stage Current Changes** / **Stage Incoming Changes**, correctly gated for AU/UA/DD statuses
  - [x] Conflicts group toolbar shows **Stage Current/Incoming for All Conflicts** when conflicts exist; clicking confirms via dialog and resolves all
  - [x] All three above flows also work when paused on a **merge** (single-file actions only — bulk is rebase-only in v1)
  - [x] Inspect view (commit details) gets the inline Stage button on conflicts (intentional side benefit) but no new context-menu items (scoped out via `webview ==`)
- [x] **Non-active worktree WIP — file actions (Bug 2)**
  - [x] Click a file in a secondary worktree's WIP row → file opens
  - [x] Right-click → "Open Changes with Working" / "Open Changes with Previous" / "Open File" all work
- [x] **Non-active worktree WIP — refresh after staging (Bug 1)**
  - [x] Stage via checkbox → row reflects staged state immediately (no click-off / re-select needed)
  - [x] Stage via inline Stage button → same
  - [x] Right-click → "Stage Current/Incoming Changes" → file moves to staged group immediately
  - [x] "Stage All Current/Incoming" toolbar → all conflicts resolve and file list refreshes
- [x] Active worktree regression — all of the above flows still work and feel unchanged
- [x] `pnpm run build` and `pnpm run lint` clean

## Notes

- Bugs 1 and 2 predate this branch (verified via `git diff main..HEAD`) but were surfaced while exercising the new conflict actions on a multi-worktree workspace. They're shipped here because they directly affect the new feature's UX on secondary worktrees.