### PR TITLE
Cuts redundant work on graph scope/focus-branch toggles

### DIFF
--- a/packages/git-cli/src/providers/commits.ts
+++ b/packages/git-cli/src/providers/commits.ts
@@ -621,6 +621,18 @@ export class CommitsGitSubProvider implements GitCommitsSubProvider {
 				cwd: repoPath,
 				cancellation: cancellation,
 				configs: gitConfigsLogWithFiles,
+				// Single-commit log serves user-initiated reads (commit details, hover, etc.).
+				// Mirrors getCommitDates: full SHAs are immutable so a 5-min TTL is safe; non-SHA refs
+				// rely on gitResults being cleared on head/heads/remotes events (60s is the failsafe
+				// for watcher latency / web with no fs watcher).
+				...(isSingleCommit && rev
+					? {
+							caching: {
+								cache: this.cache.gitResults,
+								options: { accessTTL: isSha(rev) ? 5 * 60 * 1000 : 60 * 1000 },
+							},
+						}
+					: undefined),
 			};
 			let { commits, count } = await parseCommits(
 				parser,
@@ -1392,7 +1404,10 @@ export class CommitsGitSubProvider implements GitCommitsSubProvider {
 				{
 					cwd: repoPath,
 					errors: 'ignore',
-					caching: { cache: this.cache.gitResults, options: { accessTTL: 60 * 1000 } },
+					caching: {
+						cache: this.cache.gitResults,
+						options: { accessTTL: isSha(sha) ? 5 * 60 * 1000 : 60 * 1000 },
+					},
 					configs: gitConfigsLog,
 				},
 				'log',
@@ -1419,7 +1434,10 @@ export class CommitsGitSubProvider implements GitCommitsSubProvider {
 				{
 					cwd: repoPath,
 					errors: 'ignore',
-					caching: { cache: this.cache.gitResults, options: { accessTTL: 60 * 1000 } },
+					caching: {
+						cache: this.cache.gitResults,
+						options: { accessTTL: isSha(sha) ? 5 * 60 * 1000 : 60 * 1000 },
+					},
 				},
 				'cat-file',
 				'commit',

--- a/packages/git-cli/src/providers/graph.ts
+++ b/packages/git-cli/src/providers/graph.ts
@@ -234,7 +234,14 @@ export class GraphGitSubProvider implements GitGraphSubProvider {
 					// - SHA + limit = 0: Find SHA, stop immediately
 					// - No SHA + limit > 0: Load exactly `limit` commits
 					// - No SHA + limit = 0: Load everything remaining
-					if ((limit && count >= limit && (!sha || found)) || (!limit && sha && found)) {
+					// - SHA + limit > 0 + still unfound past 10× limit: defensive cap so an unreachable
+					//   SHA (e.g. a stale merge-base the webview hasn't yet seen invalidated) can't
+					//   walk the entire history. `hasMore=true` lets callers retry; the graph-wrapper
+					//   side deduplicates re-requests so the cap doesn't loop.
+					if (
+						(limit && count >= limit && (!sha || found || count >= limit * 10)) ||
+						(!limit && sha && found)
+					) {
 						hasMore = true;
 						aborter.abort();
 						break;

--- a/src/webviews/apps/plus/graph/context.ts
+++ b/src/webviews/apps/plus/graph/context.ts
@@ -33,9 +33,6 @@ export interface AppState extends State {
 	selectedRows: GraphSelectedRows | undefined;
 	visibleDays: { top: number; bottom: number } | undefined;
 
-	/** Fetch enrichment for a branch not covered by the overview — used by the header scope popover. */
-	ensureEnrichmentForBranch(branchId: string): Promise<void>;
-
 	/**
 	 * Publish a lazily-fetched merge target into `overviewEnrichment` for the given branchId. The graph
 	 * overview's enrichment IPC skips merge-target fetching; the overview card and click-to-scope path

--- a/src/webviews/apps/plus/graph/graph-app.ts
+++ b/src/webviews/apps/plus/graph/graph-app.ts
@@ -916,9 +916,10 @@ export class GraphApp extends SignalWatcher(LitElement) {
 			return;
 		}
 
-		// Fallback: branch isn't in the overview's active/recent list. Set the scope now with
-		// whatever we know and fire an ad-hoc enrichment fetch — `syncScopeMergeTarget` will
-		// backfill `mergeTargetTipSha` once the enrichment arrives.
+		// Fallback: branch isn't in the overview's active/recent list. `setScope` fires
+		// `resolveScopeMergeBase`, which now lands `mergeTargetTipSha` directly from the
+		// host-side scope-anchor resolver — no need to also fire a full enrichment IPC for the
+		// PR/autolinks/issues/conflict status fields the scope flow doesn't render.
 		const branchRef = getBranchId(repoPath, false, branchName);
 		this.setScope(
 			{
@@ -928,7 +929,6 @@ export class GraphApp extends SignalWatcher(LitElement) {
 			},
 			'popover',
 		);
-		void this.graphState.ensureEnrichmentForBranch(branchRef);
 	}
 
 	private scopeToBranchById(

--- a/src/webviews/apps/plus/graph/graph-wrapper/graph-wrapper.ts
+++ b/src/webviews/apps/plus/graph/graph-wrapper/graph-wrapper.ts
@@ -515,11 +515,65 @@ export class GlGraphWrapper extends SignalWatcher(LitElement) {
 		this.dispatchEvent(new CustomEvent('gl-graph-change-visible-days', { detail: detail }));
 	}
 
-	private onScopeAnchorsUnreachable(_event: CustomEvent<Set<string>>) {
+	/**
+	 * SHAs we've already issued `GetMoreRowsCommand({ id: sha })` for via the unreachable-anchor
+	 * path, mapped to the loaded row count at the time the request was sent. If a targeted walk
+	 * returns without surfacing the SHA, we park it here so the next `scopeanchorsunreachable`
+	 * event doesn't re-fire the same request immediately. Entries are released two ways:
+	 * (a) scope reference changes (user re-scopes, or refs-moved invalidation produces a new
+	 *     scope object), which clears the entire map;
+	 * (b) the host response delivered new rows, growing `rows.length` past the snapshot — the
+	 *     provider's cursor advanced past where the previous walk's `limit * 10` cap aborted,
+	 *     so a retry continues the walk from the new cursor rather than re-running the same
+	 *     range. Entries whose request didn't grow rows stay parked: retrying would hit the
+	 *     same cap at the same cursor with no progress.
+	 */
+	private _unreachableAnchorRequests = new Map<string, number>();
+	private _unreachableAnchorScope: typeof graphStateContext.__context__.scope = undefined;
+
+	private onScopeAnchorsUnreachable(event: CustomEvent<Set<string>>) {
 		// The component flagged that one or more scope anchors can't reach a visible ancestor
 		// within the loaded graph rows (merge base not yet fetched). Ask the host for more rows
 		// so the synthetic edges can resolve.
 		if (this.graphState.loading || !this.graphState.paging?.hasMore) return;
+
+		// Drop prior dedupe state when the live scope reference changes — the stateProvider
+		// assigns a new scope object on every transition (re-scope, post-invalidation re-resolve),
+		// so reference inequality cleanly catches both.
+		const scope = this.graphState.scope;
+		if (scope !== this._unreachableAnchorScope) {
+			this._unreachableAnchorRequests.clear();
+			this._unreachableAnchorScope = scope;
+		}
+
+		// Forward an unreachable anchor SHA to the host so the provider's page-until-found path
+		// (graph.ts getCommitsForGraphCore stop logic) loads enough rows in one round trip,
+		// instead of one page per scope toggle. Also short-circuit if the flagged anchors are
+		// already in the loaded rows — guards against stale unreachable events fired during
+		// scope-swap re-renders.
+		const anchors = event.detail;
+		const rows = this.graphState.rows;
+		if (anchors?.size && rows?.length) {
+			const loaded = new Set(rows.map(r => r.sha));
+			const rowCount = rows.length;
+
+			// Release any prior request whose response delivered new rows — the provider's cursor
+			// advanced past where the previous walk's cap aborted, so retrying continues the walk
+			// from the new cursor instead of re-running the same range.
+			for (const [sha, requestedAtCount] of this._unreachableAnchorRequests) {
+				if (rowCount > requestedAtCount) {
+					this._unreachableAnchorRequests.delete(sha);
+				}
+			}
+
+			const missing = [...anchors].find(sha => !loaded.has(sha) && !this._unreachableAnchorRequests.has(sha));
+			if (missing == null) return;
+
+			this._unreachableAnchorRequests.set(missing, rowCount);
+			this.graphState.loading = true;
+			this._ipc.sendCommand(GetMoreRowsCommand, { id: missing });
+			return;
+		}
 
 		this.graphState.loading = true;
 		this._ipc.sendCommand(GetMoreRowsCommand, { id: undefined });

--- a/src/webviews/apps/plus/graph/stateProvider.ts
+++ b/src/webviews/apps/plus/graph/stateProvider.ts
@@ -34,6 +34,7 @@ import {
 	DidChangeWipStaleNotification,
 	DidChangeWorkingTreeNotification,
 	DidFetchNotification,
+	DidInvalidateScopeAnchorsNotification,
 	DidRequestOpenCompareModeNotification,
 	DidRequestWipRefetchNotification,
 	DidSearchNotification,
@@ -379,6 +380,12 @@ export class GraphStateProvider extends StateProviderBase<State['webviewId'], Ap
 	private _mergeBaseCache = new Map<string, { sha: string; date: number } | undefined>();
 	/** In-flight merge-base resolves, deduped per cache key. */
 	private _mergeBasePromises = new Map<string, Promise<{ sha: string; date: number } | undefined>>();
+	/**
+	 * Per-repo generation, bumped on `DidInvalidateScopeAnchorsNotification`. In-flight resolves
+	 * capture this before awaiting and skip writing back if it has advanced — otherwise the
+	 * post-await cache write would repopulate `_mergeBaseCache` with the pre-invalidation anchor.
+	 */
+	private _anchorGenerations = new Map<string, number>();
 
 	/**
 	 * Set by callers (e.g. the scope popover) right before sending a filter-changing IPC, so the
@@ -442,6 +449,10 @@ export class GraphStateProvider extends StateProviderBase<State['webviewId'], Ap
 			return;
 		}
 
+		// Capture before await — if invalidation arrives mid-flight (refs/config moved), skip the
+		// writeback so we don't repopulate `_mergeBaseCache` with the pre-invalidation anchor.
+		const generation = this._anchorGenerations.get(repoPath) ?? 0;
+
 		let promise = this._mergeBasePromises.get(cacheKey);
 		if (promise == null) {
 			promise = this.ipc
@@ -452,12 +463,17 @@ export class GraphStateProvider extends StateProviderBase<State['webviewId'], Ap
 				.then(r => r?.scope.mergeBase)
 				.catch(() => undefined)
 				.finally(() => {
-					this._mergeBasePromises.delete(cacheKey);
+					// Only clear when the stored entry still points at *this* promise — otherwise
+					// invalidation already cleared it and a newer resolve may have taken its slot.
+					if (this._mergeBasePromises.get(cacheKey) === promise) {
+						this._mergeBasePromises.delete(cacheKey);
+					}
 				});
 			this._mergeBasePromises.set(cacheKey, promise);
 		}
 
 		const mergeBase = await promise;
+		if ((this._anchorGenerations.get(repoPath) ?? 0) !== generation) return;
 		this._mergeBaseCache.set(cacheKey, mergeBase);
 		this.patchScopeMergeBase(scope, mergeBase);
 	}
@@ -503,6 +519,55 @@ export class GraphStateProvider extends StateProviderBase<State['webviewId'], Ap
 				this._state.lastFetched = msg.params.lastFetched;
 				this.updateState({ lastFetched: msg.params.lastFetched });
 				break;
+
+			case DidInvalidateScopeAnchorsNotification.is(msg): {
+				// Drop the mirrored merge-base cache when the host signals that refs/config moved —
+				// otherwise the next scope-resolve would hand back the cached pre-rebase anchor.
+				const { repoPath, branchRefs } = msg.params;
+				// Bump generation so any in-flight resolve for this repo skips its post-await
+				// writeback (per-repo is sufficient; in-flight resolves whose `branchRefs` weren't
+				// targeted simply re-issue on the next consumer call).
+				this._anchorGenerations.set(repoPath, (this._anchorGenerations.get(repoPath) ?? 0) + 1);
+				const prefix = `${repoPath}|`;
+				if (branchRefs?.length) {
+					for (const ref of branchRefs) {
+						const key = `${repoPath}|${ref}`;
+						this._mergeBaseCache.delete(key);
+						this._mergeBasePromises.delete(key);
+					}
+				} else {
+					for (const key of [...this._mergeBaseCache.keys()]) {
+						if (key.startsWith(prefix)) {
+							this._mergeBaseCache.delete(key);
+						}
+					}
+					for (const key of [...this._mergeBasePromises.keys()]) {
+						if (key.startsWith(prefix)) {
+							this._mergeBasePromises.delete(key);
+						}
+					}
+				}
+
+				// Also reset enrichment so a stale `mergeTargetTipSha` doesn't survive — the next
+				// popover open or sidebar render will re-fetch and `reconcileScopeMergeTarget` will
+				// re-anchor the live scope when it lands.
+				this._enrichmentFingerprint = undefined;
+				if (this.overviewEnrichment != null) {
+					this.overviewEnrichment = undefined;
+				}
+
+				// Proactively re-resolve the live scope. The cache clear above only ensures the
+				// *next* `resolveScopeMergeBase` call won't hand back the stale anchor — it doesn't
+				// touch the live `scope.mergeBase`/`scope.mergeTargetTipSha` themselves, which were
+				// set on the prior resolve and would otherwise keep anchoring the minimap to the
+				// pre-rebase SHA until the user re-scopes. The bumped generation just above ensures
+				// any concurrently-running stale resolve can't beat this fresh one to the writeback.
+				const liveScope = this.scope;
+				if (liveScope?.branchRef.startsWith(prefix)) {
+					void this.resolveScopeMergeBase(liveScope);
+				}
+				break;
+			}
 
 			case DidChangeAvatarsNotification.is(msg):
 				this.updateState({ avatars: msg.params.avatars });

--- a/src/webviews/apps/plus/graph/stateProvider.ts
+++ b/src/webviews/apps/plus/graph/stateProvider.ts
@@ -68,6 +68,12 @@ export function isGraphSearchResultsError(
 	return 'error' in results;
 }
 
+/** Lightweight scope anchor returned by `ResolveGraphScopeRequest` and cached webview-side. */
+type ResolvedScopeAnchor = {
+	mergeBase: { sha: string; date: number } | undefined;
+	mergeTargetTipSha: string | undefined;
+};
+
 /**
  * Returns the scope with `mergeTargetTipSha` backfilled from the branch's enrichment, or the
  * original scope reference when nothing needs to change. Callers use reference-equality to know
@@ -376,10 +382,10 @@ export class GraphStateProvider extends StateProviderBase<State['webviewId'], Ap
 	/** In-flight single-branch enrichment fetches, keyed by branch id, so concurrent callers share one request. */
 	private _adhocEnrichmentPromises = new Map<string, Promise<void>>();
 
-	/** Session cache of resolved merge-bases, keyed by `repoPath|branchRef`. */
-	private _mergeBaseCache = new Map<string, { sha: string; date: number } | undefined>();
-	/** In-flight merge-base resolves, deduped per cache key. */
-	private _mergeBasePromises = new Map<string, Promise<{ sha: string; date: number } | undefined>>();
+	/** Session cache of resolved scope anchors (mergeBase + mergeTargetTipSha), keyed by `repoPath|branchRef`. */
+	private _mergeBaseCache = new Map<string, ResolvedScopeAnchor | undefined>();
+	/** In-flight scope-anchor resolves, deduped per cache key. */
+	private _mergeBasePromises = new Map<string, Promise<ResolvedScopeAnchor | undefined>>();
 	/**
 	 * Per-repo generation, bumped on `DidInvalidateScopeAnchorsNotification`. In-flight resolves
 	 * capture this before awaiting and skip writing back if it has advanced — otherwise the
@@ -445,7 +451,7 @@ export class GraphStateProvider extends StateProviderBase<State['webviewId'], Ap
 
 		// Cache hit — patch and return without IPC.
 		if (this._mergeBaseCache.has(cacheKey)) {
-			this.patchScopeMergeBase(scope, this._mergeBaseCache.get(cacheKey));
+			this.patchScopeAnchor(scope, this._mergeBaseCache.get(cacheKey));
 			return;
 		}
 
@@ -460,8 +466,15 @@ export class GraphStateProvider extends StateProviderBase<State['webviewId'], Ap
 					repoPath: repoPath,
 					scope: scope,
 				})
-				.then(r => r?.scope.mergeBase)
-				.catch(() => undefined)
+				.then((r): ResolvedScopeAnchor | undefined =>
+					r == null
+						? undefined
+						: {
+								mergeBase: r.scope.mergeBase,
+								mergeTargetTipSha: r.scope.resolvedMergeTargetTipSha,
+							},
+				)
+				.catch((): ResolvedScopeAnchor | undefined => undefined)
 				.finally(() => {
 					// Only clear when the stored entry still points at *this* promise — otherwise
 					// invalidation already cleared it and a newer resolve may have taken its slot.
@@ -472,24 +485,40 @@ export class GraphStateProvider extends StateProviderBase<State['webviewId'], Ap
 			this._mergeBasePromises.set(cacheKey, promise);
 		}
 
-		const mergeBase = await promise;
+		const anchor = await promise;
 		if ((this._anchorGenerations.get(repoPath) ?? 0) !== generation) return;
-		this._mergeBaseCache.set(cacheKey, mergeBase);
-		this.patchScopeMergeBase(scope, mergeBase);
+		this._mergeBaseCache.set(cacheKey, anchor);
+		this.patchScopeAnchor(scope, anchor);
 	}
 
-	private patchScopeMergeBase(scope: GraphScope, mergeBase: { sha: string; date: number } | undefined): void {
-		if (mergeBase == null) return;
+	private patchScopeAnchor(scope: GraphScope, anchor: ResolvedScopeAnchor | undefined): void {
+		if (anchor == null) return;
+		// Host couldn't resolve either field — leave the live scope alone rather than assigning
+		// a no-op spread that would re-zoom the minimap for nothing.
+		if (anchor.mergeBase == null && anchor.mergeTargetTipSha == null) return;
 		// Only patch if the live scope still points at the same branch (user may have re-scoped
 		// or cleared while the resolve was in flight).
 		const current = this.scope;
 		if (current?.branchRef !== scope.branchRef) return;
-		// Skip if the authoritative mergeBase matches what's already on the scope — prevents a
-		// redundant signal update that would re-zoom the minimap needlessly.
-		if (current.mergeBase?.sha === mergeBase.sha && current.mergeBase?.date === mergeBase.date) {
-			return;
+		// Skip if both the mergeBase and target tip already match — prevents a redundant signal
+		// update that would re-zoom the minimap needlessly.
+		const mergeBaseSame =
+			current.mergeBase?.sha === anchor.mergeBase?.sha && current.mergeBase?.date === anchor.mergeBase?.date;
+		// `mergeTargetTipSha` may also be supplied by enrichment via `reconcileScopeMergeTarget`.
+		// Only overwrite when the resolver returned a value AND it differs — `undefined` from the
+		// resolver shouldn't clobber an enrichment-supplied SHA.
+		const targetTipSame =
+			anchor.mergeTargetTipSha == null || anchor.mergeTargetTipSha === current.mergeTargetTipSha;
+		if (mergeBaseSame && targetTipSame) return;
+
+		const next: GraphScope = { ...current };
+		if (anchor.mergeBase != null && !mergeBaseSame) {
+			next.mergeBase = anchor.mergeBase;
 		}
-		this.scope = { ...current, mergeBase: mergeBase };
+		if (anchor.mergeTargetTipSha != null && !targetTipSame) {
+			next.mergeTargetTipSha = anchor.mergeTargetTipSha;
+		}
+		this.scope = next;
 	}
 
 	protected onMessageReceived(msg: IpcMessage): void {

--- a/src/webviews/apps/plus/graph/stateProvider.ts
+++ b/src/webviews/apps/plus/graph/stateProvider.ts
@@ -368,13 +368,41 @@ export class GraphStateProvider extends StateProviderBase<State['webviewId'], Ap
 
 		const fingerprint = branchIds.toSorted().join(',');
 		if (fingerprint === this._enrichmentFingerprint) return;
+
+		// Skip the IPC entirely when overviewEnrichment (possibly populated by the sidebar's
+		// parallel fetch path) already covers every id in this composition.
+		const enrichment = this.overviewEnrichment;
+		if (enrichment != null && branchIds.every(id => id in enrichment)) {
+			this._enrichmentFingerprint = fingerprint;
+			return;
+		}
+
 		this._enrichmentFingerprint = fingerprint;
 
 		void this.ipc.sendRequest(GetOverviewEnrichmentRequest, { branchIds: branchIds }).then(result => {
 			// Only publish when the overview fingerprint hasn't moved on — a newer overview
-			// in flight will trigger its own fetch whose result is authoritative.
+			// in flight will trigger its own fetch whose result is authoritative. Build the next
+			// state from `result` so stale entries (e.g. a closed/retargeted PR's enrichment) for
+			// branchIds no longer in the active/recent set are dropped, but preserve any
+			// locally-merged `mergeTarget` from `mergeMergeTargetIntoEnrichment` (overview cards /
+			// click-to-scope) — the host opts out of merge-target resolution here via
+			// `skipMergeTarget: true`, so it always returns `mergeTarget: undefined`.
 			if (this._enrichmentFingerprint === fingerprint) {
-				this.overviewEnrichment = { ...this.overviewEnrichment, ...result };
+				const previous = this.overviewEnrichment;
+				if (previous == null) {
+					this.overviewEnrichment = result;
+				} else {
+					const next: typeof result = {};
+					for (const branchId in result) {
+						const incoming = result[branchId];
+						const localMergeTarget = previous[branchId]?.mergeTarget;
+						next[branchId] =
+							localMergeTarget != null && incoming?.mergeTarget == null
+								? { ...incoming, mergeTarget: localMergeTarget }
+								: incoming;
+					}
+					this.overviewEnrichment = next;
+				}
 			}
 		});
 	}

--- a/src/webviews/apps/plus/graph/stateProvider.ts
+++ b/src/webviews/apps/plus/graph/stateProvider.ts
@@ -352,9 +352,9 @@ export class GraphStateProvider extends StateProviderBase<State['webviewId'], Ap
 		}
 
 		this.updateState(this._state, true);
-		// Enrichment is fetched lazily when a consumer needs it (the overview sidebar mounting,
-		// the scope popover opening, or per-branch on-demand via `ensureEnrichmentForBranch`)
-		// rather than eagerly at bootstrap, where it competes with the graph render itself.
+		// Enrichment is fetched lazily when a consumer needs it (the overview sidebar mounting or
+		// the scope popover opening) rather than eagerly at bootstrap, where it competes with the
+		// graph render itself.
 
 		void this.ipc.sendRequest(GetAgentSessionsRequest, undefined).then(sessions => {
 			this.agentSessions = sortAgentSessions(sessions);
@@ -379,9 +379,6 @@ export class GraphStateProvider extends StateProviderBase<State['webviewId'], Ap
 		});
 	}
 
-	/** In-flight single-branch enrichment fetches, keyed by branch id, so concurrent callers share one request. */
-	private _adhocEnrichmentPromises = new Map<string, Promise<void>>();
-
 	/** Session cache of resolved scope anchors (mergeBase + mergeTargetTipSha), keyed by `repoPath|branchRef`. */
 	private _mergeBaseCache = new Map<string, ResolvedScopeAnchor | undefined>();
 	/** In-flight scope-anchor resolves, deduped per cache key. */
@@ -403,29 +400,6 @@ export class GraphStateProvider extends StateProviderBase<State['webviewId'], Ap
 	deferScopeClear(): void {
 		if (this.scope == null) return;
 		this._scopeClearDeferred = true;
-	}
-
-	/**
-	 * Fetch enrichment for a single branch that isn't covered by the overview (e.g. a branch picked
-	 * from the header scope popover that isn't active or recent). Merges the result into
-	 * `overviewEnrichment` so the reactive `syncScopeMergeTarget` hook can anchor the scope.
-	 */
-	ensureEnrichmentForBranch(branchId: string): Promise<void> {
-		if (this.overviewEnrichment?.[branchId] != null) return Promise.resolve();
-
-		const existing = this._adhocEnrichmentPromises.get(branchId);
-		if (existing != null) return existing;
-
-		const promise = this.ipc
-			.sendRequest(GetOverviewEnrichmentRequest, { branchIds: [branchId] })
-			.then(result => {
-				this.overviewEnrichment = { ...this.overviewEnrichment, ...result };
-			})
-			.finally(() => {
-				this._adhocEnrichmentPromises.delete(branchId);
-			});
-		this._adhocEnrichmentPromises.set(branchId, promise);
-		return promise;
 	}
 
 	/**

--- a/src/webviews/plus/graph/graphWebview.ts
+++ b/src/webviews/plus/graph/graphWebview.ts
@@ -24,6 +24,7 @@ import type {
 import { RemoteResourceType } from '@gitlens/git/models/remoteResource.js';
 import { rootSha, uncommitted, uncommittedStaged } from '@gitlens/git/models/revision.js';
 import type { GitCommitSearchContext, SearchQuery } from '@gitlens/git/models/search.js';
+import type { GitStatus } from '@gitlens/git/models/status.js';
 import type { GitWorktree } from '@gitlens/git/models/worktree.js';
 import {
 	getBranchId,
@@ -61,6 +62,7 @@ import {
 	pauseOnCancelOrTimeout,
 	pauseOnCancelOrTimeoutMapTuplePromise,
 } from '@gitlens/utils/promise.js';
+import { PromiseCache } from '@gitlens/utils/promiseCache.js';
 import { Stopwatch } from '@gitlens/utils/stopwatch.js';
 import type { AgentSessionState } from '../../../agents/models/agentSessionState.js';
 import type { CreatePullRequestActionContext, OpenPullRequestActionContext } from '../../../api/gitlens.d.js';
@@ -655,6 +657,7 @@ export class GraphWebviewProvider implements WebviewProvider<State, State, Graph
 		this._wipWatches.clear();
 		this._flushWipStaleDebounced?.cancel();
 		this._pendingStaleShas.clear();
+		this._wipStatusCache.clear();
 		if (this._composeVirtual != null) {
 			this._composeVirtual.provider.dispose();
 			this._composeVirtual.registration.dispose();
@@ -687,6 +690,16 @@ export class GraphWebviewProvider implements WebviewProvider<State, State, Graph
 	/** Pending WIP stale shas waiting to be flushed as a single notification. */
 	private readonly _pendingStaleShas = new Set<string>();
 	private _flushWipStaleDebounced: Deferrable<() => void> | undefined;
+
+	/**
+	 * Per-secondary-worktree cache of `getStatus()` results, keyed by worktree path.
+	 * The graph component re-asks for WIP stats on every `DidChangeWipStaleNotification`, which can
+	 * fire repeatedly across many worktrees due to ambient FS noise. Caching with a short TTL
+	 * collapses redundant fans-out; the per-WT FS watcher invalidates entries on real changes.
+	 */
+	private readonly _wipStatusCache = new PromiseCache<string, GitStatus | undefined>({
+		createTTL: 1000 * 10, // 10 seconds
+	});
 
 	private readonly _sidebarInvalidatedEvent = createRpcEvent<undefined>('sidebarInvalidated', 'signal');
 	private readonly _sidebarWorktreeEvent = createRpcEvent<{
@@ -2128,8 +2141,12 @@ export class GraphWebviewProvider implements WebviewProvider<State, State, Graph
 				if (!isSecondaryWipSha(sha)) return;
 				const path = getSecondaryWipPath(sha);
 
-				const svc = this.container.git.getRepositoryService(path);
-				const status = await svc.status.getStatus(undefined, signal);
+				const status = await this._wipStatusCache.getOrCreate(
+					path,
+					(_cacheable, factorySignal) =>
+						this.container.git.getRepositoryService(path).status.getStatus(undefined, factorySignal),
+					{ cancellation: signal },
+				);
 				if (cancellation.token.isCancellationRequested) return;
 
 				const diff = status?.diffStatus;
@@ -3438,7 +3455,10 @@ export class GraphWebviewProvider implements WebviewProvider<State, State, Graph
 				sha,
 				Disposable.from(
 					repo.watchWorkingTree(500),
-					repo.onDidChangeWorkingTree(() => this.queueWipStale(sha)),
+					repo.onDidChangeWorkingTree(() => {
+						this._wipStatusCache.invalidate(path);
+						this.queueWipStale(sha);
+					}),
 				),
 			);
 		}
@@ -6215,6 +6235,7 @@ export class GraphWebviewProvider implements WebviewProvider<State, State, Graph
 			this.resetRefsMetadata();
 			this.resetSearchState();
 			this.cancelOperation('computeIncludedRefs');
+			this._wipStatusCache.clear();
 		} else {
 			void graph.rowsStatsDeferred?.promise.then(() => {
 				if (this._graph !== graph) return;

--- a/src/webviews/plus/graph/graphWebview.ts
+++ b/src/webviews/plus/graph/graphWebview.ts
@@ -4102,35 +4102,107 @@ export class GraphWebviewProvider implements WebviewProvider<State, State, Graph
 	private async onResolveGraphScope(
 		params: IpcParams<typeof ResolveGraphScopeRequest>,
 	): Promise<IpcResponse<typeof ResolveGraphScopeRequest>> {
-		const mergeBase = await this.resolveScopeMergeBaseForBranch(params.repoPath, params.scope.branchName);
-		return { scope: { ...params.scope, mergeBase: mergeBase } };
+		const anchor = await this.resolveScopeAnchor(params.repoPath, params.scope.branchName);
+		return {
+			scope: {
+				...params.scope,
+				mergeBase: anchor?.mergeBase,
+				resolvedMergeTargetTipSha: anchor?.mergeTargetTipSha,
+			},
+		};
 	}
 
 	private invalidateScopeAnchors(): void {
+		this._scopeAnchorCache.clear();
+
 		const repoPath = this.repository?.path ?? this._graph?.repoPath;
 		if (repoPath == null) return;
 
 		void this.host.notify(DidInvalidateScopeAnchorsNotification, { repoPath: repoPath });
 	}
 
-	private async resolveScopeMergeBaseForBranch(
+	/**
+	 * Per-branch cache of resolved scope anchors. Cleared by `invalidateScopeAnchors` whenever
+	 * heads/remotes/config move so a stale anchor can't survive a rebase. Holds promises so
+	 * concurrent scope-resolves dedupe naturally.
+	 */
+	private readonly _scopeAnchorCache = new Map<
+		string,
+		Promise<{ mergeBase: { sha: string; date: number }; mergeTargetTipSha?: string } | undefined>
+	>();
+
+	/**
+	 * Lightweight scope-anchor resolver: returns just `{mergeBase, mergeTargetTipSha}` without
+	 * paying for `getContributors --shortstat` that `getBranchContributionsOverview` runs for the
+	 * overview/sidebar contributors panel. The expensive overview path is still used by enrichment
+	 * — this just stops scope from triggering it on cold branches that aren't already covered by
+	 * the package-level `branchOverviews` cache.
+	 */
+	private async resolveScopeAnchor(
 		repoPath: string,
 		branchName: string,
-	): Promise<{ sha: string; date: number } | undefined> {
-		const svc = this.container.git.getRepositoryService(repoPath);
-
-		const branch = await svc.branches.getBranch(branchName);
+	): Promise<{ mergeBase: { sha: string; date: number }; mergeTargetTipSha?: string } | undefined> {
+		// Prefer the already-loaded branch from the in-memory graph snapshot — `_graph.branches`
+		// is the same data `getBranches()` would return (same underlying cache), so this is a
+		// synchronous shortcut on the hot path, not a different source of truth.
+		const branch =
+			this._graph?.branches.get(branchName) ??
+			(await this.container.git.getRepositoryService(repoPath).branches.getBranch(branchName));
 		if (branch == null) return undefined;
 
-		// Scope resolution is interactive (graph navigation drives it), so keep the default
-		// 'normal' priority. The `branchOverviews` cache keyed on `${ref}|${mergeTarget}` handles
-		// in-flight dedup against any concurrent enrichment fetch.
-		const overview = await svc.branches.getBranchContributionsOverview(branch.ref, {
-			associatedPullRequest: getBranchAssociatedPullRequest(this.container, branch),
-		});
-		if (overview?.mergeBase == null || overview.mergeBaseDate == null) return undefined;
+		const cacheKey = branch.id;
+		const cached = this._scopeAnchorCache.get(cacheKey);
+		if (cached != null) return cached;
 
-		return { sha: overview.mergeBase, date: overview.mergeBaseDate.getTime() };
+		const promise = this.computeScopeAnchor(branch);
+		this._scopeAnchorCache.set(cacheKey, promise);
+		// Don't poison the cache with a rejection — refresh paths invalidate explicitly anyway, but
+		// a transient failure should be retryable on the next scope action.
+		promise.catch(() => {
+			if (this._scopeAnchorCache.get(cacheKey) === promise) {
+				this._scopeAnchorCache.delete(cacheKey);
+			}
+		});
+		return promise;
+	}
+
+	private async computeScopeAnchor(
+		branch: GitBranch,
+	): Promise<{ mergeBase: { sha: string; date: number }; mergeTargetTipSha?: string } | undefined> {
+		const svc = this.container.git.getRepositoryService(branch.repoPath);
+
+		// Resolve target name — `getBranchMergeTargetInfo` already shares the underlying caches
+		// with `getBranchContributionsOverview` (`getStoredMergeTargetBranchName`/`getBaseBranchName`/
+		// `getDefaultBranchName`), so this doesn't add new git calls when the overview path also
+		// fires for the same branch.
+		const targetInfo = await getBranchMergeTargetInfo(this.container, branch, { timeout: 100 });
+		// Use the immediate value; ignore the paused PR-resolution continuation. Scope doesn't need
+		// to wait on PR API — base/default fall back covers the cold path while the eventual PR
+		// answer (if any) reaches the scope via overview enrichment, where `reconcileScopeMergeTarget`
+		// re-anchors live.
+		const targetName =
+			(targetInfo.mergeTargetBranch.paused ? undefined : targetInfo.mergeTargetBranch.value) ??
+			targetInfo.baseBranch ??
+			targetInfo.defaultBranch;
+		if (targetName == null) return undefined;
+
+		// Prefer the in-memory branch list for the target tip, just like the focal branch above.
+		const targetBranch = this._graph?.branches.get(targetName) ?? (await svc.branches.getBranch(targetName));
+		const mergeTargetTipSha = targetBranch?.sha;
+
+		const mergeBaseSha = await svc.refs.getMergeBase(branch.ref, targetName);
+		if (mergeBaseSha == null) return undefined;
+
+		// Prefer the cheap dates-only lookup on desktop (git-cli); fall back to a full commit fetch
+		// for providers that don't implement it (e.g. the GitHub provider used in vscode.dev).
+		const dates = await svc.commits.getCommitDates?.(mergeBaseSha);
+		const committerDate = dates?.committerDate ?? (await svc.commits.getCommit(mergeBaseSha))?.committer.date;
+		if (committerDate == null) return undefined;
+
+		return {
+			mergeBase: { sha: mergeBaseSha, date: committerDate.getTime() },
+			mergeTargetTipSha: mergeTargetTipSha,
+		};
 	}
 
 	private _fireSelectionChangedDebounced: Deferrable<GraphWebviewProvider['fireSelectionChanged']> | undefined =

--- a/src/webviews/plus/graph/graphWebview.ts
+++ b/src/webviews/plus/graph/graphWebview.ts
@@ -344,6 +344,7 @@ import {
 	DidChangeWipStaleNotification,
 	DidChangeWorkingTreeNotification,
 	DidFetchNotification,
+	DidInvalidateScopeAnchorsNotification,
 	DidRequestOpenCompareModeNotification,
 	DidRequestWipRefetchNotification,
 	DidSearchNotification,
@@ -454,6 +455,10 @@ export class GraphWebviewProvider implements WebviewProvider<State, State, Graph
 			return;
 		}
 
+		// `resetRepositoryState` runs after `_repository` is reassigned, so its `invalidateScopeAnchors`
+		// call notifies for the new repoPath — leaving the webview's `_mergeBaseCache` entries keyed by
+		// the previous path stranded. Notify for the previous path explicitly to drop them.
+		const previousPath = this._repository?.path;
 		this._repository = value;
 		// Clear the auto-fetch attempt floor so the new repo gets a fresh schedule rather than
 		// inheriting a recent attempt timestamp from the previous repo.
@@ -461,6 +466,10 @@ export class GraphWebviewProvider implements WebviewProvider<State, State, Graph
 		this.resetRepositoryState();
 		this.ensureRepositorySubscriptions(true);
 		void this.ensureAutoFetch();
+
+		if (previousPath != null && previousPath !== value?.path) {
+			void this.host.notify(DidInvalidateScopeAnchorsNotification, { repoPath: previousPath });
+		}
 
 		if (this.host.ready) {
 			this.updateState();
@@ -2767,6 +2776,13 @@ export class GraphWebviewProvider implements WebviewProvider<State, State, Graph
 			}
 		}
 
+		// Branch tips, stored merge targets, and remote tracking can all move the merge-base anchor
+		// scope relies on. Drop the host-side overview cache and signal the webview to drop its
+		// mirrored merge-base cache so the next scope resolve recomputes against fresh refs.
+		if (e.changed('heads', 'remotes', 'config')) {
+			this.invalidateScopeAnchors();
+		}
+
 		// Invalidate sidebar panels only for changes that actually affect their data. Skipping this for
 		// config/unknown/pausedOp changes prevents the sidebar from showing a spinner during unrelated
 		// repo activity (e.g. worktrees discovered during graph scroll fire `unknown` repo events).
@@ -4088,6 +4104,13 @@ export class GraphWebviewProvider implements WebviewProvider<State, State, Graph
 	): Promise<IpcResponse<typeof ResolveGraphScopeRequest>> {
 		const mergeBase = await this.resolveScopeMergeBaseForBranch(params.repoPath, params.scope.branchName);
 		return { scope: { ...params.scope, mergeBase: mergeBase } };
+	}
+
+	private invalidateScopeAnchors(): void {
+		const repoPath = this.repository?.path ?? this._graph?.repoPath;
+		if (repoPath == null) return;
+
+		void this.host.notify(DidInvalidateScopeAnchorsNotification, { repoPath: repoPath });
 	}
 
 	private async resolveScopeMergeBaseForBranch(
@@ -6073,6 +6096,7 @@ export class GraphWebviewProvider implements WebviewProvider<State, State, Graph
 		this._stateNotifyDirty = false;
 		this._lastSentBranchState = undefined;
 		this._graphDetailsDiffCache.clear();
+		this.invalidateScopeAnchors();
 		if (this._stateFreshnessRetryTimer != null) {
 			clearTimeout(this._stateFreshnessRetryTimer);
 			this._stateFreshnessRetryTimer = undefined;

--- a/src/webviews/plus/graph/protocol.ts
+++ b/src/webviews/plus/graph/protocol.ts
@@ -515,6 +515,12 @@ export const ChooseFileRequest = new IpcRequest<ChooseFileParams, DidChooseFileP
 
 export interface ResolvedGraphScope extends GraphScope {
 	mergeBase?: { sha: string; date: number };
+	/**
+	 * Resolved merge-target tip SHA. Carried alongside `mergeBase` so the lightweight scope-anchor
+	 * path can backfill the scope without forcing a parallel `getOverviewEnrichment` IPC for branches
+	 * that aren't already in active/recent.
+	 */
+	resolvedMergeTargetTipSha?: string;
 }
 export interface ResolveGraphScopeParams {
 	repoPath: string;

--- a/src/webviews/plus/graph/protocol.ts
+++ b/src/webviews/plus/graph/protocol.ts
@@ -946,6 +946,16 @@ export interface DidFetchParams {
 }
 export const DidFetchNotification = new IpcNotification<DidFetchParams>(scope, 'didFetch');
 
+export interface DidInvalidateScopeAnchorsParams {
+	repoPath: string;
+	/** When undefined, invalidate all scope anchors for the repo. */
+	branchRefs?: string[];
+}
+export const DidInvalidateScopeAnchorsNotification = new IpcNotification<DidInvalidateScopeAnchorsParams>(
+	scope,
+	'scope/anchors/didInvalidate',
+);
+
 export interface DidStartFeaturePreviewParams {
 	featurePreview: FeaturePreview;
 	allowed: boolean;


### PR DESCRIPTION
## Summary

Stops the graph from re-running expensive git/IPC work each time the user toggles the graph's scope (focus branch). Each commit targets a specific repeat that profiling surfaced; together they keep a warm scope toggle off git almost entirely.

- **Scope-anchor caching.** `_scopeAnchorCache` keyed per branch on the host, mirrored on the webview, both invalidated together on `heads`/`remotes`/`config` movement via a new `DidInvalidateScopeAnchorsNotification`. Without this the webview's resolved-promise cache shadowed `git/cache.ts` invalidation and scope kept showing pre-rebase merge bases.
- **Lightweight anchor resolver.** New `resolveScopeAnchor` composes `getBranchMergeTargetInfo` (100 ms PR-resolution timeout) + `getMergeBase` + `getCommitDates` instead of going through `getBranchContributionsOverview` (which runs `getContributors --shortstat`). Reads from the in-memory `_graph.branches` snapshot first, falling back to `getBranch(name)` only when the branch isn't loaded. The overview path is preserved for the sidebar contributors panel.
- **Drops redundant focus-branch popover enrichment.** `handleScopeToBranchFromHeader`'s fallback was firing a full per-branch enrichment IPC (PR, autolinks, issues, merge-target counts/conflicts/merged-status) just to land the merge-target tip SHA — none of which any scope-driven UI reads. `setScope` → `resolveScopeMergeBase` now carries `mergeTargetTipSha` directly from the new resolver.
- **Skips popover-warm enrichment IPC** when the active+recent branch-id set is already covered by `overviewEnrichment`. Composes safely with the sidebar's parallel fetch path.
- **Caches secondary-worktree WIP status** in a 10 s per-worktree `PromiseCache`. Real working-tree changes invalidate the entry immediately via the existing per-WT watcher; the TTL is just a safety bound. Eliminates the cycling `git status --porcelain=v2` fan-out under ambient FS noise.
- **Caches single-commit `git log` reads** in `getLogCore` (the `isSingleCommit` branch) and bumps `getCommitSignature`/`isCommitSigned` to dynamic SHA-aware TTLs — 5 min for full SHAs (immutable), 60 s for non-SHA refs. Mirrors `getCommitDates`. Removes the per-toggle `git log -n1 <sha>` repeats for merge-base SHAs.
- **Targets graph pagination at unreachable scope anchors.** The wrapper's `onScopeAnchorsUnreachable` now forwards an unreachable anchor SHA as the `id` on `GetMoreRowsCommand`, so the provider's existing page-until-found path (`getCommitsForGraphCore` stop logic) loads enough rows in one round trip instead of trickling one page per toggle. Also short-circuits when the flagged anchors are already in the loaded rows.

## Test plan

- [x] `pnpm run build` — clean
- [x] `pnpm run lint` — clean
- [x] `pnpm run test` — existing graph/commits suites pass
- [x] Open the Commit Graph in a repo with multiple branches; toggle the focus branch between two branches three times and confirm in the GitLens (Git) output channel:
  - First toggle to a given branch: at most one `GetMoreRowsCommand` round trip; one cold `git log -n1 <merge-base-sha>` for the anchor
  - Subsequent toggles within 5 min between the same two branches: no repeated `git log -n1 <sha>`, no `git log --skip=… --shortstat` page fetch, no per-branch enrichment IPC
  - Toggle to a third never-seen branch: anchor fetches fresh exactly once
- [x] Trigger refs movement (commit, push, branch update) with the Graph open; next toggle re-fetches (`heads`/`remotes` events clear the caches), confirming we haven't traded staleness for speed
- [x] Open a repo with secondary worktrees containing WIP changes; modify a file in one worktree and confirm only that worktree's `git status` re-runs (no fan-out across siblings)
- [x] Scope to a branch whose merge base is deep in history; one IPC reaches the anchor (server-side may stream multiple pages, but no page-per-toggle accumulation)