### PR TITLE
Graph: Add discard file changes operation

### DIFF
--- a/src/webviews/apps/commitDetails/actions.ts
+++ b/src/webviews/apps/commitDetails/actions.ts
@@ -468,6 +468,16 @@ export class CommitDetailsActions {
 		gitActions.unstageFile(this.state.error, this.services.repository, file);
 	}
 
+	discardFile(file: GitFileChangeShape): void {
+		gitActions.discardFile(this.state.error, this.services.repository, file);
+	}
+
+	discardUnstagedFiles(): void {
+		const repoPath = this.getRepoPath();
+		if (!repoPath) return;
+		gitActions.discardUnstagedFiles(this.state.error, this.services.repository, repoPath);
+	}
+
 	// ============================================================
 	// File Actions
 	// ============================================================

--- a/src/webviews/apps/commitDetails/commitDetails.ts
+++ b/src/webviews/apps/commitDetails/commitDetails.ts
@@ -628,6 +628,9 @@ export class GlCommitDetailsApp extends SignalWatcherWebviewApp {
 									actions?.stageFile(e.detail)}
 								@file-unstage=${(e: CustomEvent<FileChangeListItemDetail>) =>
 									actions?.unstageFile(e.detail)}
+								@file-discard=${(e: CustomEvent<FileChangeListItemDetail>) =>
+									actions?.discardFile(e.detail)}
+								@discard-unstaged=${() => actions?.discardUnstagedFiles()}
 								@data-action=${(e: CustomEvent<{ name: string }>) => this.onBranchAction(e.detail.name)}
 								@gl-inspect-create-suggestions=${(e: CustomEvent<CreatePatchEventDetail>) =>
 									actions?.suggestChanges(e.detail)}

--- a/src/webviews/apps/commitDetails/components/gl-details-wip-panel.ts
+++ b/src/webviews/apps/commitDetails/components/gl-details-wip-panel.ts
@@ -569,18 +569,20 @@ export class GlDetailsWipPanel extends GlDetailsBase {
 
 		// Non-conflicted files: row click opens, so no Open File button. Checkbox mode handles
 		// staging via the row checkbox; non-checkbox mode shows Stage/Unstage buttons.
-		if (this.checkboxMode) return [];
+		const discard = { icon: 'discard', label: 'Discard Changes', action: 'file-discard' };
+
+		if (this.checkboxMode) return [discard];
 
 		const stage = { icon: 'plus', label: 'Stage Changes', action: 'file-stage' };
 		const unstage = { icon: 'remove', label: 'Unstage Changes', action: 'file-unstage' };
 
 		if (options?.mixed) {
-			return [stage, unstage];
+			return [stage, unstage, discard];
 		}
 		if (file.staged === true) {
-			return [unstage];
+			return [unstage, discard];
 		}
-		return [stage];
+		return [stage, discard];
 	}
 
 	override getFolderContext(folder: { relativePath: string }): string | undefined {

--- a/src/webviews/apps/plus/graph/components/detailsActions.ts
+++ b/src/webviews/apps/plus/graph/components/detailsActions.ts
@@ -2060,6 +2060,15 @@ export class DetailsActions {
 		this._pendingStagingOp = this.runStagingOp(this.services.repository.unstageAll(repoPath));
 	}
 
+	discardFile(detail: FileChangeListItemDetail): void {
+		this._pendingStagingOp = this.runStagingOp(this.services.repository.discardFile(detail));
+	}
+
+	discardUnstagedFiles(repoPath: string | undefined): void {
+		if (!repoPath) return;
+		this._pendingStagingOp = this.runStagingOp(this.services.repository.discardUnstagedFiles(repoPath));
+	}
+
 	/**
 	 * After a stage/unstage RPC completes, force a WIP re-fetch from the host. The host's
 	 * `notifyDidChangeWorkingTree` deduplicates by added/deleted/modified counts, so a pure

--- a/src/webviews/apps/plus/graph/components/gl-graph-details-panel.ts
+++ b/src/webviews/apps/plus/graph/components/gl-graph-details-panel.ts
@@ -590,6 +590,8 @@ export class GlGraphDetailsPanel extends SignalWatcher(LitElement) {
 											@file-more-actions=${this.handleFileMoreActions}
 											@file-stage=${this.handleFileStage}
 											@file-unstage=${this.handleFileUnstage}
+											@file-discard=${this.handleFileDiscard}
+											@discard-unstaged=${this.handleDiscardUnstaged}
 											@stage-all=${this.handleStageAll}
 											@unstage-all=${this.handleUnstageAll}
 											@stash-save=${this.handleStashSave}
@@ -1291,6 +1293,14 @@ export class GlGraphDetailsPanel extends SignalWatcher(LitElement) {
 
 	private handleFileUnstage = (e: CustomEvent<FileChangeListItemDetail>) => {
 		this._actions.unstageFile(e.detail);
+	};
+
+	private handleFileDiscard = (e: CustomEvent<FileChangeListItemDetail>) => {
+		this._actions.discardFile(e.detail);
+	};
+
+	private handleDiscardUnstaged = () => {
+		this._actions.discardUnstagedFiles(this.effectiveRepoPath);
 	};
 
 	private handleStageAll = () => {

--- a/src/webviews/apps/shared/actions/git.ts
+++ b/src/webviews/apps/shared/actions/git.ts
@@ -48,3 +48,19 @@ export function unstageFile(
 ): void {
 	fireRpc(errorSignal, git.unstageFile(file), 'unstage file');
 }
+
+export function discardFile(
+	errorSignal: Signal.State<string | undefined>,
+	git: { discardFile(file: GitFileChangeShape): Promise<void> },
+	file: GitFileChangeShape,
+): void {
+	fireRpc(errorSignal, git.discardFile(file), 'discard file');
+}
+
+export function discardUnstagedFiles(
+	errorSignal: Signal.State<string | undefined>,
+	git: { discardUnstagedFiles(repoPath: string): Promise<void> },
+	repoPath: string,
+): void {
+	fireRpc(errorSignal, git.discardUnstagedFiles(repoPath), 'discard unstaged files');
+}

--- a/src/webviews/apps/shared/components/tree/gl-file-tree-pane.ts
+++ b/src/webviews/apps/shared/components/tree/gl-file-tree-pane.ts
@@ -664,6 +664,7 @@ export class GlFileTreePane extends LitElement {
 					path: file.path,
 					repoPath: file.repoPath,
 					status: file.status,
+					originalPath: file.originalPath,
 					staged: file.staged,
 					showOptions: e
 						? {

--- a/src/webviews/apps/shared/components/tree/gl-wip-tree-pane.ts
+++ b/src/webviews/apps/shared/components/tree/gl-wip-tree-pane.ts
@@ -254,6 +254,7 @@ export class GlWipTreePane extends LitElement {
 							slot="leading-actions"
 							appearance="toolbar"
 							tooltip="Discard Unstaged Changes"
+							style="display: none"
 							@click=${this.onDiscardUnstaged}
 						>
 							<code-icon icon="discard" slot="prefix"></code-icon>
@@ -300,6 +301,8 @@ export class GlWipTreePane extends LitElement {
 		this.dispatchEvent(new CustomEvent('stash-save', { bubbles: true, composed: true }));
 	}
 
+	// TODO: Button hidden — bulk discard-unstaged is punted until multiselect lands in trees
+	// See https://github.com/gitkraken/vscode-gitlens/pull/5207#pullrequestreview-4286302741
 	private onDiscardUnstaged() {
 		this.dispatchEvent(new CustomEvent('discard-unstaged', { bubbles: true, composed: true }));
 	}

--- a/src/webviews/apps/shared/components/tree/gl-wip-tree-pane.ts
+++ b/src/webviews/apps/shared/components/tree/gl-wip-tree-pane.ts
@@ -242,14 +242,22 @@ export class GlWipTreePane extends LitElement {
 			${this.renderConflictBulkActions(files)}
 			${files.length > 0
 				? html`<gl-button
-						slot="leading-actions"
-						appearance="toolbar"
-						tooltip="Stash Changes"
-						@click=${this.onStashSave}
-					>
-						<code-icon icon="gl-stash-save" slot="prefix"></code-icon>
-						<span class="stash-label">Stash</span>
-					</gl-button>`
+							slot="leading-actions"
+							appearance="toolbar"
+							tooltip="Stash Changes"
+							@click=${this.onStashSave}
+						>
+							<code-icon icon="gl-stash-save" slot="prefix"></code-icon>
+							<span class="stash-label">Stash</span>
+						</gl-button>
+						<gl-button
+							slot="leading-actions"
+							appearance="toolbar"
+							tooltip="Discard Unstaged Changes"
+							@click=${this.onDiscardUnstaged}
+						>
+							<code-icon icon="discard" slot="prefix"></code-icon>
+						</gl-button>`
 				: nothing}
 			<slot name="before-tree" slot="before-tree"></slot>
 		</gl-file-tree-pane>`;
@@ -290,6 +298,10 @@ export class GlWipTreePane extends LitElement {
 
 	private onStashSave() {
 		this.dispatchEvent(new CustomEvent('stash-save', { bubbles: true, composed: true }));
+	}
+
+	private onDiscardUnstaged() {
+		this.dispatchEvent(new CustomEvent('discard-unstaged', { bubbles: true, composed: true }));
 	}
 
 	private onOpenMultiDiff(refs: { repoPath: string; lhs: string; rhs: string; title?: string }): void {

--- a/src/webviews/rpc/services/repository.ts
+++ b/src/webviews/rpc/services/repository.ts
@@ -8,7 +8,7 @@
  * - Per-repo change events (working tree FS changes, filtered repository changes)
  */
 
-import { Disposable, Uri, window } from 'vscode';
+import { Disposable, Uri, window, workspace } from 'vscode';
 import type { GitBranch } from '@gitlens/git/models/branch.js';
 import { GitCommit } from '@gitlens/git/models/commit.js';
 import type { GitFileChange, GitFileChangeShape } from '@gitlens/git/models/fileChange.js';
@@ -343,6 +343,135 @@ export class RepositoryService {
 	 */
 	async unstageAll(repoPath: string): Promise<void> {
 		await this.container.git.getRepositoryService(repoPath).staging?.unstageAll();
+	}
+
+	async discardFile(file: GitFileChangeShape): Promise<void> {
+		const confirmed = await this.confirmDiscardChanges([file.path]);
+		if (!confirmed) return;
+
+		const uri = Uri.joinPath(Uri.file(file.repoPath), file.path);
+		const svc = this.container.git.getRepositoryService(file.repoPath);
+
+		await this.trashAndUnstage(uri, svc, file);
+
+		// Untracked and newly-added files don't exist in HEAD — trash is sufficient
+		if (file.status === '?' || file.status === 'A') return;
+
+		// Renames/copies: restore the original path from HEAD (not the new name)
+		if (file.status === 'R' || file.status === 'C') {
+			if (file.originalPath) {
+				try {
+					await svc.ops?.checkout('HEAD', { path: file.originalPath });
+				} catch (ex) {
+					Logger.warn(`Failed to restore ${file.originalPath} from HEAD (file was moved to Trash): ${ex}`);
+				}
+			} else {
+				Logger.warn(`Renamed file ${file.path} missing originalPath — original not restored`);
+			}
+			return;
+		}
+
+		try {
+			await svc.ops?.checkout('HEAD', { path: file.path });
+		} catch (ex) {
+			Logger.warn(`Failed to restore ${file.path} from HEAD (file was moved to Trash): ${ex}`);
+		}
+	}
+
+	async discardUnstagedFiles(repoPath: string): Promise<void> {
+		const svc = this.container.git.getRepositoryService(repoPath);
+		const status = await svc.status.getStatus();
+		if (status == null) return;
+
+		// Only discard unstaged files — leave staged and conflicted untouched.
+		// Note: mixed files (staged + unstaged changes) are also skipped because
+		// `f.staged` is true when indexStatus is set. This is intentional — checkout
+		// HEAD would wipe their staged changes, and restoring from the index requires
+		// git restore/checkout-index which isn't in the provider layer yet. Users can
+		// still discard mixed files individually via the per-file button.
+		const unstaged = status.files.filter(f => !f.staged && !isConflictStatus(f.status));
+		if (unstaged.length === 0) return;
+
+		const untracked = unstaged.filter(f => f.status === '?');
+		const tracked = unstaged.filter(f => f.status !== '?');
+
+		const confirmed = await this.confirmDiscardUnstaged(tracked.length, untracked.length);
+		if (!confirmed) return;
+
+		// Move non-deleted files to trash so working-tree versions are recoverable
+		const toTrash = unstaged.filter(f => f.status !== 'D');
+		const trashResults = await Promise.allSettled(
+			toTrash.map(f => this.moveToTrash(Uri.joinPath(Uri.file(repoPath), f.path))),
+		);
+		for (const r of trashResults) {
+			if (r.status === 'rejected') {
+				Logger.warn(`Failed to move file to trash: ${r.reason}`);
+			}
+		}
+
+		// Restore tracked files from HEAD
+		for (const f of tracked) {
+			// 'A' (added) never appears with staged=false in practice — git reports
+			// unstaged new files as '?' (untracked), not 'A'. Guard is here defensively and to calm down robotic reviewers
+			if (f.status === 'A') continue;
+
+			const checkoutPath = f.status === 'R' || f.status === 'C' ? (f.originalPath ?? f.path) : f.path;
+			try {
+				await svc.ops?.checkout('HEAD', { path: checkoutPath });
+			} catch (ex) {
+				Logger.warn(`Failed to restore ${checkoutPath} from HEAD: ${ex}`);
+			}
+		}
+	}
+
+	private async trashAndUnstage(
+		uri: Uri,
+		svc: ReturnType<Container['git']['getRepositoryService']>,
+		file: GitFileChangeShape,
+	): Promise<void> {
+		if (file.status !== 'D') {
+			await this.moveToTrash(uri);
+		}
+		if (file.staged) {
+			await svc.staging?.unstageFile(file.path);
+		}
+	}
+
+	private async confirmDiscardChanges(paths: string[]): Promise<boolean> {
+		const fileCount = paths.length;
+		const fileLabel = fileCount === 1 ? `"${paths[0]}"` : pluralize('file', fileCount);
+		const discard = fileCount === 1 ? 'Discard Changes' : 'Discard All Changes';
+		const choice = await window.showWarningMessage(
+			`Are you sure you want to discard changes in ${fileLabel}?\n\nThis is IRREVERSIBLE!\nYour current changes will be FOREVER LOST if you proceed.`,
+			{ modal: true },
+			discard,
+		);
+		return choice === discard;
+	}
+
+	private async confirmDiscardUnstaged(trackedCount: number, untrackedCount: number): Promise<boolean> {
+		const lines: string[] = [];
+		if (untrackedCount > 0) {
+			lines.push(
+				`Are you sure you want to DELETE ${pluralize('untracked file', untrackedCount)}? You can restore these files from the Trash.`,
+			);
+		}
+		if (trackedCount > 0) {
+			if (untrackedCount > 0) {
+				lines.push('');
+			}
+			lines.push(`Are you sure you want to discard unstaged changes in ${pluralize('file', trackedCount)}?`);
+		}
+		lines.push('', 'This is IRREVERSIBLE!', 'Your current working set will be FOREVER LOST if you proceed.');
+
+		const totalCount = trackedCount + untrackedCount;
+		const discard = `Discard ${pluralize('Unstaged File', totalCount)}`;
+		const choice = await window.showWarningMessage(lines.join('\n'), { modal: true }, discard);
+		return choice === discard;
+	}
+
+	private async moveToTrash(uri: Uri): Promise<void> {
+		await workspace.fs.delete(uri, { useTrash: true });
 	}
 
 	/**


### PR DESCRIPTION
## Summary
- Adds per-file **Discard Changes** button (↩) to each file row in the Graph Working Changes panel
- Adds **Discard Unstaged Changes** button to the WIP tree pane header (next to Stash)
- Strong modal confirmation dialog before any discard operation
- Moves files to OS Trash before restoring from HEAD — recoverable safety net
- Correctly handles all file states: modified, deleted, renamed/copied, untracked, and newly added
- Excludes staged and conflicted files from bulk discard; per-file discard still works on any file

### Per-file discard
- **Modified/deleted**: Trash working-tree version, unstage if staged, restore from HEAD
- **Renamed/copied**: Trash new name, unstage, restore original path from HEAD (single click fully reverts)
- **Untracked/added**: Move to Trash (+ unstage if staged)
- **Conflicted**: Discard button hidden (conflicts need resolution, not discard)

### Discard Unstaged (bulk)
- Only affects unstaged, non-conflicted files — staged files are never touched
- Confirmation dialog shows separate counts for untracked and tracked unstaged files
- Single button: "Discard N Unstaged Files"

### Safety
- `originalPath` now included in file event dispatch for correct rename handling
- `Promise.allSettled` for bulk trash so one failure doesn't block the rest
- Per-file try/catch on checkout so one git error doesn't stop remaining files

Closes #5202

Buttons:
<img width="800" alt="image" src="https://github.com/user-attachments/assets/361c20a8-8537-4558-94d1-1c7a072b299f" />

Discard one:

<img width="800" alt="image" src="https://github.com/user-attachments/assets/b96bc333-3f47-4b46-9595-d4f9ec4d2a06" />

<img width="400" alt="image" src="https://github.com/user-attachments/assets/02662903-effb-4c6e-bec8-04edeaee6368" />


Discard all:

<img width="800" alt="image" src="https://github.com/user-attachments/assets/112f1b24-f411-4b35-aaf4-4b7735c9a755" />

<img width="400" alt="image" src="https://github.com/user-attachments/assets/8f77d534-661e-48c1-a505-0a340c7805bf" />
