### PR TITLE
Fixes #5208 agent workspace filter on Windows

### DIFF
--- a/packages/plus/agents/src/__tests__/claudeCodeProvider.test.ts
+++ b/packages/plus/agents/src/__tests__/claudeCodeProvider.test.ts
@@ -1,0 +1,157 @@
+import * as assert from 'assert';
+import type { IpcHandler } from '@gitlens/ipc/ipcServer.js';
+import { createDisposable } from '@gitlens/utils/disposable.js';
+import { ClaudeCodeProvider } from '../providers/claudeCodeProvider.js';
+import type { AgentProviderCallbacks, IpcRegistrar } from '../types.js';
+
+interface MockCallbacks {
+	callbacks: AgentProviderCallbacks;
+	handlers: Map<string, IpcHandler>;
+	publishedPaths: string[][];
+}
+
+function createMockCallbacks(options?: { resolveGitInfo?: AgentProviderCallbacks['resolveGitInfo'] }): MockCallbacks {
+	const handlers = new Map<string, IpcHandler>();
+	const publishedPaths: string[][] = [];
+
+	const ipc: IpcRegistrar = {
+		port: 1234,
+		registerHandler: <Request, Response>(name: string, handler: IpcHandler<Request, Response>) => {
+			handlers.set(name, handler as unknown as IpcHandler);
+			return createDisposable(() => {
+				handlers.delete(name);
+			});
+		},
+		publishAgents: workspacePaths => {
+			publishedPaths.push([...workspacePaths]);
+			return Promise.resolve();
+		},
+		unpublishAgents: () => Promise.resolve(),
+	};
+
+	const callbacks: AgentProviderCallbacks = {
+		ipc: ipc,
+		runCLICommand: () => Promise.resolve('[]'),
+		resolveGitInfo: options?.resolveGitInfo,
+	};
+
+	return { callbacks: callbacks, handlers: handlers, publishedPaths: publishedPaths };
+}
+
+function sessionStart(sessionId: string, cwd: string): Record<string, unknown> {
+	return { event: 'SessionStart', sessionId: sessionId, cwd: cwd, pid: process.pid };
+}
+
+/** Yield to the microtask queue so `void this.ensureIpcServer()` can finish its awaits
+ *  (publishAgents / syncSessions) and `publishedPaths` is populated. */
+function flushMicrotasks(): Promise<void> {
+	return new Promise(resolve => setImmediate(resolve));
+}
+
+suite('ClaudeCodeProvider', () => {
+	suite('workspace path normalization', () => {
+		test('start() forwards normalized paths to publishAgents', async () => {
+			const { callbacks, publishedPaths } = createMockCallbacks();
+			const provider = new ClaudeCodeProvider(callbacks);
+			try {
+				provider.start(['d:\\PROJ\\GKGL\\vscode-gitlens']);
+				await flushMicrotasks();
+
+				assert.deepStrictEqual(publishedPaths[0], ['d:/PROJ/GKGL/vscode-gitlens']);
+			} finally {
+				provider.dispose();
+			}
+		});
+
+		test('SessionStart with backslash cwd inside a backslash workspace yields a normalized session.workspacePath', async () => {
+			const { callbacks, handlers } = createMockCallbacks();
+			const provider = new ClaudeCodeProvider(callbacks);
+			try {
+				provider.start(['d:\\PROJ\\GKGL\\vscode-gitlens']);
+
+				const handler = handlers.get('agents/session');
+				assert.ok(handler != null, 'agents/session handler should be registered');
+
+				await handler(sessionStart('sess-1', 'd:\\PROJ\\GKGL\\vscode-gitlens\\src'), new URLSearchParams());
+
+				assert.strictEqual(provider.sessions.length, 1);
+				assert.strictEqual(provider.sessions[0].workspacePath, 'd:/PROJ/GKGL/vscode-gitlens');
+				assert.strictEqual(provider.sessions[0].isInWorkspace, true);
+			} finally {
+				provider.dispose();
+			}
+		});
+
+		test('SessionStart with backslash cwd matches a forward-slash workspace path', async () => {
+			const { callbacks, handlers } = createMockCallbacks();
+			const provider = new ClaudeCodeProvider(callbacks);
+			try {
+				provider.start(['d:/PROJ/GKGL/vscode-gitlens']);
+
+				const handler = handlers.get('agents/session')!;
+				await handler(sessionStart('sess-1', 'd:\\PROJ\\GKGL\\vscode-gitlens\\src'), new URLSearchParams());
+
+				assert.strictEqual(provider.sessions[0].workspacePath, 'd:/PROJ/GKGL/vscode-gitlens');
+				assert.strictEqual(provider.sessions[0].isInWorkspace, true);
+			} finally {
+				provider.dispose();
+			}
+		});
+
+		test('SessionStart with cwd outside any workspace path yields isInWorkspace=false', async () => {
+			const { callbacks, handlers } = createMockCallbacks();
+			const provider = new ClaudeCodeProvider(callbacks);
+			try {
+				provider.start(['/home/user/projectA']);
+
+				const handler = handlers.get('agents/session')!;
+				await handler(sessionStart('sess-1', '/home/user/projectB'), new URLSearchParams());
+
+				assert.strictEqual(provider.sessions[0].workspacePath, undefined);
+				assert.strictEqual(provider.sessions[0].isInWorkspace, false);
+			} finally {
+				provider.dispose();
+			}
+		});
+
+		test('resolveGitInfo fallback uses host-normalized repoRoot when cwd is outside the workspace', async () => {
+			const { callbacks, handlers } = createMockCallbacks({
+				resolveGitInfo: () =>
+					Promise.resolve({
+						branch: 'main',
+						repoRoot: 'd:/PROJ/GKGL/vscode-gitlens',
+						isWorktree: false,
+					}),
+			});
+			const provider = new ClaudeCodeProvider(callbacks);
+			try {
+				provider.start(['/home/user/projectA']);
+
+				const handler = handlers.get('agents/session')!;
+				await handler(sessionStart('sess-1', 'd:\\PROJ\\GKGL\\vscode-gitlens\\src'), new URLSearchParams());
+				await flushMicrotasks();
+
+				assert.strictEqual(provider.sessions[0].workspacePath, 'd:/PROJ/GKGL/vscode-gitlens');
+				assert.strictEqual(provider.sessions[0].isInWorkspace, false);
+			} finally {
+				provider.dispose();
+			}
+		});
+
+		test('updateWorkspacePaths normalizes and re-publishes', async () => {
+			const { callbacks, publishedPaths } = createMockCallbacks();
+			const provider = new ClaudeCodeProvider(callbacks);
+			try {
+				provider.start(['/home/user/projectA']);
+				await flushMicrotasks();
+
+				provider.updateWorkspacePaths(['d:\\PROJ\\GKGL\\vscode-gitlens']);
+				await flushMicrotasks();
+
+				assert.deepStrictEqual(publishedPaths.at(-1), ['d:/PROJ/GKGL/vscode-gitlens']);
+			} finally {
+				provider.dispose();
+			}
+		});
+	});
+});

--- a/packages/plus/agents/src/providers/claudeCodeProvider.ts
+++ b/packages/plus/agents/src/providers/claudeCodeProvider.ts
@@ -1,11 +1,11 @@
 import { readdir, readFile } from 'fs/promises';
-import { join, sep } from 'path';
-import { agentDiscoveryDir } from '@gitlens/ipc/discovery.js';
+import { join } from 'path';
 import { gate } from '@gitlens/utils/decorators/gate.js';
 import type { UnifiedDisposable } from '@gitlens/utils/disposable.js';
 import { disposableInterval } from '@gitlens/utils/disposable.js';
 import { Emitter } from '@gitlens/utils/event.js';
 import { Logger } from '@gitlens/utils/logger.js';
+import { normalizePath } from '@gitlens/utils/path.js';
 import { truncate } from '@gitlens/utils/string.js';
 import { deriveStatusFromEvent, describeToolInput, isProcessAlive, rehydrateSubagents } from '../stateMachine.js';
 import type {
@@ -106,8 +106,13 @@ type SerializedAgentSession = Omit<AgentSession, 'lastActivity' | 'phaseSince' |
 	})[];
 };
 
+/** Normalize a workspace path to GitLens canonical form (forward slashes, lower-case drive letter
+ *  on Windows). Comparisons throughout the home view assume this form, but `_workspacePaths` and
+ *  peer-session `workspacePath` values originate from `Uri.fsPath`, which on Windows uses
+ *  backslashes and preserves drive-letter casing. Without this, `session.workspacePath ===
+ *  repository.path` always fails on Windows. */
 function normalizeWorkspacePath(value: string | null | undefined): string | undefined {
-	return value ? value : undefined;
+	return value ? normalizePath(value) : undefined;
 }
 
 export class ClaudeCodeProvider implements AgentSessionProvider {
@@ -133,7 +138,7 @@ export class ClaudeCodeProvider implements AgentSessionProvider {
 	}
 
 	start(workspacePaths: string[]): void {
-		this._workspacePaths = workspacePaths;
+		this._workspacePaths = workspacePaths.map(p => normalizePath(p));
 		void this.ensureIpcServer();
 	}
 
@@ -142,7 +147,7 @@ export class ClaudeCodeProvider implements AgentSessionProvider {
 	}
 
 	updateWorkspacePaths(workspacePaths: string[]): void {
-		this._workspacePaths = workspacePaths;
+		this._workspacePaths = workspacePaths.map(p => normalizePath(p));
 
 		let changed = false;
 		for (let i = 0; i < this._sessions.length; i++) {
@@ -614,16 +619,20 @@ export class ClaudeCodeProvider implements AgentSessionProvider {
 
 	private matchesWorkspace(workspacePath: string | undefined): boolean {
 		if (!workspacePath) return false;
+		// `_workspacePaths` is normalized; normalize the input so prefix comparisons work
+		// regardless of whether the caller passed a raw `fsPath` (CLI hook cwd, peer-session
+		// workspacePath) or an already-normalized path.
+		const normalized = normalizePath(workspacePath);
 		return this._workspacePaths.some(
-			p =>
-				workspacePath === p || workspacePath.startsWith(`${p}${sep}`) || p.startsWith(`${workspacePath}${sep}`),
+			p => normalized === p || normalized.startsWith(`${p}/`) || p.startsWith(`${normalized}/`),
 		);
 	}
 
 	private resolveWorkspacePath(cwd: string | undefined): string | undefined {
 		if (!cwd) return undefined;
+		const normalized = normalizePath(cwd);
 		return this._workspacePaths.find(
-			p => cwd === p || cwd.startsWith(`${p}${sep}`) || p.startsWith(`${cwd}${sep}`),
+			p => normalized === p || normalized.startsWith(`${p}/`) || p.startsWith(`${normalized}/`),
 		);
 	}
 
@@ -910,9 +919,12 @@ export class ClaudeCodeProvider implements AgentSessionProvider {
 	}
 
 	private async querySiblingWindowSessions(): Promise<void> {
+		const discoveryDir = this.callbacks.ipc.agentDiscoveryDir;
+		if (discoveryDir == null) return;
+
 		let files: string[];
 		try {
-			files = await readdir(agentDiscoveryDir);
+			files = await readdir(discoveryDir);
 		} catch {
 			return;
 		}
@@ -922,7 +934,7 @@ export class ClaudeCodeProvider implements AgentSessionProvider {
 		const peerBatches = await Promise.all(
 			files
 				.filter(f => f.startsWith('gitlens-ipc-server-') && f.endsWith('.json'))
-				.map(async f => this.fetchPeerSessions(join(agentDiscoveryDir, f), ownPort)),
+				.map(async f => this.fetchPeerSessions(join(discoveryDir, f), ownPort)),
 		);
 
 		let changed = false;

--- a/packages/plus/agents/src/types.ts
+++ b/packages/plus/agents/src/types.ts
@@ -129,6 +129,8 @@ export interface AgentSessionProvider extends UnifiedDisposable {
  */
 export interface IpcRegistrar {
 	readonly port: number | undefined;
+	/** Directory scanned for peer-window agent discovery files. Omit to disable peer discovery (tests). */
+	readonly agentDiscoveryDir?: string;
 	registerHandler<Request = unknown, Response = unknown>(
 		name: string,
 		handler: IpcHandler<Request, Response>,
@@ -170,6 +172,7 @@ export interface AgentProviderCallbacks {
 	resolveGitInfo?(cwd: string): Promise<
 		| {
 				branch?: string;
+				/** Must be in GitLens canonical normalized form (forward slashes, lower-case drive letter on Windows). */
 				repoRoot: string;
 				isWorktree: boolean;
 				worktreeName?: string;

--- a/src/env/node/ipc/ipcService.ts
+++ b/src/env/node/ipc/ipcService.ts
@@ -31,6 +31,8 @@ interface CliPublishInfo {
  * keep working unchanged.
  */
 export class IpcService implements Disposable {
+	readonly agentDiscoveryDir = agentDiscoveryDir;
+
 	private _server: IpcServer<unknown, unknown> | undefined;
 	private _serverPromise: Promise<IpcServer<unknown, unknown> | undefined> | undefined;
 

--- a/src/env/node/providers.ts
+++ b/src/env/node/providers.ts
@@ -8,6 +8,7 @@ import type { GitProvider } from '@gitlens/git/providers/provider.js';
 import { Git } from '@gitlens/git-cli/exec/git.js';
 import { findGitPath } from '@gitlens/git-cli/exec/locator.js';
 import type { UnifiedDisposable } from '@gitlens/utils/disposable.js';
+import { normalizePath } from '@gitlens/utils/path.js';
 import type { AgentSessionProvider } from '../../agents/provider.js';
 import type { Container } from '../../container.js';
 import type { GlGitProvider } from '../../git/gitProvider.js';
@@ -155,7 +156,7 @@ export function getAgentSessionProviders(container: Container): AgentSessionProv
 				const isWorktree = commonDir != null && gitDir != null && commonDir !== gitDir;
 				return {
 					branch: branch,
-					repoRoot: isWorktree && commonDir ? dirname(resolve(cwd, commonDir)) : toplevel,
+					repoRoot: normalizePath(isWorktree && commonDir ? dirname(resolve(cwd, commonDir)) : toplevel),
 					isWorktree: isWorktree,
 					worktreeName: isWorktree ? basename(toplevel) : undefined,
 				};


### PR DESCRIPTION
## Summary

Fixes [#5208](https://github.com/gitkraken/vscode-gitlens/issues/5208). The Home view Agents tab's "workspace" filter was always empty on Windows and sessions never attached to branch cards. Root cause was a path-format mismatch: `session.workspacePath` was stored raw from `Uri.fsPath` (backslashes, mixed-case drive letter) while `repository.path` is normalized via `normalizePath()` (forward slashes, lower-case drive letter) — so the four strict-equality comparisons across the home view always failed on Windows.

- Normalizes `_workspacePaths` and matching helpers inside `ClaudeCodeProvider` so every `session.workspacePath` is emitted in GitLens canonical form. The four comparison points (`overview.ts:357`, `overview.ts:375`, `homeWebview.ts:766`, `agentUtils.ts:159`) work unchanged once the source is normalized.
- Normalizes the `repoRoot` returned by `resolveGitInfo` so the host-side fallback (used when the CLI fires outside the workspace folder) also lands in canonical form. The `IpcRegistrar.repoRoot` contract is now documented to require this form.
- Makes `agentDiscoveryDir` injectable via `IpcRegistrar` so unit tests can opt out of peer-window discovery without touching the real filesystem.

## Test plan

- [x] `pnpm --filter @gitlens/agents test` — 19 passing (6 new `ClaudeCodeProvider > workspace path normalization` tests).
- [x] Verified the new tests fail when the production normalization is reverted (4 of 5 originally-added tests catch the regression; the 6th covers the `resolveGitInfo` fallback path).
- [x] `pnpm run build:quick` clean.
- [ ] Manual Windows verification: open a folder on Windows, start a Claude Code session, confirm the "workspace" filter shows the session and that it appears under the matching branch card (with agent status pill) rather than as a standalone card.
- [ ] Manual macOS/Linux verification that nothing regresses (normalizePath is mostly a no-op on Linux).