### PR TITLE
Surfaces paused operation status in graph header and Working Changes panel

### DIFF
--- a/package.json
+++ b/package.json
@@ -1167,10 +1167,10 @@
 							"head"
 						],
 						"enumDescriptions": [
-							"Selects the working changes (WIP) row when there are uncommitted changes, otherwise selects the HEAD row",
-							"Always selects the HEAD row"
+							"Selects the \"Work in progress\" (WIP) row",
+							"Selects the HEAD row"
 						],
-						"markdownDescription": "Specifies whether to select the \"Work in progress\" (WIP) row instead of HEAD if there are uncommitted changes in the _Commit Graph_",
+						"markdownDescription": "Specifies which row to select by default in the _Commit Graph_",
 						"scope": "window",
 						"order": 501
 					},

--- a/src/git/gitProviderService.ts
+++ b/src/git/gitProviderService.ts
@@ -2378,7 +2378,7 @@ export class GitProviderService implements UnifiedDisposable {
 	 * (e.g. opening a file by URI from a terminal) where we don't yet know whether the
 	 * path is a repository at all.
 	 */
-	@debug({ exit: true })
+	@debug()
 	async getValidatedRepositoryService(repoPath: string | Uri): Promise<GitRepositoryService> {
 		const result = await this._gitService.validateRepo(repoPath);
 		if (!result.valid) {

--- a/src/webviews/apps/commitDetails/actions.ts
+++ b/src/webviews/apps/commitDetails/actions.ts
@@ -524,6 +524,10 @@ export class CommitDetailsActions {
 		gitActions.discardUnstagedFiles(this.state.error, this.services.repository, repoPath);
 	}
 
+	openConflictChanges(file: GitFileChangeShape, side: 'current' | 'incoming'): void {
+		void this.services.repository.openConflictChanges(file, side);
+	}
+
 	// ============================================================
 	// File Actions
 	// ============================================================

--- a/src/webviews/apps/commitDetails/commitDetails.ts
+++ b/src/webviews/apps/commitDetails/commitDetails.ts
@@ -634,6 +634,10 @@ export class GlCommitDetailsApp extends SignalWatcherWebviewApp {
 								@file-discard=${(e: CustomEvent<FileChangeListItemDetail>) =>
 									actions?.discardFile(e.detail)}
 								@discard-unstaged=${() => actions?.discardUnstagedFiles()}
+								@file-open-current=${(e: CustomEvent<FileChangeListItemDetail>) =>
+									actions?.openConflictChanges(e.detail, 'current')}
+								@file-open-incoming=${(e: CustomEvent<FileChangeListItemDetail>) =>
+									actions?.openConflictChanges(e.detail, 'incoming')}
 								@data-action=${(e: CustomEvent<{ name: string }>) => this.onBranchAction(e.detail.name)}
 								@gl-inspect-create-suggestions=${(e: CustomEvent<CreatePatchEventDetail>) =>
 									actions?.suggestChanges(e.detail)}

--- a/src/webviews/apps/commitDetails/components/gl-details-wip-panel.ts
+++ b/src/webviews/apps/commitDetails/components/gl-details-wip-panel.ts
@@ -546,6 +546,7 @@ export class GlDetailsWipPanel extends GlDetailsBase {
 				.searchContext=${this.searchContext}
 				.multiDiff=${this.getMultiDiffRefs()}
 				.agentTouchedFiles=${this._agentTouchedFiles}
+				empty-text=${this.emptyText}
 				@file-checked=${this._onFileChecked}
 			>
 				${this.renderChangedFilesSlottedContent()}

--- a/src/webviews/apps/plus/graph/actions/gitActionsButtons.ts
+++ b/src/webviews/apps/plus/graph/actions/gitActionsButtons.ts
@@ -1,6 +1,7 @@
 import { consume } from '@lit/context';
 import { css, html, LitElement, nothing } from 'lit';
 import { customElement, property } from 'lit/decorators.js';
+import { pausedOperationStatusStringsByType } from '@gitlens/git/utils/pausedOperationStatus.utils.js';
 import { fromNow } from '@gitlens/utils/date.js';
 import { pluralize } from '@gitlens/utils/string.js';
 import type { StashSaveCommandArgs } from '../../../../../commands/stashSave.js';
@@ -56,6 +57,31 @@ export class GitActionsButtons extends LitElement {
 			gl-tooltip {
 				margin-left: 0.4rem;
 			}
+
+			.paused-op-badge {
+				display: inline-flex;
+				align-items: center;
+				gap: 0.6rem;
+				padding: 0.1rem 0.4rem;
+				border-radius: 0.3rem;
+				background-color: var(--vscode-gitlens-decorations\\.statusMergingOrRebasingForegroundColor);
+				color: #000;
+				font-size: 1.1rem;
+				font-weight: 600;
+				line-height: 2rem;
+				white-space: nowrap;
+				cursor: pointer;
+				text-decoration: none;
+			}
+
+			.paused-op-badge--conflicts {
+				background-color: var(--vscode-gitlens-decorations\\.statusMergingOrRebasingConflictForegroundColor);
+				color: #fff;
+			}
+
+			.paused-op-badge:hover {
+				color: inherit;
+			}
 		`,
 	];
 
@@ -97,6 +123,44 @@ export class GitActionsButtons extends LitElement {
 		this.dispatchEvent(new CustomEvent('jump-to-wip', { bubbles: true, composed: true }));
 	}
 
+	private onJumpToWipAndShowDetails() {
+		this.dispatchEvent(new CustomEvent('jump-to-wip', { bubbles: true, composed: true }));
+		this.dispatchEvent(new CustomEvent('show-details', { bubbles: true, composed: true }));
+	}
+
+	private renderPausedOpBadge() {
+		const stats = this.workingTreeStats;
+		const pausedOp = stats?.pausedOpStatus;
+		if (pausedOp == null) return nothing;
+
+		const opStrings = pausedOperationStatusStringsByType[pausedOp.type];
+		const hasConflicts = stats?.hasConflicts === true;
+
+		if (hasConflicts) {
+			const count = stats.conflictsCount ?? 1;
+			return html`<gl-tooltip placement="bottom">
+				<a
+					class="paused-op-badge paused-op-badge--conflicts"
+					role="button"
+					tabindex="0"
+					@click=${this.onJumpToWipAndShowDetails}
+				>
+					<code-icon icon="warning"></code-icon>
+					${pluralize(`${pausedOp.type} conflict`, count)}
+				</a>
+				<span slot="content">Click to jump to Working Changes</span>
+			</gl-tooltip>`;
+		}
+
+		return html`<gl-tooltip placement="bottom">
+			<a class="paused-op-badge" role="button" tabindex="0" @click=${this.onJumpToWipAndShowDetails}>
+				<code-icon icon="warning"></code-icon>
+				${opStrings.label}
+			</a>
+			<span slot="content">Click to jump to Working Changes</span>
+		</gl-tooltip>`;
+	}
+
 	override render() {
 		return html`
 			<gl-push-pull-button
@@ -112,6 +176,7 @@ export class GitActionsButtons extends LitElement {
 				.autoFetchMode=${this.state.config?.autoFetchMode ?? 'off'}
 				.autoFetchIntervalSeconds=${this.state.config?.autoFetchIntervalSeconds ?? 180}
 			></gl-fetch-button>
+			${this.renderPausedOpBadge()}
 			<gl-tooltip placement="bottom">
 				<a class="action-button wip-button" @click=${this.onJumpToWip}>
 					<code-icon class="action-button__icon" icon="gl-wip"></code-icon>

--- a/src/webviews/apps/plus/graph/actions/gitActionsButtons.ts
+++ b/src/webviews/apps/plus/graph/actions/gitActionsButtons.ts
@@ -57,31 +57,6 @@ export class GitActionsButtons extends LitElement {
 			gl-tooltip {
 				margin-left: 0.4rem;
 			}
-
-			.paused-op-badge {
-				display: inline-flex;
-				align-items: center;
-				gap: 0.6rem;
-				padding: 0.1rem 0.4rem;
-				border-radius: 0.3rem;
-				background-color: var(--vscode-gitlens-decorations\\.statusMergingOrRebasingForegroundColor);
-				color: #000;
-				font-size: 1.1rem;
-				font-weight: 600;
-				line-height: 2rem;
-				white-space: nowrap;
-				cursor: pointer;
-				text-decoration: none;
-			}
-
-			.paused-op-badge--conflicts {
-				background-color: var(--vscode-gitlens-decorations\\.statusMergingOrRebasingConflictForegroundColor);
-				color: #fff;
-			}
-
-			.paused-op-badge:hover {
-				color: inherit;
-			}
 		`,
 	];
 
@@ -121,44 +96,36 @@ export class GitActionsButtons extends LitElement {
 
 	private onJumpToWip() {
 		this.dispatchEvent(new CustomEvent('jump-to-wip', { bubbles: true, composed: true }));
+		if (this.workingTreeStats?.pausedOpStatus != null) {
+			this.dispatchEvent(new CustomEvent('show-details', { bubbles: true, composed: true }));
+		}
 	}
 
-	private onJumpToWipAndShowDetails() {
-		this.dispatchEvent(new CustomEvent('jump-to-wip', { bubbles: true, composed: true }));
-		this.dispatchEvent(new CustomEvent('show-details', { bubbles: true, composed: true }));
-	}
-
-	private renderPausedOpBadge() {
+	private renderWipTooltip() {
 		const stats = this.workingTreeStats;
 		const pausedOp = stats?.pausedOpStatus;
-		if (pausedOp == null) return nothing;
-
-		const opStrings = pausedOperationStatusStringsByType[pausedOp.type];
-		const hasConflicts = stats?.hasConflicts === true;
-
-		if (hasConflicts) {
-			const count = stats.conflictsCount ?? 1;
-			return html`<gl-tooltip placement="bottom">
-				<a
-					class="paused-op-badge paused-op-badge--conflicts"
-					role="button"
-					tabindex="0"
-					@click=${this.onJumpToWipAndShowDetails}
-				>
-					<code-icon icon="warning"></code-icon>
-					${pluralize(`${pausedOp.type} conflict`, count)}
-				</a>
-				<span slot="content">Click to jump to Working Changes</span>
-			</gl-tooltip>`;
+		if (pausedOp != null) {
+			const opStrings = pausedOperationStatusStringsByType[pausedOp.type];
+			const headline = stats?.hasConflicts === true ? opStrings.conflicts : `${opStrings.label} in progress`;
+			return html`${headline}
+				<hr />
+				Jump to Working Changes`;
 		}
 
-		return html`<gl-tooltip placement="bottom">
-			<a class="paused-op-badge" role="button" tabindex="0" @click=${this.onJumpToWipAndShowDetails}>
-				<code-icon icon="warning"></code-icon>
-				${opStrings.label}
-			</a>
-			<span slot="content">Click to jump to Working Changes</span>
-		</gl-tooltip>`;
+		return html`Jump to WIP
+		${this.hasWorkingChanges
+			? html`
+					<hr />
+					Working Changes
+					<br />
+					${stats!.added ? html`${pluralize('file', stats!.added)} added<br />` : nothing}
+					${stats!.modified ? html`${pluralize('file', stats!.modified)} modified<br />` : nothing}
+					${stats!.deleted ? html`${pluralize('file', stats!.deleted)} deleted<br />` : nothing}
+				`
+			: html`
+					<hr />
+					No changes
+				`}`;
 	}
 
 	override render() {
@@ -176,7 +143,6 @@ export class GitActionsButtons extends LitElement {
 				.autoFetchMode=${this.state.config?.autoFetchMode ?? 'off'}
 				.autoFetchIntervalSeconds=${this.state.config?.autoFetchIntervalSeconds ?? 180}
 			></gl-fetch-button>
-			${this.renderPausedOpBadge()}
 			<gl-tooltip placement="bottom">
 				<a class="action-button wip-button" @click=${this.onJumpToWip}>
 					<code-icon class="action-button__icon" icon="gl-wip"></code-icon>
@@ -184,32 +150,14 @@ export class GitActionsButtons extends LitElement {
 						.added=${this.workingTreeStats?.added}
 						.modified=${this.workingTreeStats?.modified}
 						.removed=${this.workingTreeStats?.deleted}
+						.pausedOpStatus=${this.workingTreeStats?.pausedOpStatus}
+						?has-conflicts=${this.workingTreeStats?.hasConflicts === true}
+						.conflictsCount=${this.workingTreeStats?.conflictsCount}
 						clean-state="badge"
 						no-tooltip
 					></gl-wip-stats>
 				</a>
-				<span slot="content">
-					Jump to WIP
-					${this.hasWorkingChanges
-						? html`
-								<hr />
-								Working Changes
-								<br />
-								${this.workingTreeStats!.added
-									? html`${pluralize('file', this.workingTreeStats!.added)} added<br />`
-									: nothing}
-								${this.workingTreeStats!.modified
-									? html`${pluralize('file', this.workingTreeStats!.modified)} modified<br />`
-									: nothing}
-								${this.workingTreeStats!.deleted
-									? html`${pluralize('file', this.workingTreeStats!.deleted)} deleted<br />`
-									: nothing}
-							`
-						: html`
-								<hr />
-								No changes
-							`}
-				</span>
+				<span slot="content">${this.renderWipTooltip()}</span>
 			</gl-tooltip>
 			${this.hasWorkingChanges
 				? html`<gl-tooltip placement="bottom">

--- a/src/webviews/apps/plus/graph/components/detailsActions.ts
+++ b/src/webviews/apps/plus/graph/components/detailsActions.ts
@@ -178,6 +178,7 @@ export class DetailsActions {
 	private _branchCommitsController?: AbortController;
 	private _branchCommitsLoadMoreController?: AbortController;
 	private _enrichmentController?: AbortController;
+	private _generateMessageController?: AbortController;
 	private _branchCompareEnrichmentControllers = new Map<BranchComparisonContributorsScope, AbortController>();
 	private _branchCompareContributorsControllers = new Map<BranchComparisonContributorsScope, AbortController>();
 	/** Per-(tab,sha) abort controllers for lazy commit-file fetches in branch-compare. New selection
@@ -240,6 +241,7 @@ export class DetailsActions {
 		this._branchCommitsController?.abort();
 		this._branchCommitsLoadMoreController?.abort();
 		this._enrichmentController?.abort();
+		this._generateMessageController?.abort();
 		for (const c of this._branchCompareEnrichmentControllers.values()) {
 			c.abort();
 		}
@@ -2337,9 +2339,22 @@ export class DetailsActions {
 	async generateMessage(repoPath: string | undefined): Promise<void> {
 		if (!repoPath) return;
 
+		// Second invocation while generating = cancel. The sparkle button stays enabled
+		// during generation so the spinner doubles as a cancel affordance.
+		if (this._generateMessageController != null) {
+			this._generateMessageController.abort();
+			return;
+		}
+
+		const controller = new AbortController();
+		this._generateMessageController = controller;
 		this.state.generating.set(true);
 		try {
-			const result = await this.services.graphInspect.generateCommitMessage(repoPath);
+			const result = await this.services.graphInspect.generateCommitMessage(repoPath, controller.signal);
+			// Guard against a late response after the user cancelled or kicked off
+			// a new generation — only land the result if this controller is still current.
+			if (this._generateMessageController !== controller) return;
+
 			if (result) {
 				this.state.commitMessage.set(result.body ? `${result.summary}\n\n${result.body}` : result.summary);
 				// AI output is the user's intentional generation against the current diff —
@@ -2347,7 +2362,10 @@ export class DetailsActions {
 				this.state.commitMessageDirty.set(true);
 			}
 		} finally {
-			this.state.generating.set(false);
+			if (this._generateMessageController === controller) {
+				this._generateMessageController = undefined;
+				this.state.generating.set(false);
+			}
 		}
 	}
 

--- a/src/webviews/apps/plus/graph/components/gl-commit-box.ts
+++ b/src/webviews/apps/plus/graph/components/gl-commit-box.ts
@@ -100,10 +100,7 @@ export class GlCommitBox extends LitElement {
 								class="sparkle"
 								appearance="toolbar"
 								density="compact"
-								tooltip=${this.generating
-									? 'Generating commit message…'
-									: 'Generate commit message with AI'}
-								?disabled=${this.generating}
+								tooltip=${this.generating ? 'Cancel' : 'Generate Commit Message'}
 								aria-busy=${this.generating ? 'true' : 'false'}
 								@click=${this.onGenerateMessage}
 							>

--- a/src/webviews/apps/plus/graph/components/gl-details-wip-header.ts
+++ b/src/webviews/apps/plus/graph/components/gl-details-wip-header.ts
@@ -207,21 +207,28 @@ export class GlDetailsWipHeader extends LitElement {
 		const ahead = branch.tracking?.ahead ?? 0;
 		const behind = branch.tracking?.behind ?? 0;
 
-		if (behind > 0) {
+		if (ahead > 0 && behind > 0) {
 			return html`<gl-action-chip
 					icon="repo-pull"
 					label="Pull"
 					overlay="tooltip"
 					@click=${() => this.emit('pull')}
 				></gl-action-chip>
-				${ahead > 0
-					? html`<gl-action-chip
-							icon="repo-push"
-							label="Push"
-							overlay="tooltip"
-							@click=${() => this.emit('push')}
-						></gl-action-chip>`
-					: nothing}`;
+				<gl-action-chip
+					icon="repo-force-push"
+					label="Force Push"
+					overlay="tooltip"
+					@click=${() => this.emit('force-push')}
+				></gl-action-chip>`;
+		}
+
+		if (behind > 0) {
+			return html`<gl-action-chip
+				icon="repo-pull"
+				label="Pull"
+				overlay="tooltip"
+				@click=${() => this.emit('pull')}
+			></gl-action-chip>`;
 		}
 
 		if (ahead > 0) {

--- a/src/webviews/apps/plus/graph/components/gl-graph-details-panel.ts
+++ b/src/webviews/apps/plus/graph/components/gl-graph-details-panel.ts
@@ -1122,6 +1122,7 @@ export class GlGraphDetailsPanel extends SignalWatcher(LitElement) {
 		const activeMode = this._state.activeMode.get();
 		const hasChanges = (wip.changes?.files?.length ?? 0) > 0;
 		const worktreeAgentSessions = this.getWorktreeAgentSessions(wip);
+		const hasPausedOp = wip.changes?.pausedOpStatus != null;
 		const showAgentStatus = worktreeAgentSessions != null && activeMode == null;
 		// Tri-state of the agents pane drives both splitter availability and sizing:
 		//  - `closed` / `partial`: auto-size with fit-content(25%) cap (~3 cards); splitter inert
@@ -1148,7 +1149,7 @@ export class GlGraphDetailsPanel extends SignalWatcher(LitElement) {
 				? this.renderReviewMode()
 				: activeMode === 'compose'
 					? this.renderComposeMode()
-					: hasChanges
+					: hasChanges || hasPausedOp
 						? html`
 								<div class="commit-panel__files">
 									<gl-details-wip-panel
@@ -1163,6 +1164,9 @@ export class GlGraphDetailsPanel extends SignalWatcher(LitElement) {
 										.orgSettings=${this._state.orgSettings.get()}
 										.isUncommitted=${true}
 										.filesCollapsable=${false}
+										empty-text=${hasPausedOp && !hasChanges
+											? 'No conflicting or changed files'
+											: 'No working changes'}
 										@file-open=${this.handleFileOpen}
 										@file-compare-working=${this.handleFileCompareWorking}
 										@file-compare-previous=${this.handleFileComparePrevious}

--- a/src/webviews/apps/plus/graph/components/gl-graph-details-panel.ts
+++ b/src/webviews/apps/plus/graph/components/gl-graph-details-panel.ts
@@ -1243,6 +1243,7 @@ export class GlGraphDetailsPanel extends SignalWatcher(LitElement) {
 				@publish-branch=${this.handlePublishBranch}
 				@pull=${this.handlePull}
 				@push=${this.handlePush}
+				@force-push=${this.handleForcePush}
 				@fetch=${this.handleFetch}
 				@share-as-cloud-patch=${this.handleShareWipAsCloudPatch}
 				@remove-associated-issue=${this.handleRemoveAssociatedIssue}
@@ -1928,6 +1929,8 @@ export class GlGraphDetailsPanel extends SignalWatcher(LitElement) {
 	private handlePull = () => void this._actions.services.repository.pull(this.effectiveRepoPath!);
 
 	private handlePush = () => void this._actions.services.repository.push(this.effectiveRepoPath!);
+
+	private handleForcePush = () => void this._actions.services.repository.push(this.effectiveRepoPath!, true);
 
 	private handleFetch = () => void this._actions.services.repository.fetch(this.effectiveRepoPath!);
 

--- a/src/webviews/apps/plus/graph/graph-app.ts
+++ b/src/webviews/apps/plus/graph/graph-app.ts
@@ -466,6 +466,7 @@ export class GraphApp extends SignalWatcher(LitElement) {
 					.hasSelectedCommit=${single != null || multi != null}
 					@toggle-sidebar=${this.handleToggleSidebar}
 					@toggle-details=${this.handleToggleDetails}
+					@show-details=${this.handleShowDetails}
 					@toggle-minimap=${this.handleToggleMinimap}
 					@gl-graph-scope-to-branch=${this.handleScopeToBranchFromHeader}
 				></gl-graph-header>
@@ -877,6 +878,13 @@ export class GraphApp extends SignalWatcher(LitElement) {
 		} else if (gs.detailsVisible !== true) {
 			gs[this.detailsPositionKey] = e.detail.position;
 			this.setDetailsVisible(true, 'toggle');
+		}
+	};
+
+	private handleShowDetails = (): void => {
+		if (!this.graphState.detailsVisible) {
+			this.setDetailsVisible(true, 'toggle');
+			this.ensureDetailsPosition();
 		}
 	};
 

--- a/src/webviews/apps/plus/graph/graph-header.ts
+++ b/src/webviews/apps/plus/graph/graph-header.ts
@@ -74,7 +74,6 @@ import '../../shared/components/ref-button.js';
 import '../../shared/components/repo-button-group.js';
 import '../../shared/components/rich/issue-pull-request.js';
 import '../../shared/components/search/search-box.js';
-import '../shared/components/merge-rebase-status.js';
 import './actions/gitActionsButtons.js';
 
 declare global {
@@ -961,8 +960,7 @@ export class GlGraphHeader extends SignalWatcher(LitElement) {
 		return cache(
 			html`<header class="titlebar graph-app__header">
 				<progress-indicator ?active="${this.graphState.isBusy}"></progress-indicator>
-				${this.renderTitlebarHeaderRow(repo)} ${this.renderTitlebarStatusRow()}
-				${this.renderTitlebarSearchRow(repo)}
+				${this.renderTitlebarHeaderRow(repo)} ${this.renderTitlebarSearchRow(repo)}
 			</header>`,
 		);
 	}
@@ -1175,25 +1173,6 @@ export class GlGraphHeader extends SignalWatcher(LitElement) {
 					`,
 				)}
 			</div>
-		</div>`;
-	}
-
-	private renderTitlebarStatusRow() {
-		const { allowed, workingTreeStats } = this.graphState;
-		if (
-			!allowed ||
-			workingTreeStats == null ||
-			(!workingTreeStats.hasConflicts && !workingTreeStats.pausedOpStatus)
-		) {
-			return nothing;
-		}
-
-		return html`<div class="merge-conflict-warning">
-			<gl-merge-rebase-status
-				class="merge-conflict-warning__content"
-				?conflicts=${workingTreeStats?.hasConflicts}
-				.pausedOpStatus=${workingTreeStats?.pausedOpStatus}
-			></gl-merge-rebase-status>
 		</div>`;
 	}
 

--- a/src/webviews/apps/plus/graph/styles/header.css.ts
+++ b/src/webviews/apps/plus/graph/styles/header.css.ts
@@ -4,11 +4,6 @@ export const repoHeaderStyles = css`
 	.jump-to-ref {
 		--button-foreground: var(--color-foreground);
 	}
-
-	.merge-conflict-warning {
-		flex: 0 0 100%;
-		min-width: 0;
-	}
 `;
 
 export const titlebarStyles = css`

--- a/src/webviews/apps/shared/components/commit/wip-stats.ts
+++ b/src/webviews/apps/shared/components/commit/wip-stats.ts
@@ -1,5 +1,8 @@
 import { css, html, LitElement, nothing } from 'lit';
 import { customElement, property } from 'lit/decorators.js';
+import type { GitPausedOperationStatus } from '@gitlens/git/models/pausedOperationStatus.js';
+import { pausedOperationStatusStringsByType } from '@gitlens/git/utils/pausedOperationStatus.utils.js';
+import { pluralize } from '@gitlens/utils/string.js';
 import './commit-stats.js';
 import '../code-icon.js';
 import '../overlays/tooltip.js';
@@ -18,6 +21,25 @@ export class GlWipStats extends LitElement {
 			--code-icon-v-align: middle;
 			color: var(--gl-stat-added);
 		}
+
+		.paused-op-badge {
+			display: inline-flex;
+			align-items: center;
+			gap: 0.6rem;
+			padding: 0.1rem 0.4rem;
+			border-radius: 0.3rem;
+			background-color: var(--vscode-gitlens-decorations\\.statusMergingOrRebasingForegroundColor);
+			color: #000;
+			font-size: 1.1rem;
+			font-weight: 600;
+			line-height: 2rem;
+			white-space: nowrap;
+		}
+
+		.paused-op-badge--conflicts {
+			background-color: var(--vscode-gitlens-decorations\\.statusMergingOrRebasingConflictForegroundColor);
+			color: #fff;
+		}
 	`;
 
 	@property({ type: Number }) added: number | undefined;
@@ -27,7 +49,13 @@ export class GlWipStats extends LitElement {
 	@property({ attribute: 'clean-state' }) cleanState: WipStatsCleanState = 'hidden';
 	@property({ type: Boolean, attribute: 'no-tooltip' }) noTooltip = false;
 
+	@property({ attribute: false }) pausedOpStatus?: GitPausedOperationStatus;
+	@property({ type: Boolean, attribute: 'has-conflicts' }) hasConflicts = false;
+	@property({ type: Number, attribute: 'conflicts-count' }) conflictsCount?: number;
+
 	override render(): unknown {
+		if (this.pausedOpStatus != null) return this.renderPausedOp(this.pausedOpStatus);
+
 		const added = this.added ?? 0;
 		const modified = this.modified ?? 0;
 		const removed = this.removed ?? 0;
@@ -57,6 +85,25 @@ export class GlWipStats extends LitElement {
 		if (this.noTooltip) return pill;
 
 		return html`<gl-tooltip placement="bottom">${pill}<span slot="content">No changes</span></gl-tooltip>`;
+	}
+
+	private renderPausedOp(pausedOp: GitPausedOperationStatus) {
+		const opStrings = pausedOperationStatusStringsByType[pausedOp.type];
+		const label = this.hasConflicts ? pluralize('conflict', this.conflictsCount ?? 1) : opStrings.label;
+
+		const badge = html`<span
+			class="paused-op-badge${this.hasConflicts ? ' paused-op-badge--conflicts' : ''}"
+			aria-label=${label}
+		>
+			<code-icon icon="warning"></code-icon>
+			${label}
+		</span>`;
+
+		if (this.noTooltip) return badge;
+
+		return html`<gl-tooltip placement="bottom"
+			>${badge}<span slot="content">${opStrings.label} in progress</span></gl-tooltip
+		>`;
 	}
 }
 

--- a/src/webviews/apps/shared/components/tree/gl-wip-tree-pane.ts
+++ b/src/webviews/apps/shared/components/tree/gl-wip-tree-pane.ts
@@ -95,6 +95,9 @@ export class GlWipTreePane extends LitElement {
 	@property({ attribute: false })
 	folderContext?: (folder: { name: string; relativePath: string; repoPath?: string }) => string | undefined;
 
+	@property({ attribute: 'empty-text' })
+	emptyText = 'No Files';
+
 	@property({ type: Object, attribute: 'search-context' })
 	searchContext?: GitCommitSearchContext;
 
@@ -238,6 +241,7 @@ export class GlWipTreePane extends LitElement {
 			.checkableStateDefault=${this.checkableStateDefault}
 			.agentTouchedFiles=${this.agentTouchedFiles}
 			.buttons=${buttons}
+			empty-text=${this.emptyText}
 			selection-badge-label="Staged"
 			selection-action="file-open"
 			check-verb="Stage"

--- a/src/webviews/plus/graph/graphService.ts
+++ b/src/webviews/plus/graph/graphService.ts
@@ -248,7 +248,10 @@ export interface GraphInspectService {
 	 * actions so dashboards can compare which scopes users actually copy.
 	 */
 	trackReviewAction(args: { action: 'copy'; granularity: 'review' | 'focusArea' | 'finding' }): Promise<void>;
-	generateCommitMessage(repoPath: string): Promise<{ summary: string; body?: string } | undefined>;
+	generateCommitMessage(
+		repoPath: string,
+		signal?: AbortSignal,
+	): Promise<{ summary: string; body?: string } | undefined>;
 	composeChanges(
 		repoPath: string,
 		scope: ScopeSelection,

--- a/src/webviews/plus/graph/graphWebview.ts
+++ b/src/webviews/plus/graph/graphWebview.ts
@@ -4616,15 +4616,12 @@ export class GraphWebviewProvider implements WebviewProvider<State, State, Graph
 
 	private _fireSelectionChangedDebounced: Deferrable<GraphWebviewProvider['fireSelectionChanged']> | undefined =
 		undefined;
-	private _lastUserSelectionTime: number = 0;
 
 	@ipcCommand(UpdateSelectionCommand)
 	private onSelectionChanged(params: IpcParams<typeof UpdateSelectionCommand>) {
 		const item = params.selection.find(r => r.active) ?? params.selection[0];
 		this.setSelectedRows(item?.id, params.selection, { selected: true, hidden: item?.hidden });
 
-		// Track when user explicitly selects
-		this._lastUserSelectionTime = performance.now();
 		this._honorSelectedId = true;
 
 		this._fireSelectionChangedDebounced ??= debounce(this.fireSelectionChanged.bind(this), 50);
@@ -6137,34 +6134,23 @@ export class GraphWebviewProvider implements WebviewProvider<State, State, Graph
 		// If we have a set of data refresh to the same set
 		const limit = Math.max(defaultItemLimit, this._graph?.ids.size ?? defaultItemLimit);
 
-		const hasWorkingChanges = await this.repository.git.status.hasWorkingChanges(
-			{ staged: true, unstaged: true, untracked: true },
-			toAbortSignal(cancellation.token),
-		);
-
-		let selectedId = this._selectedId;
 		let selectionChanged = false;
 
-		// Skip default row selection if we are honoring the selected id or we have a pending search request
-		// to avoid overriding an honored selection or jumping to WIP/HEAD before the search is applied
 		if (
 			!this._honorSelectedId &&
 			searchRequest == null &&
-			selectedId !== uncommitted &&
-			hasWorkingChanges &&
+			this._selectedId !== uncommitted &&
 			configuration.get('graph.initialRowSelection') === 'wip'
 		) {
 			selectionChanged = true;
-
 			this.setSelectedRows(uncommitted);
-			selectedId = this._selectedId;
 		}
 
 		const columns = this.getColumns();
 		const columnSettings = this.getColumnSettings(columns);
 
 		const dataPromise = this.repository.git.graph.getGraph(
-			selectedId,
+			this._selectedId,
 			{
 				include: {
 					stats:
@@ -6184,7 +6170,7 @@ export class GraphWebviewProvider implements WebviewProvider<State, State, Graph
 		// Check for access and working tree stats
 		const promises = Promise.allSettled([
 			this.getGraphAccess(),
-			this.getWorkingTreeStatsAndPausedOperations(hasWorkingChanges, cancellation.token),
+			this.getWorkingTreeStatsAndPausedOperations(undefined, cancellation.token),
 			this.repository.git.branches.getBranch(undefined, toAbortSignal(cancellation.token)),
 			this.repository.getLastFetched(),
 			this.getWipMetadataBySha(cancellation.token),
@@ -6199,9 +6185,8 @@ export class GraphWebviewProvider implements WebviewProvider<State, State, Graph
 
 					this.setGraph(data);
 
-					// Don't override selection if user selected something in the last 500ms
-					const userRecentlySelected = performance.now() - this._lastUserSelectionTime < 500;
-					if (!userRecentlySelected && this._selectedId !== data.id) {
+					// Don't clobber an honored selection if `data.id` ever diverges (slow await, scope/filter shifts, dropped SHAs)
+					if (!this._honorSelectedId && this._selectedId !== data.id) {
 						selectionChanged = true;
 						this.setSelectedRows(data.id);
 					}
@@ -6216,7 +6201,7 @@ export class GraphWebviewProvider implements WebviewProvider<State, State, Graph
 			data = await dataPromise;
 			this.setGraph(data);
 
-			if (selectedId !== data.id) {
+			if (!this._honorSelectedId && this._selectedId !== data.id) {
 				this.setSelectedRows(data.id);
 			}
 		}

--- a/src/webviews/plus/graph/graphWebview.ts
+++ b/src/webviews/plus/graph/graphWebview.ts
@@ -6095,6 +6095,7 @@ export class GraphWebviewProvider implements WebviewProvider<State, State, Graph
 			deleted: workingTreeStatus?.deleted ?? 0,
 			modified: workingTreeStatus?.changed ?? 0,
 			hasConflicts: status?.hasConflicts,
+			conflictsCount: status?.hasConflicts ? status.conflicts.length : undefined,
 			pausedOpStatus: pausedOpStatus,
 			context: serializeWebviewItemContext<GraphItemContext>({
 				webviewItem: 'gitlens:wip',

--- a/src/webviews/plus/graph/graphWebview.ts
+++ b/src/webviews/plus/graph/graphWebview.ts
@@ -1445,12 +1445,15 @@ export class GraphWebviewProvider implements WebviewProvider<State, State, Graph
 						return { ok: false, reason: 'error', message: message };
 					}
 				},
-				generateCommitMessage: async repoPath => {
+				generateCommitMessage: async (repoPath, signal) => {
 					// Pass the Repository (not a raw diff) so the AI service applies its
 					// staged-first → unstaged-fallback convention. The previous implementation
 					// always grabbed the full uncommitted diff (staged + unstaged), which produced
 					// messages that didn't match what the user was about to commit on a
 					// staging-aware repo.
+					// Omit `progress` so no VS Code notification is shown — the WIP panel drives
+					// its own inline generating UI and exposes cancel via the sparkle button.
+					const { token: cancellation, dispose: disposeCancellation } = fromAbortSignal(signal);
 					try {
 						const repo = this.container.git.getRepository(repoPath);
 						if (repo == null) return undefined;
@@ -1458,12 +1461,7 @@ export class GraphWebviewProvider implements WebviewProvider<State, State, Graph
 						const result = await this.container.ai.actions.generateCommitMessage(
 							repo,
 							{ source: 'graph-details' },
-							{
-								progress: {
-									location: ProgressLocation.Notification,
-									title: 'Generating commit message...',
-								},
-							},
+							{ cancellation: cancellation },
 						);
 						if (result === 'cancelled' || result == null) return undefined;
 
@@ -1472,6 +1470,8 @@ export class GraphWebviewProvider implements WebviewProvider<State, State, Graph
 						// Surface the failure instead of silently returning so regressions are visible.
 						Logger.error(ex, 'graph.generateCommitMessage');
 						return undefined;
+					} finally {
+						disposeCancellation();
 					}
 				},
 				composeChanges: async (repoPath, scope, instructions, excludedFiles, aiExcludedFiles, signal) => {

--- a/src/webviews/plus/graph/protocol.ts
+++ b/src/webviews/plus/graph/protocol.ts
@@ -267,6 +267,7 @@ export interface BranchState extends GitTrackingState {
 
 export type GraphWorkingTreeStats = WorkDirStats & {
 	hasConflicts?: boolean;
+	conflictsCount?: number;
 	pausedOpStatus?: GitPausedOperationStatus;
 };
 

--- a/src/webviews/rpc/services/repository.ts
+++ b/src/webviews/rpc/services/repository.ts
@@ -500,7 +500,7 @@ export class RepositoryService {
 			// trash. Fall back to a direct delete — the user already accepted the IRREVERSIBLE
 			// warning in confirmDiscardChanges, so losing the recovery path is in policy.
 			const msg = ex instanceof Error ? ex.message : String(ex);
-			if (!/via trash because provider does not support/.test(msg)) throw ex;
+			if (!msg.includes('via trash because provider does not support')) throw ex;
 
 			Logger.warn(`Trash unsupported for ${uri.toString()}; deleting without trash`);
 			await workspace.fs.delete(uri, { useTrash: false });
@@ -533,9 +533,9 @@ export class RepositoryService {
 	/**
 	 * Push to remote.
 	 */
-	async push(repoPath: string): Promise<void> {
+	async push(repoPath: string, force?: boolean): Promise<void> {
 		const repo = this.container.git.getRepository(repoPath);
-		await RepoActions.push(repo ?? repoPath);
+		await RepoActions.push(repo ?? repoPath, force);
 	}
 
 	async publishBranch(repoPath: string): Promise<void> {


### PR DESCRIPTION
## Summary

Closes #5187

- Moves the paused-op indicator from a full-width graph header banner into a compact badge in the header action bar (next to Fetch)
- Badge shows operation type and conflict count: "1 merge conflict", "Rebasing", "Cherry picking", etc.
- Conflict states use the red `gl-merge-rebase-status` color; non-conflict paused states use yellow
- Wires up conflict file actions (Open Current/Incoming Changes) in the standalone Inspect view
- Shows the WIP panel instead of the empty pane when a paused operation exists but no files have changed
- Forwards `emptyText` through the `gl-wip-tree-pane` chain for contextual messaging
- Adds `conflictsCount` to `GraphWorkingTreeStats` for the badge display

## Screenshots

### Merge — with conflicts
<img width="800" alt="image" src="https://github.com/user-attachments/assets/56ede2e2-e8b6-4a4e-bd4c-7c8f00d4e815" />


### Merge — no conflicts
<img width="800" alt="image" src="https://github.com/user-attachments/assets/3afc3f44-4ebb-4d23-9342-cf9e4b81fbf5" />

### Cherry-pick — with conflicts
<img width="800" alt="image" src="https://github.com/user-attachments/assets/0dfc37dc-96b9-4e17-b233-767a8aa1bf67" />

### Cherry-pick — no conflicts (resolved, ready to continue)
<img width="800" alt="image" src="https://github.com/user-attachments/assets/7c7e6954-5e1a-4c53-b2f5-92b1fa42ecd1" />

### Rebase — with conflicts
<img width="800" alt="image" src="https://github.com/user-attachments/assets/265cc3e7-3e79-405d-b2f2-550a7f817728" />

### Rebase — no conflicts (edit pause)
<img width="800" alt="image" src="https://github.com/user-attachments/assets/afa005ee-365c-44ea-970a-6f3be1756c6a" />
