### PR TITLE
Fixes #5203 _Interactive Rebase_ editor splits to new pane

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/) and this p
 ### Added
 
 - Adds a close-tab warning banner to the _Interactive Rebase_ editor &mdash; displays a dismissible informational banner during the planning phase to clarify that closing the tab automatically starts the rebase ([#5123](https://github.com/gitkraken/vscode-gitlens/issues/5123))
+- Adds a `gitlens.rebaseEditor.openBehavior` setting to control where the _Interactive Rebase_ editor opens when automatically reopened on a paused rebase &mdash; `auto` (default) opens beside only when a multi-pane layout already exists; `beside` always opens in a side group
 
 ### Changed
 
@@ -16,6 +17,7 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/) and this p
 
 ### Fixed
 
+- Fixes an issue where starting an interactive rebase forced a split-pane layout when git paused for a `reword` &mdash; the _Interactive Rebase_ editor now opens as a hidden background tab alongside the commit message editor instead of stealing the active tab ([#5203](https://github.com/gitkraken/vscode-gitlens/issues/5203))
 - Fixes an issue where untracked files were missing from the _Compare Working Tree with&hellip;_ file list unless manually staged with `git add -N` first ([#5158](https://github.com/gitkraken/vscode-gitlens/issues/5158))
 - Fixes an issue where newlines in commit messages were not rendered in hovers and tooltips, collapsing multi-line commit bodies onto a single line &mdash; regression in v17.12.0 ([#5157](https://github.com/gitkraken/vscode-gitlens/issues/5157))
 - Fixes an issue where the status bar blame does not appear after updating to v17.12.0+ &mdash; regression in v17.12.0 ([#5160](https://github.com/gitkraken/vscode-gitlens/issues/5160))

--- a/docs/telemetry-events.md
+++ b/docs/telemetry-events.md
@@ -3955,6 +3955,7 @@ void
 {
   'context.ascending': boolean,
   'context.config.density': 'compact' | 'comfortable',
+  'context.config.openBehavior': 'auto' | 'beside',
   'context.config.openOnPausedRebase': boolean | 'interactive',
   'context.config.ordering': 'asc' | 'desc',
   'context.config.revealBehavior': 'onDoubleClick' | 'onSelection',

--- a/package.json
+++ b/package.json
@@ -3804,6 +3804,21 @@
 						"scope": "window",
 						"order": 11
 					},
+					"gitlens.rebaseEditor.openBehavior": {
+						"type": "string",
+						"default": "auto",
+						"enum": [
+							"auto",
+							"beside"
+						],
+						"enumDescriptions": [
+							"Opens the editor beside the commit message editor when a multi-pane layout already exists; otherwise opens in the active editor group",
+							"Always opens the editor beside the active editor, creating a new editor group if needed"
+						],
+						"markdownDescription": "Specifies which editor group the _Interactive Rebase Editor_ opens in when it is automatically reopened on a paused rebase",
+						"scope": "window",
+						"order": 12
+					},
 					"gitlens.rebaseEditor.revealLocation": {
 						"type": "string",
 						"default": "graph",

--- a/src/config.ts
+++ b/src/config.ts
@@ -673,6 +673,7 @@ interface PlusFeaturesConfig {
 
 interface RebaseEditorConfig {
 	readonly density: 'compact' | 'comfortable';
+	readonly openBehavior: 'auto' | 'beside';
 	readonly openOnPausedRebase: boolean | 'interactive';
 	readonly ordering: 'asc' | 'desc';
 	readonly revealLocation: 'graph' | 'inspect';

--- a/src/git/utils/-webview/rebase.utils.ts
+++ b/src/git/utils/-webview/rebase.utils.ts
@@ -68,6 +68,9 @@ export function isRebaseTodoEditorEnabled(): boolean {
 }
 
 export interface OpenRebaseEditorOptions {
+	/** When `true`, opens the editor as an inactive tab (doesn't become the visible/active tab in its group) */
+	background?: boolean;
+	preserveFocus?: boolean;
 	viewColumn?: ViewColumn;
 }
 
@@ -86,9 +89,13 @@ export async function openRebaseEditor(
 	const rebaseTodoUri = Uri.joinPath(gitDir.uri, 'rebase-merge', 'git-rebase-todo');
 	const existingTab = getOpenRebaseEditorTab(rebaseTodoUri);
 	if (existingTab != null) {
+		// Leave the existing tab as-is when a background open was requested — don't activate it
+		if (options?.background) return;
+
 		// Focus the existing rebase editor tab
 		await executeCoreCommand('vscode.openWith', rebaseTodoUri, 'gitlens.rebase', {
 			preview: false,
+			preserveFocus: options?.preserveFocus,
 			viewColumn: existingTab.group.viewColumn,
 		});
 		return;
@@ -102,8 +109,12 @@ export async function openRebaseEditor(
 		options.viewColumn = ViewColumn.Active;
 	}
 
+	// `background: true` is honored at runtime by VS Code's `vscode.openWith` command (microsoft/vscode#96964),
+	// even though it isn't in the public `TextDocumentShowOptions` type
 	await executeCoreCommand('vscode.openWith', rebaseTodoUri, 'gitlens.rebase', {
+		background: options?.background,
 		preview: false,
+		preserveFocus: options?.preserveFocus,
 		viewColumn: options?.viewColumn,
 	});
 }

--- a/src/webviews/rebase/rebaseEditor.ts
+++ b/src/webviews/rebase/rebaseEditor.ts
@@ -100,6 +100,20 @@ export class RebaseEditorProvider implements CustomTextEditorProvider, Disposabl
 		return false;
 	}
 
+	private isCommitMessageTabActive(): boolean {
+		const activeTab = window.tabGroups.activeTabGroup.activeTab;
+		if (activeTab == null) return false;
+
+		const input = activeTab.input;
+		if (input != null && typeof input === 'object' && 'uri' in input) {
+			const uri = input.uri;
+			if (uri instanceof Uri && uri.path.endsWith('COMMIT_EDITMSG')) {
+				return true;
+			}
+		}
+		return false;
+	}
+
 	private onAnyConfigurationChanged(e: ConfigurationChangeEvent) {
 		if (!configuration.changedCore(e, 'workbench.editorAssociations')) return;
 
@@ -116,8 +130,32 @@ export class RebaseEditorProvider implements CustomTextEditorProvider, Disposabl
 		if (status?.type === 'rebase' && status.isPaused) {
 			if (openOnPausedRebase === 'interactive' && !status.isInteractive) return;
 
-			// Open beside the current editor (e.g., commit message editor) during active rebase
-			await openRebaseEditor(this.container, repoPath, { viewColumn: ViewColumn.Beside });
+			// `openBehavior` controls the viewColumn:
+			//   - 'auto': reuse an existing non-active editor group if one exists; otherwise open in the
+			//     active group. Never creates a new group. (`ViewColumn.Beside` can't be used here because
+			//     it splits when the active group is the rightmost.)
+			//   - 'beside': always beside (forces a new group if no sibling exists)
+			// When the commit message editor is active (the reword case), keep focus on it so we don't
+			// disrupt the user's typing — and additionally use background: true when opening in the same
+			// group so the rebase editor doesn't get pushed behind the commit message tab.
+			// For other pauses (e.g., the user picked `edit` first and there's no commit message editor
+			// open), open the rebase editor normally so the user sees the pause.
+			const openBehavior = configuration.get('rebaseEditor.openBehavior');
+			let viewColumn: ViewColumn;
+			if (openBehavior === 'beside') {
+				viewColumn = ViewColumn.Beside;
+			} else {
+				const activeColumn = window.tabGroups.activeTabGroup.viewColumn;
+				viewColumn =
+					window.tabGroups.all.find(g => g.viewColumn !== activeColumn)?.viewColumn ?? ViewColumn.Active;
+			}
+			const commitMessageActive = this.isCommitMessageTabActive();
+			const opensInActiveGroup = viewColumn === ViewColumn.Active;
+			await openRebaseEditor(this.container, repoPath, {
+				background: opensInActiveGroup && commitMessageActive,
+				preserveFocus: commitMessageActive,
+				viewColumn: viewColumn,
+			});
 		}
 	}
 


### PR DESCRIPTION
## Summary

Fixes [#5203](https://github.com/gitkraken/vscode-gitlens/issues/5203) — starting an interactive rebase was forcing the workspace into a split-pane layout when git paused for `reword`. The auto-reopen flow stole the active tab from `COMMIT_EDITMSG`, causing a visible flicker as the rebase editor opened on top of the commit message editor.

The auto-reopen path (`RebaseEditorProvider.onRebaseChanged`) now decides where to open based on the user's existing layout instead of always opening `Beside`:

- **Multi-pane layout** → opens `Beside` (visible in a sibling group, the original intent of showing both at once)
- **Single-pane + `COMMIT_EDITMSG` active** → opens in active group with `background: true` (rebase editor lands as a hidden tab; `COMMIT_EDITMSG` stays visible and focused — no flicker, no stolen focus)
- **Single-pane + no `COMMIT_EDITMSG`** → opens in active group, visible (e.g., the user picked `edit` first and needs to see that a pause occurred)

`background: true` is honored at runtime by VS Code's `vscode.openWith` command (microsoft/vscode#96964), even though it isn't on the public `TextDocumentShowOptions` type — `executeCoreCommand` passes it through unobstructed.

Also adds a `gitlens.rebaseEditor.editorOpeningBehavior` setting (`auto` | `beside`, default `auto`) for users who want to override the auto heuristic and always get a side-by-side layout.

## Behavior matrix

| Layout | `COMMIT_EDITMSG` active | `auto` (default) | `beside` |
|---|---|---|---|
| Single pane | Yes | Active + background | Beside (new group) |
| Single pane | No | Active (visible) | Beside (new group) |
| Multi-pane | Yes | Beside (visible) | Beside (visible) |
| Multi-pane | No | Beside (visible) | Beside (visible) |

## Test plan

- [x] Single-pane workspace, interactive rebase with first action = `reword` → rebase editor closes on Start, `COMMIT_EDITMSG` opens visible/focused, rebase editor reopens as a background tab in the same group (not visible). No flicker.
- [x] Single-pane workspace, interactive rebase with first action = `edit` → rebase editor closes on Start, no `COMMIT_EDITMSG` opens, rebase editor reopens visible in the active group.
- [x] Multi-pane workspace, interactive rebase with `reword` → rebase editor opens visible in the sibling group, `COMMIT_EDITMSG` stays in the original group.
- [x] Set `gitlens.rebaseEditor.editorOpeningBehavior: beside` → confirm a single-pane workspace always forces a split on pause.
- [x] Multi-step rebase with multiple rewords → no flicker between continues; rebase editor stays in background tab.
- [x] Settings UI: new setting appears under _Interactive Rebase Editor_ with `auto`/`beside` dropdown and correct descriptions.