### PR TITLE
Improve Working Changes empty state UX in Commit Details and Graph panels

### DIFF
--- a/src/commands/createPullRequestOnRemote.ts
+++ b/src/commands/createPullRequestOnRemote.ts
@@ -2,9 +2,11 @@ import { window } from 'vscode';
 import type { CreatePullRequestRemoteResource } from '@gitlens/git/models/remoteResource.js';
 import { RemoteResourceType } from '@gitlens/git/models/remoteResource.js';
 import { getBranchNameWithoutRemote, getRemoteNameFromBranchName } from '@gitlens/git/utils/branch.utils.js';
+import { take } from '@gitlens/utils/event.js';
+import { getRepositoryKey } from '@gitlens/utils/uri.js';
 import type { Source } from '../constants.telemetry.js';
 import type { Container } from '../container.js';
-import { getBranchMergeTargetName } from '../git/utils/-webview/branch.utils.js';
+import { getBranchAssociatedPullRequest, getBranchMergeTargetName } from '../git/utils/-webview/branch.utils.js';
 import { getRepositoryOrShowPicker } from '../quickpicks/repositoryPicker.js';
 import { command, executeCommand } from '../system/-webview/command.js';
 import { GlCommandBase } from './commandBase.js';
@@ -94,5 +96,24 @@ export class CreatePullRequestOnRemoteCommand extends GlCommandBase {
 			resource: resource,
 			remotes: remotes,
 		}));
+
+		const compareBranchName = args.compare;
+		const repoPath = repo.path;
+		take(
+			window.onDidChangeWindowState,
+			2,
+		)(async e => {
+			if (!e.focused) return;
+
+			const branch = await repo.git.branches.getBranch(compareBranchName);
+			if (branch == null) return;
+
+			await getBranchAssociatedPullRequest(this.container, branch, { expiryOverride: true });
+
+			this.container.events.fire('git:repo:change', {
+				repoPath: getRepositoryKey(repoPath),
+				changes: ['remoteProviders'],
+			});
+		});
 	}
 }

--- a/src/git/utils/-webview/branch.issue.utils.ts
+++ b/src/git/utils/-webview/branch.issue.utils.ts
@@ -5,6 +5,7 @@ import type { IssueResourceDescriptor, RepositoryDescriptor } from '@gitlens/git
 import { Logger } from '@gitlens/utils/logger.js';
 import type { MaybePausedResult } from '@gitlens/utils/promise.js';
 import { getSettledValue, pauseOnCancelOrTimeout } from '@gitlens/utils/promise.js';
+import { getRepositoryKey } from '@gitlens/utils/uri.js';
 import type { GkConfigKeys } from '../../../constants.js';
 import type { Container } from '../../../container.js';
 import type { GitConfigEntityIdentifier } from '../../../plus/integrations/providers/models.js';
@@ -38,6 +39,10 @@ export async function addAssociatedIssueToBranch(
 		await container.git
 			.getRepositoryService(branch.repoPath)
 			.config.setGkConfig?.(key, JSON.stringify(associatedIssues));
+		container.events.fire('git:repo:change', {
+			repoPath: getRepositoryKey(branch.repoPath),
+			changes: ['gkConfig'],
+		});
 	} catch (ex) {
 		Logger.error(ex, 'addAssociatedIssueToBranch');
 	}
@@ -110,6 +115,10 @@ export async function removeAssociatedIssueFromBranch(
 				.getRepositoryService(branch.repoPath)
 				.config.setGkConfig?.(key, JSON.stringify(associatedIssues));
 		}
+		container.events.fire('git:repo:change', {
+			repoPath: getRepositoryKey(branch.repoPath),
+			changes: ['gkConfig'],
+		});
 	} catch (ex) {
 		Logger.error(ex, 'removeAssociatedIssueFromBranch');
 	}

--- a/src/webviews/apps/commitDetails/actions.ts
+++ b/src/webviews/apps/commitDetails/actions.ts
@@ -490,12 +490,14 @@ export class CommitDetailsActions {
 	createBranch(): void {
 		const repoPath = this.getRepoPath();
 		if (!repoPath) return;
+
 		void this.services.repository.createBranch(repoPath);
 	}
 
 	applyStash(): void {
 		const repoPath = this.getRepoPath();
 		if (!repoPath) return;
+
 		void this.services.commands.execute('gitlens.stashesApply', { repoPath: repoPath });
 	}
 

--- a/src/webviews/apps/commitDetails/actions.ts
+++ b/src/webviews/apps/commitDetails/actions.ts
@@ -57,6 +57,7 @@ import {
 	optimisticBatchFireAndForget,
 	optimisticFireAndForget,
 } from '../shared/actions/rpc.js';
+import { getRemoteNameFromBranchName } from '../shared/git-utils.js';
 import type { Resource } from '../shared/state/resource.js';
 import type { CreatePatchEventDetail } from './components/gl-inspect-patch.js';
 import type { CommitDetailsState, ExplainState, GenerateState } from './state.js';
@@ -464,6 +465,42 @@ export class CommitDetailsActions {
 		if (!repoPath) return;
 
 		gitActions.switchBranch(this.services.repository, repoPath);
+	}
+
+	startWork(): void {
+		void this.services.commands.execute('gitlens.startWork', { source: 'inspect' });
+	}
+
+	createPullRequest(): void {
+		const repoPath = this.getRepoPath();
+		if (!repoPath) return;
+
+		const wip = this.state.wipState.get();
+		const branch = wip?.branch;
+		const upstreamName = branch?.upstream?.name;
+		if (branch?.name == null || upstreamName == null) return;
+
+		void this.services.commands.execute('gitlens.createPullRequestOnRemote', {
+			repoPath: repoPath,
+			compare: branch.name,
+			remote: getRemoteNameFromBranchName(upstreamName),
+		});
+	}
+
+	createBranch(): void {
+		const repoPath = this.getRepoPath();
+		if (!repoPath) return;
+		void this.services.repository.createBranch(repoPath);
+	}
+
+	applyStash(): void {
+		const repoPath = this.getRepoPath();
+		if (!repoPath) return;
+		void this.services.commands.execute('gitlens.stashesApply', { repoPath: repoPath });
+	}
+
+	createWorktree(): void {
+		void this.services.commands.execute('gitlens.views.createWorktree');
 	}
 
 	stageFile(file: GitFileChangeShape): void {
@@ -1049,6 +1086,21 @@ export class CommitDetailsActions {
 				break;
 			case 'switch':
 				this.switchBranch();
+				break;
+			case 'create-pr':
+				this.createPullRequest();
+				break;
+			case 'start-work':
+				this.startWork();
+				break;
+			case 'create-branch':
+				this.createBranch();
+				break;
+			case 'apply-stash':
+				this.applyStash();
+				break;
+			case 'new-worktree':
+				this.createWorktree();
 				break;
 			case 'open-pr-changes':
 				this.openPullRequestChanges();

--- a/src/webviews/apps/commitDetails/components/gl-details-wip-panel.ts
+++ b/src/webviews/apps/commitDetails/components/gl-details-wip-panel.ts
@@ -36,6 +36,7 @@ import '../../shared/components/commit/commit-stats.js';
 import '../../shared/components/pills/tracking.js';
 import '../../shared/components/tree/gl-wip-tree-pane.js';
 import '../../plus/shared/components/merge-rebase-status.js';
+import '../../plus/graph/components/gl-details-wip-empty-pane.js';
 import './gl-inspect-patch.js';
 
 @customElement('gl-details-wip-panel')
@@ -473,6 +474,26 @@ export class GlDetailsWipPanel extends GlDetailsBase {
 
 		if (this.variant === 'embedded') {
 			return this.renderEmbedded();
+		}
+
+		const hasFiles = (this.files?.length ?? 0) > 0;
+		if (!hasFiles && !this.inReview) {
+			return html`
+				${this.renderActions()} ${this.renderPausedOpStatus()}
+				<gl-details-wip-empty-pane
+					.wip=${this.wip}
+					.hasPullRequest=${this.pullRequest != null}
+					@publish-branch=${() => this.onDataActionClick('publish-branch')}
+					@pull=${() => this.onDataActionClick('pull')}
+					@push=${() => this.onDataActionClick('push')}
+					@create-pr=${() => this.onDataActionClick('create-pr')}
+					@start-work=${() => this.onDataActionClick('start-work')}
+					@switch-branch=${() => this.onDataActionClick('switch')}
+					@create-branch=${() => this.onDataActionClick('create-branch')}
+					@apply-stash=${() => this.onDataActionClick('apply-stash')}
+					@new-worktree=${() => this.onDataActionClick('new-worktree')}
+				></gl-details-wip-empty-pane>
+			`;
 		}
 
 		return html`

--- a/src/webviews/apps/plus/graph/components/detailsActions.ts
+++ b/src/webviews/apps/plus/graph/components/detailsActions.ts
@@ -59,6 +59,7 @@ import {
 	noopUnlessReal,
 } from '../../../shared/actions/rpc.js';
 import { subscribeAll } from '../../../shared/events/subscriptions.js';
+import { getRemoteNameFromBranchName } from '../../../shared/git-utils.js';
 import type { Resource } from '../../../shared/state/resource.js';
 import type { DetailsState } from './detailsState.js';
 import type { ScopeItem } from './gl-commits-scope-pane.js';
@@ -2399,6 +2400,21 @@ export class DetailsActions {
 
 	startWork(): void {
 		void this.services.commands.execute('gitlens.startWork', { source: 'graph-details' as const });
+	}
+
+	createPullRequest(repoPath: string | undefined): void {
+		if (!repoPath) return;
+
+		const wip = this.state.wip.get();
+		const branch = wip?.branch;
+		const upstreamName = branch?.upstream?.name;
+		if (branch?.name == null || upstreamName == null) return;
+
+		void this.services.commands.execute('gitlens.createPullRequestOnRemote', {
+			repoPath: repoPath,
+			compare: branch.name,
+			remote: getRemoteNameFromBranchName(upstreamName),
+		});
 	}
 
 	openOnRemote(repoPath: string | undefined, sha: string): void {

--- a/src/webviews/apps/plus/graph/components/detailsState.ts
+++ b/src/webviews/apps/plus/graph/components/detailsState.ts
@@ -27,6 +27,7 @@ import type { PullRequestShape } from '@gitlens/git/models/pullRequest.js';
 import type { GitCommitSearchContext } from '@gitlens/git/models/search.js';
 import type { GitCommitReachability } from '@gitlens/git/providers/commits.js';
 import type { Autolink } from '../../../../../autolinks/models/autolinks.js';
+import type { LaunchpadSummaryResult } from '../../../../../plus/launchpad/launchpadIndicator.js';
 import type { CommitDetails, CommitSignatureShape, Preferences, Wip } from '../../../../plus/graph/detailsProtocol.js';
 import type {
 	BranchCommitEntry,
@@ -206,6 +207,8 @@ function createDurableState() {
 	const hasRemotes = signal(false);
 	const aiModel = signal<AiModelInfo | undefined>(undefined);
 
+	const launchpadSummary = signal<LaunchpadSummaryResult | { error: Error } | undefined>(undefined);
+
 	return {
 		commit: commit,
 		wip: wip,
@@ -274,6 +277,8 @@ function createDurableState() {
 		hasIntegrationsConnected: hasIntegrationsConnected,
 		hasRemotes: hasRemotes,
 		aiModel: aiModel,
+
+		launchpadSummary: launchpadSummary,
 
 		resetAll: resetAll,
 	};

--- a/src/webviews/apps/plus/graph/components/detailsWorkflowController.ts
+++ b/src/webviews/apps/plus/graph/components/detailsWorkflowController.ts
@@ -1498,7 +1498,7 @@ export class DetailsWorkflowController implements ReactiveController {
 					this.actions.services.repository.onRepositoryChanged(repoPath, data => {
 						if (this.host.isWipSelection()) {
 							const relevant = data.changes.some(
-								c => c === 'gkConfig' || c === 'config' || c === 'heads',
+								c => c === 'gkConfig' || c === 'config' || c === 'heads' || c === 'remoteProviders',
 							);
 							if (relevant) {
 								this.actions.refreshWipBranchEnrichment();

--- a/src/webviews/apps/plus/graph/components/gl-details-wip-empty-pane.css.ts
+++ b/src/webviews/apps/plus/graph/components/gl-details-wip-empty-pane.css.ts
@@ -97,4 +97,36 @@ export const detailsWipEmptyPaneStyles = css`
 	.start-fresh gl-button code-icon {
 		margin-right: 0.4rem;
 	}
+
+	.launchpad-items {
+		list-style: none;
+		padding-inline-start: 0;
+		margin-block: 0 0.6rem;
+		display: flex;
+		flex-direction: column;
+		gap: 0.4rem;
+	}
+
+	.launchpad-item {
+		display: flex;
+		align-items: center;
+		gap: 0.6rem;
+		font-size: 1.2rem;
+	}
+
+	.launchpad-item__icon {
+		color: var(--gl-launchpad-item-color, inherit);
+	}
+
+	.launchpad-item--mergeable {
+		--gl-launchpad-item-color: var(--vscode-gitlens-launchpadIndicatorMergeableColor);
+	}
+
+	.launchpad-item--blocked {
+		--gl-launchpad-item-color: var(--vscode-gitlens-launchpadIndicatorBlockedColor);
+	}
+
+	.launchpad-item--attention {
+		--gl-launchpad-item-color: var(--vscode-gitlens-launchpadIndicatorAttentionColor);
+	}
 `;

--- a/src/webviews/apps/plus/graph/components/gl-details-wip-empty-pane.ts
+++ b/src/webviews/apps/plus/graph/components/gl-details-wip-empty-pane.ts
@@ -1,6 +1,8 @@
+import type { TemplateResult } from 'lit';
 import { html, LitElement, nothing } from 'lit';
 import { customElement, property } from 'lit/decorators.js';
 import { pluralize } from '@gitlens/utils/string.js';
+import type { LaunchpadSummaryResult } from '../../../../../plus/launchpad/launchpadIndicator.js';
 import type { GitBranchShape, Wip } from '../../../../plus/graph/detailsProtocol.js';
 import { elementBase } from '../../../shared/components/styles/lit/base.css.js';
 import { detailsWipEmptyPaneStyles } from './gl-details-wip-empty-pane.css.js';
@@ -26,6 +28,8 @@ export class GlDetailsWipEmptyPane extends LitElement {
 	static override styles = [elementBase, detailsWipEmptyPaneStyles];
 
 	@property({ type: Object }) wip?: Wip;
+	@property({ type: Boolean }) hasPullRequest = false;
+	@property({ type: Object }) launchpadSummary?: LaunchpadSummaryResult | { error: Error };
 	@property({ type: Boolean }) aiEnabled = false;
 
 	override render(): unknown {
@@ -61,9 +65,11 @@ export class GlDetailsWipEmptyPane extends LitElement {
 			</section>
 			${this.aiEnabled && hasDiverged ? this.renderAiWorkflows(ahead) : nothing}
 			<section class="section">
+				<h3 class="section__heading">Launchpad</h3>
+				${this.renderLaunchpadSummary()}
 				<div class="start-fresh">
 					<gl-button appearance="secondary" @click=${() => this.emit('start-work')}>
-						<code-icon icon="rocket"></code-icon>Start Work…
+						<code-icon icon="rocket"></code-icon>Start Work on an Issue…
 					</gl-button>
 				</div>
 			</section>
@@ -119,6 +125,69 @@ export class GlDetailsWipEmptyPane extends LitElement {
 		</div>`;
 	}
 
+	private renderLaunchpadSummary(): TemplateResult | typeof nothing {
+		const summary = this.launchpadSummary;
+		if (summary == null || !('total' in summary) || summary.total === 0) return nothing;
+		if (!summary.hasGroupedItems) return nothing;
+
+		const items: TemplateResult[] = [];
+
+		for (const group of summary.groups) {
+			switch (group) {
+				case 'mergeable': {
+					const total = summary.mergeable?.total ?? 0;
+					if (total === 0) continue;
+					items.push(
+						html`<li class="launchpad-item launchpad-item--mergeable">
+							<code-icon class="launchpad-item__icon" icon="rocket"></code-icon>
+							<span>${pluralize('PR', total)} can be merged</span>
+						</li>`,
+					);
+					break;
+				}
+				case 'blocked': {
+					const total = summary.blocked?.total ?? 0;
+					if (total === 0) continue;
+					items.push(
+						html`<li class="launchpad-item launchpad-item--blocked">
+							<code-icon class="launchpad-item__icon" icon="error"></code-icon>
+							<span>${pluralize('PR', total)} ${total > 1 ? 'are' : 'is'} blocked</span>
+						</li>`,
+					);
+					break;
+				}
+				case 'follow-up': {
+					const total = summary.followUp?.total ?? 0;
+					if (total === 0) continue;
+					items.push(
+						html`<li class="launchpad-item launchpad-item--attention">
+							<code-icon class="launchpad-item__icon" icon="report"></code-icon>
+							<span>${pluralize('PR', total)} ${total > 1 ? 'require' : 'requires'} follow-up</span>
+						</li>`,
+					);
+					break;
+				}
+				case 'needs-review': {
+					const total = summary.needsReview?.total ?? 0;
+					if (total === 0) continue;
+					items.push(
+						html`<li class="launchpad-item launchpad-item--attention">
+							<code-icon class="launchpad-item__icon" icon="comment-unresolved"></code-icon>
+							<span>${pluralize('PR', total)} ${total > 1 ? 'need' : 'needs'} your review</span>
+						</li>`,
+					);
+					break;
+				}
+			}
+		}
+
+		if (items.length === 0) return nothing;
+
+		return html`<ul class="launchpad-items">
+			${items}
+		</ul>`;
+	}
+
 	private computeNextSteps(branch: GitBranchShape): NextStep[] {
 		const ahead = branch.tracking?.ahead ?? 0;
 		const behind = branch.tracking?.behind ?? 0;
@@ -153,6 +222,17 @@ export class GlDetailsWipEmptyPane extends LitElement {
 				label: `Push ${pluralize('commit', ahead)} to ${remoteName}`,
 				actionLabel: 'Push',
 				event: 'push',
+			});
+		}
+
+		// Show "Create PR" for any published branch without an existing PR,
+		// regardless of ahead/behind state — matches Home view behavior.
+		if (!this.hasPullRequest) {
+			steps.push({
+				icon: 'git-pull-request-create',
+				label: 'Create a Pull Request',
+				actionLabel: 'Create PR',
+				event: 'create-pr',
 			});
 		}
 

--- a/src/webviews/apps/plus/graph/components/gl-details-wip-empty-pane.ts
+++ b/src/webviews/apps/plus/graph/components/gl-details-wip-empty-pane.ts
@@ -137,6 +137,7 @@ export class GlDetailsWipEmptyPane extends LitElement {
 				case 'mergeable': {
 					const total = summary.mergeable?.total ?? 0;
 					if (total === 0) continue;
+
 					items.push(
 						html`<li class="launchpad-item launchpad-item--mergeable">
 							<code-icon class="launchpad-item__icon" icon="rocket"></code-icon>
@@ -148,6 +149,7 @@ export class GlDetailsWipEmptyPane extends LitElement {
 				case 'blocked': {
 					const total = summary.blocked?.total ?? 0;
 					if (total === 0) continue;
+
 					items.push(
 						html`<li class="launchpad-item launchpad-item--blocked">
 							<code-icon class="launchpad-item__icon" icon="error"></code-icon>
@@ -159,6 +161,7 @@ export class GlDetailsWipEmptyPane extends LitElement {
 				case 'follow-up': {
 					const total = summary.followUp?.total ?? 0;
 					if (total === 0) continue;
+
 					items.push(
 						html`<li class="launchpad-item launchpad-item--attention">
 							<code-icon class="launchpad-item__icon" icon="report"></code-icon>
@@ -170,6 +173,7 @@ export class GlDetailsWipEmptyPane extends LitElement {
 				case 'needs-review': {
 					const total = summary.needsReview?.total ?? 0;
 					if (total === 0) continue;
+
 					items.push(
 						html`<li class="launchpad-item launchpad-item--attention">
 							<code-icon class="launchpad-item__icon" icon="comment-unresolved"></code-icon>
@@ -214,9 +218,7 @@ export class GlDetailsWipEmptyPane extends LitElement {
 				actionLabel: 'Pull',
 				event: 'pull',
 			});
-		}
-
-		if (ahead > 0) {
+		} else if (ahead > 0) {
 			steps.push({
 				icon: 'repo-push',
 				label: `Push ${pluralize('commit', ahead)} to ${remoteName}`,

--- a/src/webviews/apps/plus/graph/components/gl-graph-details-panel.ts
+++ b/src/webviews/apps/plus/graph/components/gl-graph-details-panel.ts
@@ -900,8 +900,11 @@ export class GlGraphDetailsPanel extends SignalWatcher(LitElement) {
 		// the repo-change subscription without an extra call here.
 		this._workflow = new DetailsWorkflowController(this, this._actions);
 
-		// Fetch capabilities in parallel
 		void this._actions.fetchCapabilities();
+		// Fetched eagerly (not gated on isWip) because resolveServices runs once on
+		// connect — if the initial selection is a commit, a isWip guard would skip
+		// the fetch and it never re-runs when the user later selects a WIP row.
+		void this.fetchLaunchpadSummary(services);
 		if (this.isMultiCommit) {
 			void this._actions.fetchCompareDetails(this.shas, this.repoPath, this.commitLites);
 		} else {
@@ -1939,9 +1942,21 @@ export class GlGraphDetailsPanel extends SignalWatcher(LitElement) {
 
 	private handleStartWork = () => this._actions.startWork();
 
+	private handleCreatePr = () => this._actions.createPullRequest(this.effectiveRepoPath);
+
 	private handleApplyStash = () => this._actions.applyStash(this.effectiveRepoPath);
 
 	private handleNewWorktree = () => this._actions.createWorktree();
+
+	private async fetchLaunchpadSummary(services: Remote<GraphServices>): Promise<void> {
+		try {
+			const launchpad = await services.launchpad;
+			const summary = await launchpad.getSummary();
+			this._state.launchpadSummary.set(summary);
+		} catch (ex) {
+			this._state.launchpadSummary.set({ error: ex instanceof Error ? ex : new Error(String(ex)) });
+		}
+	}
 
 	private handleCompareWithMergeTarget = (
 		e: CustomEvent<{ rightRef: string; rightRefType: 'branch' | 'commit' }>,

--- a/src/webviews/apps/plus/graph/components/gl-graph-details-panel.ts
+++ b/src/webviews/apps/plus/graph/components/gl-graph-details-panel.ts
@@ -1201,9 +1201,12 @@ export class GlGraphDetailsPanel extends SignalWatcher(LitElement) {
 								<gl-details-wip-empty-pane
 									.wip=${wip}
 									.aiEnabled=${false}
+									.hasPullRequest=${this._state.wipPullRequestLoading.get() ||
+									this._state.wipPullRequest.get() != null}
 									.launchpadSummary=${this._state.launchpadSummary.get()}
 									@switch-branch=${this.handleSwitchBranch}
 									@create-branch=${this.handleCreateBranch}
+									@create-pr=${this.handleCreatePullRequest}
 									@start-work=${this.handleStartWork}
 									@apply-stash=${this.handleApplyStash}
 									@new-worktree=${this.handleNewWorktree}
@@ -1927,6 +1930,8 @@ export class GlGraphDetailsPanel extends SignalWatcher(LitElement) {
 	private handlePush = () => void this._actions.services.repository.push(this.effectiveRepoPath!);
 
 	private handleFetch = () => void this._actions.services.repository.fetch(this.effectiveRepoPath!);
+
+	private handleCreatePullRequest = () => this._actions.createPullRequest(this.effectiveRepoPath);
 
 	private handleShareWipAsCloudPatch = () =>
 		void this._actions.services.commands.executeScoped('gitlens.shareWipAsCloudPatch:graph', {

--- a/src/webviews/apps/plus/graph/components/gl-graph-details-panel.ts
+++ b/src/webviews/apps/plus/graph/components/gl-graph-details-panel.ts
@@ -1201,6 +1201,7 @@ export class GlGraphDetailsPanel extends SignalWatcher(LitElement) {
 								<gl-details-wip-empty-pane
 									.wip=${wip}
 									.aiEnabled=${false}
+									.launchpadSummary=${this._state.launchpadSummary.get()}
 									@switch-branch=${this.handleSwitchBranch}
 									@create-branch=${this.handleCreateBranch}
 									@start-work=${this.handleStartWork}

--- a/src/webviews/plus/graph/graphService.ts
+++ b/src/webviews/plus/graph/graphService.ts
@@ -2,6 +2,7 @@ import type { AIReviewDetailResult, AIReviewResult } from '@gitlens/ai/models/re
 import type { GitFileChangeShape } from '@gitlens/git/models/fileChange.js';
 import type { GitCommitSearchContext } from '@gitlens/git/models/search.js';
 import type { GlCommands } from '../../../constants.commands.js';
+import type { LaunchpadSummaryResult } from '../../../plus/launchpad/launchpadIndicator.js';
 import type { ExplainResult } from '../../commitDetails/commitDetailsService.js';
 import type { SharedWebviewServices } from '../../rpc/services/common.js';
 import type { RpcEventSubscription } from '../../rpc/services/types.js';
@@ -332,6 +333,11 @@ export interface GraphTimelineService {
 
 export interface GraphServices extends SharedWebviewServices {
 	readonly graphInspect: GraphInspectService;
+	readonly launchpad: GraphLaunchpadService;
 	readonly sidebar: GraphSidebarService;
 	readonly graphTimeline: GraphTimelineService;
+}
+
+export interface GraphLaunchpadService {
+	getSummary(): Promise<LaunchpadSummaryResult | { error: Error } | undefined>;
 }

--- a/src/webviews/plus/graph/graphWebview.ts
+++ b/src/webviews/plus/graph/graphWebview.ts
@@ -227,6 +227,7 @@ import { ipcCommand, ipcRequest } from '../../ipc/handlerRegistry.js';
 import type { IpcNotification } from '../../ipc/models/ipc.js';
 import type { EventVisibilityBuffer, SubscriptionTracker } from '../../rpc/eventVisibilityBuffer.js';
 import { createRpcEvent } from '../../rpc/eventVisibilityBuffer.js';
+import { LaunchpadService } from '../../rpc/launchpadService.js';
 import { createSharedServices, proxyServices } from '../../rpc/services/common.js';
 import type { BranchAndTargetRefs, BranchRef } from '../../shared/branchRefs.js';
 import type {
@@ -1868,6 +1869,7 @@ export class GraphWebviewProvider implements WebviewProvider<State, State, Graph
 				onSidebarInvalidated: this._sidebarInvalidatedEvent.subscribe(buffer, tracker),
 				onWorktreeStateChanged: this._sidebarWorktreeEvent.subscribe(buffer, tracker),
 			},
+			launchpad: new LaunchpadService(this.container, buffer, tracker),
 			graphTimeline: {
 				getDataset: async (scope, config, signal) => {
 					const result = await buildTimelineDataset(this.container, scope, config, signal);

--- a/src/webviews/rpc/services/repository.ts
+++ b/src/webviews/rpc/services/repository.ts
@@ -526,42 +526,48 @@ export class RepositoryService {
 	 * Fetch from remote.
 	 */
 	async fetch(repoPath: string): Promise<void> {
-		await RepoActions.fetch(repoPath);
+		const repo = this.container.git.getRepository(repoPath);
+		await RepoActions.fetch(repo ?? repoPath);
 	}
 
 	/**
 	 * Push to remote.
 	 */
 	async push(repoPath: string): Promise<void> {
-		await RepoActions.push(repoPath);
+		const repo = this.container.git.getRepository(repoPath);
+		await RepoActions.push(repo ?? repoPath);
 	}
 
 	async publishBranch(repoPath: string): Promise<void> {
 		const branch = await this.container.git.getRepositoryService(repoPath).branches.getBranch();
 		if (branch == null) return;
 
-		await RepoActions.push(repoPath, undefined, getReferenceFromBranch(branch));
+		const repo = this.container.git.getRepository(repoPath);
+		await RepoActions.push(repo ?? repoPath, undefined, getReferenceFromBranch(branch));
 	}
 
 	/**
 	 * Pull from remote.
 	 */
 	async pull(repoPath: string): Promise<void> {
-		await RepoActions.pull(repoPath);
+		const repo = this.container.git.getRepository(repoPath);
+		await RepoActions.pull(repo ?? repoPath);
 	}
 
 	/**
 	 * Switch branches.
 	 */
 	async switchBranch(repoPath: string): Promise<void> {
-		await RepoActions.switchTo(repoPath);
+		const repo = this.container.git.getRepository(repoPath);
+		await RepoActions.switchTo(repo ?? repoPath);
 	}
 
 	/**
 	 * Create a new branch.
 	 */
 	async createBranch(repoPath: string): Promise<void> {
-		await BranchActions.create(repoPath);
+		const repo = this.container.git.getRepository(repoPath);
+		await BranchActions.create(repo ?? repoPath);
 	}
 
 	// ============================================================


### PR DESCRIPTION
## Summary

Closes #5188

Improves the empty state UX in the Commit Details (Inspect) and Graph Details panels when there are no working changes, adding contextual next steps and Launchpad integration.

### Empty state improvements
- Integrates the existing `gl-details-wip-empty-pane` component into the Commit Details (Inspect) WIP panel — previously only used in the Graph panel
- Adds **"Create a Pull Request"** next step for any published branch without an existing PR (not just when ahead of upstream)
- Adds **"Launchpad"** section with PR status summary (mergeable, blocked, follow-up, needs review) to the Graph Details panel, matching the Home view
- Adds **"Start Work on an Issue..."** button in both panels

### Action wiring
- Wires new actions in CommitDetailsActions: `startWork`, `createPullRequest`, `createBranch`, `applyStash`, `createWorktree`
- Fixes `createPullRequest` in both Graph and Commit Details panels to pass complete args (`compare`, `remote`, `base`) to `gitlens.createPullRequestOnRemote` — previously only passed `repoPath`, causing "Unable to create PR for branch `undefined`" error
- Uses `wipPullRequest` (not `pullRequest`) for the Graph empty pane so "Create PR" correctly hides when a PR already exists

### Launchpad summary in Graph
- Composes `LaunchpadService` into Graph webview RPC services
- Adds `launchpadSummary` signal to `DetailsState`
- Fetches summary on service resolution and passes to empty pane
- Renders PR group counts with color-coded icons matching Home view theme tokens
