### PR TITLE
Fix Graph Details publish branch for branches without upstream

### DIFF
--- a/packages/git-cli/src/providers/operations.ts
+++ b/packages/git-cli/src/providers/operations.ts
@@ -586,7 +586,10 @@ export class OperationsGitSubProvider implements GitOperationsSubProvider {
 			}
 
 			this.context.hooks?.cache?.onReset?.(repoPath, 'branches');
-			this.context.hooks?.repository?.onChanged?.(repoPath, ['remotes']);
+			this.context.hooks?.repository?.onChanged?.(
+				repoPath,
+				options?.publish != null ? ['config', 'heads', 'remotes'] : ['remotes'],
+			);
 		} catch (ex) {
 			scope?.error(ex);
 			throw ex;

--- a/src/webviews/apps/plus/graph/components/gl-graph-details-panel.ts
+++ b/src/webviews/apps/plus/graph/components/gl-graph-details-panel.ts
@@ -1187,7 +1187,7 @@ export class GlGraphDetailsPanel extends SignalWatcher(LitElement) {
 
 	private handleCreateBranch = () => this._actions.createBranch(this.effectiveRepoPath);
 
-	private handlePublishBranch = () => void this._actions.services.repository.push(this.effectiveRepoPath!);
+	private handlePublishBranch = () => void this._actions.services.repository.publishBranch(this.effectiveRepoPath!);
 
 	private handlePull = () => void this._actions.services.repository.pull(this.effectiveRepoPath!);
 

--- a/src/webviews/rpc/services/repository.ts
+++ b/src/webviews/rpc/services/repository.ts
@@ -36,6 +36,7 @@ import {
 	stageConflictResolution as stageConflictResolutionHelper,
 } from '../../../git/utils/-webview/conflictResolution.utils.js';
 import { countConflictMarkers } from '../../../git/utils/-webview/mergeConflicts.utils.js';
+import { getReferenceFromBranch } from '../../../git/utils/-webview/reference.utils.js';
 import { executeCommand, executeCoreCommand } from '../../../system/-webview/command.js';
 import { serialize } from '../../../system/serialize.js';
 import type { EventVisibilityBuffer, SubscriptionTracker } from '../eventVisibilityBuffer.js';
@@ -501,6 +502,13 @@ export class RepositoryService {
 	 */
 	async push(repoPath: string): Promise<void> {
 		await RepoActions.push(repoPath);
+	}
+
+	async publishBranch(repoPath: string): Promise<void> {
+		const branch = await this.container.git.getRepositoryService(repoPath).branches.getBranch();
+		if (branch == null) return;
+
+		await RepoActions.push(repoPath, undefined, getReferenceFromBranch(branch));
 	}
 
 	/**


### PR DESCRIPTION
## Summary

Fixes #5220

- Adds a dedicated `publishBranch(repoPath)` RPC method that resolves the current branch and passes it as a reference to `RepoActions.push`, matching the pattern used by the graph webview's host-side `publishBranch` command
- Updates `handlePublishBranch` in the Graph Details panel to call the new method instead of the generic `push`
- Expands the repository change notification after a successful publish to include `config` and `heads` (not just `remotes`), so the graph updates the branch label to reflect the new upstream tracking

Previously, the "Publish Branch" button in the Graph Details panel's WIP section called the same `push(repoPath)` as the regular Push button. This failed in linked worktrees where upstream ref resolution returns stale data, causing `OperationsGitSubProvider` to throw "Unable to push".

Additionally, after a successful publish, the graph showed the new remote branch but didn't update the local branch label because the operations provider only notified about `remotes` changes, missing the `config` and `heads` updates needed for the branch to reflect its new upstream.
