### PR TITLE
Adds Copy and Send to Agent actions to Review mode outputs

### DIFF
--- a/packages/plus/ai/src/models/promptTemplates.ts
+++ b/packages/plus/ai/src/models/promptTemplates.ts
@@ -101,6 +101,13 @@ interface ReviewDetailPromptTemplateContext {
 	instructions?: string;
 }
 
+interface AddressReviewFindingsPromptTemplateContext {
+	reviewMarkdown: string;
+	scopeLabel: string;
+	granularity: 'review' | 'focusArea' | 'finding';
+	instructions?: string;
+}
+
 interface StartWorkIssuePromptTemplateContext {
 	issue: string;
 	instructions?: string;
@@ -117,6 +124,7 @@ export type PromptTemplateType =
 	| 'review-changes'
 	| 'review-overview'
 	| 'review-detail'
+	| 'address-review-findings'
 	| 'start-review-pullRequest'
 	| 'start-work-issue';
 
@@ -147,6 +155,8 @@ export type PromptTemplateContext<T extends PromptTemplateType> = T extends 'gen
 	? ReviewOverviewPromptTemplateContext
 	: T extends 'review-detail'
 	? ReviewDetailPromptTemplateContext
+	: T extends 'address-review-findings'
+	? AddressReviewFindingsPromptTemplateContext
 	: T extends 'start-review-pullRequest'
 	? ReviewPullRequestPromptTemplateContext
 	: T extends 'start-work-issue'

--- a/packages/plus/ai/src/prompts.ts
+++ b/packages/plus/ai/src/prompts.ts
@@ -623,6 +623,30 @@ Guidelines:
 Assess the changes and produce the structured XML output above.`,
 };
 
+export const addressReviewFindings: PromptTemplate<'address-review-findings'> = {
+	id: 'address-review-findings',
+	variables: ['reviewMarkdown', 'scopeLabel', 'granularity', 'instructions'],
+	template: `You are an AI coding agent tasked with addressing the issues identified in a code review. Your goal is to understand each finding and, where appropriate, propose or make the code changes needed to fix it.
+
+The review was performed against: \${scopeLabel}
+
+The findings are provided as structured markdown below. Each finding includes a severity (\`**[CRITICAL]**\`, \`**[WARNING]**\`, or \`**[SUGGESTION]**\`), a short title, a description of the problem, and (when available) a file path and line range. Focus areas group related findings and include a rationale explaining why they matter.
+
+<~~review~~>
+\${reviewMarkdown}
+</~~review~~>
+
+Guidelines:
+- Treat the findings as a working list. Prioritize critical issues, then warnings, then suggestions.
+- For each finding, locate the referenced file(s) in the workspace before proposing a fix. If the file or line range no longer matches the review (the code may have evolved), reconcile against the current state.
+- When making code changes, address the underlying problem the finding describes — do not just paper over symptoms.
+- Prefer minimal, focused edits that don't introduce unrelated changes.
+- If a finding is ambiguous, contradicts the surrounding code's intent, or is already addressed in the current state, say so explicitly rather than fabricating a fix.
+- If a finding is out of scope (touches unrelated systems, requires significant refactoring, or contradicts established patterns), surface that as a tradeoff rather than acting on it.
+
+\${instructions}`,
+};
+
 export const reviewDetail: PromptTemplate<'review-detail'> = {
 	id: 'review-detail',
 	variables: ['diff', 'overview', 'message', 'focusArea', 'context', 'instructions'],

--- a/src/commands/git/branch/create.ts
+++ b/src/commands/git/branch/create.ts
@@ -17,7 +17,7 @@ import type { Container } from '../../../container.js';
 import type { GlRepository } from '../../../git/models/repository.js';
 import { addAssociatedIssueToBranch } from '../../../git/utils/-webview/branch.issue.utils.js';
 import { showGitErrorMessage } from '../../../messages.js';
-import type { ChatActions } from '../../../plus/chat/chatActions.js';
+import type { StartReviewChatAction, StartWorkChatAction } from '../../../plus/chat/chatActions.js';
 import { getIssueOwner } from '../../../plus/integrations/providers/utils.js';
 import type { FlagsQuickPickItem } from '../../../quickpicks/items/flags.js';
 import { createFlagsQuickPickItem } from '../../../quickpicks/items/flags.js';
@@ -76,7 +76,7 @@ interface State<Repo = string | GlRepository> {
 	result?: Deferred<{ branch: GitBranch; worktree?: GitWorktree }>;
 
 	// Chat action for deeplink storage
-	chatAction?: ChatActions;
+	chatAction?: StartWorkChatAction | StartReviewChatAction;
 }
 export type BranchCreateState = State;
 

--- a/src/commands/git/worktree/create.ts
+++ b/src/commands/git/worktree/create.ts
@@ -18,7 +18,7 @@ import { convertLocationToOpenFlags, revealWorktree } from '../../../git/actions
 import type { GlRepository } from '../../../git/models/repository.js';
 import { getWorktreeForBranch } from '../../../git/utils/-webview/worktree.utils.js';
 import { showGitErrorMessage } from '../../../messages.js';
-import type { ChatActions } from '../../../plus/chat/chatActions.js';
+import type { StartReviewChatAction, StartWorkChatAction } from '../../../plus/chat/chatActions.js';
 import { storeChatActionDeepLink } from '../../../plus/chat/chatActions.js';
 import { createQuickPickSeparator } from '../../../quickpicks/items/common.js';
 import { Directive } from '../../../quickpicks/items/directive.js';
@@ -91,7 +91,7 @@ interface State<Repo = string | GlRepository> {
 	worktreeDefaultOpen?: 'new' | 'current';
 
 	// Chat action for deeplink storage
-	chatAction?: ChatActions;
+	chatAction?: StartWorkChatAction | StartReviewChatAction;
 }
 export type WorktreeCreateState = State;
 

--- a/src/commands/sendToChat.ts
+++ b/src/commands/sendToChat.ts
@@ -19,6 +19,12 @@ export interface SendToChatCommandArgs {
 	 * Whether the chat will await more input from the user.
 	 */
 	execute?: boolean;
+
+	/**
+	 * Chat mode to request (Copilot Chat). Other hosts ignore this — Cursor/Windsurf/Kiro/Trae
+	 * already open agent-mode sessions via their dedicated commands.
+	 */
+	mode?: 'agent' | 'edit' | 'ask';
 }
 
 /**
@@ -35,6 +41,8 @@ export class SendToChatCommand extends GlCommandBase {
 			throw new Error('Prompt is required for sendToChat command');
 		}
 
-		return openChat(args.query, args.execute != null ? { execute: args.execute } : undefined);
+		const options =
+			args.execute != null || args.mode != null ? { execute: args.execute, mode: args.mode } : undefined;
+		return openChat(args.query, options);
 	}
 }

--- a/src/constants.telemetry.ts
+++ b/src/constants.telemetry.ts
@@ -1888,6 +1888,8 @@ export type TrackedUsage = {
  */
 export type TrackedGlActions =
 	| 'gitlens.ai.generateCommits'
+	| 'gitlens.ai.review.copied'
+	| 'gitlens.ai.review.sentToChat'
 	| 'gitlens.mcp.ipcRequest'
 	| 'gitlens.mcp.chatInteraction'
 	| 'gitlens.mcp.bundledMcpDefinitionProvided';

--- a/src/plus/ai/utils/-webview/prompt.utils.ts
+++ b/src/plus/ai/utils/-webview/prompt.utils.ts
@@ -6,6 +6,7 @@ import type {
 	TruncationHandler,
 } from '@gitlens/ai/models/promptTemplates.js';
 import {
+	addressReviewFindings,
 	explainChanges,
 	generateChangelog,
 	generateCommitMessage,
@@ -78,6 +79,8 @@ export function getLocalPromptTemplate<T extends PromptTemplateType>(
 			return reviewOverview as PromptTemplate<T>;
 		case 'review-detail':
 			return reviewDetail as PromptTemplate<T>;
+		case 'address-review-findings':
+			return addressReviewFindings as PromptTemplate<T>;
 		case 'start-review-pullRequest':
 			return reviewPullRequest as PromptTemplate<T>;
 		case 'start-work-issue':

--- a/src/plus/chat/chatActions.ts
+++ b/src/plus/chat/chatActions.ts
@@ -23,7 +23,15 @@ export interface StartReviewChatAction {
 	instructions?: string;
 }
 
-export type ChatActions = StartWorkChatAction | StartReviewChatAction;
+export interface AddressReviewFindingsChatAction {
+	type: 'addressReviewFindings';
+	scopeLabel: string;
+	reviewMarkdown: string;
+	granularity: 'review' | 'focusArea' | 'finding';
+	instructions?: string;
+}
+
+export type ChatActions = StartWorkChatAction | StartReviewChatAction | AddressReviewFindingsChatAction;
 
 export async function executeChatAction(
 	container: Container,
@@ -31,6 +39,8 @@ export async function executeChatAction(
 	source?: Sources,
 ): Promise<void> {
 	let promptToSend: string | undefined;
+	let mode: SendToChatCommandArgs['mode'];
+	let execute = true;
 
 	try {
 		if (chatAction.type === 'startWork') {
@@ -45,6 +55,18 @@ export async function executeChatAction(
 				instructions: chatAction.instructions,
 			});
 			promptToSend = prompt;
+		} else if (chatAction.type === 'addressReviewFindings') {
+			const { prompt } = await container.ai.getPrompt('address-review-findings', undefined, {
+				reviewMarkdown: chatAction.reviewMarkdown,
+				scopeLabel: chatAction.scopeLabel,
+				granularity: chatAction.granularity,
+				instructions: chatAction.instructions,
+			});
+			promptToSend = prompt;
+			mode = 'agent';
+			// Review-level is a conversational opener (let the user choose where to start);
+			// area- and finding-level are self-contained tasks that should auto-execute.
+			execute = chatAction.granularity !== 'review';
 		}
 	} catch (ex) {
 		Logger.error(ex, 'ChatActions', 'executeChatAction');
@@ -53,10 +75,14 @@ export async function executeChatAction(
 	if (promptToSend != null) {
 		// Track MCP chat interaction usage
 		void container.usage.track('action:gitlens.mcp.chatInteraction:happened');
+		if (chatAction.type === 'addressReviewFindings') {
+			void container.usage.track('action:gitlens.ai.review.sentToChat:happened');
+		}
 
 		return executeCommand('gitlens.sendToChat', {
 			query: promptToSend,
-			execute: true,
+			execute: execute,
+			mode: mode,
 			source: source,
 		} as SendToChatCommandArgs);
 	}
@@ -64,7 +90,7 @@ export async function executeChatAction(
 
 export async function storeChatActionDeepLink(
 	container: Container,
-	chatAction: ChatActions,
+	chatAction: StartWorkChatAction | StartReviewChatAction,
 	repoPath: string,
 ): Promise<void> {
 	const schemeOverride = configuration.get('deepLinks.schemeOverride');

--- a/src/plus/chat/utils/-webview/chat.utils.ts
+++ b/src/plus/chat/utils/-webview/chat.utils.ts
@@ -8,6 +8,12 @@ export async function openChat(
 	args: string,
 	options?: {
 		execute?: boolean;
+		/**
+		 * Chat mode to request. Honored by Copilot Chat (`workbench.action.chat.open`); the
+		 * other hosts already open their dedicated agent-mode chat command, so this is a no-op
+		 * for them.
+		 */
+		mode?: 'agent' | 'edit' | 'ask';
 	},
 ): Promise<void> {
 	const appName = await getHostAppName();
@@ -27,6 +33,7 @@ export async function openChat(
 	return openCopilotChat({
 		query: args,
 		isPartialQuery: options?.execute != null ? !options.execute : true,
+		mode: options?.mode,
 	});
 }
 

--- a/src/webviews/apps/plus/graph/components/gl-details-review-mode-panel.css.ts
+++ b/src/webviews/apps/plus/graph/components/gl-details-review-mode-panel.css.ts
@@ -114,6 +114,52 @@ export const reviewModePanelStyles = css`
 		opacity: 0.85;
 	}
 
+	.review-header__actions {
+		display: inline-flex;
+		align-items: center;
+		gap: 0.2rem;
+		flex-shrink: 0;
+		margin-left: 0.4rem;
+	}
+
+	.review-area__header-row {
+		display: flex;
+		align-items: center;
+		padding-right: 0.4rem;
+	}
+
+	.review-area__header-row > .review-area__header {
+		flex: 1;
+		min-width: 0;
+	}
+
+	.review-area__actions {
+		display: inline-flex;
+		align-items: center;
+		gap: 0.2rem;
+		flex-shrink: 0;
+	}
+
+	.review-finding__actions {
+		display: inline-flex;
+		align-items: center;
+		gap: 0.2rem;
+		flex-shrink: 0;
+		margin-left: auto;
+	}
+
+	.review-finding__actions gl-button,
+	.review-finding__actions gl-copy-container {
+		opacity: 0.7;
+	}
+
+	.review-finding:hover .review-finding__actions gl-button,
+	.review-finding:hover .review-finding__actions gl-copy-container,
+	.review-finding__actions gl-button:focus-within,
+	.review-finding__actions gl-copy-container:focus-within {
+		opacity: 1;
+	}
+
 	/* Compact metadata bar for compare-style review (multi-commit selection). Mirrors the
 	   single-commit case (rendered by the host gl-details-commit-panel) and the comparison metadata
 	   bar in gl-details-multicommit-panel — keeps the result framing consistent across scopes. */
@@ -464,20 +510,6 @@ export const reviewModePanelStyles = css`
 		flex: 1;
 		font-weight: 500;
 		font-size: var(--gl-font-base);
-	}
-
-	.review-finding__dismiss {
-		flex-shrink: 0;
-		color: var(--vscode-descriptionForeground);
-		background: transparent;
-		border: none;
-		cursor: pointer;
-		padding: 0.1rem;
-		opacity: 0.6;
-	}
-
-	.review-finding__dismiss:hover {
-		opacity: 1;
 	}
 
 	.review-finding__description {

--- a/src/webviews/apps/plus/graph/components/gl-details-review-mode-panel.ts
+++ b/src/webviews/apps/plus/graph/components/gl-details-review-mode-panel.ts
@@ -9,6 +9,7 @@ import type {
 import type { GitFileChangeShape } from '@gitlens/git/models/fileChange.js';
 import { uncommitted } from '@gitlens/git/models/revision.js';
 import type { GitCommitSearchContext } from '@gitlens/git/models/search.js';
+import { shortenRevision } from '@gitlens/git/utils/revision.utils.js';
 import { pluralize } from '@gitlens/utils/string.js';
 import type { ViewFilesLayout } from '../../../../../config.js';
 import { serializeWebviewItemContext } from '../../../../../system/webview.js';
@@ -35,12 +36,15 @@ import {
 	resumeBarStyles,
 	reviewModePanelStyles,
 } from './gl-details-review-mode-panel.css.js';
+import { formatFindingAsMarkdown, formatFocusAreaAsMarkdown, formatReviewAsMarkdown } from './reviewFormat.js';
 import { getScopeSplitPickerChrome, renderErrorState, renderLoadingState } from './shared-panel-templates.js';
 import '../../../shared/components/actions/action-item.js';
 import '../../../shared/components/actions/action-nav.js';
 import '../../../shared/components/ai-input.js';
 import '../../../shared/components/button.js';
+import '../../../shared/components/code-icon.js';
 import '../../../shared/components/commit-sha.js';
+import '../../../shared/components/copy-container.js';
 import '../../../shared/components/gl-ai-model-chip.js';
 import '../../../shared/components/overlays/tooltip.js';
 import '../../../shared/components/split-panel/split-panel.js';
@@ -57,6 +61,16 @@ export interface ReviewOpenFileDetail {
 export interface ReviewAnalyzeAreaDetail {
 	focusAreaId: string;
 	files: string[];
+}
+
+export interface ReviewSendToChatDetail {
+	granularity: 'review' | 'focusArea' | 'finding';
+	scopeLabel: string;
+	reviewMarkdown: string;
+}
+
+export interface ReviewCopiedDetail {
+	granularity: 'review' | 'focusArea' | 'finding';
 }
 
 @customElement('gl-details-review-mode-panel')
@@ -104,6 +118,20 @@ export class GlDetailsReviewModePanel extends LitElement {
 
 	@property()
 	repoPath?: string;
+
+	/** Friendly name of the current repo/worktree (basename of the worktree path). Used to
+	 *  identify the scope in clipboard markdown and agent prompts. */
+	@property()
+	repoName?: string;
+
+	/** Whether the current repo is a linked worktree (true) or the primary/main worktree (false).
+	 *  Drives the "main worktree" vs "<name> worktree" phrasing in the scope context label. */
+	@property({ type: Boolean })
+	isLinkedWorktree = false;
+
+	/** Current HEAD branch name. Identifies WIP scope in markdown/agent context. */
+	@property()
+	branchName?: string;
 
 	@property({ type: Object })
 	searchContext?: GitCommitSearchContext;
@@ -220,6 +248,7 @@ export class GlDetailsReviewModePanel extends LitElement {
 		const includedCount = this.getEffectiveFileCount();
 		const scopeLabel = this.scopeSummary();
 		const findingCount = this.result?.focusAreas.reduce((sum, a) => sum + (a.findings?.length ?? 0), 0) ?? 0;
+		const reviewMarkdown = this.result ? formatReviewAsMarkdown(this.result, this.formatOptions()) : '';
 
 		return html`<div class="review-header">
 			<gl-button
@@ -242,7 +271,78 @@ export class GlDetailsReviewModePanel extends LitElement {
 					${pluralize('file', includedCount)}
 				</span>
 			</span>
+			<span class="review-header__actions">
+				<gl-copy-container
+					appearance="toolbar"
+					.content=${reviewMarkdown}
+					copyLabel="Copy Review Findings"
+					copiedLabel="Copied!"
+					placement="bottom"
+					timeout=${2500}
+					@click=${() => this.dispatchCopied('review')}
+				>
+					<code-icon icon="copy"></code-icon>
+				</gl-copy-container>
+				<gl-button
+					appearance="toolbar"
+					density="compact"
+					tooltip="Send Review to AI Agent"
+					@click=${() => this.handleSendToChat('review')}
+				>
+					<code-icon icon="comment-discussion"></code-icon>
+				</gl-button>
+			</span>
 		</div>`;
+	}
+
+	private formatOptions(): { scopeLabel: string; dismissed: ReadonlySet<string> } {
+		return { scopeLabel: this.scopeContextLabel(), dismissed: this._dismissedFindings };
+	}
+
+	private buildReviewMarkdown(
+		granularity: 'review' | 'focusArea' | 'finding',
+		opts: { area?: AIReviewFocusArea; finding?: AIReviewFinding },
+	): string {
+		if (granularity === 'review') {
+			return this.result ? formatReviewAsMarkdown(this.result, this.formatOptions()) : '';
+		}
+		if (granularity === 'focusArea' && opts.area) {
+			return formatFocusAreaAsMarkdown(opts.area, this._dismissedFindings);
+		}
+		if (granularity === 'finding' && opts.finding) {
+			const enclosing = opts.area ? { label: opts.area.label, rationale: opts.area.rationale } : undefined;
+			return formatFindingAsMarkdown(opts.finding, enclosing);
+		}
+		return '';
+	}
+
+	private handleSendToChat(
+		granularity: 'review' | 'focusArea' | 'finding',
+		opts: { area?: AIReviewFocusArea; finding?: AIReviewFinding } = {},
+	): void {
+		const reviewMarkdown = this.buildReviewMarkdown(granularity, opts);
+		if (!reviewMarkdown) return;
+		this.dispatchEvent(
+			new CustomEvent<ReviewSendToChatDetail>('review-send-to-chat', {
+				detail: {
+					granularity: granularity,
+					scopeLabel: this.scopeContextLabel(),
+					reviewMarkdown: reviewMarkdown,
+				},
+				bubbles: true,
+				composed: true,
+			}),
+		);
+	}
+
+	private dispatchCopied(granularity: 'review' | 'focusArea' | 'finding'): void {
+		this.dispatchEvent(
+			new CustomEvent<ReviewCopiedDetail>('review-copied', {
+				detail: { granularity: granularity },
+				bubbles: true,
+				composed: true,
+			}),
+		);
 	}
 
 	private renderReadyMetadataBar() {
@@ -307,6 +407,46 @@ export class GlDetailsReviewModePanel extends LitElement {
 			parts.push(pluralize('commit', shaCount));
 		}
 		return parts.length ? parts.join(' + ') : 'changes';
+	}
+
+	/**
+	 * Richer scope label intended for clipboard markdown and AI agent prompts — gives the agent
+	 * the actual identifiers (worktree name, branch, SHAs) so it can locate the changes the
+	 * findings refer to. {@link scopeSummary} is intentionally terse for the visible header.
+	 */
+	private scopeContextLabel(): string {
+		const scope = this.scope;
+		const worktreeSuffix = this.repoName
+			? this.isLinkedWorktree
+				? ` in the \`${this.repoName}\` worktree`
+				: ` in the \`${this.repoName}\` repository (main worktree)`
+			: '';
+
+		if (!scope) return `changes${worktreeSuffix}`;
+
+		if (scope.type === 'commit') {
+			return `commit \`${shortenRevision(scope.sha)}\`${worktreeSuffix}`;
+		}
+
+		if (scope.type === 'compare') {
+			const range = `\`${shortenRevision(scope.fromSha)}\` … \`${shortenRevision(scope.toSha)}\``;
+			const count = scope.includeShas?.length;
+			return count
+				? `${pluralize('commit', count)} in comparison ${range}${worktreeSuffix}`
+				: `comparison between ${range}${worktreeSuffix}`;
+		}
+
+		// WIP
+		const parts: string[] = [];
+		if (scope.includeStaged || scope.includeUnstaged) {
+			parts.push(this.branchName ? `WIP changes on \`${this.branchName}\`` : 'WIP changes');
+		}
+		const shaCount = scope.includeShas?.length ?? 0;
+		if (shaCount > 0) {
+			parts.push(pluralize('commit', shaCount));
+		}
+		const wipLabel = parts.length ? parts.join(' + ') : 'changes';
+		return `${wipLabel}${worktreeSuffix}`;
 	}
 
 	private handleBack = () => {
@@ -618,36 +758,39 @@ export class GlDetailsReviewModePanel extends LitElement {
 		const needsAnalyze = isTwoPass && !isAnalyzed && !isLoading && !hasError;
 
 		return html`<div class="review-area ${isExpanded ? 'review-area--expanded' : ''}">
-			<button
-				class="review-area__header"
-				@click=${() => this.handleToggleArea(area.id)}
-				aria-expanded=${isExpanded}
-			>
-				<code-icon
-					icon=${isExpanded ? 'chevron-down' : 'chevron-right'}
-					class="review-area__chevron"
-				></code-icon>
-				<gl-tooltip
-					content=${area.severity === 'critical'
-						? 'Critical Issue'
-						: area.severity === 'warning'
-							? 'Warning (Non-Critical)'
-							: 'Suggestion'}
-					placement="bottom-start"
+			<div class="review-area__header-row">
+				<button
+					class="review-area__header"
+					@click=${() => this.handleToggleArea(area.id)}
+					aria-expanded=${isExpanded}
 				>
-					<span class="review-area__severity review-area__severity--${area.severity}">
-						<code-icon
-							icon=${area.severity === 'critical'
-								? 'error'
-								: area.severity === 'warning'
-									? 'warning'
-									: 'info'}
-						></code-icon>
-					</span>
-				</gl-tooltip>
-				<span class="review-area__label">${area.label}</span>
-				<span class="review-area__file-count">${pluralize('file', area.files.length)}</span>
-			</button>
+					<code-icon
+						icon=${isExpanded ? 'chevron-down' : 'chevron-right'}
+						class="review-area__chevron"
+					></code-icon>
+					<gl-tooltip
+						content=${area.severity === 'critical'
+							? 'Critical Issue'
+							: area.severity === 'warning'
+								? 'Warning (Non-Critical)'
+								: 'Suggestion'}
+						placement="bottom-start"
+					>
+						<span class="review-area__severity review-area__severity--${area.severity}">
+							<code-icon
+								icon=${area.severity === 'critical'
+									? 'error'
+									: area.severity === 'warning'
+										? 'warning'
+										: 'info'}
+							></code-icon>
+						</span>
+					</gl-tooltip>
+					<span class="review-area__label">${area.label}</span>
+					<span class="review-area__file-count">${pluralize('file', area.files.length)}</span>
+				</button>
+				${this.renderFocusAreaActions(area, { isAnalyzed: isAnalyzed })}
+			</div>
 			${isExpanded
 				? html`<div class="review-area__body">
 						<div class="review-area__rationale">${area.rationale}</div>
@@ -685,7 +828,7 @@ export class GlDetailsReviewModePanel extends LitElement {
 								</div>`
 							: nothing}
 						${hasFindings
-							? this.renderFindings(area.findings)
+							? this.renderFindings(area.findings, area)
 							: isAnalyzed && !isLoading && !hasError
 								? html`<div class="review-area__clean">
 										<code-icon icon="pass"></code-icon>
@@ -697,12 +840,43 @@ export class GlDetailsReviewModePanel extends LitElement {
 		</div>`;
 	}
 
-	private renderFindings(findings: readonly AIReviewFinding[]) {
+	private renderFocusAreaActions(area: AIReviewFocusArea, state: { isAnalyzed: boolean }) {
+		const areaMarkdown = state.isAnalyzed ? formatFocusAreaAsMarkdown(area, this._dismissedFindings) : '';
+		const disabled = !state.isAnalyzed;
+		const copyLabel = disabled ? "Run 'Review Files' first" : 'Copy Focus Area Findings';
+		const sendLabel = disabled ? "Run 'Review Files' first" : 'Send Focus Area to AI Agent';
+
+		return html`<span class="review-area__actions" @click=${(e: Event) => e.stopPropagation()}>
+			<gl-copy-container
+				appearance="toolbar"
+				.content=${areaMarkdown}
+				copyLabel=${copyLabel}
+				copiedLabel="Copied!"
+				placement="bottom"
+				timeout=${2500}
+				?disabled=${disabled}
+				@click=${() => !disabled && this.dispatchCopied('focusArea')}
+			>
+				<code-icon icon="copy"></code-icon>
+			</gl-copy-container>
+			<gl-button
+				appearance="toolbar"
+				density="compact"
+				tooltip=${sendLabel}
+				?disabled=${disabled}
+				@click=${() => !disabled && this.handleSendToChat('focusArea', { area: area })}
+			>
+				<code-icon icon="comment-discussion"></code-icon>
+			</gl-button>
+		</span>`;
+	}
+
+	private renderFindings(findings: readonly AIReviewFinding[], area?: AIReviewFocusArea) {
 		const visible = findings.filter(f => !this._dismissedFindings.has(f.id));
 		const dismissedCount = findings.length - visible.length;
 
 		return html`<div class="review-findings">
-			${visible.map(f => this.renderFinding(f))}
+			${visible.map(f => this.renderFinding(f, area))}
 			${dismissedCount > 0
 				? html`<button class="review-findings__dismissed" @click=${this.handleShowDismissed}>
 						${dismissedCount} dismissed finding${dismissedCount > 1 ? 's' : ''}
@@ -711,20 +885,47 @@ export class GlDetailsReviewModePanel extends LitElement {
 		</div>`;
 	}
 
-	private renderFinding(finding: AIReviewFinding) {
+	private renderFinding(finding: AIReviewFinding, area?: AIReviewFocusArea) {
+		const findingMarkdown = formatFindingAsMarkdown(
+			finding,
+			area ? { label: area.label, rationale: area.rationale } : undefined,
+		);
+
 		return html`<div class="review-finding" data-severity=${finding.severity}>
 			<div class="review-finding__header">
 				<span class="review-finding__severity review-finding__severity--${finding.severity}">
 					${finding.severity.toUpperCase()}
 				</span>
 				<span class="review-finding__title">${finding.title}</span>
-				<button
-					class="review-finding__dismiss"
-					title="Dismiss"
-					@click=${() => this.handleDismissFinding(finding.id)}
-				>
-					<code-icon icon="close"></code-icon>
-				</button>
+				<span class="review-finding__actions">
+					<gl-copy-container
+						appearance="toolbar"
+						.content=${findingMarkdown}
+						copyLabel="Copy Finding"
+						copiedLabel="Copied!"
+						placement="bottom"
+						timeout=${2500}
+						@click=${() => this.dispatchCopied('finding')}
+					>
+						<code-icon icon="copy"></code-icon>
+					</gl-copy-container>
+					<gl-button
+						appearance="toolbar"
+						density="compact"
+						tooltip="Send to AI Agent"
+						@click=${() => this.handleSendToChat('finding', { area: area, finding: finding })}
+					>
+						<code-icon icon="comment-discussion"></code-icon>
+					</gl-button>
+					<gl-button
+						appearance="toolbar"
+						density="compact"
+						tooltip="Dismiss"
+						@click=${() => this.handleDismissFinding(finding.id)}
+					>
+						<code-icon icon="close"></code-icon>
+					</gl-button>
+				</span>
 			</div>
 			<div class="review-finding__description">${finding.description}</div>
 			${finding.filePath

--- a/src/webviews/apps/plus/graph/components/gl-graph-details-panel.ts
+++ b/src/webviews/apps/plus/graph/components/gl-graph-details-panel.ts
@@ -25,7 +25,12 @@ import type { DetailsContext, DetailsState } from './detailsState.js';
 import { createDetailsState } from './detailsState.js';
 import type { DetailsSelection } from './detailsWorkflowController.js';
 import { DetailsWorkflowController } from './detailsWorkflowController.js';
-import type { ReviewAnalyzeAreaDetail, ReviewOpenFileDetail } from './gl-details-review-mode-panel.js';
+import type {
+	ReviewAnalyzeAreaDetail,
+	ReviewCopiedDetail,
+	ReviewOpenFileDetail,
+	ReviewSendToChatDetail,
+} from './gl-details-review-mode-panel.js';
 import '../../../commitDetails/components/gl-details-commit-panel.js';
 import '../../../commitDetails/components/gl-details-wip-panel.js';
 import '../../../shared/components/code-icon.js';
@@ -1010,6 +1015,15 @@ export class GlGraphDetailsPanel extends SignalWatcher(LitElement) {
 
 		const scopeItems = this._actions.buildWipScopeItems();
 
+		// Repo/branch identity for the review's scope label — sourced from WIP state which is
+		// always loaded for the active repo regardless of which scope (commit/compare/wip) the
+		// user is reviewing. Provides the agent prompt with concrete identifiers (worktree name,
+		// branch, SHAs) so it knows where the findings come from.
+		const wipForScope = this._state.wip.get();
+		const reviewRepoName = wipForScope?.repo.name;
+		const reviewIsLinkedWorktree = wipForScope?.repo.isWorktree === true;
+		const reviewBranchName = wipForScope?.branch?.name;
+
 		const reviewResource = this._actions.resources.review;
 		const reviewValue = reviewResource.value.get();
 		const reviewResult = reviewValue && 'result' in reviewValue ? reviewValue.result : undefined;
@@ -1037,6 +1051,9 @@ export class GlGraphDetailsPanel extends SignalWatcher(LitElement) {
 			.aiExcludedFiles=${this._state.aiExcludedFiles.get()}
 			.fileLayout=${this._state.preferences.get()?.files?.layout ?? 'auto'}
 			.repoPath=${this.effectiveRepoPath}
+			.repoName=${reviewRepoName}
+			?isLinkedWorktree=${reviewIsLinkedWorktree}
+			.branchName=${reviewBranchName}
 			.aiModel=${this._state.aiModel.get()}
 			?forward-available=${this._state.reviewForwardAvailable.get()}
 			.backPreview=${this._state.reviewBackPreview.get()}
@@ -1072,6 +1089,12 @@ export class GlGraphDetailsPanel extends SignalWatcher(LitElement) {
 			@review-back=${() => this._workflow.review.back()}
 			@review-forward=${() => this._workflow.review.forward()}
 			@review-forward-invalidate=${() => this._workflow.review.invalidateSnapshot()}
+			@review-send-to-chat=${(e: CustomEvent<ReviewSendToChatDetail>) => this.handleReviewSendToChat(e)}
+			@review-copied=${(e: CustomEvent<ReviewCopiedDetail>) =>
+				void this._actions.services.graphInspect.trackReviewAction({
+					action: 'copy',
+					granularity: e.detail.granularity,
+				})}
 			@review-cancel=${this.handleCancelMode}
 			@scope-change=${(e: CustomEvent<{ selectedIds: string[] }>) =>
 				this.handleScopeChange(scopeItems, new Set(e.detail.selectedIds))}
@@ -1185,6 +1208,21 @@ export class GlGraphDetailsPanel extends SignalWatcher(LitElement) {
 		} catch {
 			panel?.setFocusAreaError(focusAreaId);
 		}
+	}
+
+	private async handleReviewSendToChat(e: CustomEvent<ReviewSendToChatDetail>): Promise<void> {
+		const repoPath = this.effectiveRepoPath;
+		if (!repoPath) return;
+
+		const { granularity, scopeLabel, reviewMarkdown } = e.detail;
+		if (!reviewMarkdown) return;
+
+		await this._actions.services.graphInspect.addressReviewFindingsInChat({
+			repoPath: repoPath,
+			scopeLabel: scopeLabel,
+			reviewMarkdown: reviewMarkdown,
+			granularity: granularity,
+		});
 	}
 
 	private handleSelectCommit(sha: string) {

--- a/src/webviews/apps/plus/graph/components/reviewFormat.ts
+++ b/src/webviews/apps/plus/graph/components/reviewFormat.ts
@@ -1,0 +1,111 @@
+import type {
+	AIReviewFinding,
+	AIReviewFocusArea,
+	AIReviewResult,
+	AIReviewSeverity,
+} from '@gitlens/ai/models/results.js';
+
+export interface ReviewFormatOptions {
+	scopeLabel: string;
+	dismissed?: ReadonlySet<string>;
+}
+
+const severityLabel: Record<AIReviewSeverity, string> = {
+	critical: 'CRITICAL',
+	warning: 'WARNING',
+	suggestion: 'SUGGESTION',
+};
+
+function severityPrefix(severity: AIReviewSeverity): string {
+	return `**[${severityLabel[severity]}]**`;
+}
+
+function formatLineRange(range: AIReviewFinding['lineRange']): string {
+	if (range == null) return '';
+	return range.end !== range.start ? `${range.start}-${range.end}` : `${range.start}`;
+}
+
+function formatFindingLines(finding: AIReviewFinding): string[] {
+	const lines: string[] = [];
+	lines.push(`### ${severityPrefix(finding.severity)} ${finding.title}`);
+	lines.push('');
+	lines.push(finding.description);
+	if (finding.filePath) {
+		const range = formatLineRange(finding.lineRange);
+		lines.push('');
+		lines.push(`File: \`${finding.filePath}${range ? `:${range}` : ''}\``);
+	}
+	return lines;
+}
+
+export function formatFindingAsMarkdown(
+	finding: AIReviewFinding,
+	enclosingArea?: Pick<AIReviewFocusArea, 'label' | 'rationale'>,
+): string {
+	const lines: string[] = [];
+	if (enclosingArea) {
+		lines.push(`## ${enclosingArea.label}`);
+		lines.push('');
+		lines.push(enclosingArea.rationale);
+		lines.push('');
+	}
+	lines.push(...formatFindingLines(finding));
+	return lines.join('\n');
+}
+
+export function formatFocusAreaAsMarkdown(area: AIReviewFocusArea, dismissed?: ReadonlySet<string>): string {
+	const lines: string[] = [];
+	lines.push(`## ${severityPrefix(area.severity)} ${area.label}`);
+	lines.push('');
+	lines.push(area.rationale);
+
+	if (area.files.length > 0) {
+		lines.push('');
+		lines.push('Files:');
+		for (const file of area.files) {
+			lines.push(`- \`${file}\``);
+		}
+	}
+
+	if (area.findings == null) {
+		lines.push('');
+		lines.push('_Not yet analyzed — run "Review Files" to generate findings for this focus area._');
+		return lines.join('\n');
+	}
+
+	const visible = dismissed ? area.findings.filter(f => !dismissed.has(f.id)) : [...area.findings];
+	if (visible.length === 0) {
+		lines.push('');
+		lines.push('_No findings._');
+		return lines.join('\n');
+	}
+
+	for (const finding of visible) {
+		lines.push('');
+		lines.push(...formatFindingLines(finding));
+	}
+	return lines.join('\n');
+}
+
+export function formatReviewAsMarkdown(result: AIReviewResult, options: ReviewFormatOptions): string {
+	const lines: string[] = [];
+	lines.push(`# Code Review — ${options.scopeLabel}`);
+
+	if (result.overview) {
+		lines.push('');
+		lines.push(result.overview);
+	}
+
+	if (result.focusAreas.length === 0) {
+		lines.push('');
+		lines.push('_No issues found. The changes look good!_');
+		return lines.join('\n');
+	}
+
+	for (const area of result.focusAreas) {
+		lines.push('');
+		lines.push(formatFocusAreaAsMarkdown(area, options.dismissed));
+	}
+
+	return lines.join('\n');
+}

--- a/src/webviews/commitDetails/commitDetailsWebview.ts
+++ b/src/webviews/commitDetails/commitDetailsWebview.ts
@@ -1068,6 +1068,7 @@ function serializeWipContext(wip?: WipContext): Wip | undefined {
 			uri: wip.repo.uri.toString(),
 			name: wip.repo.name,
 			path: wip.repo.path,
+			isWorktree: wip.repo.isWorktree,
 		},
 	};
 }

--- a/src/webviews/commitDetails/protocol.ts
+++ b/src/webviews/commitDetails/protocol.ts
@@ -86,6 +86,8 @@ export interface Wip {
 		uri: string;
 		name: string;
 		path: string;
+		/** True when this repo is a linked worktree (`git worktree`), false for the primary/main worktree. */
+		isWorktree: boolean;
 	};
 }
 

--- a/src/webviews/plus/graph/graphService.ts
+++ b/src/webviews/plus/graph/graphService.ts
@@ -36,6 +36,18 @@ export type ReviewResult = { result: AIReviewResult } | { error: { message: stri
 
 export type ReviewDetailResult = { result: AIReviewDetailResult } | { error: { message: string } };
 
+export type AddressReviewFindingsResult =
+	| { ok: true }
+	| { ok: false; reason: 'no-chat-host' | 'no-ai-model' | 'error'; message?: string };
+
+export interface AddressReviewFindingsArgs {
+	repoPath: string;
+	scopeLabel: string;
+	reviewMarkdown: string;
+	granularity: 'review' | 'focusArea' | 'finding';
+	instructions?: string;
+}
+
 export type ProposedCommitFile = GitFileChangeShape & {
 	/** Topmost layer this file's hunks come from in the AI-grouped commit. */
 	anchor: 'unstaged' | 'staged' | 'committed';
@@ -218,6 +230,19 @@ export interface GraphInspectService {
 		excludedFiles?: string[],
 		signal?: AbortSignal,
 	): Promise<ReviewDetailResult>;
+	/**
+	 * Sends the review findings (entire review, a focus area, or a single finding) to the user's
+	 * AI agent chat. The webview pre-renders the markdown so Copy and Send-to-agent produce
+	 * byte-identical content. Returns an `ok: false` result when no chat host is available, no
+	 * AI model is selected, or the dispatch fails — the webview surfaces these inline.
+	 */
+	addressReviewFindingsInChat(args: AddressReviewFindingsArgs): Promise<AddressReviewFindingsResult>;
+	/**
+	 * Fire-and-forget telemetry hop for review-panel actions that happen entirely in the webview
+	 * (clipboard copies). Granularity distinguishes review-wide vs per-focus-area vs per-finding
+	 * actions so dashboards can compare which scopes users actually copy.
+	 */
+	trackReviewAction(args: { action: 'copy'; granularity: 'review' | 'focusArea' | 'finding' }): Promise<void>;
 	generateCommitMessage(repoPath: string): Promise<{ summary: string; body?: string } | undefined>;
 	composeChanges(
 		repoPath: string,

--- a/src/webviews/plus/graph/graphWebview.ts
+++ b/src/webviews/plus/graph/graphWebview.ts
@@ -79,6 +79,7 @@ import type { ExplainWipCommandArgs } from '../../../commands/explainWip.js';
 import type { GenerateChangelogCommandArgs } from '../../../commands/generateChangelog.js';
 import { generateChangelogAndOpenMarkdownDocument } from '../../../commands/generateChangelog.js';
 import type { GenerateCommitMessageCommandArgs } from '../../../commands/generateCommitMessage.js';
+import type { OpenChatActionCommandArgs } from '../../../commands/openChatAction.js';
 import type { OpenIssueOnRemoteCommandArgs } from '../../../commands/openIssueOnRemote.js';
 import type { OpenOnRemoteCommandArgs } from '../../../commands/openOnRemote.js';
 import type { OpenPullRequestOnRemoteCommandArgs } from '../../../commands/openPullRequestOnRemote.js';
@@ -173,6 +174,7 @@ import {
 	formatChangesContextForPrompt,
 	gatherContextForChanges,
 } from '../../../plus/ai/utils/-webview/changesContext.js';
+import { supportsChat } from '../../../plus/chat/utils/-webview/chat.utils.js';
 import { showPatchesView } from '../../../plus/drafts/actions.js';
 import type { FeaturePreviewChangeEvent, SubscriptionChangeEvent } from '../../../plus/gk/subscriptionService.js';
 import { isHooksBannerEnabled, isMcpBannerEnabled } from '../../../plus/gk/utils/-webview/mcp.utils.js';
@@ -1009,6 +1011,7 @@ export class GraphWebviewProvider implements WebviewProvider<State, State, Graph
 							uri: repo.uri.toString(),
 							name: repo.name,
 							path: repo.path,
+							isWorktree: repo.isWorktree,
 						},
 					};
 				},
@@ -1315,6 +1318,57 @@ export class GraphWebviewProvider implements WebviewProvider<State, State, Graph
 						return { result: response.result };
 					} catch (ex) {
 						return { error: { message: ex instanceof Error ? ex.message : String(ex) } };
+					}
+				},
+				trackReviewAction: args => {
+					if (args.action === 'copy') {
+						void this.container.usage.track('action:gitlens.ai.review.copied:happened');
+						const label =
+							args.granularity === 'review'
+								? 'Review findings copied to clipboard'
+								: args.granularity === 'focusArea'
+									? 'Focus area findings copied to clipboard'
+									: 'Finding copied to clipboard';
+						window.setStatusBarMessage(`$(check) ${label}`, 3000);
+					}
+					return Promise.resolve();
+				},
+				addressReviewFindingsInChat: async args => {
+					try {
+						if (!(await supportsChat())) {
+							void window.showWarningMessage(
+								'No supported AI chat is available in this editor. The review has been copied to your clipboard so you can paste it elsewhere.',
+							);
+							await env.clipboard.writeText(args.reviewMarkdown);
+							return { ok: false, reason: 'no-chat-host' };
+						}
+
+						// `{ silent: true }` avoids prompting from the RPC. The webview gates the
+						// "Send to agent" button on `aiModel != null`, so this is a defensive check
+						// for the race where the model was cleared between the gate and the call.
+						const aiModel = await this.container.ai.getModel({ silent: true });
+						if (aiModel == null) {
+							void window.showWarningMessage(
+								'An AI model must be selected before sending review findings to chat.',
+							);
+							return { ok: false, reason: 'no-ai-model' };
+						}
+
+						await executeCommand('gitlens.openChatAction', {
+							chatAction: {
+								type: 'addressReviewFindings',
+								scopeLabel: args.scopeLabel,
+								reviewMarkdown: args.reviewMarkdown,
+								granularity: args.granularity,
+								instructions: args.instructions,
+							},
+							source: 'graph',
+						} as OpenChatActionCommandArgs);
+						return { ok: true };
+					} catch (ex) {
+						const message = ex instanceof Error ? ex.message : String(ex);
+						void window.showWarningMessage(`Unable to send review findings to chat: ${message}`);
+						return { ok: false, reason: 'error', message: message };
 					}
 				},
 				generateCommitMessage: async repoPath => {


### PR DESCRIPTION
Closes #5228

Adds to graph details Review mode output:

Entire review - inline buttons for "Copy Review Findings" and "Send Review to AI Agent"

Focus areas - inline buttons for "Copy Focus Area Findings" and "Send Focus Area to AI Agent"

Findings - inline buttons for "Copy Finding" and "Send Finding to AI Agent"

The first formats and copies the selected scope to clipboard.
The second sends it to an agent in a chat window as a chat action.

Note once @d13 work lands: we may want to update the "send to agent" action to utilize CLI-detected terminal agents in the UX somehow (a picker perhaps, and one option is the current chat flow). Marking this as Draft until we make a decision on that.