### PR TITLE
Require sign-in for commit message generation

### DIFF
--- a/src/features.ts
+++ b/src/features.ts
@@ -55,11 +55,12 @@ export type ProAIFeatures =
 	| 'generate-changelog'
 	| 'generate-create-pullRequest'
 	| 'generate-commits'
+	| 'generate-commitMessage'
 	| 'generate-searchQuery';
 
 export type AdvancedFeatures = never;
 
-export type AIFeatures = 'generate-commitMessage' | ProAIFeatures;
+export type AIFeatures = ProAIFeatures;
 
 export function isProFeature(feature: PlusFeatures): feature is ProFeatures {
 	switch (feature) {
@@ -90,6 +91,7 @@ export function isProFeatureOnAllRepos(feature: PlusFeatures): feature is ProFea
 		case 'generate-changelog':
 		case 'generate-create-pullRequest':
 		case 'generate-commits':
+		case 'generate-commitMessage':
 		case 'generate-searchQuery':
 			return true;
 		default:

--- a/src/plus/ai/aiProviderService.ts
+++ b/src/plus/ai/aiProviderService.ts
@@ -930,8 +930,6 @@ export class AIProviderService implements AIService, Disposable {
 	private async ensureFeatureAccess(feature: AIFeatures, source: Source): Promise<boolean> {
 		if (!(await ensureAccess(this.container, undefined, source))) return false;
 
-		if (feature === 'generate-commitMessage') return true;
-
 		const suffix = isAdvancedFeature(feature)
 			? 'requires GitLens Advanced or a trial'
 			: 'requires GitLens Pro or a trial';


### PR DESCRIPTION
## Summary
- Removes the `generate-commitMessage` bypass in `ensureFeatureAccess`, so commit message generation now goes through the same sign-in/subscription gate as all other AI features
- Adds `generate-commitMessage` to `ProAIFeatures` so it is treated consistently with other gated AI actions

Closes gitkraken/vscode-gitlens-private#86
