### PR TITLE
Fix inverted diff direction in compare mode Show All Diffs

### DIFF
--- a/src/webviews/apps/plus/graph/components/gl-details-compare-mode-panel.ts
+++ b/src/webviews/apps/plus/graph/components/gl-details-compare-mode-panel.ts
@@ -978,8 +978,8 @@ export class GlDetailsCompareModePanel extends LitElement {
 
 		return {
 			repoPath: repoPath,
-			lhs: lhs,
-			rhs: hasWorkingTreeFiles ? '' : rhs,
+			lhs: hasWorkingTreeFiles ? lhs : rhs,
+			rhs: hasWorkingTreeFiles ? '' : lhs,
 			title: hasWorkingTreeFiles
 				? `Working tree changes from ${shortenRevision(lhs)}`
 				: `Changes between ${shortenRevision(lhs)} and ${shortenRevision(rhs)}`,


### PR DESCRIPTION
## Summary
- Fixes the "Show All Diffs" button in compare mode opening diffs in the wrong direction (additions shown as deletions)
- The `getMultiDiffRefs` method was passing `leftRef` as `lhs` and `rightRef` as `rhs`, but the diff editor treats `lhs` as "before" and `rhs` as "after" — swaps them to match individual file diff behavior

Closes #5171
