### PR TITLE
Fixes default-worktree agents missing from Home agents filter

### DIFF
--- a/src/webviews/home/homeWebview.ts
+++ b/src/webviews/home/homeWebview.ts
@@ -759,14 +759,18 @@ export class HomeWebviewProvider implements WebviewProvider<State, State, HomeWe
 
 		// Agent branches: return only branches whose worktree has an active agent session.
 		// Sessions associate with worktrees by full path — the worktree's *current* branch is
-		// the agent's effective branch. Match by `(repoPath, worktreePath)`.
+		// the agent's effective branch. Match by `(repoPath, worktreePath)`, collapsing the
+		// default-worktree representations (`undefined` and `worktreePath === repoPath`) to
+		// `''` on both sides — same convention as `normalizeWorktreeKey` in `agentUtils.ts`.
 		if (type === 'agents') {
 			const sessions = this.container.agentStatus?.sessions ?? [];
 			const repoPath = repo.path;
 			const sessionWorktreePaths = new Set<string>();
 			for (const session of sessions) {
 				if (session.workspacePath === repoPath) {
-					sessionWorktreePaths.add(session.worktreePath ?? '');
+					sessionWorktreePaths.add(
+						session.worktreePath != null && session.worktreePath !== repoPath ? session.worktreePath : '',
+					);
 				}
 			}
 


### PR DESCRIPTION
## Summary

- Pre-release regression: when filtering the Home view by "Agents", branches in the default worktree were dropped from the result even when an agent session was running there. Named-worktree agents were unaffected.
- Root cause: commit eb61f02b ("Fixes default-worktree agent association") changed sessions so `session.worktreePath` is always set (= `repo.path` for default worktrees, was previously `undefined`). The webview-side matchers in `agentUtils.ts` were updated to collapse `worktreePath === repoPath` to `''` via `normalizeWorktreeKey`, but the host-side filter at `src/webviews/home/homeWebview.ts:763-783` (`type === 'agents'`) wasn't updated and still expected the old `''`/`wt.path` convention.
- Fix: mirror the same `normalizeWorktreeKey`-style collapse in the host filter so default-worktree sessions match the branch side's `wt.isDefault ? '' : wt.path`.

Originally suspected as a Windows path-normalization issue (which is where it was reproduced), but the bug is platform-independent — Windows is incidental.

## Test plan

- [x] Open a single-folder workspace (workspace root == repo root, default worktree).
- [x] Start a Claude Code agent in the workspace root.
- [x] Open Home view, set the agents filter to show only branches with agents.
- [x] Verify the current branch's card appears with an agent pill (regression case).
- [x] Add a named worktree and start an agent there; verify it still appears under the agents filter (no regression on named worktrees).
- [x] Switch the agent's cwd back and forth and confirm the filter still resolves correctly.