### PR TITLE
Fixes extra WIP rows in graph scope mode

### DIFF
--- a/src/webviews/apps/plus/graph/__tests__/stateProvider.test.ts
+++ b/src/webviews/apps/plus/graph/__tests__/stateProvider.test.ts
@@ -3,6 +3,7 @@ import type { GraphWipMetadataBySha } from '../../../../plus/graph/protocol.js';
 import type { GetOverviewEnrichmentResponse } from '../../../../shared/overviewBranches.js';
 import type { AppState } from '../context.js';
 import { mergeWipMetadata, reconcileScopeMergeTarget } from '../stateProvider.js';
+import { filterSecondariesForScope } from '../utils/wip.utils.js';
 
 suite('mergeWipMetadata', () => {
 	test('returns undefined when incoming is undefined', () => {
@@ -87,10 +88,29 @@ suite('mergeWipMetadata', () => {
 		assert.deepStrictEqual(merged?.workDirStats, { added: 7, deleted: 3, modified: 1 });
 		assert.strictEqual(merged?.workDirStatsStale, false);
 	});
+
+	test('produces a new object when branchRef changes (branch rename without sha change)', () => {
+		const prev: GraphWipMetadataBySha = { 'worktree-wip::/a': entry('a', 'sha1', '/repo|heads/old') };
+		const incoming: GraphWipMetadataBySha = { 'worktree-wip::/a': entry('a', 'sha1', '/repo|heads/new') };
+
+		const result = mergeWipMetadata(prev, incoming);
+
+		assert.notStrictEqual(result, prev);
+		assert.strictEqual(result?.['worktree-wip::/a']?.branchRef, '/repo|heads/new');
+	});
+
+	test('preserves prev reference when branchRef matches (and other anchors match)', () => {
+		const prev: GraphWipMetadataBySha = { 'worktree-wip::/a': entry('a', 'sha1', '/repo|heads/feature') };
+		const incoming: GraphWipMetadataBySha = { 'worktree-wip::/a': entry('a', 'sha1', '/repo|heads/feature') };
+
+		const result = mergeWipMetadata(prev, incoming);
+
+		assert.strictEqual(result, prev);
+	});
 });
 
-function entry(label: string, parentSha: string) {
-	return { repoPath: `/repos/${label}`, parentSha: parentSha, label: label };
+function entry(label: string, parentSha: string, branchRef?: string) {
+	return { repoPath: `/repos/${label}`, parentSha: parentSha, label: label, branchRef: branchRef };
 }
 
 suite('reconcileScopeMergeTarget', () => {
@@ -159,3 +179,98 @@ function makeEnrichment(branchRef: string, sha: string): GetOverviewEnrichmentRe
 		},
 	};
 }
+
+suite('filterSecondariesForScope', () => {
+	const branchRef = '/repo|heads/feature';
+	const upstreamRef = '/repo|remotes/origin/feature';
+	const otherRef = '/repo|heads/other';
+
+	test('returns input unchanged when scope is undefined', () => {
+		const meta: GraphWipMetadataBySha = { 'worktree-wip::/a': entry('a', 'sha1', branchRef) };
+		const result = filterSecondariesForScope(meta, undefined);
+		assert.strictEqual(result, meta);
+	});
+
+	test('returns input unchanged when metadata is undefined', () => {
+		const result = filterSecondariesForScope(undefined, { branchRef: branchRef, branchName: 'feature' });
+		assert.strictEqual(result, undefined);
+	});
+
+	test('keeps entries whose branchRef matches scope.branchRef', () => {
+		const meta: GraphWipMetadataBySha = { 'worktree-wip::/a': entry('a', 'sha1', branchRef) };
+		const result = filterSecondariesForScope(meta, { branchRef: branchRef, branchName: 'feature' });
+		assert.strictEqual(result, meta, 'no entries dropped → same reference');
+	});
+
+	test('drops worktrees on sibling local branches even when the scope has an upstream', () => {
+		// Production worktree branchRefs are always `heads/*` (git only attaches worktrees to local
+		// branches), so a worktree on a different local branch that tracks the same upstream as the
+		// scope is treated as a sibling, not part of the scope. The `remotes/*` `upstreamRef` is
+		// deliberately not part of the match set — see `filterSecondariesForScope`.
+		const meta: GraphWipMetadataBySha = {
+			'worktree-wip::/scoped': entry('scoped', 'sha1', branchRef),
+			'worktree-wip::/sibling': entry('sibling', 'sha2', '/repo|heads/feature-mirror'),
+		};
+		const result = filterSecondariesForScope(meta, {
+			branchRef: branchRef,
+			branchName: 'feature',
+			upstreamRef: upstreamRef,
+		});
+		assert.ok(result?.['worktree-wip::/scoped']);
+		assert.strictEqual(result?.['worktree-wip::/sibling'], undefined);
+	});
+
+	test('drops entries whose branchRef is unrelated to the scope', () => {
+		const meta: GraphWipMetadataBySha = {
+			'worktree-wip::/a': entry('a', 'sha1', branchRef),
+			'worktree-wip::/b': entry('b', 'sha2', otherRef),
+		};
+		const result = filterSecondariesForScope(meta, { branchRef: branchRef, branchName: 'feature' });
+		assert.notStrictEqual(result, meta);
+		assert.ok(result?.['worktree-wip::/a']);
+		assert.strictEqual(result?.['worktree-wip::/b'], undefined);
+	});
+
+	test('drops sha-colliding worktree on unrelated branch (the reproduction case)', () => {
+		// Both worktrees have parentSha === scope.branchRef tip sha, but only one is actually on
+		// the scoped branch — the other coincidentally shares a HEAD sha. Without branchRef-aware
+		// filtering, the graph component's SHA filter would let both through.
+		const meta: GraphWipMetadataBySha = {
+			'worktree-wip::/scoped': entry('scoped', 'sha-tip', branchRef),
+			'worktree-wip::/coincident': entry('coincident', 'sha-tip', otherRef),
+		};
+		const result = filterSecondariesForScope(meta, { branchRef: branchRef, branchName: 'feature' });
+		assert.ok(result?.['worktree-wip::/scoped']);
+		assert.strictEqual(result?.['worktree-wip::/coincident'], undefined);
+	});
+
+	test('keeps detached worktrees (branchRef undefined) — defers to SHA filter', () => {
+		const meta: GraphWipMetadataBySha = { 'worktree-wip::/detached': entry('detached', 'sha1') };
+		const result = filterSecondariesForScope(meta, { branchRef: branchRef, branchName: 'feature' });
+		assert.strictEqual(result, meta, 'detached entry passes through unchanged');
+	});
+
+	test('does not match entries with undefined branchRef when scope upstream is missing', () => {
+		// Regression guard: building the scope-ref set must not insert `undefined`. If it did,
+		// detached entries would match the bogus undefined slot. They should pass via the
+		// branchRef == null fall-through instead.
+		const meta: GraphWipMetadataBySha = {
+			'worktree-wip::/detached': entry('detached', 'sha1'),
+			'worktree-wip::/unrelated': entry('unrelated', 'sha2', otherRef),
+		};
+		const result = filterSecondariesForScope(meta, { branchRef: branchRef, branchName: 'feature' });
+		assert.ok(result?.['worktree-wip::/detached'], 'detached kept');
+		assert.strictEqual(result?.['worktree-wip::/unrelated'], undefined, 'unrelated dropped');
+	});
+
+	test('honors scope.additionalBranchRefs (stacked-branches forward-compat)', () => {
+		const stackedRef = '/repo|heads/stacked';
+		const meta: GraphWipMetadataBySha = { 'worktree-wip::/stacked': entry('stacked', 'sha1', stackedRef) };
+		const result = filterSecondariesForScope(meta, {
+			branchRef: branchRef,
+			branchName: 'feature',
+			additionalBranchRefs: [stackedRef],
+		});
+		assert.strictEqual(result, meta);
+	});
+});

--- a/src/webviews/apps/plus/graph/graph-wrapper/graph-wrapper.ts
+++ b/src/webviews/apps/plus/graph/graph-wrapper/graph-wrapper.ts
@@ -22,6 +22,7 @@ import { areEqual } from '@gitlens/utils/object.js';
 import type { CommitDetails } from '../../../../commitDetails/protocol.js';
 import type {
 	GraphAvatars,
+	GraphScope,
 	GraphSelection,
 	GraphWipMetadataBySha,
 	RowAction,
@@ -47,6 +48,7 @@ import type { Disposable } from '../../../shared/events.js';
 import type { ThemeChangeEvent } from '../../../shared/theme.js';
 import { onDidChangeTheme } from '../../../shared/theme.js';
 import { graphStateContext } from '../context.js';
+import { filterSecondariesForScope } from '../utils/wip.utils.js';
 import type { GlGraph } from './gl-graph.js';
 import type { GraphWrapperTheming } from './gl-graph.react.jsx';
 import './gl-graph.js';
@@ -192,11 +194,15 @@ export class GlGraphWrapper extends SignalWatcher(LitElement) {
 		this.ensureAndSelectCommit(e.detail.sha);
 	};
 
-	// Cache keyed by the triplet (rows, wipMetadataBySha, workingTreeStats) — any reference change invalidates.
+	// Cache keyed by the quad (rows, wipMetadataBySha, workingTreeStats, scope) — any reference
+	// change invalidates. Scope must be in the key because the secondary-WIP scope filter below
+	// (`filterSecondariesForScope`) reads `scope.branchRef`/`upstreamRef`/`additionalBranchRefs`,
+	// so the cached result is stale when scope changes even if the row/metadata refs don't.
 	private _decoratedRowsCache?: {
 		rows: GraphRow[] | undefined;
 		wipMetadataBySha: GraphWipMetadataBySha | undefined;
 		workingTreeStats: typeof graphStateContext.__context__.workingTreeStats;
+		scope: GraphScope | undefined;
 		result: GraphRow[] | undefined;
 	};
 
@@ -208,19 +214,23 @@ export class GlGraphWrapper extends SignalWatcher(LitElement) {
 		const rows = graphState.rows;
 		const wipMetadataBySha = graphState.wipMetadataBySha;
 		const workingTreeStats = graphState.workingTreeStats;
+		const scope = graphState.scope;
 
 		const cached = this._decoratedRowsCache;
 		if (
 			cached != null &&
 			cached.rows === rows &&
 			cached.wipMetadataBySha === wipMetadataBySha &&
-			cached.workingTreeStats === workingTreeStats
+			cached.workingTreeStats === workingTreeStats &&
+			cached.scope === scope
 		) {
 			return cached.result;
 		}
 
+		const filteredMetadata = filterSecondariesForScope(wipMetadataBySha, scope);
+
 		let result: GraphRow[] | undefined;
-		if (rows == null || wipMetadataBySha == null || Object.keys(wipMetadataBySha).length === 0) {
+		if (rows == null || filteredMetadata == null || Object.keys(filteredMetadata).length === 0) {
 			// Let the GK component handle the primary WIP auto-inject from workingTreeStats.
 			result = rows?.slice();
 		} else {
@@ -255,7 +265,7 @@ export class GlGraphWrapper extends SignalWatcher(LitElement) {
 			}
 
 			const secondariesByParentIdx = new Map<number, GraphRow[]>();
-			for (const [sha, meta] of Object.entries(wipMetadataBySha)) {
+			for (const [sha, meta] of Object.entries(filteredMetadata)) {
 				const idx = realRowIndexBySha.get(meta.parentSha);
 				if (idx == null) continue;
 
@@ -295,6 +305,7 @@ export class GlGraphWrapper extends SignalWatcher(LitElement) {
 			rows: rows,
 			wipMetadataBySha: wipMetadataBySha,
 			workingTreeStats: workingTreeStats,
+			scope: scope,
 			result: result,
 		};
 		return result;

--- a/src/webviews/apps/plus/graph/stateProvider.ts
+++ b/src/webviews/apps/plus/graph/stateProvider.ts
@@ -986,7 +986,8 @@ export function mergeWipMetadata(
 		if (
 			entry.repoPath !== prevEntry?.repoPath ||
 			entry.parentSha !== prevEntry?.parentSha ||
-			entry.label !== prevEntry?.label
+			entry.label !== prevEntry?.label ||
+			entry.branchRef !== prevEntry?.branchRef
 		) {
 			changed = true;
 		}

--- a/src/webviews/apps/plus/graph/utils/wip.utils.ts
+++ b/src/webviews/apps/plus/graph/utils/wip.utils.ts
@@ -1,0 +1,44 @@
+import type { GraphScope, GraphWipMetadataBySha } from '../../../../plus/graph/protocol.js';
+
+/**
+ * Filters secondary worktree WIP metadata for the active scope: drops any entry whose worktree
+ * branch isn't one of the scoped local refs (branchRef / additionalBranchRefs).
+ *
+ * `scope.upstreamRef` is deliberately not part of the match set — see the inline comment.
+ *
+ * Entries with `branchRef` undefined (detached worktrees) pass through — they have no branch
+ * identity to compare against, so the graph component's SHA-based scope filter handles them.
+ * That preserves prior behavior for detached worktrees that happen to be at scope anchor SHAs.
+ *
+ * When no scope is active, this is identity (returns the same reference).
+ */
+export function filterSecondariesForScope(
+	wipMetadataBySha: GraphWipMetadataBySha | undefined,
+	scope: GraphScope | undefined,
+): GraphWipMetadataBySha | undefined {
+	if (wipMetadataBySha == null || scope == null) return wipMetadataBySha;
+
+	// Build the scope ref set once. `scope.upstreamRef` is intentionally excluded — it's a
+	// `remotes/*` id, while non-detached worktrees always have a `heads/*` branchRef (git only
+	// attaches worktrees to local branches), so the two can never collide. Detached worktrees
+	// pass via the `meta.branchRef == null` fall-through below and defer to the graph
+	// component's SHA filter.
+	const scopeRefs = new Set<string>();
+	scopeRefs.add(scope.branchRef);
+	if (scope.additionalBranchRefs != null) {
+		for (const ref of scope.additionalBranchRefs) {
+			scopeRefs.add(ref);
+		}
+	}
+
+	const result: GraphWipMetadataBySha = {};
+	let dropped = false;
+	for (const [sha, meta] of Object.entries(wipMetadataBySha)) {
+		if (meta.branchRef != null && !scopeRefs.has(meta.branchRef)) {
+			dropped = true;
+			continue;
+		}
+		result[sha] = meta;
+	}
+	return dropped ? result : wipMetadataBySha;
+}

--- a/src/webviews/plus/graph/graphWebview.ts
+++ b/src/webviews/plus/graph/graphWebview.ts
@@ -5544,10 +5544,16 @@ export class GraphWebviewProvider implements WebviewProvider<State, State, Graph
 			if (wt.type === 'bare' || wt.sha == null) continue;
 			if (wt.path === this.repository.path) continue;
 
+			// Use the MAIN repo's path for branchRef so it matches the format scope uses (see
+			// `setScope` in graph-app.ts) — `GitWorktree.repoPath` is the main repo's path anyway.
+			// Detached worktrees have no `wt.branch`; leaving `branchRef` undefined defers them
+			// to the graph component's SHA filter.
+			const branchName = wt.branch?.name;
 			result[makeSecondaryWipSha(wt.path)] = {
 				repoPath: wt.path,
 				parentSha: wt.sha,
 				label: wt.name,
+				branchRef: branchName != null ? getBranchId(this.repository.path, false, branchName) : undefined,
 			};
 		}
 

--- a/src/webviews/plus/graph/protocol.ts
+++ b/src/webviews/plus/graph/protocol.ts
@@ -264,6 +264,12 @@ export interface GraphWipNodeMetadata {
 	parentSha: string;
 	/** Host-only: user-visible suffix for the row message (e.g. worktree name). */
 	label: string;
+	/**
+	 * Host-only: the worktree branch in scope ref-id format (`{repoPath}|heads/{name}`), or undefined
+	 * for detached worktrees. Used by the webview's scope filter to drop secondary WIPs whose branch
+	 * isn't part of the active scope — independent of SHA collisions with scope anchors.
+	 */
+	branchRef?: string;
 }
 
 export type GraphWipMetadataBySha = Record<string, GraphWipNodeMetadata>;


### PR DESCRIPTION
## Summary

- Worktree WIP rows leaked into focused-branch scope when a worktree's HEAD coincidentally equalled a scope anchor SHA (branch/upstream/additional tip) — common after a merge/push leaves sibling branches sharing a tip
- Pre-filter `wipMetadataBySha` host-side by branch ref so only worktrees on the scoped local branches contribute WIP rows; detached worktrees still defer to the graph component's SHA filter
- Scope is now part of the decorated-rows memoization key so re-scopes correctly invalidate

Closes #5177

## Test plan

- [ ] In a repo with multiple worktrees where at least two share a HEAD SHA (e.g., one branch's tip equals another's after a push), focus the Commit Graph on one of those branches and confirm only one WIP row renders
- [x] Unfocus the scope and confirm every worktree's WIP row renders as before
- [x] Focus a branch and confirm a detached worktree parked at an unrelated SHA does not render a WIP