### PR TITLE
Add Graph walkthrough as separate state in Welcome view

### DIFF
--- a/docs/telemetry-events.md
+++ b/docs/telemetry-events.md
@@ -4923,7 +4923,7 @@ or
 
 ```typescript
 {
-  'context.key': 'homeView' | 'gettingStarted' | 'visualizeCodeHistory' | 'gitBlame' | 'prReviews' | 'mcpFeatures' | 'aiFeatures'
+  'context.key': 'homeView' | 'gettingStarted' | 'visualizeCodeHistory' | 'gitBlame' | 'prReviews' | 'mcpFeatures' | 'aiFeatures' | 'graphAgentMonitoring' | 'graphParallelWork' | 'graphAiReview' | 'graphCompose' | 'graphCompare' | 'graphNextSteps'
 }
 ```
 

--- a/src/commands/showView.ts
+++ b/src/commands/showView.ts
@@ -3,6 +3,7 @@ import type { Container } from '../container.js';
 import { command, executeCoreCommand } from '../system/-webview/command.js';
 import type { HomeWebviewShowingArgs } from '../webviews/home/registration.js';
 import type { GraphWebviewShowingArgs } from '../webviews/plus/graph/registration.js';
+import type { WelcomeWebviewShowingArgs } from '../webviews/welcome/registration.js';
 import { GlCommandBase } from './commandBase.js';
 import type { CommandContext } from './commandContext.js';
 
@@ -114,7 +115,7 @@ export class ShowViewCommand extends GlCommandBase {
 				await this.waitForRepo();
 				return this.container.views.timeline.show();
 			case 'gitlens.showWelcomeView':
-				return this.container.views.welcome.show();
+				return this.container.views.welcome.show(undefined, ...(args as WelcomeWebviewShowingArgs));
 			case 'gitlens.showWorktreesView':
 				await this.waitForRepo();
 				return this.container.views.showView('worktrees');

--- a/src/constants.context.ts
+++ b/src/constants.context.ts
@@ -8,7 +8,7 @@ import type {
 	WebviewPanelTypes,
 	WebviewViewTypes,
 } from './constants.views.js';
-import type { WalkthroughContextKeys } from './constants.walkthroughs.js';
+import type { GraphWalkthroughContextKeys, WalkthroughContextKeys } from './constants.walkthroughs.js';
 import type { Features } from './features.js';
 import type { OrgAIProviders } from './plus/gk/models/organization.js';
 import type { PromoKeys } from './plus/gk/models/promo.js';
@@ -94,4 +94,5 @@ export type ContextKeys = {
 	Record<`gitlens:views:scm:grouped:views:${GroupableTreeViewTypes}`, boolean> &
 	Record<`gitlens:webview:${CustomEditorTypes | WebviewPanelTypes}:visible`, boolean> &
 	Record<`gitlens:webviewView:${WebviewViewTypes}:visible`, boolean> &
+	Record<`gitlens:walkthroughState:${GraphWalkthroughContextKeys}`, boolean> &
 	Record<`gitlens:walkthroughState:${WalkthroughContextKeys}`, boolean>;

--- a/src/constants.onboarding.ts
+++ b/src/constants.onboarding.ts
@@ -24,6 +24,12 @@ export const onboardingDefinitions = {
 		state: undefined as unknown as { stepReached: number },
 	},
 
+	// Graph Walkthrough Banner
+	'graph-walkthrough:banner': {
+		schema: '18.0.0',
+		scope: 'global',
+	},
+
 	// Views
 	'views:scmGrouped:welcome': { schema: '17.8.0', scope: 'global' },
 } as const satisfies Record<string, OnboardingItemDefinition<unknown>>;

--- a/src/constants.telemetry.ts
+++ b/src/constants.telemetry.ts
@@ -14,7 +14,7 @@ import type {
 	WebviewTypes,
 	WebviewViewTypes,
 } from './constants.views.js';
-import type { WalkthroughContextKeys } from './constants.walkthroughs.js';
+import type { GraphWalkthroughContextKeys, WalkthroughContextKeys } from './constants.walkthroughs.js';
 import type { FeaturePreviews, FeaturePreviewStatus } from './features.js';
 import type { AgentDescriptor, AgentRoute } from './plus/agents/agentDescriptor.js';
 import type { Subscription, SubscriptionAccount, SubscriptionStateString } from './plus/gk/models/subscription.js';
@@ -1776,7 +1776,7 @@ type WalkthroughActionEvent =
 	| { type: 'url'; name: WalkthroughActionNames; url: string; detail?: string };
 
 interface WalkthroughCompletionEvent {
-	'context.key': WalkthroughContextKeys;
+	'context.key': WalkthroughContextKeys | GraphWalkthroughContextKeys;
 }
 
 type WelcomeActionNames =
@@ -1917,6 +1917,12 @@ export type TrackedGlActions =
 	| 'gitlens.ai.openInAgent.useDefaultsFallback'
 	| 'gitlens.ai.review.copied'
 	| 'gitlens.ai.review.sentToChat'
+	| 'gitlens.graph.details.compareMode'
+	| 'gitlens.graph.details.composeMode'
+	| 'gitlens.graph.details.reviewMode'
+	| 'gitlens.graph.details.wipShown'
+	| 'gitlens.graph.overview.shown'
+	| 'gitlens.graph.scope.changed'
 	| 'gitlens.mcp.ipcRequest'
 	| 'gitlens.mcp.bundledMcpDefinitionProvided';
 

--- a/src/constants.walkthroughs.ts
+++ b/src/constants.walkthroughs.ts
@@ -16,3 +16,11 @@ export const walkthroughProgressSteps: Record<WalkthroughContextKeys, string> = 
 	prReviews: 'Launchpad',
 	mcpFeatures: 'MCP Features',
 };
+
+export type GraphWalkthroughContextKeys =
+	| 'graphAgentMonitoring'
+	| 'graphParallelWork'
+	| 'graphAiReview'
+	| 'graphCompose'
+	| 'graphCompare'
+	| 'graphNextSteps';

--- a/src/onboarding/walkthroughStateProvider.ts
+++ b/src/onboarding/walkthroughStateProvider.ts
@@ -3,7 +3,7 @@ import { Disposable, env, EventEmitter } from 'vscode';
 import { wait } from '@gitlens/utils/promise.js';
 import { SubscriptionState } from '../constants.subscription.js';
 import type { TrackedUsageKeys } from '../constants.telemetry.js';
-import type { WalkthroughContextKeys } from '../constants.walkthroughs.js';
+import type { GraphWalkthroughContextKeys, WalkthroughContextKeys } from '../constants.walkthroughs.js';
 import type { Container } from '../container.js';
 import type { SubscriptionChangeEvent } from '../plus/gk/subscriptionService.js';
 import { setContext } from '../system/-webview/context.js';
@@ -119,6 +119,48 @@ const walkthroughRequiredMapping: Readonly<Map<WalkthroughContextKeys, Walkthrou
 	],
 ]);
 
+const graphWalkthroughRequiredMapping: Readonly<Map<GraphWalkthroughContextKeys, WalkthroughUsage>> = new Map<
+	GraphWalkthroughContextKeys,
+	WalkthroughUsage
+>([
+	[
+		'graphAgentMonitoring',
+		{
+			usage: ['action:gitlens.graph.overview.shown:happened'],
+		},
+	],
+	[
+		'graphParallelWork',
+		{
+			usage: ['action:gitlens.graph.scope.changed:happened'],
+		},
+	],
+	[
+		'graphAiReview',
+		{
+			usage: ['action:gitlens.graph.details.reviewMode:happened'],
+		},
+	],
+	[
+		'graphCompose',
+		{
+			usage: ['action:gitlens.graph.details.composeMode:happened'],
+		},
+	],
+	[
+		'graphCompare',
+		{
+			usage: ['action:gitlens.graph.details.compareMode:happened'],
+		},
+	],
+	[
+		'graphNextSteps',
+		{
+			usage: ['action:gitlens.graph.details.wipShown:happened'],
+		},
+	],
+]);
+
 export class WalkthroughStateProvider implements Disposable {
 	private readonly _onDidChangeProgress = new EventEmitter<void>();
 	get onDidChangeProgress(): Event<void> {
@@ -126,9 +168,11 @@ export class WalkthroughStateProvider implements Disposable {
 	}
 
 	readonly walkthroughSize = walkthroughRequiredMapping.size;
+	readonly graphWalkthroughSize = graphWalkthroughRequiredMapping.size;
 
 	protected disposables: Disposable[] = [];
 	private readonly completed = new Set<WalkthroughContextKeys>();
+	private readonly graphCompleted = new Set<GraphWalkthroughContextKeys>();
 	private subscriptionState: SubscriptionState | undefined;
 
 	readonly isWalkthroughSupported = isWalkthroughSupported();
@@ -155,6 +199,13 @@ export class WalkthroughStateProvider implements Disposable {
 				void this.completeStep(key);
 			}
 		}
+
+		for (const key of graphWalkthroughRequiredMapping.keys()) {
+			if (this.validateGraphStep(key)) {
+				void this.completeGraphStep(key);
+			}
+		}
+
 		this._onDidChangeProgress.fire(undefined);
 	}
 
@@ -180,6 +231,22 @@ export class WalkthroughStateProvider implements Disposable {
 				shouldFire = true;
 			}
 		}
+
+		const graphStepsToValidate = this.getGraphStepsFromUsage(usageTrackingKey);
+		for (const step of graphStepsToValidate) {
+			if (this.graphCompleted.has(step)) {
+				continue;
+			}
+
+			if (this.validateGraphStep(step)) {
+				void this.completeGraphStep(step);
+				this.container.telemetry.sendEvent('walkthrough/completion', {
+					'context.key': step,
+				});
+				shouldFire = true;
+			}
+		}
+
 		if (shouldFire) {
 			this._onDidChangeProgress.fire(undefined);
 		}
@@ -255,6 +322,22 @@ export class WalkthroughStateProvider implements Disposable {
 		return state;
 	}
 
+	get graphDoneCount(): number {
+		return this.graphCompleted.size;
+	}
+
+	get graphProgress(): number {
+		return this.graphDoneCount / this.graphWalkthroughSize;
+	}
+
+	getGraphState(): Map<GraphWalkthroughContextKeys, boolean> {
+		const state = new Map<GraphWalkthroughContextKeys, boolean>();
+		for (const key of graphWalkthroughRequiredMapping.keys()) {
+			state.set(key, this.graphCompleted.has(key));
+		}
+		return state;
+	}
+
 	dispose(): void {
 		Disposable.from(...this.disposables).dispose();
 	}
@@ -279,6 +362,33 @@ export class WalkthroughStateProvider implements Disposable {
 		}
 
 		return keys;
+	}
+
+	private async completeGraphStep(key: GraphWalkthroughContextKeys) {
+		this.graphCompleted.add(key);
+		await this.waitForWalkthroughInitialized();
+		void setContext(`gitlens:walkthroughState:${key}`, true);
+	}
+
+	private getGraphStepsFromUsage(usageKey: TrackedUsageKeys): GraphWalkthroughContextKeys[] {
+		const keys: GraphWalkthroughContextKeys[] = [];
+		for (const [key, { usage }] of graphWalkthroughRequiredMapping) {
+			if (usage.includes(usageKey)) {
+				keys.push(key);
+			}
+		}
+		return keys;
+	}
+
+	private validateGraphStep(key: GraphWalkthroughContextKeys): boolean {
+		const mapping = graphWalkthroughRequiredMapping.get(key);
+		if (mapping == null) return false;
+
+		const { usage } = mapping;
+		if (usage.length > 0 && !usage.some(event => this.container.usage.isUsed(event))) {
+			return false;
+		}
+		return true;
 	}
 
 	private validateStep(key: WalkthroughContextKeys): boolean {

--- a/src/webviews/apps/plus/graph/components/gl-details-wip-empty-pane.ts
+++ b/src/webviews/apps/plus/graph/components/gl-details-wip-empty-pane.ts
@@ -44,6 +44,8 @@ export class GlDetailsWipEmptyPane extends LitElement {
 	@property({ type: Boolean }) aiCreatePrEnabled = false;
 	@property({ type: Object }) mergeTargetStatus?: BranchMergeTargetStatus;
 
+	private _hadNextSteps = false;
+
 	override render(): unknown {
 		const branch = this.wip?.branch;
 		if (!branch) return this.renderIdle();
@@ -76,6 +78,15 @@ export class GlDetailsWipEmptyPane extends LitElement {
 		if (mergeTarget == null) return false;
 
 		return (mergeTarget.status?.ahead ?? 0) > 0;
+	}
+
+	protected override updated(): void {
+		const branch = this.wip?.branch;
+		const hasNextSteps = branch != null && this.computeNextSteps(branch).length > 0;
+		if (hasNextSteps && !this._hadNextSteps) {
+			this.emit('next-steps-shown');
+		}
+		this._hadNextSteps = hasNextSteps;
 	}
 
 	private renderActive(branch: GitBranchShape, nextSteps: NextStep[]) {

--- a/src/webviews/apps/plus/graph/components/gl-details-wip-empty-pane.ts
+++ b/src/webviews/apps/plus/graph/components/gl-details-wip-empty-pane.ts
@@ -45,12 +45,18 @@ export class GlDetailsWipEmptyPane extends LitElement {
 	@property({ type: Object }) mergeTargetStatus?: BranchMergeTargetStatus;
 
 	private _hadNextSteps = false;
+	private _cachedNextSteps: NextStep[] = [];
+
+	protected override willUpdate(): void {
+		const branch = this.wip?.branch;
+		this._cachedNextSteps = branch != null ? this.computeNextSteps(branch) : [];
+	}
 
 	override render(): unknown {
 		const branch = this.wip?.branch;
 		if (!branch) return this.renderIdle();
 
-		const nextSteps = this.computeNextSteps(branch);
+		const nextSteps = this._cachedNextSteps;
 		// Pending steps win — Review/Recompose ride along below the pending list with the
 		// active-state ordering rule. With no pending steps, the panel falls back to the idle
 		// UI (renderIdle handles the Review/Recompose buttons itself).
@@ -81,8 +87,7 @@ export class GlDetailsWipEmptyPane extends LitElement {
 	}
 
 	protected override updated(): void {
-		const branch = this.wip?.branch;
-		const hasNextSteps = branch != null && this.computeNextSteps(branch).length > 0;
+		const hasNextSteps = this._cachedNextSteps.length > 0;
 		if (hasNextSteps && !this._hadNextSteps) {
 			this.emit('next-steps-shown');
 		}

--- a/src/webviews/apps/plus/graph/graph-app.ts
+++ b/src/webviews/apps/plus/graph/graph-app.ts
@@ -375,8 +375,7 @@ export class GraphApp extends SignalWatcher(LitElement) {
 		}
 
 		this._pendingScopeToBranch = false;
-		const selected = this.graphState.repositories?.find(r => r.id === this.graphState.selectedRepository);
-		const repoPath = selected != null ? (selected.commonPath ?? selected.path) : this.fallbackRepoPath;
+		const repoPath = this.fallbackRepoPath;
 		if (repoPath != null) {
 			const branchRef = getBranchId(repoPath, false, branch.name);
 			this.setScope(

--- a/src/webviews/apps/plus/graph/graph-app.ts
+++ b/src/webviews/apps/plus/graph/graph-app.ts
@@ -21,6 +21,7 @@ import type {
 	DidRequestOpenCompareModeParams,
 	GraphDisplayMode,
 	GraphMinimapMarkerTypes,
+	GraphShowAction,
 	GraphSidebarPanel,
 	OverviewRecentThreshold,
 } from '../../../plus/graph/protocol.js';
@@ -30,6 +31,11 @@ import {
 	GetWipStatsRequest,
 	isSecondaryWipSha,
 	isWipSha,
+	TrackGraphDetailsCompareModeCommand,
+	TrackGraphDetailsComposeModeCommand,
+	TrackGraphDetailsReviewModeCommand,
+	TrackGraphDetailsWipShownCommand,
+	TrackGraphScopeChangedCommand,
 	UpdateGraphConfigurationCommand,
 	UpdateGraphDisplayModeCommand,
 } from '../../../plus/graph/protocol.js';
@@ -329,6 +335,61 @@ export class GraphApp extends SignalWatcher(LitElement) {
 		this.detailsPanelEl?.openCompareMode(params);
 	}
 
+	private _pendingScopeToBranch = false;
+
+	private async consumePendingAction(action: GraphShowAction): Promise<void> {
+		if (action === 'scope-to-branch') {
+			this.scopeToBranch();
+			return;
+		}
+
+		const repoPath = this.fallbackRepoPath ?? '';
+		this._selectedCommit = { sha: uncommitted, repoPath: repoPath };
+		this._selectedCommits = undefined;
+
+		this.setDetailsVisible(true, 'request-mode');
+		this.ensureDetailsPosition();
+
+		await this.updateComplete;
+		if (action === 'enter-review' || action === 'enter-compose') {
+			this.detailsPanelEl?.enterModeForWip(
+				action === 'enter-review' ? 'review' : 'compose',
+				repoPath,
+				uncommitted,
+			);
+		} else if (action === 'open-compare') {
+			this.detailsPanelEl?.openCompareMode({
+				repoPath: repoPath,
+				leftRef: this.graphState.branch?.name ?? 'HEAD',
+				rightRef: uncommitted,
+				includeWorkingTree: true,
+			});
+		}
+	}
+
+	private scopeToBranch(): void {
+		const branch = this.graphState.branch;
+		if (branch == null) {
+			this._pendingScopeToBranch = true;
+			return;
+		}
+
+		this._pendingScopeToBranch = false;
+		const selected = this.graphState.repositories?.find(r => r.id === this.graphState.selectedRepository);
+		const repoPath = selected != null ? (selected.commonPath ?? selected.path) : this.fallbackRepoPath;
+		if (repoPath != null) {
+			const branchRef = getBranchId(repoPath, false, branch.name);
+			this.setScope(
+				{
+					branchRef: branchRef,
+					branchName: branch.name,
+					upstreamRef: branch.upstream?.name ? getBranchId(repoPath, true, branch.upstream.name) : undefined,
+				},
+				'overview-card',
+			);
+		}
+	}
+
 	/** Handles a WIP-row inline-button click (Compose / Review / agent indicator). Selects the
 	 *  row, opens the details panel, and routes to the requested target. Compose/Review enter
 	 *  the matching workflow mode; `agents` expands the agents section. The graph component
@@ -458,6 +519,17 @@ export class GraphApp extends SignalWatcher(LitElement) {
 			}
 		}
 
+		// Handle pending action from walkthrough CTA or external show request
+		const pendingAction = this.graphState.pendingAction;
+		if (pendingAction != null) {
+			this.graphState.pendingAction = undefined;
+			void this.updateComplete.then(() => this.consumePendingAction(pendingAction));
+		}
+
+		if (this._pendingScopeToBranch && this.graphState.branch != null) {
+			void this.updateComplete.then(() => this.scopeToBranch());
+		}
+
 		// Check for external search request (from file history command, etc.)
 		const searchRequest = this.graphState.searchRequest;
 		if (searchRequest && searchRequest !== this._lastSearchRequest) {
@@ -537,6 +609,7 @@ export class GraphApp extends SignalWatcher(LitElement) {
 					.commitLites=${multi?.commitLites}
 					@select-commit=${this.handleSelectCommit}
 					@gl-graph-details-mode-changed=${this.handleDetailsModeChanged}
+					@next-steps-shown=${this.handleNextStepsShown}
 				></gl-graph-details-panel>
 			</div>
 		</gl-split-panel>`;
@@ -553,6 +626,17 @@ export class GraphApp extends SignalWatcher(LitElement) {
 		}
 
 		this.graph?.selectCommits([e.detail.sha], { ensureVisible: true });
+	}
+
+	private _nextStepsShownWhileHidden = false;
+
+	private handleNextStepsShown() {
+		if (!this.graphState.detailsVisible) {
+			this._nextStepsShownWhileHidden = true;
+			return;
+		}
+
+		this._ipc.sendCommand(TrackGraphDetailsWipShownCommand, undefined);
 	}
 
 	private renderGraphPaneContent() {
@@ -848,7 +932,12 @@ export class GraphApp extends SignalWatcher(LitElement) {
 			const { single, multi } = this.activeSelection;
 			const selectionCount = multi != null ? multi.shas.length : single != null ? 1 : 0;
 			const selectedSha = single?.sha;
-			const selectionUncommitted = isWipSha(selectedSha);
+			const effectivelyUncommitted =
+				isWipSha(selectedSha) || (single == null && multi == null && this.fallbackRepoPath != null);
+			if (effectivelyUncommitted && this._nextStepsShownWhileHidden) {
+				this._nextStepsShownWhileHidden = false;
+				this._ipc.sendCommand(TrackGraphDetailsWipShownCommand, undefined);
+			}
 			const host = this.graphState.webviewId === 'gitlens.graph' ? 'editor' : 'panel';
 			const location = this.graphState.config?.detailsLocation === 'bottom' ? 'bottom' : 'right';
 			this._telemetry.sendEvent({
@@ -858,7 +947,7 @@ export class GraphApp extends SignalWatcher(LitElement) {
 					host: host,
 					mode: this.detailsPanelEl?.currentMode ?? 'none',
 					'selection.count': selectionCount,
-					'selection.uncommitted': selectionUncommitted,
+					'selection.uncommitted': effectivelyUncommitted,
 					position: this.graphState[this.detailsPositionKey],
 					location: location,
 				},
@@ -878,6 +967,18 @@ export class GraphApp extends SignalWatcher(LitElement) {
 		// panel stays visible (e.g. swap-to-close, mode chip toggles), so the event isolates
 		// in-panel transitions from open/close noise.
 		if (this.graphState.detailsVisible !== true) return;
+
+		switch (e.detail.current) {
+			case 'review':
+				this._ipc.sendCommand(TrackGraphDetailsReviewModeCommand, undefined);
+				break;
+			case 'compose':
+				this._ipc.sendCommand(TrackGraphDetailsComposeModeCommand, undefined);
+				break;
+			case 'compare':
+				this._ipc.sendCommand(TrackGraphDetailsCompareModeCommand, undefined);
+				break;
+		}
 
 		this._telemetry.sendEvent({
 			name: 'graphDetails/mode/changed',
@@ -1225,6 +1326,7 @@ export class GraphApp extends SignalWatcher(LitElement) {
 			return;
 		}
 
+		this._ipc.sendCommand(TrackGraphScopeChangedCommand, undefined);
 		emitTelemetrySentEvent<'graph/scope/changed'>(this, {
 			name: 'graph/scope/changed',
 			data: {

--- a/src/webviews/apps/plus/graph/graph-header.ts
+++ b/src/webviews/apps/plus/graph/graph-header.ts
@@ -31,6 +31,7 @@ import type {
 import {
 	ChooseRefRequest,
 	ChooseRepositoryCommand,
+	CloseGraphWalkthroughBannerCommand,
 	EnsureRowRequest,
 	JumpToHeadRequest,
 	OpenPullRequestDetailsCommand,
@@ -145,8 +146,13 @@ export class GlGraphHeader extends SignalWatcher(LitElement) {
 				--max-width: 320px;
 			}
 
+			.graph-walkthrough-tooltip::part(body) {
+				--max-width: 400px;
+			}
+
 			.mcp-tooltip__content a,
-			.hooks-tooltip__content a {
+			.hooks-tooltip__content a,
+			.graph-walkthrough-tooltip__content a {
 				color: var(--vscode-textLink-foreground);
 			}
 
@@ -154,6 +160,45 @@ export class GlGraphHeader extends SignalWatcher(LitElement) {
 			.action-button--hooks {
 				background: linear-gradient(135deg, #a100ff1a 0%, #255ed11a 100%);
 				border: 1px solid var(--vscode-panel-border);
+			}
+
+			.action-button--graph-walkthrough {
+				background: linear-gradient(135deg, #a100ff1a 0%, #255ed11a 100%);
+				border: 1px solid var(--vscode-panel-border);
+				outline: 1px solid var(--vscode-panel-border);
+			}
+
+			.preview-badge {
+				float: right;
+				opacity: 0.7;
+			}
+
+			.graph-walkthrough-tooltip__title {
+				display: block;
+				margin-bottom: 0.4rem;
+			}
+
+			.graph-walkthrough-tooltip__actions {
+				display: flex;
+				justify-content: flex-end;
+				align-items: center;
+				gap: 0.8rem;
+				margin-top: 0.8rem;
+			}
+
+			.graph-walkthrough-tooltip__actions .action-btn {
+				padding: 0.4rem 0.8rem;
+				border: none;
+				border-radius: 2px;
+				background: var(--vscode-button-background);
+				color: var(--vscode-button-foreground);
+				cursor: pointer;
+				text-decoration: none;
+				font-size: inherit;
+			}
+
+			.graph-walkthrough-tooltip__actions .action-btn:hover {
+				background: var(--vscode-button-hoverBackground);
 			}
 
 			/* Search is meaningless in Timeline mode — visually dim it and let \`inert\` block focus
@@ -336,6 +381,20 @@ export class GlGraphHeader extends SignalWatcher(LitElement) {
 		if (rows?.[0]?.hidden) {
 			this._searchResultHidden = true;
 		}
+	}
+
+	private onGraphWalkthroughBannerHide(): void {
+		this._ipc.sendCommand(CloseGraphWalkthroughBannerCommand, {});
+	}
+
+	private onGraphWalkthroughBannerDismiss(e: Event): void {
+		e.preventDefault();
+		this._ipc.sendCommand(CloseGraphWalkthroughBannerCommand, {});
+	}
+
+	private onGraphWalkthroughBannerButtonClick(e: Event): void {
+		e.preventDefault();
+		this._ipc.sendCommand(CloseGraphWalkthroughBannerCommand, { openWelcome: true });
 	}
 
 	private onOpenPullRequest(pr: NonNullable<NonNullable<State['branchState']>['pr']>): void {
@@ -1130,6 +1189,7 @@ export class GlGraphHeader extends SignalWatcher(LitElement) {
 						</gl-popover>
 					`,
 				)}
+				${this.renderGraphWalkthroughBanner(state)}
 				<gl-button
 					appearance="toolbar"
 					href=${`command:gitlens.showLaunchpad?${encodeURIComponent(
@@ -1166,6 +1226,49 @@ export class GlGraphHeader extends SignalWatcher(LitElement) {
 				)}
 			</div>
 		</div>`;
+	}
+
+	private renderGraphWalkthroughBanner(state: State) {
+		const dismissed = state.graphWalkthroughBannerCollapsed ?? true;
+
+		if (dismissed) {
+			return nothing;
+		}
+
+		const highlighted = !state.graphWalkthroughComplete;
+
+		return html`
+			<gl-popover
+				class="graph-walkthrough-tooltip"
+				placement="bottom"
+				trigger="click"
+				open
+				@gl-popover-hide=${this.onGraphWalkthroughBannerHide}
+			>
+				<button
+					type="button"
+					class="action-button ${highlighted ? 'action-button--graph-walkthrough' : ''}"
+					slot="anchor"
+					@click=${this.onGraphWalkthroughBannerButtonClick}
+				>
+					<code-icon class="action-button__icon" icon="megaphone"></code-icon>
+				</button>
+				<div class="graph-walkthrough-tooltip__content" slot="content">
+					<span class="graph-walkthrough-tooltip__title">
+						<strong>Welcome to the new GitLens Commit Graph</strong>
+						<span class="preview-badge">PREVIEW</span>
+					</span>
+					The Graph is where your work gets done. Launch agents, monitor their work across worktrees, and
+					streamline next steps to ship faster.
+					<div class="graph-walkthrough-tooltip__actions">
+						<a href="#" @click=${this.onGraphWalkthroughBannerDismiss}>Dismiss</a>
+						<a class="action-btn" href="#" @click=${this.onGraphWalkthroughBannerButtonClick}
+							>See what's new</a
+						>
+					</div>
+				</div>
+			</gl-popover>
+		`;
 	}
 
 	private renderHiddenRefs(excludeRefs: GraphExcludeRefs | undefined) {

--- a/src/webviews/apps/plus/graph/graph-header.ts
+++ b/src/webviews/apps/plus/graph/graph-header.ts
@@ -383,17 +383,23 @@ export class GlGraphHeader extends SignalWatcher(LitElement) {
 		}
 	}
 
+	private _bannerClosing = false;
+
 	private onGraphWalkthroughBannerHide(): void {
+		if (this._bannerClosing) return;
+
 		this._ipc.sendCommand(CloseGraphWalkthroughBannerCommand, {});
 	}
 
 	private onGraphWalkthroughBannerDismiss(e: Event): void {
 		e.preventDefault();
+		this._bannerClosing = true;
 		this._ipc.sendCommand(CloseGraphWalkthroughBannerCommand, {});
 	}
 
 	private onGraphWalkthroughBannerButtonClick(e: Event): void {
 		e.preventDefault();
+		this._bannerClosing = true;
 		this._ipc.sendCommand(CloseGraphWalkthroughBannerCommand, { openWelcome: true });
 	}
 

--- a/src/webviews/apps/plus/graph/overview/graph-overview.ts
+++ b/src/webviews/apps/plus/graph/overview/graph-overview.ts
@@ -18,6 +18,7 @@ import {
 	GetOverviewRequest,
 	GetOverviewWipDetailedRequest,
 	GetOverviewWipRequest,
+	TrackGraphOverviewShownCommand,
 } from '../../../../plus/graph/protocol.js';
 import { indexAgentSessionsByRepoAndWorktree, matchAgentSessionsForWorktree } from '../../../shared/agentUtils.js';
 import { scrollableBase } from '../../../shared/components/styles/lit/base.css.js';
@@ -288,10 +289,11 @@ export class GlGraphOverview extends SignalWatcher(LitElement) {
 			this._wipData = nextWipData;
 		}
 
-		// Fire the shown event once overview data is available so the branch counts are accurate.
-		// Mount-time emit would always report 0/0 since the initial GetOverviewRequest is still in flight.
-		if (!this._shownEmitted && overview != null) {
+		// Fire the shown event once overview data is available AND the sidebar is visible so the
+		// walkthrough step only completes when the user actually sees the overview.
+		if (!this._shownEmitted && overview != null && this._state.sidebarVisible) {
 			this._shownEmitted = true;
+			this._ipc.sendCommand(TrackGraphOverviewShownCommand, undefined);
 			emitTelemetrySentEvent<'graph/overview/shown'>(this, {
 				name: 'graph/overview/shown',
 				data: {

--- a/src/webviews/apps/plus/graph/stateProvider.ts
+++ b/src/webviews/apps/plus/graph/stateProvider.ts
@@ -1003,7 +1003,7 @@ export class GraphStateProvider extends StateProviderBase<State['webviewId'], Ap
 			case DidRequestGraphActionNotification.is(msg):
 				this.updateState({
 					pendingAction: msg.params.action,
-					detailsVisible: msg.params.action !== 'scope-to-branch' ? true : undefined,
+					...(msg.params.action !== 'scope-to-branch' ? { detailsVisible: true } : {}),
 				});
 				break;
 

--- a/src/webviews/apps/plus/graph/stateProvider.ts
+++ b/src/webviews/apps/plus/graph/stateProvider.ts
@@ -20,6 +20,8 @@ import {
 	DidChangeCanInstallClaudeHook,
 	DidChangeColumnsNotification,
 	DidChangeGraphConfigurationNotification,
+	DidChangeGraphWalkthroughBanner,
+	DidChangeGraphWalkthroughComplete,
 	DidChangeHooksBanner,
 	DidChangeMcpBanner,
 	DidChangeNotification,
@@ -38,6 +40,8 @@ import {
 	DidChangeWorkingTreeNotification,
 	DidFetchNotification,
 	DidInvalidateScopeAnchorsNotification,
+	DidRequestActiveSidebarPanelNotification,
+	DidRequestGraphActionNotification,
 	DidRequestOpenCompareModeNotification,
 	DidRequestWipRefetchNotification,
 	DidSearchNotification,
@@ -202,6 +206,9 @@ export class GraphStateProvider extends StateProviderBase<State['webviewId'], Ap
 
 	@signalState()
 	accessor minimapPosition: AppState['minimapPosition'];
+
+	@signalState()
+	accessor pendingAction: AppState['pendingAction'];
 
 	get isBusy(): AppState['isBusy'] {
 		return this.loading || this.searching || /*this.rowsStatsLoading ||*/ false;
@@ -388,6 +395,8 @@ export class GraphStateProvider extends StateProviderBase<State['webviewId'], Ap
 	mcpBannerCollapsed?: boolean | undefined;
 	hooksBannerCollapsed?: boolean | undefined;
 	canInstallClaudeHook?: boolean | undefined;
+	graphWalkthroughBannerCollapsed?: boolean | undefined;
+	graphWalkthroughComplete?: boolean | undefined;
 
 	constructor(
 		host: ReactiveElementHost,
@@ -984,6 +993,20 @@ export class GraphStateProvider extends StateProviderBase<State['webviewId'], Ap
 				);
 				break;
 
+			case DidRequestActiveSidebarPanelNotification.is(msg):
+				this.updateState({
+					activeSidebarPanel: msg.params.panel,
+					sidebarVisible: true,
+				});
+				break;
+
+			case DidRequestGraphActionNotification.is(msg):
+				this.updateState({
+					pendingAction: msg.params.action,
+					detailsVisible: msg.params.action !== 'scope-to-branch' ? true : undefined,
+				});
+				break;
+
 			case DidChangeGraphConfigurationNotification.is(msg):
 				this.updateState({ config: msg.params.config });
 				break;
@@ -1021,6 +1044,16 @@ export class GraphStateProvider extends StateProviderBase<State['webviewId'], Ap
 
 			case DidChangeCanInstallClaudeHook.is(msg):
 				this.updateState({ canInstallClaudeHook: msg.params });
+				break;
+
+			case DidChangeGraphWalkthroughBanner.is(msg):
+				this.updateState({
+					graphWalkthroughBannerCollapsed: msg.params.dismissed,
+				});
+				break;
+
+			case DidChangeGraphWalkthroughComplete.is(msg):
+				this.updateState({ graphWalkthroughComplete: msg.params });
 				break;
 
 			case DidChangeWorkingTreeNotification.is(msg): {

--- a/src/webviews/apps/welcome/components/welcome-page.css.ts
+++ b/src/webviews/apps/welcome/components/welcome-page.css.ts
@@ -298,9 +298,28 @@ const scrollableFeatures = css`
 	}
 `;
 
+const backLink = css`
+	.section--back {
+		text-align: left;
+		align-items: flex-start;
+	}
+
+	.section .back-link {
+		color: var(--dimmed-text-color);
+		text-decoration: none;
+		font-size: var(--card-font-size);
+	}
+
+	.back-link:hover {
+		color: var(--vscode-textLink-activeForeground);
+		text-decoration: underline;
+	}
+`;
+
 export const welcomeStyles = css`
 	${colorScheme} ${typography} ${main}
 	${heroGradient} ${section} ${header}
 	${scrollableFeatures}
 	${cards}
+	${backLink}
 `;

--- a/src/webviews/apps/welcome/components/welcome-page.ts
+++ b/src/webviews/apps/welcome/components/welcome-page.ts
@@ -3,6 +3,7 @@ import { html, LitElement, nothing } from 'lit';
 import { customElement, property, query, state } from 'lit/decorators.js';
 import { urls } from '../../../../constants.js';
 import { SubscriptionState } from '../../../../constants.subscription.js';
+import type { GraphWalkthroughContextKeys } from '../../../../constants.walkthroughs.js';
 import { createCommandLink } from '../../../../system/commands.js';
 import type { State } from '../../../welcome/protocol.js';
 import { scrollableBase } from '../../shared/components/styles/lit/base.css.js';
@@ -16,6 +17,13 @@ import '../../shared/components/button.js';
 import '../../shared/components/code-icon.js';
 import './welcome-parts.js';
 import type { GlWalkthrough, WalkthroughStep } from './welcome-parts.js';
+
+type GraphWalkthroughStep = {
+	id: string;
+	graphWalkthroughKey: GraphWalkthroughContextKeys;
+	title: string;
+	body: ReturnType<typeof html>;
+};
 
 declare global {
 	interface HTMLElementTagNameMap {
@@ -317,6 +325,115 @@ const walkthroughSteps: WalkthroughStep[] = [
 	},
 ];
 
+const graphWalkthroughSteps: GraphWalkthroughStep[] = [
+	{
+		id: 'graph-agent-monitoring',
+		graphWalkthroughKey: 'graphAgentMonitoring',
+		title: 'Stay on top of every running agent',
+		body: html`
+			<p>
+				Every active agent session shows up alongside your work. See a status pill for each session on the
+				branch cards in the Home view and Graph sidebar, or see associated agents in the details panel when
+				viewing working changes. See what needs attention. Hover for the full picture. Take action &mdash;
+				resume, respond, switch &mdash; straight from the status. No more rotating through terminal tabs or chat
+				panes to figure out which agent needs you.
+			</p>
+			<div class="card-part--centered">
+				<gl-button href="${createCommandLink('gitlens.showGraph', { sidebarPanel: 'overview' })}"
+					>Open the Overview Sidebar</gl-button
+				>
+			</div>
+		`,
+	},
+	{
+		id: 'graph-parallel-work',
+		graphWalkthroughKey: 'graphParallelWork',
+		title: 'All your parallel work, in one Graph',
+		body: html`
+			<p>
+				With agents running across multiple worktrees, working changes used to mean opening another window or
+				directory just to remember what you (or your agent) left half-finished. Not anymore.
+				<strong>Multi-WIP visibility:</strong> every worktree's working changes are visible at the same time, in
+				the same Graph. <strong>Focused Graph mode:</strong> when you're heads-down on one branch, scope the
+				Graph to just the commits that matter &mdash; the bigger picture is always one click away.
+			</p>
+			<div class="card-part--centered">
+				<gl-button href="${createCommandLink('gitlens.showGraph', { action: 'scope-to-branch' })}"
+					>Focus the Commit Graph</gl-button
+				>
+			</div>
+		`,
+	},
+	{
+		id: 'graph-ai-review',
+		graphWalkthroughKey: 'graphAiReview',
+		title: 'Review changes with AI in the details panel',
+		body: html`
+			<p>
+				The new Review mode in the details panel reads through any commits or WIP and surfaces severity-tagged
+				insights and a summary of changes, so you can ensure nothing's missed before you ship.
+			</p>
+			<div class="card-part--centered">
+				<gl-button href="${createCommandLink('gitlens.showGraph', { action: 'enter-review' })}"
+					>Try Review Mode</gl-button
+				>
+			</div>
+		`,
+	},
+	{
+		id: 'graph-compose',
+		graphWalkthroughKey: 'graphCompose',
+		title: 'Compose working changes into logical Commits',
+		body: html`
+			<p>
+				Compose mode lives right in the details panel: select files, exclude noise, and let AI split a sprawling
+				WIP into a series of focused commits &mdash; without ever opening a separate view. Your reviewers will
+				thank you, and so will your future self.
+			</p>
+			<div class="card-part--centered">
+				<gl-button href="${createCommandLink('gitlens.showGraph', { action: 'enter-compose' })}"
+					>Try Compose Mode</gl-button
+				>
+			</div>
+		`,
+	},
+	{
+		id: 'graph-compare',
+		graphWalkthroughKey: 'graphCompare',
+		title: 'Compare any refs from your Graph selection',
+		body: html`
+			<p>
+				Select a commit or multi-select rows in the Graph and jump straight into Compare mode in the details
+				panel. Branch vs. branch, commit vs. commit, working changes vs. anything &mdash; just select and
+				compare. It's the fastest way to get eyes on the exact diff you care about.
+			</p>
+			<div class="card-part--centered">
+				<gl-button href="${createCommandLink('gitlens.showGraph', { action: 'open-compare' })}"
+					>Open Compare Mode</gl-button
+				>
+			</div>
+		`,
+	},
+	{
+		id: 'graph-next-steps',
+		graphWalkthroughKey: 'graphNextSteps',
+		title: 'Always know what to do next',
+		body: html`
+			<p>
+				The working changes view of the details panel is your workflow guide. Selecting on a working changes row
+				surfaces the next action that keeps the loop moving: respond to an awaiting agent, push, open a PR,
+				resolve a conflict, finish the rebase. Nothing in flight? The integrated Launchpad points you to the
+				next PR or issue worth picking up.
+			</p>
+			<div class="card-part--centered">
+				<gl-button href="${createCommandLink('gitlens.showGraph', { action: 'show-wip' })}"
+					>See My Working Changes</gl-button
+				>
+			</div>
+		`,
+	},
+];
+
 @customElement('gl-welcome-page')
 export class GlWelcomePage extends LitElement {
 	static override styles = [scrollableBase, welcomeStyles];
@@ -381,6 +498,13 @@ export class GlWelcomePage extends LitElement {
 	override render(): unknown {
 		if (!this._state) return nothing;
 
+		if (this._state.mode === 'graph') {
+			return this.renderGraphWalkthrough();
+		}
+		return this.renderMainWalkthrough();
+	}
+
+	private renderMainWalkthrough(): unknown {
 		return html`
 			<div part="page" class="welcome scrollable">
 				<div class="section header">
@@ -411,6 +535,54 @@ export class GlWelcomePage extends LitElement {
 								</gl-walkthrough-step>
 							`,
 						)}
+				</gl-walkthrough>
+				<div class="section section--centered">
+					<p>
+						<a href="${createCommandLink('gitlens.showWelcomeView', { mode: 'graph' })}"
+							>See what's new in the Commit Graph &rarr;</a
+						>
+					</p>
+					<p>
+						You also have access to the
+						<a href="https://gitkraken.dev/tools" target="_blank">GitKraken DevEx platform</a>, unleashing
+						powerful Git visualization & productivity capabilities everywhere you work: IDE, desktop,
+						browser, and terminal.
+					</p>
+				</div>
+			</div>
+		`;
+	}
+
+	private renderGraphWalkthrough(): unknown {
+		return html`
+			<div part="page" class="welcome scrollable">
+				<div class="section section--back">
+					<a href="${createCommandLink('gitlens.showWelcomeView')}" class="back-link"
+						>&larr; Back to the GitLens walkthrough</a
+					>
+				</div>
+				<div class="section header">
+					<h1><gitlens-logo-circle></gitlens-logo-circle><span>What's new in GitLens 18</span></h1>
+				</div>
+				<gl-walkthrough-progress
+					class="section"
+					.doneCount=${this._state.graphWalkthroughProgress?.doneCount ?? 0}
+					.allCount=${this._state.graphWalkthroughProgress?.allCount ?? 0}
+				></gl-walkthrough-progress>
+				<gl-walkthrough class="section">
+					${graphWalkthroughSteps.map(
+						step => html`
+							<gl-walkthrough-step
+								class="card"
+								stepId=${step.id}
+								.completed=${this._state.graphWalkthroughProgress?.state[step.graphWalkthroughKey] ===
+								true}
+							>
+								<h1 slot="title">${step.title}</h1>
+								${step.body}
+							</gl-walkthrough-step>
+						`,
+					)}
 				</gl-walkthrough>
 				<div class="section section--centered">
 					<p>

--- a/src/webviews/apps/welcome/stateProvider.ts
+++ b/src/webviews/apps/welcome/stateProvider.ts
@@ -1,7 +1,13 @@
 import { ContextProvider } from '@lit/context';
 import type { IpcMessage } from '../../ipc/models/ipc.js';
 import type { State } from '../../welcome/protocol.js';
-import { DidChangeSubscription, DidChangeWalkthroughProgress, DidFocusWalkthrough } from '../../welcome/protocol.js';
+import {
+	DidChangeGraphWalkthroughProgress,
+	DidChangeSubscription,
+	DidChangeWalkthroughProgress,
+	DidFocusWalkthrough,
+	DidSwitchWalkthroughMode,
+} from '../../welcome/protocol.js';
 import type { ReactiveElementHost } from '../shared/appHost.js';
 import { StateProviderBase } from '../shared/stateProviderBase.js';
 import { stateContext } from './context.js';
@@ -27,6 +33,20 @@ export class WelcomeStateProvider extends StateProviderBase<State['webviewId'], 
 
 			case DidChangeWalkthroughProgress.is(msg):
 				this._state.walkthroughProgress = msg.params.walkthroughProgress;
+				this._state.timestamp = Date.now();
+
+				this.provider.setValue(this._state, true);
+				break;
+
+			case DidChangeGraphWalkthroughProgress.is(msg):
+				this._state.graphWalkthroughProgress = msg.params.graphWalkthroughProgress;
+				this._state.timestamp = Date.now();
+
+				this.provider.setValue(this._state, true);
+				break;
+
+			case DidSwitchWalkthroughMode.is(msg):
+				this._state.mode = msg.params.mode;
 				this._state.timestamp = Date.now();
 
 				this.provider.setValue(this._state, true);

--- a/src/webviews/plus/graph/graphWebview.ts
+++ b/src/webviews/plus/graph/graphWebview.ts
@@ -1,6 +1,16 @@
 import type { emptySetMarker, GraphRefOptData, GraphRow, GraphSearchMode } from '@gitkraken/gitkraken-components';
 import type { CancellationToken, ColorTheme, ConfigurationChangeEvent, TextDocumentShowOptions } from 'vscode';
-import { CancellationTokenSource, Disposable, env, ProgressLocation, Uri, ViewColumn, window, workspace } from 'vscode';
+import {
+	CancellationTokenSource,
+	commands,
+	Disposable,
+	env,
+	ProgressLocation,
+	Uri,
+	ViewColumn,
+	window,
+	workspace,
+} from 'vscode';
 import { createGraphComposeIntegration } from '@env/coretools/composer.js';
 import { getClaudeAgent } from '@env/providers.js';
 import { GitSearchError } from '@gitlens/git/errors.js';
@@ -290,6 +300,7 @@ import {
 } from './graphWebview.utils.js';
 import type {
 	BranchState,
+	CloseGraphWalkthroughBannerParams,
 	DidGetSidebarDataParams,
 	DidRequestOpenCompareModeParams,
 	GetWipStatsResponse,
@@ -322,10 +333,12 @@ import type {
 	GraphSearchResults,
 	GraphSelectedRows,
 	GraphSelection,
+	GraphShowAction,
 	GraphSidebarPanel,
 	GraphSidebarWorktree,
 	GraphStashContextValue,
 	GraphTagContextValue,
+	GraphWalkthroughBannerState,
 	GraphWipMetadataBySha,
 	GraphWorkingTreeStats,
 	State,
@@ -336,6 +349,7 @@ import {
 	ChooseFileRequest,
 	ChooseRefRequest,
 	ChooseRepositoryCommand,
+	CloseGraphWalkthroughBannerCommand,
 	createSecondaryWipSha,
 	createWipSha,
 	DidChangeAgentSessionsNotification,
@@ -344,6 +358,8 @@ import {
 	DidChangeCanInstallClaudeHook,
 	DidChangeColumnsNotification,
 	DidChangeGraphConfigurationNotification,
+	DidChangeGraphWalkthroughBanner,
+	DidChangeGraphWalkthroughComplete,
 	DidChangeHooksBanner,
 	DidChangeMcpBanner,
 	DidChangeNotification,
@@ -362,6 +378,8 @@ import {
 	DidChangeWorkingTreeNotification,
 	DidFetchNotification,
 	DidInvalidateScopeAnchorsNotification,
+	DidRequestActiveSidebarPanelNotification,
+	DidRequestGraphActionNotification,
 	DidRequestOpenCompareModeNotification,
 	DidRequestWipRefetchNotification,
 	DidSearchNotification,
@@ -394,6 +412,12 @@ import {
 	SearchRequest,
 	supportedRefMetadataTypes,
 	SyncWipWatchesCommand,
+	TrackGraphDetailsCompareModeCommand,
+	TrackGraphDetailsComposeModeCommand,
+	TrackGraphDetailsReviewModeCommand,
+	TrackGraphDetailsWipShownCommand,
+	TrackGraphOverviewShownCommand,
+	TrackGraphScopeChangedCommand,
 	UpdateColumnsCommand,
 	UpdateExcludeTypesCommand,
 	UpdateGraphConfigurationCommand,
@@ -423,6 +447,14 @@ interface ResolvedScopeAnchor {
 
 function hasSearchQuery(arg: any): arg is { repository: GlRepository; search: SearchQuery } {
 	return arg?.repository != null && arg?.search != null;
+}
+
+function hasSidebarPanel(arg: any): arg is { sidebarPanel: GraphSidebarPanel } {
+	return typeof arg?.sidebarPanel === 'string';
+}
+
+function hasAction(arg: any): arg is { action: GraphShowAction } {
+	return typeof arg?.action === 'string';
 }
 
 const defaultGraphColumnsSettings: GraphColumnsSettings = {
@@ -633,6 +665,7 @@ export class GraphWebviewProvider implements WebviewProvider<State, State, Graph
 			this.container.storage.onDidChange(this.onStorageChanged, this),
 			this.container.subscription.onDidChange(this.onSubscriptionChanged, this),
 			this.container.onboarding.onDidChange(this.onOnboardingChanged, this),
+			this.container.walkthrough.onDidChangeProgress(this.onGraphWalkthroughProgressChanged, this),
 			onDidChangeContext(this.onContextChanged, this),
 			this.container.subscription.onDidChangeFeaturePreview(this.onFeaturePreviewChanged, this),
 			this.container.git.onDidChangeRepositories(async e => {
@@ -1954,6 +1987,8 @@ export class GraphWebviewProvider implements WebviewProvider<State, State, Graph
 	}
 
 	private _searchRequest: SearchQuery | undefined;
+	private _pendingSidebarPanel: GraphSidebarPanel | undefined;
+	private _pendingAction: GraphShowAction | undefined;
 
 	async onShowing(
 		loading: boolean,
@@ -1996,6 +2031,21 @@ export class GraphWebviewProvider implements WebviewProvider<State, State, Graph
 			this.repository = arg.repository;
 			this._searchRequest = arg.search;
 			this.updateState();
+		} else if (hasSidebarPanel(arg)) {
+			if (loading) {
+				this._pendingSidebarPanel = arg.sidebarPanel;
+			} else {
+				void this.host.notify(DidRequestActiveSidebarPanelNotification, { panel: arg.sidebarPanel });
+			}
+		} else if (hasAction(arg)) {
+			if (arg.action !== 'scope-to-branch') {
+				this.setSelectedRows('work-dir-changes');
+			}
+			if (loading) {
+				this._pendingAction = arg.action;
+			} else {
+				void this.host.notify(DidRequestGraphActionNotification, { action: arg.action });
+			}
 		} else {
 			if (isSerializedState<State>(arg) && arg.state.selectedRepository != null) {
 				this.repository = this.container.git.openRepositories.find(r => r.id === arg.state.selectedRepository);
@@ -3030,6 +3080,8 @@ export class GraphWebviewProvider implements WebviewProvider<State, State, Graph
 			this.onHooksBannerChanged();
 		} else if (e.key === 'hooks:banner') {
 			this.onHooksBannerChanged();
+		} else if (e.key === 'graph-walkthrough:banner') {
+			this.onGraphWalkthroughBannerChanged();
 		}
 	}
 
@@ -3051,6 +3103,66 @@ export class GraphWebviewProvider implements WebviewProvider<State, State, Graph
 
 	private getHooksBannerCollapsed() {
 		return !isHooksBannerEnabled(this.container);
+	}
+
+	@ipcCommand(CloseGraphWalkthroughBannerCommand)
+	private onCloseGraphWalkthroughBanner(params: CloseGraphWalkthroughBannerParams) {
+		void this.container.onboarding.dismiss('graph-walkthrough:banner');
+		if (params.openWelcome) {
+			void commands.executeCommand('gitlens.showWelcomeView', { mode: 'graph' });
+		}
+	}
+
+	@ipcCommand(TrackGraphOverviewShownCommand)
+	private onTrackGraphOverviewShown() {
+		void this.container.usage.track('action:gitlens.graph.overview.shown:happened');
+	}
+
+	@ipcCommand(TrackGraphScopeChangedCommand)
+	private onTrackGraphScopeChanged() {
+		void this.container.usage.track('action:gitlens.graph.scope.changed:happened');
+	}
+
+	@ipcCommand(TrackGraphDetailsReviewModeCommand)
+	private onTrackGraphDetailsReviewMode() {
+		void this.container.usage.track('action:gitlens.graph.details.reviewMode:happened');
+	}
+
+	@ipcCommand(TrackGraphDetailsComposeModeCommand)
+	private onTrackGraphDetailsComposeMode() {
+		void this.container.usage.track('action:gitlens.graph.details.composeMode:happened');
+	}
+
+	@ipcCommand(TrackGraphDetailsCompareModeCommand)
+	private onTrackGraphDetailsCompareMode() {
+		void this.container.usage.track('action:gitlens.graph.details.compareMode:happened');
+	}
+
+	@ipcCommand(TrackGraphDetailsWipShownCommand)
+	private onTrackGraphDetailsWipShown() {
+		void this.container.usage.track('action:gitlens.graph.details.wipShown:happened');
+	}
+
+	private onGraphWalkthroughBannerChanged() {
+		if (!this.host.visible) return;
+
+		void this.host.notify(DidChangeGraphWalkthroughBanner, this.getGraphWalkthroughBannerState());
+	}
+
+	private onGraphWalkthroughProgressChanged() {
+		if (!this.host.visible) return;
+
+		void this.host.notify(DidChangeGraphWalkthroughComplete, this.getGraphWalkthroughComplete());
+	}
+
+	private getGraphWalkthroughBannerState(): GraphWalkthroughBannerState {
+		return {
+			dismissed: this.container.onboarding.isDismissed('graph-walkthrough:banner'),
+		};
+	}
+
+	private getGraphWalkthroughComplete() {
+		return this.container.walkthrough.graphProgress >= 1;
 	}
 
 	private onThemeChanged(theme: ColorTheme) {
@@ -6428,6 +6540,8 @@ export class GraphWebviewProvider implements WebviewProvider<State, State, Graph
 		// tick will push authoritative data.
 		const resolvedWorkingTreeStats = getSettledValue(workingStatsResult);
 
+		const graphWalkthroughBanner = this.getGraphWalkthroughBannerState();
+
 		const result: State = {
 			...this.host.baseWebviewState,
 			webroot: this.host.getWebRoot(),
@@ -6486,20 +6600,28 @@ export class GraphWebviewProvider implements WebviewProvider<State, State, Graph
 			mcpBannerCollapsed: this.getMcpBannerCollapsed(),
 			hooksBannerCollapsed: this.getHooksBannerCollapsed(),
 			canInstallClaudeHook: this._lastCanInstallClaudeHook ?? false,
+			graphWalkthroughBannerCollapsed: graphWalkthroughBanner.dismissed,
+			graphWalkthroughComplete: this.getGraphWalkthroughComplete(),
 			searchRequest: searchRequest,
-			detailsVisible: storedPanels?.details?.visible ?? true,
+			detailsVisible:
+				this._pendingAction != null && this._pendingAction !== 'scope-to-branch'
+					? true
+					: (storedPanels?.details?.visible ?? true),
 			detailsPosition: storedPanels?.details?.position,
 			detailsBottomPosition: storedPanels?.details?.bottomPosition,
-			sidebarVisible: storedPanels?.sidebar?.visible ?? true,
-			activeSidebarPanel: storedPanels?.sidebar?.activePanel,
+			sidebarVisible: this._pendingSidebarPanel != null || (storedPanels?.sidebar?.visible ?? true),
+			activeSidebarPanel: this._pendingSidebarPanel ?? storedPanels?.sidebar?.activePanel,
 			sidebarPosition: storedPanels?.sidebar?.position,
 			minimapVisible: storedPanels?.minimap?.visible ?? true,
 			minimapPosition: storedPanels?.minimap?.position,
+			pendingAction: this._pendingAction,
 			timelinePeriod: storedGraphState?.timeline?.period,
 			timelineSliceBy: storedGraphState?.timeline?.sliceBy,
 			timelineShowAllBranches: storedGraphState?.timeline?.showAllBranches,
 			overviewRecentThreshold: this._overviewRecentThreshold,
 		};
+		this._pendingSidebarPanel = undefined;
+		this._pendingAction = undefined;
 		return result;
 	}
 

--- a/src/webviews/plus/graph/protocol.ts
+++ b/src/webviews/plus/graph/protocol.ts
@@ -159,6 +159,8 @@ export type GraphSidebarPanel = 'agents' | 'branches' | 'overview' | 'remotes' |
 /** Top-level rendering mode for the Graph webview. New modes (e.g. 'treemap') plug in here. */
 export type GraphDisplayMode = 'graph' | 'timeline';
 
+export type GraphShowAction = 'show-wip' | 'enter-review' | 'enter-compose' | 'open-compare' | 'scope-to-branch';
+
 export interface GraphOverviewData {
 	active: OverviewBranch[];
 	recent: OverviewBranch[];
@@ -241,6 +243,8 @@ export interface State extends WebviewState<'gitlens.graph' | 'gitlens.views.gra
 	mcpBannerCollapsed?: boolean;
 	hooksBannerCollapsed?: boolean;
 	canInstallClaudeHook?: boolean;
+	graphWalkthroughBannerCollapsed?: boolean;
+	graphWalkthroughComplete?: boolean;
 
 	// Persisted UI state (from `graph:state` workspace memento)
 	displayMode?: GraphDisplayMode;
@@ -252,6 +256,7 @@ export interface State extends WebviewState<'gitlens.graph' | 'gitlens.views.gra
 	sidebarPosition?: number;
 	minimapVisible?: boolean;
 	minimapPosition?: number;
+	pendingAction?: GraphShowAction;
 	// Persisted Timeline-mode chart options (when `displayMode === 'timeline'`).
 	timelinePeriod?: TimelinePeriod;
 	timelineSliceBy?: TimelineSliceBy;
@@ -910,6 +915,52 @@ export const DidChangeCanInstallClaudeHook = new IpcNotification<boolean>(
 	scope,
 	'agents/canInstallClaudeHook/didChange',
 );
+
+export interface CloseGraphWalkthroughBannerParams {
+	openWelcome?: boolean;
+}
+
+export const CloseGraphWalkthroughBannerCommand = new IpcCommand<CloseGraphWalkthroughBannerParams>(
+	scope,
+	'graphWalkthrough/banner/close',
+);
+
+export interface GraphWalkthroughBannerState {
+	dismissed: boolean;
+}
+
+export const DidChangeGraphWalkthroughBanner = new IpcNotification<GraphWalkthroughBannerState>(
+	scope,
+	'graphWalkthrough/banner/didChange',
+);
+
+export const DidChangeGraphWalkthroughComplete = new IpcNotification<boolean>(
+	scope,
+	'graphWalkthrough/complete/didChange',
+);
+
+export interface DidRequestActiveSidebarPanelParams {
+	panel: GraphSidebarPanel;
+}
+export const DidRequestActiveSidebarPanelNotification = new IpcNotification<DidRequestActiveSidebarPanelParams>(
+	scope,
+	'sidebar/activePanel/didRequest',
+);
+
+export interface DidRequestGraphActionParams {
+	action: GraphShowAction;
+}
+export const DidRequestGraphActionNotification = new IpcNotification<DidRequestGraphActionParams>(
+	scope,
+	'action/didRequest',
+);
+
+export const TrackGraphOverviewShownCommand = new IpcCommand(scope, 'track/overview/shown');
+export const TrackGraphScopeChangedCommand = new IpcCommand(scope, 'track/scope/changed');
+export const TrackGraphDetailsReviewModeCommand = new IpcCommand(scope, 'track/details/reviewMode');
+export const TrackGraphDetailsComposeModeCommand = new IpcCommand(scope, 'track/details/composeMode');
+export const TrackGraphDetailsCompareModeCommand = new IpcCommand(scope, 'track/details/compareMode');
+export const TrackGraphDetailsWipShownCommand = new IpcCommand(scope, 'track/details/wipShown');
 
 export interface DidChangeBranchStateParams {
 	branchState: BranchState;

--- a/src/webviews/plus/graph/registration.ts
+++ b/src/webviews/plus/graph/registration.ts
@@ -23,12 +23,14 @@ import type {
 	WebviewsController,
 	WebviewViewProxy,
 } from '../../webviewsController.js';
-import type { State } from './protocol.js';
+import type { GraphShowAction, GraphSidebarPanel, State } from './protocol.js';
 
 export type GraphWebviewShowingArgs = [
 	| GlRepository
 	| { ref: GitReference; source?: Source }
 	| { repository: GlRepository; search?: SearchQuery; source?: Source }
+	| { sidebarPanel: GraphSidebarPanel; source?: Source }
+	| { action: GraphShowAction; source?: Source }
 	| undefined,
 ];
 

--- a/src/webviews/welcome/protocol.ts
+++ b/src/webviews/welcome/protocol.ts
@@ -1,10 +1,12 @@
 import type { SubscriptionState } from '../../constants.subscription.js';
-import type { WalkthroughContextKeys } from '../../constants.walkthroughs.js';
+import type { GraphWalkthroughContextKeys, WalkthroughContextKeys } from '../../constants.walkthroughs.js';
 import type { IpcScope } from '../ipc/models/ipc.js';
 import { IpcCommand, IpcNotification } from '../ipc/models/ipc.js';
 import type { WebviewState } from '../protocol.js';
 
 export const scope: IpcScope = 'welcome';
+
+export type WalkthroughMode = 'main' | 'graph';
 
 export interface WalkthroughProgress {
 	doneCount: number;
@@ -13,11 +15,20 @@ export interface WalkthroughProgress {
 	state: Record<WalkthroughContextKeys, boolean>;
 }
 
+export interface GraphWalkthroughProgress {
+	doneCount: number;
+	allCount: number;
+	progress: number;
+	state: Record<GraphWalkthroughContextKeys, boolean>;
+}
+
 export interface State extends WebviewState<'gitlens.views.welcome'> {
 	webroot?: string;
 	hostAppName: string;
 	plusState: SubscriptionState;
 	walkthroughProgress?: WalkthroughProgress;
+	graphWalkthroughProgress?: GraphWalkthroughProgress;
+	mode?: WalkthroughMode;
 	mcpNeedsInstall: boolean;
 	mcpShowCleanupNotice: boolean;
 }
@@ -35,6 +46,22 @@ export interface DidChangeWalkthroughProgressParams {
 export const DidChangeWalkthroughProgress = new IpcNotification<DidChangeWalkthroughProgressParams>(
 	scope,
 	'walkthroughProgress/didChange',
+);
+
+export interface DidChangeGraphWalkthroughProgressParams {
+	graphWalkthroughProgress: GraphWalkthroughProgress;
+}
+export const DidChangeGraphWalkthroughProgress = new IpcNotification<DidChangeGraphWalkthroughProgressParams>(
+	scope,
+	'graphWalkthroughProgress/didChange',
+);
+
+export interface DidSwitchWalkthroughModeParams {
+	mode: WalkthroughMode;
+}
+export const DidSwitchWalkthroughMode = new IpcNotification<DidSwitchWalkthroughModeParams>(
+	scope,
+	'walkthroughMode/didSwitch',
 );
 
 export const DidFocusWalkthrough = new IpcNotification<void>(scope, 'walkthrough/didFocus');

--- a/src/webviews/welcome/registration.ts
+++ b/src/webviews/welcome/registration.ts
@@ -1,7 +1,7 @@
 import type { WebviewsController, WebviewViewProxy } from '../webviewsController.js';
 import type { State } from './protocol.js';
 
-export type WelcomeWebviewShowingArgs = [];
+export type WelcomeWebviewShowingArgs = [{ mode?: 'main' | 'graph' }?];
 
 export function registerWelcomeWebviewView(
 	controller: WebviewsController,

--- a/src/webviews/welcome/welcomeWebview.ts
+++ b/src/webviews/welcome/welcomeWebview.ts
@@ -1,6 +1,7 @@
 import { Disposable, env } from 'vscode';
 import { SubscriptionState } from '../../constants.subscription.js';
 import type { WebviewTelemetryContext } from '../../constants.telemetry.js';
+import type { GraphWalkthroughContextKeys, WalkthroughContextKeys } from '../../constants.walkthroughs.js';
 import type { Container } from '../../container.js';
 import type { SubscriptionChangeEvent } from '../../plus/gk/subscriptionService.js';
 import { mcpRegistrationAllowed, needsCursorMcpCleanupNotice } from '../../plus/gk/utils/-webview/mcp.utils.js';
@@ -8,13 +9,20 @@ import { registerCommand } from '../../system/-webview/command.js';
 import { getContext } from '../../system/-webview/context.js';
 import type { WebviewHost, WebviewProvider, WebviewShowingArgs } from '../webviewProvider.js';
 import type { WebviewShowOptions } from '../webviewsController.js';
-import type { State, WalkthroughProgress } from './protocol.js';
-import { DidChangeSubscription, DidChangeWalkthroughProgress, DidFocusWalkthrough } from './protocol.js';
+import type { GraphWalkthroughProgress, State, WalkthroughMode, WalkthroughProgress } from './protocol.js';
+import {
+	DidChangeGraphWalkthroughProgress,
+	DidChangeSubscription,
+	DidChangeWalkthroughProgress,
+	DidFocusWalkthrough,
+	DidSwitchWalkthroughMode,
+} from './protocol.js';
 import type { WelcomeWebviewShowingArgs } from './registration.js';
 
 export class WelcomeWebviewProvider implements WebviewProvider<State, State, WelcomeWebviewShowingArgs> {
 	private readonly _disposable: Disposable;
 	private _etagSubscription?: number;
+	private _mode: WalkthroughMode = 'main';
 
 	constructor(
 		private readonly container: Container,
@@ -39,10 +47,19 @@ export class WelcomeWebviewProvider implements WebviewProvider<State, State, Wel
 	onShowing(
 		loading: boolean,
 		_options?: WebviewShowOptions,
-		..._args: WebviewShowingArgs<WelcomeWebviewShowingArgs, State>
+		...args: WebviewShowingArgs<WelcomeWebviewShowingArgs, State>
 	): [boolean, Record<`context.${string}`, string | number | boolean> | undefined] {
-		// If not loading (already loaded), notify the webview to reset and focus the walkthrough
+		const modeArg = args[0];
+		const mode: WalkthroughMode = modeArg != null && 'mode' in modeArg ? (modeArg.mode ?? 'main') : 'main';
+		this._mode = mode;
+
+		if (mode === 'graph') {
+			void this.container.onboarding.dismiss('graph-walkthrough:banner');
+		}
+
 		if (!loading) {
+			// If already loaded, notify the webview to switch mode and focus
+			void this.host.notify(DidSwitchWalkthroughMode, { mode: mode });
 			void this.host.notify(DidFocusWalkthrough, undefined);
 		}
 		return [true, undefined];
@@ -72,19 +89,38 @@ export class WelcomeWebviewProvider implements WebviewProvider<State, State, Wel
 
 	private onWalkthroughProgressChanged(): void {
 		const walkthroughProgress = this.getWalkthroughProgress();
-		if (walkthroughProgress == null) return;
+		if (walkthroughProgress != null) {
+			void this.host.notify(DidChangeWalkthroughProgress, { walkthroughProgress: walkthroughProgress });
+		}
 
-		void this.host.notify(DidChangeWalkthroughProgress, { walkthroughProgress: walkthroughProgress });
+		const graphWalkthroughProgress = this.getGraphWalkthroughProgress();
+		if (graphWalkthroughProgress != null) {
+			void this.host.notify(DidChangeGraphWalkthroughProgress, {
+				graphWalkthroughProgress: graphWalkthroughProgress,
+			});
+		}
 	}
 
 	private getWalkthroughProgress(): WalkthroughProgress | undefined {
 		const walkthroughState = this.container.walkthrough.getState();
-		const state: Record<string, boolean> = Object.fromEntries(walkthroughState);
+		const state = Object.fromEntries(walkthroughState) as Record<WalkthroughContextKeys, boolean>;
 
 		return {
 			allCount: this.container.walkthrough.walkthroughSize,
 			doneCount: this.container.walkthrough.doneCount,
 			progress: this.container.walkthrough.progress,
+			state: state,
+		};
+	}
+
+	private getGraphWalkthroughProgress(): GraphWalkthroughProgress | undefined {
+		const graphState = this.container.walkthrough.getGraphState();
+		const state = Object.fromEntries(graphState) as Record<GraphWalkthroughContextKeys, boolean>;
+
+		return {
+			allCount: this.container.walkthrough.graphWalkthroughSize,
+			doneCount: this.container.walkthrough.graphDoneCount,
+			progress: this.container.walkthrough.graphProgress,
 			state: state,
 		};
 	}
@@ -115,6 +151,8 @@ export class WelcomeWebviewProvider implements WebviewProvider<State, State, Wel
 			hostAppName: env.appName,
 			plusState: plusState,
 			walkthroughProgress: this.getWalkthroughProgress(),
+			graphWalkthroughProgress: this.getGraphWalkthroughProgress(),
+			mode: this._mode,
 			mcpNeedsInstall: this.getMcpNeedsInstall(),
 			mcpShowCleanupNotice: this.getMcpShowCleanupNotice(),
 		};


### PR DESCRIPTION
## Summary

- Adds a dedicated Graph walkthrough flow with 6 steps (agent monitoring, parallel work, AI review, compose, compare, next steps) as a separate mode in the Welcome view
- Implements independent progress tracking for the Graph walkthrough via `WalkthroughStateProvider`
- Adds a "What's new in GitLens 18" banner in the Graph header to drive discovery
- Fixes back-link color specificity so "Back to the GitLens walkthrough" renders in gray per design

Closes #5149
Ref: https://github.com/gitkraken/vscode-gitlens/issues/5149#issuecomment-4454898461

## Test plan

- [ ] Open the Welcome view — verify the main walkthrough renders normally with progress tracking
- [ ] Open the Commit Graph — verify "What's new in GitLens 18" banner appears in the header
- [ ] Click the banner — verify Welcome view switches to Graph walkthrough mode
- [ ] Verify "Back to the GitLens walkthrough" link is gray (not blue link color)
- [ ] Click "Back to the GitLens walkthrough" — verify it returns to main walkthrough
- [ ] Complete Graph walkthrough steps and verify progress tracking works independently
- [ ] Test in light, dark, and high-contrast themes
