### PR TITLE
Fix agent state flicker between working and idle

### DIFF
--- a/packages/plus/agents/src/providers/claudeCodeProvider.ts
+++ b/packages/plus/agents/src/providers/claudeCodeProvider.ts
@@ -17,6 +17,7 @@ import {
 import type {
 	AgentProviderCallbacks,
 	AgentSession,
+	AgentSessionPhase,
 	AgentSessionProvider,
 	AgentSessionStatus,
 	ClaudeCodeHookEvent,
@@ -80,12 +81,27 @@ interface SessionBookkeeping {
 	 *  every subsequent hook event. Cleared when the session's cwd changes (re-resolution
 	 *  warranted) or on resetBookkeeping (Stop/SessionStart). */
 	gitInfoUnresolvable: boolean;
+	/** Phase that immediately preceded the current one, with its original `phaseSince`. Used by
+	 *  `resolvePhaseSince` to restore continuity when phase oscillates back within a short
+	 *  window (e.g., Stop → idle → working after a continuation crosses the debounce). */
+	priorPhase?: { phase: AgentSessionPhase; phaseSince: Date };
 }
 
 const staleCheckIntervalMs = 60 * 1000; // 1 minute
 /** Cooldown between PostToolUse and dropping the file from `currentFiles`. Keeps the WIP "agent
  *  editing this file" decoration stable across rapid sequential tool calls to the same path. */
 const postToolUseClearDelayMs = 20000;
+
+/** Grace period before `Stop` commits to `idle`. Long enough to absorb a same-turn continuation
+ *  (hook-driven re-prompt, IPC event reordering, auto-resume); short enough that legitimate idle
+ *  is visible promptly. */
+const stopToIdleDebounceMs = 750;
+
+/** If a phase transitions away and then back within this window, restore the prior `phaseSince`
+ *  so the displayed elapsed time doesn't snap to 0 on transient oscillations. Slightly longer
+ *  than `stopToIdleDebounceMs` so a continuation that just barely crosses the debounce still
+ *  restores continuity. */
+const phaseSinceRestoreWindowMs = 2000;
 
 interface SessionFileData {
 	sessionId: string;
@@ -171,6 +187,9 @@ export class ClaudeCodeProvider implements AgentSessionProvider {
 	private readonly _pendingPermissions = new Map<string, PendingPermissionEntry>();
 	private readonly _resolveGitInfoInFlight = new Set<string>();
 	private readonly _sessionBookkeeping = new Map<string, SessionBookkeeping>();
+	/** Per-session timers for the deferred `Stop → idle` commit. The handle is cleared (and the
+	 *  transition cancelled) by any non-idle status update arriving before the timer fires. */
+	private readonly _pendingIdleTimers = new Map<string, NodeJS.Timeout>();
 	private _workspacePaths: string[] = [];
 	private _staleCheckTimer: UnifiedDisposable | undefined;
 
@@ -252,6 +271,10 @@ export class ClaudeCodeProvider implements AgentSessionProvider {
 		for (const bk of this._sessionBookkeeping.values()) {
 			this.cancelPendingFileClears(bk);
 		}
+		for (const timer of this._pendingIdleTimers.values()) {
+			clearTimeout(timer);
+		}
+		this._pendingIdleTimers.clear();
 		this._sessionBookkeeping.clear();
 		if (this._ipcStarted) {
 			void this.callbacks.ipc.unpublishAgents();
@@ -358,20 +381,29 @@ export class ClaudeCodeProvider implements AgentSessionProvider {
 
 		switch (event.event) {
 			case 'SessionStart': {
+				const wasNew = this._sessions.findIndex(s => s.id === event.sessionId) < 0;
 				const { index } = this.ensureSession(event.sessionId, eventContext);
-				this.resetBookkeeping(event.sessionId);
-				const prev = this._sessions[index];
-				const newPhase = getPhaseForStatus('idle');
-				this._sessions[index] = {
-					...prev,
-					pid: event.pid ?? prev.pid,
-					status: 'idle',
-					phase: newPhase,
-					phaseSince: prev.phase !== newPhase ? new Date() : prev.phaseSince,
-					statusDetail: undefined,
-					pendingPermission: undefined,
-					lastActivity: new Date(),
-				};
+
+				if (wasNew) {
+					// ensureSession created the session at 'idle' already. Just refresh pid if
+					// the event carries one — bookkeeping was implicitly clean.
+					this.resetBookkeeping(event.sessionId);
+					if (event.pid != null) {
+						const prev = this._sessions[index];
+						if (prev.pid !== event.pid) {
+							this._sessions[index] = { ...prev, pid: event.pid };
+						}
+					}
+				} else {
+					// SessionStart for a session we already track is almost always a CLI replay
+					// (resume/reconnect/hook re-init). Don't clobber live state — the next real
+					// event will re-establish status. Refresh pid only.
+					const prev = this._sessions[index];
+					if (event.pid != null && event.pid !== prev.pid) {
+						this._sessions[index] = { ...prev, pid: event.pid, lastActivity: new Date() };
+					}
+				}
+
 				this._onDidChangeSessions.fire();
 				this.callbacks.onSessionStarted?.(this.id);
 				break;
@@ -383,6 +415,7 @@ export class ClaudeCodeProvider implements AgentSessionProvider {
 					pending.reject(new Error('Session ended'));
 					this._pendingPermissions.delete(event.sessionId);
 				}
+				this.cancelPendingIdleTransition(event.sessionId);
 
 				const index = this._sessions.findIndex(s => s.id === event.sessionId);
 				if (index >= 0) {
@@ -459,7 +492,18 @@ export class ClaudeCodeProvider implements AgentSessionProvider {
 					this._pendingPermissions.delete(event.sessionId);
 				}
 				this.resetBookkeeping(event.sessionId);
-				this.updateSessionStatus(event.sessionId, 'idle', eventContext);
+				// Apply Stop's metadata synchronously so we don't carry stale context through the
+				// debounce window — any in-window mutations (e.g. CwdChanged) survive when the
+				// timer fires. ensureSession doesn't fire on metadata-only updates of existing
+				// sessions, so fire here to match the original Stop-handler's UI-update semantics.
+				const { changed } = this.ensureSession(event.sessionId, eventContext);
+				if (changed) {
+					this._onDidChangeSessions.fire();
+				}
+				// Defer the status change — if the agent continues within the debounce window
+				// (hook-driven re-prompt, IPC reordering, auto-resume), the next non-idle event
+				// cancels this and we never flick through idle.
+				this.scheduleIdleTransition(event.sessionId);
 				break;
 			}
 
@@ -801,6 +845,58 @@ export class ClaudeCodeProvider implements AgentSessionProvider {
 		return true;
 	}
 
+	/** Defer the `Stop → idle` commit. If the agent produces a non-idle event within
+	 *  `stopToIdleDebounceMs`, `cancelPendingIdleTransition` (called from `updateSessionStatus`)
+	 *  cancels this and the session stays in its prior phase — no working → idle → working flicker.
+	 *
+	 *  Intentionally takes no context: the caller is expected to apply any event metadata
+	 *  synchronously before scheduling. Carrying Stop-time context into the timer would let
+	 *  in-window metadata mutations (e.g. `CwdChanged` updating `_sessions[i].cwd` directly)
+	 *  get reverted when the deferred commit replays the stale context through `ensureSession`. */
+	private scheduleIdleTransition(sessionId: string): void {
+		this.cancelPendingIdleTransition(sessionId);
+		const timer = setTimeout(() => {
+			this._pendingIdleTimers.delete(sessionId);
+			// Session may have been removed (SessionEnd, prune) during the window.
+			if (this._sessions.findIndex(s => s.id === sessionId) < 0) return;
+
+			this.updateSessionStatus(sessionId, 'idle');
+		}, stopToIdleDebounceMs);
+		this._pendingIdleTimers.set(sessionId, timer);
+	}
+
+	private cancelPendingIdleTransition(sessionId: string): void {
+		const timer = this._pendingIdleTimers.get(sessionId);
+		if (timer == null) return;
+
+		clearTimeout(timer);
+		this._pendingIdleTimers.delete(sessionId);
+	}
+
+	/** Stable phase-since: if we're oscillating back into the phase we were just in (within a
+	 *  short window), restore its original timestamp so the displayed elapsed time doesn't snap
+	 *  to 0. Otherwise records the current phase as the new "prior" and returns `now`. */
+	private resolvePhaseSince(
+		sessionId: string,
+		prevPhase: AgentSessionPhase,
+		prevPhaseSince: Date,
+		newPhase: AgentSessionPhase,
+	): Date {
+		if (prevPhase === newPhase) return prevPhaseSince;
+
+		const bk = this.getBookkeeping(sessionId);
+		const now = new Date();
+
+		if (bk.priorPhase?.phase === newPhase && now.getTime() - prevPhaseSince.getTime() < phaseSinceRestoreWindowMs) {
+			const restored = bk.priorPhase.phaseSince;
+			bk.priorPhase = { phase: prevPhase, phaseSince: prevPhaseSince };
+			return restored;
+		}
+
+		bk.priorPhase = { phase: prevPhase, phaseSince: prevPhaseSince };
+		return now;
+	}
+
 	// Called when a pending permission was resolved outside GitLens (e.g. via the CLI terminal).
 	// The 'deny' response is a safe no-op since the tool has already run or been denied upstream.
 	private clearStalePermission(sessionId: string, reason: string): void {
@@ -873,6 +969,10 @@ export class ClaudeCodeProvider implements AgentSessionProvider {
 	}
 
 	private updateSessionWithPermission(sessionId: string, permission: PendingPermission, pid?: number): void {
+		// A pending permission is a working/waiting transition — cancel any deferred Stop → idle
+		// commit so the session doesn't briefly flip to idle before showing the prompt.
+		this.cancelPendingIdleTransition(sessionId);
+
 		const { index } = this.ensureSession(sessionId, { pid: pid });
 
 		const prev = this._sessions[index];
@@ -882,7 +982,7 @@ export class ClaudeCodeProvider implements AgentSessionProvider {
 			...prev,
 			status: 'permission_requested',
 			phase: newPhase,
-			phaseSince: prev.phase !== newPhase ? new Date() : prev.phaseSince,
+			phaseSince: this.resolvePhaseSince(sessionId, prev.phase, prev.phaseSince, newPhase),
 			statusDetail: permission.toolDescription,
 			pendingPermission: permission,
 			lastActivity: new Date(),
@@ -895,6 +995,13 @@ export class ClaudeCodeProvider implements AgentSessionProvider {
 		status: AgentSessionStatus,
 		options?: SessionContext & { statusDetail?: string },
 	): void {
+		// Any non-idle status update implicitly cancels a deferred Stop → idle commit. The
+		// timer is owned here so the schedule/cancel pair is uniformly enforced regardless of
+		// which event path produced the next status.
+		if (status !== 'idle') {
+			this.cancelPendingIdleTransition(sessionId);
+		}
+
 		const { index, changed: metadataChanged } = this.ensureSession(sessionId, options);
 
 		const prev = this._sessions[index];
@@ -925,7 +1032,7 @@ export class ClaudeCodeProvider implements AgentSessionProvider {
 			...prev,
 			status: status,
 			phase: newPhase,
-			phaseSince: prev.phase !== newPhase ? new Date() : prev.phaseSince,
+			phaseSince: this.resolvePhaseSince(sessionId, prev.phase, prev.phaseSince, newPhase),
 			statusDetail: statusDetail,
 			pendingPermission: status === 'permission_requested' ? bk.pendingPermission : undefined,
 			lastActivity: new Date(),
@@ -1112,6 +1219,7 @@ export class ClaudeCodeProvider implements AgentSessionProvider {
 				pending.reject(new Error('Session pruned'));
 				this._pendingPermissions.delete(id);
 			}
+			this.cancelPendingIdleTransition(id);
 			this._sessionBookkeeping.delete(id);
 		}
 		Logger.debug(


### PR DESCRIPTION
## Summary

Users have reported that agent status indicators flicker between states — e.g., transitioning from working → idle → working in under a second without any user input. This PR addresses the three observed root causes.

- **Debounce `Stop → idle` (750ms)**: Claude Code's `Stop` hook fires at the end of every turn, but the agent may immediately continue (hook-driven re-prompts, autonomous loops, IPC event reordering, auto-resume). The handler now schedules a deferred commit; any non-idle status update inside the window cancels it.
- **Preserve state on `SessionStart` replay**: The CLI can replay `SessionStart` on `--resume`, reconnect, or hook re-init. The handler used to clobber `status`, `phase`, `phaseSince`, `statusDetail`, and `pendingPermission` unconditionally. Now, for an already-tracked session, only `pid` is refreshed — the next real event re-establishes status.
- **Stabilize `phaseSince` across short oscillations**: If a phase transitions away and back within 2s, the original `phaseSince` is restored so the UI's "Last active Ns ago" doesn't snap to 0 on transient changes.

Timer cleanup is wired into `dispose`, `SessionEnd`, and `pruneDeadSessions` so deferred commits never fire against removed sessions.

All changes are isolated to `packages/plus/agents/src/providers/claudeCodeProvider.ts` — the serialization/IPC layer and webview consumers are unchanged.

## Test plan

- [x] `pnpm run build` — passes cleanly
- [x] `pnpm run test` — 657 existing unit tests pass
- [x] Live: run an agent flow with autonomous continuation (e.g. `/loop` or any hook-driven re-prompt) and verify the agent-status pill stays solid "Working" instead of blinking through "Idle"
- [x] Live: let an agent finish a turn with no follow-on and confirm the pill transitions to "Idle" after ~750ms
- [x] Live: trigger a `SessionStart` replay (`claude --resume` on a live session) and verify the pill doesn't flick to idle if the session was mid-flow
- [x] Live: verify "Last active Ns ago" stays continuous across a brief Stop/continue cycle