### PR TITLE
fix: quote YAML description in modern-css skill

### DIFF
--- a/.claude/skills/modern-css/SKILL.md
+++ b/.claude/skills/modern-css/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: modern-css
-description: Use when touching any CSS — new files, edits, audits, refactors, `<style>` blocks, CSS-in-JS, Tailwind config, design-token files, or reviewing CSS a teammate wrote. Applies to vanilla CSS, shadow DOM internals, web-component consumers, VS Code webviews, and framework-scoped styles. Skip signals — file imports `openai`/other non-CSS SDK, `.py`/`.go`/`.rs` files without embedded styles. Skipping when applicable ships miscalibrated output — wrong browser target, hardcoded values where tokens exist, cascade fights fixed with `!important`, shadow-DOM piercing selectors, viewport queries for component-internal layout, `transform: translateZ(0)` for layer promotion — that passes local checks but breaks in production browsers, themes, or shadow roots.
+description: "Guide CSS authoring, review, and auditing with context-aware detection of browser targets, token systems, and shadow DOM boundaries. Use when touching any CSS — new files, edits, audits, refactors, style blocks, CSS-in-JS, Tailwind config, design-token files, or reviewing CSS a teammate wrote. Applies to vanilla CSS, shadow DOM internals, web-component consumers, VS Code webviews, and framework-scoped styles. Skip when file imports non-CSS SDKs or targets non-web languages without embedded styles."
 ---
 
 # Modern CSS


### PR DESCRIPTION
Hey @d13 👋

great work truly. 28 skills covering everything from accessibility audits and deep planning to live pairing and performance inspection. The breadth is striking, especially the a11y skills (audit, flow-audit, remediate) that show accessibility isn't an afterthought. With merge-mate already handling AI review, you've clearly invested in making AI a first-class part of the GitLens development workflow.

ran your skills through `tessl skill review` at work and found some targeted improvements. Here's the before/after:

| Skill | Before | After | Change |
|-------|--------|-------|--------|
| modern-css | 16% | 94% | +78% |

the `modern-css` skill had the most headroom. Its YAML frontmatter contained unquoted backticks and special characters that broke YAML parsing entirely, causing validation to fail before the content judge could even evaluate the (excellent) body and 7 reference files.

<details>
<summary>Changes Summary</summary>

- Quoted the YAML description field - the original contained unquoted backticks and angle brackets that broke YAML frontmatter parsing, preventing the skill from passing validation
- Restructured the description - added a clear capability statement, preserved the "Use when..." trigger clause and "Skip when..." exclusion, trimmed the lengthy consequence explanation that was contributing to the parse failure
- Preserved all domain expertise - the body content, detection spine, routing table, load-bearing rules, audit guidance, and all 7 reference files are untouched

</details>

---

quick honest disclosure. I work at https://github.com/tesslio where we build tooling around skills like these. Not a pitch, just saw room for improvement and wanted to contribute.

if you want to self-improve your skills, or define your own scenarios to pressure test, just ask your agent (Claude Code, Codex, etc.) to evaluate and optimize your skill with Tessl. Ping me [@yogesh-tessl](https://github.com/yogesh-tessl), if you hit any snags.
