### PR TITLE
Fix stale pin/unpin context menu in Commit Graph

### DIFF
--- a/src/webviews/plus/graph/graphWebview.ts
+++ b/src/webviews/plus/graph/graphWebview.ts
@@ -4922,6 +4922,7 @@ export class GraphWebviewProvider implements WebviewProvider<State, State, Graph
 			graph.avatars.size,
 			graph.downstreams,
 			statsLoading,
+			this.getFiltersByRepo(graph.repoPath)?.pinnedRef?.id,
 		);
 
 		return this.host.notify(
@@ -5284,6 +5285,7 @@ export class GraphWebviewProvider implements WebviewProvider<State, State, Graph
 								state.avatars != null ? Object.keys(state.avatars).length : 0,
 								state.downstreams,
 								state.rowsStatsLoading === true,
+								this.getFiltersByRepo(this._graph?.repoPath)?.pinnedRef?.id,
 							)
 						: undefined;
 				const skipRows = fingerprint != null && fingerprint === this._lastSentGraphFingerprint;
@@ -9246,6 +9248,7 @@ function buildGraphFingerprint(
 	avatarCount: number,
 	downstreams: ReadonlyMap<string, readonly string[]> | Readonly<Record<string, readonly string[]>> | undefined,
 	statsLoading: boolean,
+	pinnedRefId: string | undefined,
 ): string {
 	const first = rows?.[0]?.sha ?? '';
 	const last = rows?.at(-1)?.sha ?? '';
@@ -9257,7 +9260,9 @@ function buildGraphFingerprint(
 	// Captures: ref renames (different id at same sha), tip moves (refs disappear from one sha and
 	// appear on another), tag set changes. Skipped for the bulk of rows that have no refs at all.
 	// Pushed into an array and joined at the end so V8 doesn't rope-flatten on each `+=`.
-	const parts: string[] = [`${rowCount}|${first}|${last}|${avatarCount}|${downstreamCount}|${statsLoading ? 1 : 0}`];
+	const parts: string[] = [
+		`${rowCount}|${first}|${last}|${avatarCount}|${downstreamCount}|${statsLoading ? 1 : 0}|${pinnedRefId ?? ''}`,
+	];
 	if (rows != null) {
 		for (const r of rows) {
 			const hl = r.heads?.length;


### PR DESCRIPTION
## Summary

- Includes `pinnedRefId` in `buildGraphFingerprint()` so pin/unpin state changes bust the row-dedup cache, fixing the context menu showing "Pin to Left" on an already-pinned branch (or vice versa)

## Root Cause

`buildGraphFingerprint()` computed fingerprints from ref IDs and structural fields but **not** from `head.context` strings — the serialized `webviewItem` values that carry the `+pinned` flag. When `updatePinnedRef()` triggered `updateState(true)`, the fingerprint matched `_lastSentGraphFingerprint` causing `skipRows = true` — the webview kept stale `head.context` and the context menu `when`-clause evaluated against stale data.

The pin *icon* was unaffected because it is driven by `pinnedBranchFullName` prop via `DidChangePinnedRefNotification`, independent of rows.

## Fix

Added `pinnedRefId` as a fingerprint component — when pin state changes, the fingerprint changes, and rows are re-sent with updated `head.context` values.

## Test plan

- [ ] Open Commit Graph, right-click a branch → Pin to Left → verify pin icon + context menu shows Unpin from Left
- [ ] Click Unpin from Left → verify pin icon removed + context menu shows Pin to Left
- [ ] Repeat pin/unpin cycle 2-3 more times — context menu should always match pin state
- [ ] Verify no console errors during pin/unpin cycles
- [ ] Verify no regression in graph performance on large repos (fingerprint computation is O(1) addition)

Closes #5243