### PR TITLE
Filter Claude Code harness wrappers from displayed agent prompts

### DIFF
--- a/packages/plus/agents/src/__tests__/claudeCodeProvider.test.ts
+++ b/packages/plus/agents/src/__tests__/claudeCodeProvider.test.ts
@@ -187,6 +187,175 @@ suite('ClaudeCodeProvider', () => {
 			}
 		});
 
+		test('IDE-prefixed prompts are stripped before storing as lastPrompt', async () => {
+			const { callbacks, handlers } = createMockCallbacks();
+			const provider = new ClaudeCodeProvider(callbacks);
+			try {
+				provider.start(['/repo']);
+
+				const handler = handlers.get('agents/session')!;
+				await handler(sessionStart('s1', '/repo'), new URLSearchParams());
+				await handler(
+					{
+						event: 'UserPromptSubmit',
+						sessionId: 's1',
+						cwd: '/repo',
+						pid: process.pid,
+						prompt:
+							'<ide_opened_file>The user opened the file /repo/foo.ts in the IDE. ' +
+							'This may or may not be related to the current task.</ide_opened_file>\n' +
+							'/investigate sky color',
+					},
+					new URLSearchParams(),
+				);
+
+				assert.strictEqual(provider.sessions[0].lastPrompt, '/investigate sky color');
+			} finally {
+				provider.dispose();
+			}
+		});
+
+		test('rehydrated sessions from syncSessions have prompts sanitized', async () => {
+			const sessionPayload = [
+				{
+					sessionId: 'sync-1',
+					cwd: '/repo',
+					pid: process.pid,
+					event: 'UserPromptSubmit',
+					updatedAt: new Date().toISOString(),
+					prompt: '<task-notification><status>completed</status><summary>done</summary></task-notification>',
+					firstPrompt:
+						'<ide_opened_file>The user opened /repo/foo.ts</ide_opened_file>\n' +
+						'investigate the failing test',
+				},
+			];
+			const { callbacks } = createMockCallbacks();
+			const provider = new ClaudeCodeProvider({
+				...callbacks,
+				runCLICommand: () => Promise.resolve(JSON.stringify(sessionPayload)),
+			});
+			try {
+				provider.start(['/repo']);
+				await flushMicrotasks();
+				await flushMicrotasks();
+
+				const session = provider.sessions.find(s => s.id === 'sync-1');
+				assert.ok(session, 'session sync-1 should be rehydrated');
+				assert.strictEqual(
+					session.lastPrompt,
+					undefined,
+					'pure task-notification payload must not surface as lastPrompt',
+				);
+				assert.strictEqual(
+					session.firstPrompt,
+					'investigate the failing test',
+					'IDE wrapper must be stripped from rehydrated firstPrompt',
+				);
+			} finally {
+				provider.dispose();
+			}
+		});
+
+		test('background-bash task-notification prompts do not overwrite the previous lastPrompt', async () => {
+			const { callbacks, handlers } = createMockCallbacks();
+			const provider = new ClaudeCodeProvider(callbacks);
+			try {
+				provider.start(['/repo']);
+
+				const handler = handlers.get('agents/session')!;
+				await handler(sessionStart('s1', '/repo'), new URLSearchParams());
+				await handler(
+					{
+						event: 'UserPromptSubmit',
+						sessionId: 's1',
+						cwd: '/repo',
+						pid: process.pid,
+						prompt: 'Run a background bash command that prints the date every 5 seconds',
+						firstPrompt: 'Run a background bash command that prints the date every 5 seconds',
+					},
+					new URLSearchParams(),
+				);
+				const statusBefore = provider.sessions[0].status;
+				const statusDetailBefore = provider.sessions[0].statusDetail;
+				await handler(
+					{
+						event: 'UserPromptSubmit',
+						sessionId: 's1',
+						cwd: '/repo',
+						pid: process.pid,
+						prompt:
+							'<task-notification>\n' +
+							'<task-id>b3b6icuho</task-id>\n' +
+							'<tool-use-id>toolu_01FEnSf5</tool-use-id>\n' +
+							'<output-file>/tmp/.../b3b6icuho.output</output-file>\n' +
+							'<status>completed</status>\n' +
+							'<summary>Background command completed (exit code 0)</summary>\n' +
+							'</task-notification>',
+					},
+					new URLSearchParams(),
+				);
+
+				assert.strictEqual(
+					provider.sessions[0].status,
+					statusBefore,
+					'synthetic task-notification must not transition session status',
+				);
+				assert.strictEqual(
+					provider.sessions[0].statusDetail,
+					statusDetailBefore,
+					'synthetic task-notification must not change statusDetail',
+				);
+				assert.strictEqual(
+					provider.sessions[0].lastPrompt,
+					'Run a background bash command that prints the date every 5 seconds',
+					'task-notification synthetic prompt must not overwrite real lastPrompt',
+				);
+			} finally {
+				provider.dispose();
+			}
+		});
+
+		test('prompts that are nothing but IDE context do not overwrite the previous lastPrompt', async () => {
+			const { callbacks, handlers } = createMockCallbacks();
+			const provider = new ClaudeCodeProvider(callbacks);
+			try {
+				provider.start(['/repo']);
+
+				const handler = handlers.get('agents/session')!;
+				await handler(sessionStart('s1', '/repo'), new URLSearchParams());
+				await handler(
+					{
+						event: 'UserPromptSubmit',
+						sessionId: 's1',
+						cwd: '/repo',
+						pid: process.pid,
+						prompt: 'what is 2+2?',
+						firstPrompt: 'what is 2+2?',
+					},
+					new URLSearchParams(),
+				);
+				await handler(
+					{
+						event: 'UserPromptSubmit',
+						sessionId: 's1',
+						cwd: '/repo',
+						pid: process.pid,
+						prompt: '<ide_opened_file>just context, no prompt</ide_opened_file>',
+					},
+					new URLSearchParams(),
+				);
+
+				assert.strictEqual(provider.sessions[0].firstPrompt, 'what is 2+2?');
+				assert.strictEqual(
+					provider.sessions[0].lastPrompt,
+					'what is 2+2?',
+					'IDE-context-only prompt must not overwrite real lastPrompt',
+				);
+			} finally {
+				provider.dispose();
+			}
+		});
+
 		test('subsequent UserPromptSubmit preserves firstPrompt and updates lastPrompt', async () => {
 			const { callbacks, handlers } = createMockCallbacks();
 			const provider = new ClaudeCodeProvider(callbacks);

--- a/packages/plus/agents/src/__tests__/sanitizePrompt.test.ts
+++ b/packages/plus/agents/src/__tests__/sanitizePrompt.test.ts
@@ -1,0 +1,196 @@
+import * as assert from 'node:assert';
+import { sanitizeAgentPrompt } from '../sanitizePrompt.js';
+
+suite('sanitizeAgentPrompt', () => {
+	test('returns undefined for undefined', () => {
+		assert.strictEqual(sanitizeAgentPrompt(undefined), undefined);
+	});
+
+	test('returns undefined for empty string', () => {
+		assert.strictEqual(sanitizeAgentPrompt(''), undefined);
+	});
+
+	test('returns undefined for whitespace-only input', () => {
+		assert.strictEqual(sanitizeAgentPrompt('   \n\t  '), undefined);
+	});
+
+	test('returns plain prompt trimmed', () => {
+		assert.strictEqual(sanitizeAgentPrompt('  fix the failing test  '), 'fix the failing test');
+	});
+
+	suite('ide_* wrappers', () => {
+		test('strips <ide_opened_file> prefix and keeps user text', () => {
+			const input =
+				'<ide_opened_file>The user opened the file /repo/foo.ts in the IDE. ' +
+				'This may or may not be related to the current task.</ide_opened_file>\n' +
+				'/investigate sky color';
+			assert.strictEqual(sanitizeAgentPrompt(input), '/investigate sky color');
+		});
+
+		test('strips <ide_selection> with multiline content', () => {
+			const input =
+				'<ide_selection>The user selected the lines 10 to 20 from /repo/foo.ts:\n' +
+				'function foo() {\n  return 1;\n}\n\n' +
+				'This may or may not be related to the current task.</ide_selection>\n' +
+				'explain this code';
+			assert.strictEqual(sanitizeAgentPrompt(input), 'explain this code');
+		});
+
+		test('strips a hypothetical future <ide_anything_new> via prefix match', () => {
+			const input = '<ide_anything_new>future context</ide_anything_new>\nuser text';
+			assert.strictEqual(sanitizeAgentPrompt(input), 'user text');
+		});
+
+		test('strips <ide_opened_file> with attributes', () => {
+			const input = '<ide_opened_file path="/repo/foo.ts">context</ide_opened_file>\nuser text';
+			assert.strictEqual(sanitizeAgentPrompt(input), 'user text');
+		});
+
+		test('returns undefined when input is only IDE context', () => {
+			const input = '<ide_opened_file>just context, no prompt</ide_opened_file>';
+			assert.strictEqual(sanitizeAgentPrompt(input), undefined);
+		});
+
+		test('does not strip a bare <ide_> with no name suffix', () => {
+			const input = '<ide_>not a real tag</ide_>';
+			assert.strictEqual(sanitizeAgentPrompt(input), input);
+		});
+	});
+
+	suite('@terminal mention expansion', () => {
+		test('strips <terminal name="..."> and keeps user text', () => {
+			const input = '<terminal name="bash-1">$ ls\nfoo.ts bar.ts</terminal>\nwhy did that fail?';
+			assert.strictEqual(sanitizeAgentPrompt(input), 'why did that fail?');
+		});
+
+		test('does NOT strip plain <terminal> without a name attribute', () => {
+			const input = '<terminal>like in markdown</terminal>';
+			assert.strictEqual(sanitizeAgentPrompt(input), input);
+		});
+	});
+
+	suite('@browser mention expansion', () => {
+		test('strips <browser tabGroupId="..." tabId="..."> and keeps user text', () => {
+			const input = '<browser tabGroupId="g1" tabId="t1">https://example.com</browser>\nsummarize this';
+			assert.strictEqual(sanitizeAgentPrompt(input), 'summarize this');
+		});
+
+		test('strips <browser_instruction>', () => {
+			const input =
+				'<browser_instruction>Use the browser tool to fetch URLs.</browser_instruction>\n' +
+				'what does this say?';
+			assert.strictEqual(sanitizeAgentPrompt(input), 'what does this say?');
+		});
+
+		test('does NOT strip plain <browser> without tab attributes', () => {
+			const input = '<browser>like a code example</browser>';
+			assert.strictEqual(sanitizeAgentPrompt(input), input);
+		});
+	});
+
+	suite('CLI harness wrappers', () => {
+		test('strips <task-notification> with nested children', () => {
+			const input =
+				'<task-notification>\n' +
+				'<task-id>b3b6icuho</task-id>\n' +
+				'<tool-use-id>toolu_01FEnSf5</tool-use-id>\n' +
+				'<output-file>/tmp/.../b3b6icuho.output</output-file>\n' +
+				'<status>completed</status>\n' +
+				'<summary>Background command "Print date" completed (exit code 0)</summary>\n' +
+				'</task-notification>';
+			assert.strictEqual(sanitizeAgentPrompt(input), undefined);
+		});
+
+		test('strips <local-command-stdout>', () => {
+			const input = '<local-command-stdout>Set model to claude-opus-4-7</local-command-stdout>';
+			assert.strictEqual(sanitizeAgentPrompt(input), undefined);
+		});
+
+		test('strips <local-command-stderr>', () => {
+			const input = '<local-command-stderr>error</local-command-stderr>\nfollow up';
+			assert.strictEqual(sanitizeAgentPrompt(input), 'follow up');
+		});
+
+		test('strips <local-command-caveat>', () => {
+			const input = '<local-command-caveat>Caveat: ...</local-command-caveat>\nuser text';
+			assert.strictEqual(sanitizeAgentPrompt(input), 'user text');
+		});
+
+		test('strips <bash-input>/<bash-stdout>/<bash-stderr>', () => {
+			const input =
+				'<bash-input>ls -la</bash-input>\n' +
+				'<bash-stdout>foo.ts\nbar.ts</bash-stdout>\n' +
+				'<bash-stderr></bash-stderr>\n' +
+				'what is in foo.ts?';
+			assert.strictEqual(sanitizeAgentPrompt(input), 'what is in foo.ts?');
+		});
+
+		test('strips <permissionresponse>', () => {
+			const input = '<permissionresponse>allow</permissionresponse>\nproceed';
+			assert.strictEqual(sanitizeAgentPrompt(input), 'proceed');
+		});
+
+		test('strips <shared-context> with attributes', () => {
+			const input =
+				'<shared-context id="abc" type="markdown" version="1" title="Notes">' +
+				'some shared context body' +
+				'</shared-context>\nthe actual question';
+			assert.strictEqual(sanitizeAgentPrompt(input), 'the actual question');
+		});
+	});
+
+	suite('combinations', () => {
+		test('strips multiple concatenated wrappers', () => {
+			const input =
+				'<ide_opened_file>foo.ts context</ide_opened_file>\n' +
+				'<browser_instruction>browser hint</browser_instruction>\n' +
+				'do the thing';
+			assert.strictEqual(sanitizeAgentPrompt(input), 'do the thing');
+		});
+
+		test('collapses extra blank lines after stripping', () => {
+			const input =
+				'<ide_opened_file>a</ide_opened_file>\n\n\n\n' +
+				'<browser_instruction>b</browser_instruction>\n\n\n' +
+				'after';
+			assert.strictEqual(sanitizeAgentPrompt(input), 'after');
+		});
+
+		test('normalizes CRLF line endings around a stripped wrapper', () => {
+			const input = '<ide_opened_file>The user opened /repo/foo.ts</ide_opened_file>\r\n/investigate sky color';
+			assert.strictEqual(sanitizeAgentPrompt(input), '/investigate sky color');
+		});
+
+		test('preserves internal whitespace when no wrapper matched', () => {
+			const input = 'line one   \n\n\n\nline two';
+			assert.strictEqual(sanitizeAgentPrompt(input), input);
+		});
+	});
+
+	suite('user content passes through', () => {
+		test('preserves <details>/<summary>', () => {
+			const input = '<details><summary>Click</summary>hidden body</details>';
+			assert.strictEqual(sanitizeAgentPrompt(input), input);
+		});
+
+		test('preserves <img>', () => {
+			const input = 'See <img src="https://example.com/foo.png"> for context';
+			assert.strictEqual(sanitizeAgentPrompt(input), input);
+		});
+
+		test('preserves triple-backtick code blocks', () => {
+			const input = '```ts\nconst x = 1;\n```\nwhat does this do';
+			assert.strictEqual(sanitizeAgentPrompt(input), input);
+		});
+
+		test('preserves TypeScript generic-shaped angle brackets', () => {
+			const input = "Property does not exist on type 'IntrinsicAttributes & Readonly<Props>'.";
+			assert.strictEqual(sanitizeAgentPrompt(input), input);
+		});
+
+		test('preserves GitLens component-name-shaped tags', () => {
+			const input = 'rendering <gl-tooltip> inside <gl-popover> failed';
+			assert.strictEqual(sanitizeAgentPrompt(input), input);
+		});
+	});
+});

--- a/packages/plus/agents/src/providers/claudeCodeProvider.ts
+++ b/packages/plus/agents/src/providers/claudeCodeProvider.ts
@@ -6,7 +6,7 @@ import { disposableInterval } from '@gitlens/utils/disposable.js';
 import { Emitter } from '@gitlens/utils/event.js';
 import { Logger } from '@gitlens/utils/logger.js';
 import { normalizePath } from '@gitlens/utils/path.js';
-import { truncate } from '@gitlens/utils/string.js';
+import { prepareStoredPrompt } from '../sanitizePrompt.js';
 import {
 	classifyPermissionKind,
 	deriveStatusFromEvent,
@@ -438,15 +438,18 @@ export class ClaudeCodeProvider implements AgentSessionProvider {
 
 			case 'UserPromptSubmit': {
 				const { index } = this.ensureSession(event.sessionId, eventContext);
-				if (event.prompt) {
-					const existing = this._sessions[index];
-					this._sessions[index] = {
-						...existing,
-						lastPrompt: truncate(event.prompt, 500),
-						firstPrompt:
-							existing.firstPrompt ?? (event.firstPrompt ? truncate(event.firstPrompt, 500) : undefined),
-					};
-				}
+				const cleaned = prepareStoredPrompt(event.prompt);
+				// A `UserPromptSubmit` whose payload sanitizes to nothing is harness-synthetic
+				// (e.g. background-bash <task-notification>, slash-command stdout echo). Treat it
+				// as informational so it doesn't flip the session to `thinking` or wipe a pending
+				// permission when no real user activity occurred.
+				if (!cleaned) break;
+				const existing = this._sessions[index];
+				this._sessions[index] = {
+					...existing,
+					lastPrompt: cleaned,
+					firstPrompt: existing.firstPrompt ?? prepareStoredPrompt(event.firstPrompt),
+				};
 				this.clearStalePermission(event.sessionId, 'UserPromptSubmit');
 				this.updateSessionStatus(event.sessionId, 'thinking', eventContext);
 				break;
@@ -1314,8 +1317,8 @@ export class ClaudeCodeProvider implements AgentSessionProvider {
 				cwd: data.cwd,
 				planFile: data.planFile ?? undefined,
 				isInWorkspace: isInWorkspace,
-				lastPrompt: data.prompt ?? undefined,
-				firstPrompt: data.firstPrompt ?? undefined,
+				lastPrompt: prepareStoredPrompt(data.prompt ?? undefined),
+				firstPrompt: prepareStoredPrompt(data.firstPrompt ?? undefined),
 				subagents: subagents,
 			});
 			changed = true;

--- a/packages/plus/agents/src/sanitizePrompt.ts
+++ b/packages/plus/agents/src/sanitizePrompt.ts
@@ -1,0 +1,71 @@
+import { truncate } from '@gitlens/utils/string.js';
+
+const maxStoredPromptLength = 500;
+
+// Wrappers the Claude Code harness or its VS Code extension prepend to the `prompt` field of
+// `UserPromptSubmit` hook events. These are synthetic context blocks, not user-typed content,
+// and shouldn't appear verbatim in GitLens agent status UI.
+const harnessBlockPatterns: readonly RegExp[] = [
+	// VS Code extension: any current or future IDE-context tag (e.g. <ide_opened_file>,
+	// <ide_selection>). Prefix-matched so newly-added ones are handled automatically.
+	/<(ide_[a-zA-Z0-9_]+)(?:\s[^>]*)?>[\s\S]*?<\/\1>/g,
+	// VS Code extension: @terminal:<name> mention expansion. Gated on the `name` attribute so we
+	// don't strip a bare <terminal> a user pasted as code.
+	/<terminal\s+name="[^"]*"[^>]*>[\s\S]*?<\/terminal>/g,
+	// VS Code extension: @browser mention expansion. Gated on tabGroupId/tabId for the same reason.
+	/<browser\s+[^>]*\b(?:tabGroupId|tabId)="[^"]*"[^>]*>[\s\S]*?<\/browser>/g,
+	// VS Code extension: one-shot system instruction prepended whenever any @browser is present.
+	/<browser_instruction>[\s\S]*?<\/browser_instruction>/g,
+	// CLI harness: background-bash task lifecycle event (status, summary, output-file, etc.).
+	/<task-notification>[\s\S]*?<\/task-notification>/g,
+	// CLI harness: built-in slash-command stdout/stderr echo and caveat note.
+	/<(local-command-(?:stdout|stderr|caveat))>[\s\S]*?<\/\1>/g,
+	// CLI harness: bang-prefix bash invocation echo (input/stdout/stderr).
+	/<(bash-(?:input|stdout|stderr))>[\s\S]*?<\/\1>/g,
+	// CLI harness: tool-permission response wrapper.
+	/<permissionresponse>[\s\S]*?<\/permissionresponse>/g,
+	// Anthropic shared-context blocks (claude.ai web-app feature; defensive).
+	/<shared-context(?:\s[^>]*)?>[\s\S]*?<\/shared-context>/g,
+];
+
+/**
+ * Normalizes a Claude Code `UserPromptSubmit` event prompt into something fit for display in
+ * GitLens (agent status pill, sidebar tooltip, etc.) by stripping harness-injected wrappers.
+ *
+ * Returns `undefined` for empty input or when the prompt was nothing but harness context, so the
+ * caller can skip overwriting the previously-captured user prompt.
+ */
+export function sanitizeAgentPrompt(prompt: string | undefined): string | undefined {
+	if (!prompt) return undefined;
+
+	// Normalize CRLF up-front so the harness-block and whitespace-collapse regexes (which target
+	// `\n`) behave identically for Windows-originated prompts.
+	let result = prompt.replace(/\r\n/g, '\n');
+	let stripped = false;
+	for (const pattern of harnessBlockPatterns) {
+		const next = result.replace(pattern, '');
+		if (next !== result) {
+			stripped = true;
+			result = next;
+		}
+	}
+
+	// Only collapse the whitespace runs around stripped blocks. Untouched user prompts pass
+	// through with their internal whitespace intact (the final trim still removes the outer
+	// padding either way).
+	if (stripped) {
+		result = result.replace(/[ \t]+\n/g, '\n').replace(/\n{3,}/g, '\n\n');
+	}
+	result = result.trim();
+	return result || undefined;
+}
+
+/**
+ * Sanitizes and truncates a raw prompt for storage on an `AgentSession`. Use this everywhere a
+ * session's `lastPrompt` / `firstPrompt` is populated so the sanitize+truncate pipeline can't be
+ * applied inconsistently across capture paths (hook events, CLI session-state syncs, etc.).
+ */
+export function prepareStoredPrompt(prompt: string | undefined): string | undefined {
+	const cleaned = sanitizeAgentPrompt(prompt);
+	return cleaned ? truncate(cleaned, maxStoredPromptLength) : undefined;
+}


### PR DESCRIPTION
## Summary

- Claude Code's `UserPromptSubmit` hook payload (and the CLI session-state sync) can include synthetic XML wrappers — `<ide_opened_file>`, `<ide_selection>`, `<terminal name="…">`, `<browser …>`, `<browser_instruction>`, `<task-notification>`, `<local-command-*>`, `<bash-*>`, `<permissionresponse>`, `<shared-context>` — that the agent status pill, sidebar tooltip, and graph details card render verbatim, drowning out the actual prompt.
- Adds `sanitizeAgentPrompt()` + a single `prepareStoredPrompt()` helper to strip those wrappers; both the live `UserPromptSubmit` capture and the `syncSessions` rehydration funnel through it so the sanitize+truncate contract can't drift apart.
- Synthetic prompts (e.g. the background-bash `<task-notification>` that fires when a long-running task finishes) no longer overwrite the real `lastPrompt` — sanitization returns `undefined`, caller skips the update.
- User-pasted content (`<details>`, `<img>`, code fences, TS generics, `<gl-*>` component tags) passes through unchanged.

## Test plan

- [x] `pnpm --filter @gitlens/agents test` — 54 tests pass (sanitizer + provider regression coverage for IDE prefix, task-notification, rehydration path)
- [x] `pnpm run build:quick` clean
- [x] Live: open a file in VS Code, attach it via the Claude Code extension and send any prompt → agent status pill shows just the prompt, not the `<ide_opened_file>` prefix
- [x] Live: run a Claude Code background Bash task and let it complete → `lastPrompt` remains the user's prior real prompt, not the `<task-notification>` payload
- [x] Live: restart the extension with existing sessions on disk → rehydrated `lastPrompt` / `firstPrompt` arrive sanitized