### PR TITLE
Reformats Graph TARGET/BASE pills in scope/focus mode

### DIFF
--- a/src/webviews/apps/plus/graph/graph.scss
+++ b/src/webviews/apps/plus/graph/graph.scss
@@ -1209,6 +1209,55 @@ web-graph {
 	}
 }
 
+// Reformat the third-party graph component's TARGET/BASE pills:
+//   - Default state shows "<icon> TARGET" / "<icon> BASE".
+//   - When the ref column is shrunk, the pill collapses to icon-only.
+// The pill itself stays flex-shrink: 0 so it never gets squished; the
+// container query on the .flex parent (which has the column-width inline
+// style) drives the icon-only ↔ icon+text mode swap. Padding/margin are
+// tightened so the dashed right border doesn't clip against the parent's
+// overflow:hidden at minimum width.
+.gk-graph .ref-zone > .flex:has(> .merge-target-ref-node),
+.gk-graph .ref-zone > .flex:has(> .merge-base-ref-node) {
+	container-type: inline-size;
+	container-name: refcol;
+}
+
+.gk-graph .ref-zone .merge-base-ref-node,
+.gk-graph .ref-zone .merge-target-ref-node {
+	flex-shrink: 0;
+	white-space: nowrap;
+	font-size: 0;
+	margin-left: 0;
+	padding: 0 4px;
+	align-items: center;
+
+	&::before {
+		font-size: 13px;
+		line-height: 1;
+		display: inline-block;
+	}
+}
+
+.gk-graph .ref-zone .merge-target-ref-node::before {
+	font-family: 'glicons';
+	@include iconUtils.glicon('merge-target');
+}
+
+.gk-graph .ref-zone .merge-base-ref-node::before {
+	font-family: codicon;
+	@include iconUtils.codicon('git-branch');
+}
+
+@container refcol (min-width: 100px) {
+	.gk-graph .ref-zone .merge-base-ref-node,
+	.gk-graph .ref-zone .merge-target-ref-node {
+		font-size: 11px;
+		padding: 0 6px;
+		gap: 4px;
+	}
+}
+
 // Light DOM
 .graph-app:not(:hover) {
 	.gk-graph .graph-header {


### PR DESCRIPTION
## Summary

- Replaces the third-party graph component's literal `TARGET` / `BASE` text labels with icons (`gl-merge-target` glicon and `git-branch` codicon) so the pills no longer dominate the ref column in scope/focus mode
- Adds a CSS container query on the parent `.flex` element so the pill renders as `<icon> TARGET` / `<icon> BASE` when the column is wide (≥100px) and collapses to icon-only when the user shrinks it
- Pins the pills with `flex-shrink: 0` and tightens margin/padding so the dashed right border stays clear of the parent's `overflow: hidden` clip box at the column's minimum width — previously it was clipping by ~1px at minimum width

## Test plan

- [x] Open the Commit Graph on a feature branch with a defined merge target (e.g. this branch vs `main`)
- [x] Activate scope/focus mode on that branch — TARGET / BASE pills appear in the ref column
- [x] At the default ref-column width: pills show `<icon> TARGET` and `<icon> BASE`
- [x] Drag the ref column narrower: at ≈100px parent width pills collapse to icon-only
- [x] At the column's minimum width: pills stay crisp, dashed border fully visible, no right-edge clipping; adjacent ref pills clip first (intended)
- [x] Theme sweep: pills readable in light + dark themes