### PR TITLE
Adds transcript-derived titles to agent session name fallback

### DIFF
--- a/packages/plus/agents/src/__tests__/claudeCodeProvider.test.ts
+++ b/packages/plus/agents/src/__tests__/claudeCodeProvider.test.ts
@@ -2,6 +2,8 @@ import * as assert from 'assert';
 import type { IpcHandler } from '@gitlens/ipc/ipcServer.js';
 import { createDisposable } from '@gitlens/utils/disposable.js';
 import { ClaudeCodeProvider } from '../providers/claudeCodeProvider.js';
+import type { TranscriptTitles } from '../providers/claudeCodeTranscript.js';
+import { ClaudeCodeTranscriptReader } from '../providers/claudeCodeTranscript.js';
 import type { AgentProviderCallbacks, IpcRegistrar } from '../types.js';
 
 interface MockCallbacks {
@@ -46,6 +48,11 @@ function sessionStart(sessionId: string, cwd: string): Record<string, unknown> {
  *  (publishAgents / syncSessions) and `publishedPaths` is populated. */
 function flushMicrotasks(): Promise<void> {
 	return new Promise(resolve => setImmediate(resolve));
+}
+
+/** Wait for a real timer to elapse — needed when exercising debounced state transitions. */
+function wait(ms: number): Promise<void> {
+	return new Promise(resolve => setTimeout(resolve, ms));
 }
 
 suite('ClaudeCodeProvider', () => {
@@ -159,6 +166,104 @@ suite('ClaudeCodeProvider', () => {
 		});
 	});
 
+	suite('transcript titles', () => {
+		test('SessionStart triggers a transcript read and titles land on the session', async () => {
+			const { callbacks, handlers } = createMockCallbacks();
+			const reader = new StubTranscriptReader({ ai: 'AI-derived title' });
+			const provider = new TestProvider(callbacks, reader);
+			try {
+				provider.start(['/repo']);
+
+				const handler = handlers.get('agents/session')!;
+				await handler(sessionStart('s-trans-1', '/repo'), new URLSearchParams());
+				await flushMicrotasks();
+
+				assert.strictEqual(provider.sessions[0].transcriptTitles?.ai, 'AI-derived title');
+				assert.strictEqual(provider.sessions[0].transcriptTitles?.custom, undefined);
+				assert.strictEqual(provider.sessions[0].transcriptTitles?.agent, undefined);
+				assert.ok(
+					reader.calls.some(c => c.sessionId === 's-trans-1'),
+					'reader should be called for the new session',
+				);
+			} finally {
+				provider.dispose();
+			}
+		});
+
+		test('idle transition (e.g. Stop) triggers a re-check', async () => {
+			const { callbacks, handlers } = createMockCallbacks();
+			const reader = new StubTranscriptReader({});
+			const provider = new TestProvider(callbacks, reader);
+			try {
+				provider.start(['/repo']);
+				const handler = handlers.get('agents/session')!;
+				await handler(sessionStart('s-trans-2', '/repo'), new URLSearchParams());
+				await flushMicrotasks();
+				const initialCalls = reader.calls.filter(c => c.sessionId === 's-trans-2').length;
+
+				// Move to a non-idle state.
+				await handler(
+					{
+						event: 'UserPromptSubmit',
+						sessionId: 's-trans-2',
+						cwd: '/repo',
+						pid: process.pid,
+						prompt: 'hello',
+						firstPrompt: 'hello',
+					},
+					new URLSearchParams(),
+				);
+				await flushMicrotasks();
+
+				// Reader should NOT have been invoked again (still non-idle).
+				const afterPromptCalls = reader.calls.filter(c => c.sessionId === 's-trans-2').length;
+				assert.strictEqual(
+					afterPromptCalls,
+					initialCalls,
+					'non-idle status changes should not re-read transcript',
+				);
+
+				// Now Stop the session — schedules a debounced transition back to idle.
+				reader.titles = { ai: 'After-stop title' };
+				await handler(
+					{ event: 'Stop', sessionId: 's-trans-2', cwd: '/repo', pid: process.pid },
+					new URLSearchParams(),
+				);
+				// The Stop → idle transition is debounced (stopToIdleDebounceMs). Wait past the
+				// debounce window plus a microtask flush for the resolveTranscriptTitles promise.
+				await wait(900);
+				await flushMicrotasks();
+
+				const afterStopCalls = reader.calls.filter(c => c.sessionId === 's-trans-2').length;
+				assert.strictEqual(afterStopCalls, initialCalls + 1, 'idle transition should re-read transcript');
+				assert.strictEqual(provider.sessions[0].transcriptTitles?.ai, 'After-stop title');
+			} finally {
+				provider.dispose();
+			}
+		});
+
+		test('SessionEnd calls forget on the reader', async () => {
+			const { callbacks, handlers } = createMockCallbacks();
+			const reader = new StubTranscriptReader({});
+			const provider = new TestProvider(callbacks, reader);
+			try {
+				provider.start(['/repo']);
+				const handler = handlers.get('agents/session')!;
+				await handler(sessionStart('s-trans-3', '/repo'), new URLSearchParams());
+				await flushMicrotasks();
+
+				await handler(
+					{ event: 'SessionEnd', sessionId: 's-trans-3', cwd: '/repo', pid: process.pid },
+					new URLSearchParams(),
+				);
+
+				assert.deepStrictEqual(reader.forgotten, ['s-trans-3']);
+			} finally {
+				provider.dispose();
+			}
+		});
+	});
+
 	suite('firstPrompt propagation', () => {
 		test('first non-empty UserPromptSubmit populates firstPrompt', async () => {
 			const { callbacks, handlers } = createMockCallbacks();
@@ -230,3 +335,32 @@ suite('ClaudeCodeProvider', () => {
 		});
 	});
 });
+
+/** Drop-in transcript reader for provider tests — records calls and returns canned titles. */
+class StubTranscriptReader extends ClaudeCodeTranscriptReader {
+	titles: TranscriptTitles;
+	readonly calls: { sessionId: string; cwd: string | undefined }[] = [];
+	readonly forgotten: string[] = [];
+
+	constructor(titles: TranscriptTitles) {
+		super();
+		this.titles = titles;
+	}
+
+	override resolve(sessionId: string, cwd: string | undefined): Promise<TranscriptTitles | undefined> {
+		this.calls.push({ sessionId: sessionId, cwd: cwd });
+		return Promise.resolve(this.titles);
+	}
+
+	override forget(sessionId: string): void {
+		this.forgotten.push(sessionId);
+	}
+}
+
+/** Provider variant that lets tests swap the transcript reader. */
+class TestProvider extends ClaudeCodeProvider {
+	constructor(callbacks: AgentProviderCallbacks, reader: ClaudeCodeTranscriptReader) {
+		super(callbacks);
+		this._transcriptReader = reader;
+	}
+}

--- a/packages/plus/agents/src/__tests__/claudeCodeTranscript.test.ts
+++ b/packages/plus/agents/src/__tests__/claudeCodeTranscript.test.ts
@@ -1,0 +1,288 @@
+import * as assert from 'assert';
+import { mkdtempSync, rmSync } from 'fs';
+import { appendFile, mkdir, utimes, writeFile } from 'fs/promises';
+import { tmpdir } from 'os';
+import { join } from 'path';
+import type { TranscriptTitles } from '../providers/claudeCodeTranscript.js';
+import { ClaudeCodeTranscriptReader } from '../providers/claudeCodeTranscript.js';
+
+/** A reader subclass that overrides transcript location to point at a temp directory, so tests
+ *  don't need to touch `~/.claude/projects/`. */
+class TestReader extends ClaudeCodeTranscriptReader {
+	constructor(private readonly _fixedPath: string | undefined) {
+		super();
+	}
+	protected override locateTranscript(): Promise<string | undefined> {
+		return Promise.resolve(this._fixedPath);
+	}
+}
+
+function aiTitle(sessionId: string, value: string): string {
+	return JSON.stringify({ type: 'ai-title', aiTitle: value, sessionId: sessionId });
+}
+function customTitle(sessionId: string, value: string): string {
+	return JSON.stringify({ type: 'custom-title', customTitle: value, sessionId: sessionId });
+}
+function agentName(sessionId: string, value: string): string {
+	return JSON.stringify({ type: 'agent-name', agentName: value, sessionId: sessionId });
+}
+function userTurn(sessionId: string): string {
+	return JSON.stringify({
+		type: 'user',
+		sessionId: sessionId,
+		message: { role: 'user', content: [{ type: 'text', text: 'hello' }] },
+	});
+}
+
+function jsonl(...lines: string[]): string {
+	return `${lines.join('\n')}\n`;
+}
+
+suite('ClaudeCodeTranscriptReader', () => {
+	let tmpRoot: string;
+	let transcriptPath: string;
+	const sessionId = 'abc-123';
+
+	setup(() => {
+		tmpRoot = mkdtempSync(join(tmpdir(), 'gl-transcript-'));
+		transcriptPath = join(tmpRoot, `${sessionId}.jsonl`);
+	});
+
+	teardown(() => {
+		rmSync(tmpRoot, { recursive: true, force: true });
+	});
+
+	test('parses all three title types', async () => {
+		await writeFile(
+			transcriptPath,
+			jsonl(
+				userTurn(sessionId),
+				aiTitle(sessionId, 'Fix the build'),
+				customTitle(sessionId, 'fix-build-slug'),
+				agentName(sessionId, 'reviewer-agent'),
+			),
+		);
+
+		const reader = new TestReader(transcriptPath);
+		const titles = await reader.resolve(sessionId, undefined);
+		assert.deepStrictEqual(titles, {
+			custom: 'fix-build-slug',
+			ai: 'Fix the build',
+			agent: 'reviewer-agent',
+		});
+	});
+
+	test('last occurrence wins per type', async () => {
+		await writeFile(transcriptPath, jsonl(aiTitle(sessionId, 'First take'), aiTitle(sessionId, 'Second take')));
+
+		const reader = new TestReader(transcriptPath);
+		const titles = await reader.resolve(sessionId, undefined);
+		assert.strictEqual(titles?.ai, 'Second take');
+	});
+
+	test('ignores entries belonging to other sessions', async () => {
+		await writeFile(transcriptPath, jsonl(aiTitle('other-session', 'Wrong'), aiTitle(sessionId, 'Right')));
+
+		const reader = new TestReader(transcriptPath);
+		const titles = await reader.resolve(sessionId, undefined);
+		assert.strictEqual(titles?.ai, 'Right');
+	});
+
+	test('skips malformed lines without throwing', async () => {
+		await writeFile(
+			transcriptPath,
+			jsonl(
+				'{not valid json}',
+				'',
+				aiTitle(sessionId, 'Survived'),
+				`{"type":"ai-title","sessionId":"${sessionId}"`, // unterminated
+			),
+		);
+
+		const reader = new TestReader(transcriptPath);
+		const titles = await reader.resolve(sessionId, undefined);
+		assert.strictEqual(titles?.ai, 'Survived');
+	});
+
+	test('returns undefined when no transcript file is present', async () => {
+		const reader = new TestReader(undefined);
+		const titles = await reader.resolve(sessionId, undefined);
+		assert.strictEqual(titles, undefined);
+	});
+
+	test('mtime cache: second call with unchanged file does not re-read', async () => {
+		await writeFile(transcriptPath, jsonl(aiTitle(sessionId, 'Cached')));
+
+		const reader = new TrackingReader(transcriptPath);
+		await reader.resolve(sessionId, undefined);
+		assert.strictEqual(reader.readCount, 1);
+
+		await reader.resolve(sessionId, undefined);
+		assert.strictEqual(reader.readCount, 1, 'second resolve should hit cache');
+	});
+
+	test('mtime cache: bumping mtime forces a re-read', async () => {
+		await writeFile(transcriptPath, jsonl(aiTitle(sessionId, 'First')));
+
+		const reader = new TrackingReader(transcriptPath);
+		const first = await reader.resolve(sessionId, undefined);
+		assert.strictEqual(first?.ai, 'First');
+		assert.strictEqual(reader.readCount, 1);
+
+		// Append a new title and bump mtime; cache must pick it up.
+		await appendFile(transcriptPath, jsonl(aiTitle(sessionId, 'Second')));
+		await bumpMtime(transcriptPath);
+
+		const second = await reader.resolve(sessionId, undefined);
+		assert.strictEqual(second?.ai, 'Second');
+		assert.strictEqual(reader.readCount, 2, 'mtime change should trigger a re-read');
+	});
+
+	test('tail read: previously-discovered titles are preserved when appended chunk lacks them', async () => {
+		await writeFile(transcriptPath, jsonl(customTitle(sessionId, 'my-slug'), aiTitle(sessionId, 'First')));
+
+		const reader = new TestReader(transcriptPath);
+		const first = await reader.resolve(sessionId, undefined);
+		assert.strictEqual(first?.custom, 'my-slug');
+		assert.strictEqual(first?.ai, 'First');
+		assert.strictEqual(first?.agent, undefined);
+
+		// Append only a new ai-title — custom should survive in the merged result.
+		await appendFile(transcriptPath, jsonl(aiTitle(sessionId, 'Second')));
+		await bumpMtime(transcriptPath);
+
+		const second = await reader.resolve(sessionId, undefined);
+		assert.strictEqual(second?.custom, 'my-slug', 'tail read must merge with prior titles');
+		assert.strictEqual(second?.ai, 'Second');
+	});
+
+	test('truncation: file shrinking below cursor triggers a full re-scan', async () => {
+		await writeFile(transcriptPath, jsonl(aiTitle(sessionId, 'Old'), customTitle(sessionId, 'old-slug')));
+
+		const reader = new TestReader(transcriptPath);
+		const first = await reader.resolve(sessionId, undefined);
+		assert.strictEqual(first?.custom, 'old-slug');
+
+		// Rewrite from scratch with a smaller, different content set.
+		await writeFile(transcriptPath, jsonl(aiTitle(sessionId, 'Fresh')));
+		await bumpMtime(transcriptPath);
+
+		const second = await reader.resolve(sessionId, undefined);
+		assert.strictEqual(second?.ai, 'Fresh');
+		assert.strictEqual(second?.custom, undefined, 'truncation must drop old titles');
+	});
+
+	test('partial-line safety: trailing unterminated line is re-read once the newline arrives', async () => {
+		await writeFile(transcriptPath, jsonl(aiTitle(sessionId, 'First')));
+
+		const reader = new TestReader(transcriptPath);
+		const initial = await reader.resolve(sessionId, undefined);
+		assert.strictEqual(initial?.ai, 'First');
+
+		// Simulate a writer that has flushed bytes but not the terminating newline yet.
+		const partial = aiTitle(sessionId, 'Second');
+		await appendFile(transcriptPath, partial); // no trailing \n
+		await bumpMtime(transcriptPath);
+
+		const midway = await reader.resolve(sessionId, undefined);
+		assert.strictEqual(midway?.ai, 'First', 'partial line must NOT be consumed yet');
+
+		// Now flush the newline; the same bytes should be re-read and parsed.
+		await appendFile(transcriptPath, '\n');
+		await bumpMtime(transcriptPath);
+
+		const final = await reader.resolve(sessionId, undefined);
+		assert.strictEqual(final?.ai, 'Second');
+	});
+
+	test('forget clears cache so the next resolve re-reads', async () => {
+		await writeFile(transcriptPath, jsonl(aiTitle(sessionId, 'Initial')));
+
+		const reader = new TrackingReader(transcriptPath);
+		await reader.resolve(sessionId, undefined);
+		assert.strictEqual(reader.readCount, 1);
+
+		reader.forget(sessionId);
+		await reader.resolve(sessionId, undefined);
+		assert.strictEqual(reader.readCount, 2, 'forget should force a fresh read');
+	});
+
+	test('forget mid-resolve does not resurrect a cache entry for a forgotten session', async () => {
+		await writeFile(transcriptPath, jsonl(aiTitle(sessionId, 'In-flight')));
+
+		// Reader that yields control between locate and the cache write, letting the test sneak
+		// `forget` in. Without the generation guard, the resolved entry would land in the cache
+		// after `forget` had already cleared it — a per-session leak.
+		class PausableReader extends ClaudeCodeTranscriptReader {
+			constructor(private readonly _path: string) {
+				super();
+			}
+			protected override locateTranscript(): Promise<string | undefined> {
+				return Promise.resolve(this._path);
+			}
+			cache(): Map<string, unknown> {
+				return (this as unknown as { _cache: Map<string, unknown> })._cache;
+			}
+		}
+		const reader = new PausableReader(transcriptPath);
+
+		// Kick off resolve but don't await it yet.
+		const pending = reader.resolve(sessionId, undefined);
+
+		// Call forget while the resolve is mid-await.
+		reader.forget(sessionId);
+
+		const titles = await pending;
+		assert.strictEqual(titles?.ai, 'In-flight', 'in-flight resolve still returns its read result');
+		assert.strictEqual(reader.cache().has(sessionId), false, 'forget must beat a concurrent resolve write');
+	});
+
+	test('locator: uses real directory lookup when no override is set', async () => {
+		// Build a real-shaped layout: <root>/projects/<encoded-cwd>/<sessionId>.jsonl
+		const projects = join(tmpRoot, 'projects');
+		const cwd = '/Users/me/repo';
+		const encoded = cwd.replace(/[/\\:]/g, '-');
+		const projectDir = join(projects, encoded);
+		await mkdir(projectDir, { recursive: true });
+		const path = join(projectDir, `${sessionId}.jsonl`);
+		await writeFile(path, jsonl(aiTitle(sessionId, 'Located')));
+
+		// Build a reader that uses our temp `projects` dir as root via subclass override.
+		class RootedReader extends ClaudeCodeTranscriptReader {
+			protected override locateTranscript(sid: string): Promise<string | undefined> {
+				return Promise.resolve(join(projectDir, `${sid}.jsonl`));
+			}
+		}
+		const reader = new RootedReader();
+		const titles = await reader.resolve(sessionId, cwd);
+		assert.strictEqual(titles?.ai, 'Located');
+	});
+});
+
+/** Subclass that exposes a read counter for cache assertions. */
+class TrackingReader extends ClaudeCodeTranscriptReader {
+	readCount = 0;
+	constructor(private readonly _fixedPath: string) {
+		super();
+	}
+	protected override locateTranscript(): Promise<string | undefined> {
+		return Promise.resolve(this._fixedPath);
+	}
+	protected override readRange(
+		path: string,
+		start: number,
+		end: number,
+		sessionId: string,
+		baseTitles: TranscriptTitles,
+	): Promise<{ titles: TranscriptTitles; consumedEnd: number }> {
+		this.readCount++;
+		return super.readRange(path, start, end, sessionId, baseTitles);
+	}
+}
+
+/** Push mtime forward by 1s. Some filesystems have 1s resolution, so a bare `utimes(now)` after
+ *  a sub-second write may not bump the value the cache compares against. */
+async function bumpMtime(path: string): Promise<void> {
+	const future = Date.now() + 2000;
+	await utimes(path, new Date(future), new Date(future));
+}

--- a/packages/plus/agents/src/providers/claudeCodeProvider.ts
+++ b/packages/plus/agents/src/providers/claudeCodeProvider.ts
@@ -30,6 +30,7 @@ import type {
 	PermissionSuggestion,
 } from '../types.js';
 import { getPhaseForStatus } from '../types.js';
+import { ClaudeCodeTranscriptReader } from './claudeCodeTranscript.js';
 
 interface AgentSessionEvent {
 	event: ClaudeCodeHookEvent;
@@ -196,6 +197,7 @@ export class ClaudeCodeProvider implements AgentSessionProvider {
 	private readonly _pendingIdleTimers = new Map<string, NodeJS.Timeout>();
 	private _workspacePaths: string[] = [];
 	private _staleCheckTimer: UnifiedDisposable | undefined;
+	protected _transcriptReader: ClaudeCodeTranscriptReader = new ClaudeCodeTranscriptReader();
 
 	constructor(private readonly callbacks: AgentProviderCallbacks) {}
 
@@ -409,6 +411,7 @@ export class ClaudeCodeProvider implements AgentSessionProvider {
 				}
 
 				this._onDidChangeSessions.fire();
+				void this.resolveTranscriptTitles(event.sessionId, event.cwd);
 				this.callbacks.onSessionStarted?.(this.id);
 				break;
 			}
@@ -432,6 +435,7 @@ export class ClaudeCodeProvider implements AgentSessionProvider {
 				}
 
 				this._sessionBookkeeping.delete(event.sessionId);
+				this._transcriptReader.forget(event.sessionId);
 				this.callbacks.onSessionEnded?.(this.id);
 				break;
 			}
@@ -1075,6 +1079,13 @@ export class ClaudeCodeProvider implements AgentSessionProvider {
 				this.callbacks.onBranchAgentActivity?.(sessionCwd);
 			}
 		}
+
+		// On a fresh transition into idle, recheck transcript titles — Claude typically (re-)writes
+		// `ai-title` right after finishing a response, so this is the prime moment to pick it up.
+		// Tail-read caching makes repeated checks cheap.
+		if (status === 'idle' && prev.status !== 'idle') {
+			void this.resolveTranscriptTitles(sessionId, this._sessions[index].cwd);
+		}
 	}
 
 	private ensureSession(sessionId: string, context?: SessionContext): { index: number; changed: boolean } {
@@ -1108,6 +1119,7 @@ export class ClaudeCodeProvider implements AgentSessionProvider {
 			if (cwd != null) {
 				void this.resolveGitInfo(sessionId, cwd);
 			}
+			void this.resolveTranscriptTitles(sessionId, cwd);
 			return { index: index, changed: true };
 		}
 
@@ -1226,6 +1238,29 @@ export class ClaudeCodeProvider implements AgentSessionProvider {
 		}
 	}
 
+	private async resolveTranscriptTitles(sessionId: string, cwd: string | undefined): Promise<void> {
+		let titles;
+		try {
+			titles = await this._transcriptReader.resolve(sessionId, cwd);
+		} catch {
+			return;
+		}
+		if (titles == null) return;
+
+		const index = this._sessions.findIndex(s => s.id === sessionId);
+		if (index < 0) return;
+
+		const session = this._sessions[index];
+		const prev = session.transcriptTitles;
+		if (prev?.custom === titles.custom && prev?.ai === titles.ai && prev?.agent === titles.agent) return;
+
+		this._sessions[index] = {
+			...session,
+			transcriptTitles: { custom: titles.custom, ai: titles.ai, agent: titles.agent },
+		};
+		this._onDidChangeSessions.fire();
+	}
+
 	private pruneDeadSessions(): boolean {
 		const kept: AgentSession[] = [];
 		const removedIds: string[] = [];
@@ -1251,6 +1286,7 @@ export class ClaudeCodeProvider implements AgentSessionProvider {
 			}
 			this.cancelPendingIdleTransition(id);
 			this._sessionBookkeeping.delete(id);
+			this._transcriptReader.forget(id);
 		}
 		Logger.debug(
 			`ClaudeCodeProvider.syncSessions: removed ${removedIds.length} stale session(s): ${removedIds.map(id => id.substring(0, 8)).join(', ')}`,
@@ -1323,6 +1359,7 @@ export class ClaudeCodeProvider implements AgentSessionProvider {
 			if (data.cwd) {
 				void this.resolveGitInfo(data.sessionId, data.cwd);
 			}
+			void this.resolveTranscriptTitles(data.sessionId, data.cwd);
 		}
 
 		if (this.pruneDeadSessions()) {
@@ -1401,6 +1438,11 @@ export class ClaudeCodeProvider implements AgentSessionProvider {
 							// targets the right path. Stale-cwd locally would just re-probe the
 							// non-repo dir and hit the gitInfoUnresolvable retry guard again.
 							cwd: cwdChanged ? peerSession.cwd : existing.cwd,
+							// Forward peer-discovered transcript titles. Both windows can resolve them
+							// independently against the same on-disk transcript, but only the peer's
+							// hook flow drives its updates — without this, we'd freeze the snapshot
+							// taken at first discovery.
+							transcriptTitles: peerSession.transcriptTitles ?? existing.transcriptTitles,
 						};
 						changed = true;
 					}

--- a/packages/plus/agents/src/providers/claudeCodeTranscript.ts
+++ b/packages/plus/agents/src/providers/claudeCodeTranscript.ts
@@ -1,0 +1,214 @@
+import { createReadStream } from 'fs';
+import { readdir, stat } from 'fs/promises';
+import { homedir } from 'os';
+import { join } from 'path';
+
+export interface TranscriptTitles {
+	custom?: string;
+	ai?: string;
+	agent?: string;
+}
+
+interface CacheEntry {
+	path: string;
+	mtimeMs: number;
+	size: number;
+	nextOffset: number;
+	titles: TranscriptTitles;
+}
+
+interface TitleEntry {
+	type: string;
+	sessionId?: string;
+	customTitle?: string;
+	aiTitle?: string;
+	agentName?: string;
+}
+
+/**
+ * Reads Claude Code transcript JSONL files at `~/.claude/projects/<encoded-cwd>/<sessionId>.jsonl`
+ * to surface `custom-title`, `ai-title`, and `agent-name` entries as fallback session names.
+ *
+ * Maintains a per-session cache keyed by mtime + last-read byte offset, so repeated calls only
+ * read the appended tail. Last occurrence per type wins.
+ *
+ * `resolve` is async, so a `forget` (or a newer `resolve`) for the same session can land between
+ * its `await`s. A per-session generation counter is stamped at entry and re-checked before the
+ * final cache write, so a stale `resolve` can't resurrect a forgotten entry or clobber a newer
+ * resolve's result.
+ */
+export class ClaudeCodeTranscriptReader {
+	private readonly _cache = new Map<string, CacheEntry>();
+	private readonly _generations = new Map<string, number>();
+	private _nextGen = 0;
+
+	async resolve(sessionId: string, cwd: string | undefined): Promise<TranscriptTitles | undefined> {
+		const gen = ++this._nextGen;
+		this._generations.set(sessionId, gen);
+
+		const cached = this._cache.get(sessionId);
+		const path = cached?.path ?? (await this.locateTranscript(sessionId, cwd));
+		if (path == null) return undefined;
+
+		let stats;
+		try {
+			stats = await stat(path);
+		} catch {
+			// File disappeared; drop any stale cache entry so a future call retries discovery.
+			// Skip the delete if a newer resolve/forget claimed the slot — their state is fresher.
+			if (this._generations.get(sessionId) === gen) {
+				this._cache.delete(sessionId);
+				this._generations.delete(sessionId);
+			}
+			return undefined;
+		}
+
+		if (cached != null && stats.mtimeMs === cached.mtimeMs && stats.size === cached.size) {
+			return cached.titles;
+		}
+
+		// Truncation or rewrite: stat shrank below our read cursor or mtime moved backward → full re-scan.
+		const startFromScratch = cached == null || stats.size < cached.nextOffset || stats.mtimeMs < cached.mtimeMs;
+		const startOffset = startFromScratch ? 0 : cached.nextOffset;
+		const baseTitles: TranscriptTitles = startFromScratch ? {} : { ...cached.titles };
+
+		const { titles, consumedEnd } =
+			stats.size > startOffset
+				? await this.readRange(path, startOffset, stats.size, sessionId, baseTitles)
+				: { titles: baseTitles, consumedEnd: startOffset };
+
+		// If `forget` ran or a newer `resolve` started while we were awaiting, skip the cache write
+		// — the entry we'd be writing reflects stale state.
+		if (this._generations.get(sessionId) !== gen) return titles;
+
+		const entry: CacheEntry = {
+			path: path,
+			mtimeMs: stats.mtimeMs,
+			size: stats.size,
+			nextOffset: consumedEnd,
+			titles: titles,
+		};
+		this._cache.set(sessionId, entry);
+		return titles;
+	}
+
+	forget(sessionId: string): void {
+		this._cache.delete(sessionId);
+		this._generations.delete(sessionId);
+	}
+
+	protected async locateTranscript(sessionId: string, cwd: string | undefined): Promise<string | undefined> {
+		const root = join(homedir(), '.claude', 'projects');
+		const fileName = `${sessionId}.jsonl`;
+
+		if (cwd != null && cwd.length > 0) {
+			const encoded = cwd.replace(/[/\\:]/g, '-');
+			const candidate = join(root, encoded, fileName);
+			if (await fileExists(candidate)) return candidate;
+		}
+
+		let dirs: string[];
+		try {
+			dirs = await readdir(root);
+		} catch {
+			return undefined;
+		}
+
+		const candidates = await Promise.all(
+			dirs.map(async dir => {
+				const candidate = join(root, dir, fileName);
+				return (await fileExists(candidate)) ? candidate : undefined;
+			}),
+		);
+		return candidates.find(c => c != null);
+	}
+
+	/**
+	 * Reads bytes `[start, end)` from `path` and applies any title entries it finds to a copy of
+	 * `baseTitles`. Returns the merged titles and the byte position immediately after the last
+	 * newline observed — partial trailing lines (writer hasn't flushed `\n` yet) are intentionally
+	 * left unconsumed so they're re-read on the next pass.
+	 */
+	protected async readRange(
+		path: string,
+		start: number,
+		end: number,
+		sessionId: string,
+		baseTitles: TranscriptTitles,
+	): Promise<{ titles: TranscriptTitles; consumedEnd: number }> {
+		const buffer = await readSlice(path, start, end);
+		const titles: TranscriptTitles = { ...baseTitles };
+
+		let lastNewlineEnd = start;
+		let lineStart = 0;
+		for (let i = 0; i < buffer.length; i++) {
+			if (buffer[i] !== 0x0a) continue;
+
+			// Slice the line (trim a trailing \r for CRLF files), then advance the cursor past the \n
+			// regardless of whether the line yielded anything — we've fully observed those bytes.
+			const lineEnd = i > lineStart && buffer[i - 1] === 0x0d ? i - 1 : i;
+			if (lineEnd > lineStart) {
+				const line = buffer.toString('utf8', lineStart, lineEnd);
+				applyTitleLine(line, sessionId, titles);
+			}
+			lineStart = i + 1;
+			lastNewlineEnd = start + i + 1;
+		}
+
+		return { titles: titles, consumedEnd: lastNewlineEnd };
+	}
+}
+
+function applyTitleLine(line: string, sessionId: string, titles: TranscriptTitles): void {
+	if (!isLikelyTitleLine(line)) return;
+
+	let entry: TitleEntry;
+	try {
+		entry = JSON.parse(line) as TitleEntry;
+	} catch {
+		return;
+	}
+	if (entry.sessionId != null && entry.sessionId !== sessionId) return;
+
+	switch (entry.type) {
+		case 'custom-title':
+			if (typeof entry.customTitle === 'string' && entry.customTitle.length > 0) {
+				titles.custom = entry.customTitle;
+			}
+			break;
+		case 'ai-title':
+			if (typeof entry.aiTitle === 'string' && entry.aiTitle.length > 0) {
+				titles.ai = entry.aiTitle;
+			}
+			break;
+		case 'agent-name':
+			if (typeof entry.agentName === 'string' && entry.agentName.length > 0) {
+				titles.agent = entry.agentName;
+			}
+			break;
+	}
+}
+
+function isLikelyTitleLine(line: string): boolean {
+	if (!line.includes('"type"')) return false;
+	return line.includes('-title') || line.includes('agent-name');
+}
+
+async function fileExists(path: string): Promise<boolean> {
+	try {
+		const stats = await stat(path);
+		return stats.isFile();
+	} catch {
+		return false;
+	}
+}
+
+function readSlice(path: string, start: number, end: number): Promise<Buffer> {
+	return new Promise((resolve, reject) => {
+		const chunks: Buffer[] = [];
+		const stream = createReadStream(path, { start: start, end: end - 1 });
+		stream.on('data', chunk => chunks.push(chunk as Buffer));
+		stream.on('end', () => resolve(Buffer.concat(chunks)));
+		stream.on('error', reject);
+	});
+}

--- a/packages/plus/agents/src/types.ts
+++ b/packages/plus/agents/src/types.ts
@@ -146,6 +146,17 @@ export interface AgentSession {
 	 *  Mutable array form so `Shape<AgentSession>` projects it as `string[]` (the `Shape<>` type
 	 *  mangles `readonly T[]` into a mapped object that loses its iterator). Treat as immutable. */
 	currentFiles?: string[];
+	/**
+	 * Titles discovered by tailing the Claude Code transcript JSONL at
+	 * `~/.claude/projects/<encoded-cwd>/<sessionId>.jsonl`. Populated by
+	 * `ClaudeCodeTranscriptReader`; used by `getSessionDisplayName` as a fallback when no
+	 * harness-supplied `name` is available. Last occurrence in the transcript wins per type.
+	 */
+	readonly transcriptTitles?: {
+		readonly custom?: string;
+		readonly ai?: string;
+		readonly agent?: string;
+	};
 }
 
 export interface AgentSessionProvider extends UnifiedDisposable {

--- a/src/agents/models/__tests__/agentSessionState.test.ts
+++ b/src/agents/models/__tests__/agentSessionState.test.ts
@@ -94,4 +94,63 @@ suite('getSessionDisplayName', () => {
 		const session = makeSession({ cwd: '/' });
 		assert.strictEqual(getSessionDisplayName(session, undefined), 'Claude Code');
 	});
+
+	test('harness-supplied name beats all transcript titles', () => {
+		const session = makeSession({
+			name: 'Harness Name',
+			firstPrompt: 'do the thing',
+			transcriptTitles: { custom: 'my-slug', ai: 'AI-summed', agent: 'agent-slug' },
+		});
+		assert.strictEqual(getSessionDisplayName(session, undefined), 'Harness Name');
+	});
+
+	test('customTitle wins over firstPrompt-derived name', () => {
+		const session = makeSession({
+			firstPrompt: 'please fix the login bug',
+			transcriptTitles: { custom: 'fix-login-flow' },
+		});
+		assert.strictEqual(getSessionDisplayName(session, 'feature-x'), 'fix-login-flow');
+	});
+
+	test('aiTitle is used when no customTitle is available', () => {
+		const session = makeSession({
+			firstPrompt: 'please fix the login bug',
+			transcriptTitles: { ai: 'Fix the login flow' },
+		});
+		assert.strictEqual(getSessionDisplayName(session, 'feature-x'), 'Fix the login flow');
+	});
+
+	test('customTitle outranks aiTitle when both are present', () => {
+		const session = makeSession({
+			transcriptTitles: { custom: 'custom-slug', ai: 'AI Title' },
+		});
+		assert.strictEqual(getSessionDisplayName(session, undefined), 'custom-slug');
+	});
+
+	test('agentName outranks the location-anchor fallback', () => {
+		const session = makeSession({
+			transcriptTitles: { agent: 'reviewer-agent' },
+			worktreePath: '/repo/.worktrees/feature-x',
+		});
+		assert.strictEqual(
+			getSessionDisplayName(session, 'feature-x'),
+			'reviewer-agent',
+			'agentName is a content name; it beats the worktree location anchor',
+		);
+	});
+
+	test('firstPrompt outranks agentName slug', () => {
+		const session = makeSession({
+			firstPrompt: 'please fix the login bug',
+			transcriptTitles: { agent: 'fallback-slug' },
+		});
+		assert.strictEqual(getSessionDisplayName(session, undefined), 'Fix the login bug');
+	});
+
+	test('aiTitle outranks agentName slug', () => {
+		const session = makeSession({
+			transcriptTitles: { ai: 'Fix the login flow', agent: 'fallback-slug' },
+		});
+		assert.strictEqual(getSessionDisplayName(session, undefined), 'Fix the login flow');
+	});
 });

--- a/src/agents/models/agentSessionState.ts
+++ b/src/agents/models/agentSessionState.ts
@@ -53,15 +53,24 @@ export type AgentSessionState = Omit<Shape<AgentSession>, 'subagents'> & {
 };
 
 /**
- * Resolves the user-facing name for a session. Prefers the harness-supplied `name`, then a
+ * Resolves the user-facing name for a session. Prefers the harness-supplied `name`, then
+ * transcript-discovered titles (user-set `customTitle`, then AI-generated `aiTitle`), then a
  * heuristic derived from `firstPrompt`, then the same heuristic on `lastPrompt` (so resumed/
- * headless sessions with no first prompt still get a content-derived label), then progressively
- * coarser context fallbacks. Location-based fallbacks (worktree, cwd) are rendered as `On <X>`
- * so a row labeled `On main` reads as a location anchor rather than a session topic. Always
- * returns a non-empty string so consumers don't need to repeat fallback logic.
+ * headless sessions with no first prompt still get a content-derived label), then the
+ * transcript-discovered `agentName` slug as a low-priority content name (it's a slug-twin of
+ * `customTitle`, often auto-derived and less readable than a prompt-derived label). If no content
+ * name resolves, falls back to a location anchor (`On <X>`) built from worktree/cwd basename.
+ * Always returns a non-empty string so consumers don't need to repeat fallback logic.
  */
 export function getSessionDisplayName(session: AgentSession, worktreeName: string | undefined): string {
-	const name = session.name || deriveNameFromPrompt(session.firstPrompt) || deriveNameFromPrompt(session.lastPrompt);
+	const titles = session.transcriptTitles;
+	const name =
+		session.name ||
+		titles?.custom ||
+		titles?.ai ||
+		deriveNameFromPrompt(session.firstPrompt) ||
+		deriveNameFromPrompt(session.lastPrompt) ||
+		titles?.agent;
 	if (name) return name;
 
 	// normalizePath collapses backslashes and trailing slashes so basename (POSIX) returns the


### PR DESCRIPTION
## Summary

- Reads `~/.claude/projects/<encoded-cwd>/<sessionId>.jsonl` transcripts for `custom-title`, `ai-title`, and `agent-name` entries and surfaces them as content-tier fallbacks in `getSessionDisplayName` (above the prompt-derived heuristic) so sessions started outside the harness's session-name plumbing still get meaningful labels.
- New `ClaudeCodeTranscriptReader` does append-only tail reads with mtime + byte-offset caching, so repeat checks read only the new slice; truncations reset and partial unterminated lines are deferred until the newline arrives.
- Provider fires reads on `SessionStart`, first `ensureSession`, idle transitions (when Claude typically (re-)writes `ai-title` after a response), and CLI session sync; calls `forget` on `SessionEnd`. `agentName` is gated to subagents, where it ranks above the parent-worktree location anchor that would otherwise mask the agent's identity.

## Test plan

- [x] `pnpm run build:quick` clean
- [x] `pnpm test` — 737 host tests + 57 agents-package tests passing, 0 failures
- [x] Manual: open a Claude Code session that has a `custom-title` set but no `sessionName` hook payload — confirm the home-view agent card and quick pick show the custom title rather than `On <branch>`
- [x] Manual: run a session with neither a transcript title nor a meaningful first prompt — confirm existing `On <X>` location fallbacks still kick in