### PR TITLE
Fix scoped graph paging when mergeBase row is out of page

### DIFF
--- a/src/webviews/apps/plus/graph/__tests__/scopePaging.utils.test.ts
+++ b/src/webviews/apps/plus/graph/__tests__/scopePaging.utils.test.ts
@@ -1,0 +1,61 @@
+import * as assert from 'assert';
+import { pickScopePageTarget } from '../utils/scopePaging.utils.js';
+
+suite('pickScopePageTarget', () => {
+	test('returns an unloaded, unrequested anchor sha when one exists', () => {
+		const anchors = new Set(['anchor1']);
+		const loaded = new Set<string>();
+		const requested = new Set<string>();
+		assert.strictEqual(pickScopePageTarget(anchors, loaded, requested, undefined), 'anchor1');
+	});
+
+	test('skips loaded anchors and falls through to mergeBase when none missing', () => {
+		// Mirrors the actual bug scenario: library flags loaded branch/upstream tips as unreachable
+		// because `scope.mergeBase` row isn't loaded yet. The handler must page targeted at the
+		// mergeBase sha, not return undefined.
+		const anchors = new Set(['branchTipLoaded', 'upstreamTipLoaded']);
+		const loaded = new Set(['branchTipLoaded', 'upstreamTipLoaded']);
+		const requested = new Set<string>();
+		assert.strictEqual(pickScopePageTarget(anchors, loaded, requested, 'mergeBaseSha'), 'mergeBaseSha');
+	});
+
+	test('returns undefined when mergeBase is already loaded', () => {
+		const anchors = new Set(['branchTip']);
+		const loaded = new Set(['branchTip', 'mergeBaseSha']);
+		const requested = new Set<string>();
+		assert.strictEqual(pickScopePageTarget(anchors, loaded, requested, 'mergeBaseSha'), undefined);
+	});
+
+	test('returns undefined when mergeBase is already in flight', () => {
+		// Dedupe guard — a previous unreachable event already issued GetMoreRowsCommand for the
+		// mergeBase. Don't re-fire while the response is still in flight.
+		const anchors = new Set(['branchTip']);
+		const loaded = new Set(['branchTip']);
+		const requested = new Set(['mergeBaseSha']);
+		assert.strictEqual(pickScopePageTarget(anchors, loaded, requested, 'mergeBaseSha'), undefined);
+	});
+
+	test('returns undefined when no anchors are missing and mergeBase is undefined', () => {
+		// Pre-mergeBase-resolution state: scope just got set, ResolveGraphScopeRequest hasn't
+		// returned yet. Library can't have flagged anchors unreachable for the mergeBase path
+		// since u is undefined; nothing useful for us to page.
+		const anchors = new Set(['branchTip']);
+		const loaded = new Set(['branchTip']);
+		const requested = new Set<string>();
+		assert.strictEqual(pickScopePageTarget(anchors, loaded, requested, undefined), undefined);
+	});
+
+	test('skips already-requested anchors and returns next unloaded one', () => {
+		const anchors = new Set(['a', 'b', 'c']);
+		const loaded = new Set(['a']);
+		const requested = new Set(['b']);
+		assert.strictEqual(pickScopePageTarget(anchors, loaded, requested, undefined), 'c');
+	});
+
+	test('returns undefined when every anchor is loaded or requested and no mergeBase', () => {
+		const anchors = new Set(['a', 'b']);
+		const loaded = new Set(['a']);
+		const requested = new Set(['b']);
+		assert.strictEqual(pickScopePageTarget(anchors, loaded, requested, undefined), undefined);
+	});
+});

--- a/src/webviews/apps/plus/graph/graph-wrapper/graph-wrapper.ts
+++ b/src/webviews/apps/plus/graph/graph-wrapper/graph-wrapper.ts
@@ -56,6 +56,7 @@ import { pickWipRowAgentStatus } from '../components/wipRowAgentStatus.js';
 import { graphStateContext } from '../context.js';
 import type { GraphCrossPaneState } from '../graphCrossPaneState.js';
 import { graphCrossPaneContext } from '../graphCrossPaneState.js';
+import { pickScopePageTarget } from '../utils/scopePaging.utils.js';
 import {
 	filterSecondariesForIncludeOnlyRefs,
 	filterSecondariesForScope,
@@ -774,11 +775,11 @@ export class GlGraphWrapper extends SignalWatcher(LitElement) {
 			this._unreachableAnchorScope = scope;
 		}
 
-		// Forward an unreachable anchor SHA to the host so the provider's page-until-found path
-		// (graph.ts getCommitsForGraphCore stop logic) loads enough rows in one round trip,
-		// instead of one page per scope toggle. Also short-circuit if the flagged anchors are
-		// already in the loaded rows — guards against stale unreachable events fired during
-		// scope-swap re-renders.
+		// Forward a page-target SHA to the host so the provider's page-until-found path (graph.ts
+		// `getCommitsForGraphCore` stop logic) loads enough rows in one round trip — typically the
+		// `scope.mergeBase.sha` when the library flagged loaded branch tips as "unreachable"
+		// because their parent chain can't reach a visible ancestor. Without that targeted page,
+		// `isBounded` stays false and the library's scroll/fill-viewport paths leak generic pages.
 		const anchors = event.detail;
 		const rows = this.graphState.rows;
 		if (anchors?.size && rows?.length) {
@@ -794,12 +795,17 @@ export class GlGraphWrapper extends SignalWatcher(LitElement) {
 				}
 			}
 
-			const missing = [...anchors].find(sha => !loaded.has(sha) && !this._unreachableAnchorRequests.has(sha));
-			if (missing == null) return;
+			const target = pickScopePageTarget(
+				anchors,
+				loaded,
+				new Set(this._unreachableAnchorRequests.keys()),
+				scope?.mergeBase?.sha,
+			);
+			if (target == null) return;
 
-			this._unreachableAnchorRequests.set(missing, rowCount);
+			this._unreachableAnchorRequests.set(target, rowCount);
 			this.graphState.loading = true;
-			this._ipc.sendCommand(GetMoreRowsCommand, { id: missing });
+			this._ipc.sendCommand(GetMoreRowsCommand, { id: target });
 			return;
 		}
 

--- a/src/webviews/apps/plus/graph/utils/scopePaging.utils.ts
+++ b/src/webviews/apps/plus/graph/utils/scopePaging.utils.ts
@@ -1,0 +1,25 @@
+/**
+ * Decides which sha to target with `GetMoreRowsCommand` in response to a `scopeanchorsunreachable`
+ * event from the GK graph component. Returns `undefined` to suppress paging.
+ *
+ * The library's anchors are typically branchRef/upstreamRef/additionalBranchRefs tips (resolved
+ * from `shaByRefId`, so already loaded) plus `mergeTargetTipSha`. When `scope.mergeBase` is known
+ * but its commit hasn't been loaded as a row, the library marks the (loaded) branch tip as
+ * unreachable — meaning "this anchor's parent chain can't reach a visible ancestor because the
+ * merge base isn't in the loaded graph rows". The right consumer response is to page targeted at
+ * `mergeBase.sha` so a single round-trip lands the row and the library can flip `isBounded` true.
+ */
+export function pickScopePageTarget(
+	anchors: ReadonlySet<string>,
+	loaded: ReadonlySet<string>,
+	requested: ReadonlySet<string>,
+	mergeBaseSha: string | undefined,
+): string | undefined {
+	for (const sha of anchors) {
+		if (!loaded.has(sha) && !requested.has(sha)) return sha;
+	}
+	if (mergeBaseSha != null && !loaded.has(mergeBaseSha) && !requested.has(mergeBaseSha)) {
+		return mergeBaseSha;
+	}
+	return undefined;
+}


### PR DESCRIPTION
## Summary

- Targets `scope.mergeBase.sha` from `scopeanchorsunreachable` when every flagged anchor is already loaded — the GK graph component flags loaded branch/upstream tips as "unreachable" when the merge-base row itself isn't in the loaded graph rows. Dropping the event in that case (prior behavior) left `scopeVisibility.isBounded` stuck false and the library's scroll/fill-viewport paths leaked generic pages on sparse scoped views.
- Extracts the page-target decision into a pure `pickScopePageTarget` helper alongside the wrapper so it can be unit-tested without dragging the React-bound graph module into the test runtime.
- Adds a unit suite covering the bug scenario plus the dedupe / already-loaded / pre-mergeBase-resolution paths.

## Why this happened

In scoped mode the host fetches the first ~5000 commits by date across all refs (`git log --all`) without scope context. On a large repo with active sibling branches the focal branch's `mergeBase` can fall outside that first page even when the visible scoped slice (HEAD → branch commits → mergeBase pill → target tip pill) all "look complete" to the user. The GK component's scope-visibility pass marks branch/upstream tips unreachable in that state; the consumer code returned without firing a targeted page, so `isBounded` never flipped and the library's other paging triggers stayed armed.

## Test plan

- [x] `pnpm run build:quick` — clean compile (extension + webviews + unit-tests)
- [x] `pnpm run test` — 737 passing, 3 pending, 0 failing; 7 new `pickScopePageTarget` cases pass
- [x] Manual: open Graph on a large repo, scope to a feature branch whose `mergeBase` is older than the first 5000 commits; confirm a single targeted `GetMoreRowsCommand({ id: mergeBaseSha })` lands the mergeBase row and subsequent scroll/refresh doesn't leak pages
- [x] Manual: scope to a branch whose `mergeBase` IS in the first page; confirm no `GetMoreRowsCommand` fires from the unreachable handler
- [x] Manual: re-scope to a different branch mid-resolution; confirm the dedupe map clears with the new scope reference