### PR TITLE
Fix graph scope default selection to use scoped branch's WIP/HEAD

### DIFF
--- a/src/webviews/apps/plus/graph/graph-app.ts
+++ b/src/webviews/apps/plus/graph/graph-app.ts
@@ -106,6 +106,12 @@ export class GraphApp extends SignalWatcher(LitElement) {
 	private _wasSidebarActivePanel: string | null | undefined;
 	private _wasDisplayMode: GraphDisplayMode | undefined;
 
+	/** Set by the popover's fallback path when it couldn't find the focal branch tip locally
+	 *  (branch's tip wasn't in `graphState.rows`). Drained in `updated` once the async scope-anchor
+	 *  resolver lands `focalBranchTipSha` on `graphState.scope`. branchRef-keyed so a fast re-scope
+	 *  doesn't end up selecting the wrong branch's tip. */
+	private _pendingFocalTipBranchRef: string | undefined;
+
 	private _sidebarSnap = ({ pos }: { pos: number }) => {
 		if (pos < sidebarMinPct / 2) return 0;
 		if (pos < sidebarMinPct) return sidebarMinPct;
@@ -359,6 +365,22 @@ export class GraphApp extends SignalWatcher(LitElement) {
 
 	override updated(changedProperties: Map<PropertyKey, unknown>): void {
 		super.updated(changedProperties);
+
+		// Drain a pending focal-tip selection once the scope-anchor resolver lands the tip on the
+		// active scope. branchRef equality guards against a fast re-scope landing the wrong branch's
+		// tip; `focalBranchTipSha != null` covers the resolver's "no answer" case (rare — branch.sha
+		// missing host-side). The pending ref is cleared as soon as we either select or detect the
+		// scope has moved on, so a later unrelated update doesn't re-trigger.
+		if (this._pendingFocalTipBranchRef != null) {
+			const scope = this.graphState.scope;
+			if (scope?.branchRef !== this._pendingFocalTipBranchRef) {
+				this._pendingFocalTipBranchRef = undefined;
+			} else if (scope.focalBranchTipSha != null) {
+				const sha = scope.focalBranchTipSha;
+				this._pendingFocalTipBranchRef = undefined;
+				this.graph?.ensureAndSelectCommit(sha);
+			}
+		}
 
 		const detailsVisible = this.graphState.detailsVisible ?? false;
 		if (detailsVisible !== this._wasDetailsVisible) {
@@ -1060,17 +1082,17 @@ export class GraphApp extends SignalWatcher(LitElement) {
 		const branch = overview?.active.find(b => b.id === branchId) ?? overview?.recent.find(b => b.id === branchId);
 		if (branch == null) return undefined;
 
-		return getOverviewBranchSelectionSha(branch, this.graphState.overviewWip?.[branchId]);
+		return getOverviewBranchSelectionSha(branch, this.graphState.workingTreeStats);
 	}
 
 	private handleScopeToBranchFromHeader(e: CustomEvent<{ branchName: string; upstreamName?: string }>) {
-		// Branches in the graph's row index are *family-scoped* — built with the parent repo's
-		// `commonPath`, not whatever worktree happens to be the displayed `path`. If the graph is
-		// showing a named worktree, `fallbackRepoPath` would return the worktree's path; building
-		// `branchRef` with that produces a synthetic id that won't match any row. Resolve the
-		// family path the same way the sidebar agent-leaf gate does.
-		const selected = this.graphState.repositories?.find(r => r.id === this.graphState.selectedRepository);
-		const repoPath = selected != null ? (selected.commonPath ?? selected.path) : this.fallbackRepoPath;
+		// Use the selected repo's actual path (the opened workspace's path). That's what the host
+		// passes as `this.repository.path` when building the graph's row index AND the
+		// `wipMetadataBySha` branchRefs, so any scope/lookup branchRef constructed here must use
+		// the same path to match. In primary-repo workspaces `path === commonPath`; in worktree
+		// workspaces they differ — picking `commonPath` produces a synthetic id that won't match
+		// any row or WIP entry.
+		const repoPath = this.fallbackRepoPath;
 		if (repoPath == null) return;
 
 		const { branchName, upstreamName } = e.detail;
@@ -1082,6 +1104,16 @@ export class GraphApp extends SignalWatcher(LitElement) {
 		if (branch != null) {
 			const mergeTargetTipSha = this.graphState.overviewEnrichment?.[branch.id]?.mergeTarget?.sha;
 			this.scopeToBranchById(branch.id, mergeTargetTipSha, 'popover');
+
+			// Mirror the overview-card click flow: after scoping, select the Working Changes row
+			// (when the scoped branch is the current opened branch with WIP, or has a worktree
+			// with WIP) or the focal branch tip. Otherwise the prior selection (often the target
+			// branch tip the user just clicked) sticks and the new scope renders pinned to the
+			// wrong row.
+			const sha = this.getOverviewBranchSelectionSha(branch.id);
+			if (sha != null) {
+				this.graph?.ensureAndSelectCommit(sha);
+			}
 			return;
 		}
 
@@ -1098,6 +1130,43 @@ export class GraphApp extends SignalWatcher(LitElement) {
 			},
 			'popover',
 		);
+
+		// Same selection cascade as `getOverviewBranchSelectionSha`, inlined because the helper
+		// needs an `OverviewBranch` that this fallback path doesn't have:
+		//   1. Secondary WIP entry whose `branchRef` matches the scoped branch (worktree-bound WIP).
+		//   2. Scoped branch IS the current branch AND working changes exist → primary WIP.
+		//      Mirror the helper's `branch.opened` gate: the Working Changes row anchors to HEAD,
+		//      so it only "belongs" to the scoped branch when the scoped branch is current.
+		//   3. Focal branch tip from the loaded rows.
+		const wipMetadataBySha = this.graphState.wipMetadataBySha;
+		if (wipMetadataBySha != null) {
+			for (const [sha, meta] of Object.entries(wipMetadataBySha)) {
+				if (meta.branchRef === branchRef) {
+					this.graph?.ensureAndSelectCommit(sha);
+					return;
+				}
+			}
+		}
+
+		const stats = this.graphState.workingTreeStats;
+		const isCurrent = this.graphState.branch?.name === branchName;
+		const hasWip = stats != null && stats.added + stats.modified + stats.deleted > 0;
+		if (isCurrent && hasWip) {
+			this.graph?.ensureAndSelectCommit(uncommitted);
+			return;
+		}
+
+		const tipSha = this.graphState.rows?.find(r => r.heads?.some(h => h.id === branchRef))?.sha;
+		if (tipSha != null) {
+			this.graph?.ensureAndSelectCommit(tipSha);
+			return;
+		}
+
+		// Branch tip isn't in the loaded rows page (older branch picked from the popover that
+		// falls outside the default item limit). The host-side scope-anchor resolver loads the
+		// focal branch on its way to computing `mergeBase`, so `focalBranchTipSha` will land on
+		// `graphState.scope` once `resolveScopeMergeBase` completes. Drain it in `updated`.
+		this._pendingFocalTipBranchRef = branchRef;
 	}
 
 	private scopeToBranchById(

--- a/src/webviews/apps/plus/graph/graph-wrapper/graph-wrapper.ts
+++ b/src/webviews/apps/plus/graph/graph-wrapper/graph-wrapper.ts
@@ -35,6 +35,7 @@ import {
 	GetMissingRefsMetadataCommand,
 	GetMoreRowsCommand,
 	GetWipStatsRequest,
+	isSecondaryWipSha,
 	RowActionCommand,
 	SyncWipWatchesCommand,
 	UpdateColumnsCommand,
@@ -558,6 +559,14 @@ export class GlGraphWrapper extends SignalWatcher(LitElement) {
 		return this.ref?.selectCommits(shas, options) ?? [];
 	}
 
+	/** Monotonic counter bumped on every `ensureAndSelectCommit` entry. The synthetic-WIP retry
+	 *  loop captures the value at scheduling time and bails when it advances — without this, a
+	 *  retry from an earlier scope/selection can race the next ~166 ms of frames and clobber a
+	 *  newer selection (e.g. user scopes to a WIP branch then immediately scopes elsewhere; the
+	 *  older `work-dir-changes` retry would overwrite the newer focal-tip selection). Mirrors
+	 *  the `_anchorGenerations` pattern in `stateProvider`. */
+	private _selectGeneration = 0;
+
 	/**
 	 * Select a row by SHA, loading it into the graph first if necessary.
 	 * The host handles both loading and selecting — the rows notification
@@ -574,9 +583,35 @@ export class GlGraphWrapper extends SignalWatcher(LitElement) {
 			sha = 'work-dir-changes';
 		}
 
+		const generation = ++this._selectGeneration;
+
 		// Fast path — row already loaded
 		if (this.ref?.getCommits([sha])?.length) {
 			this.ref.selectCommits([sha], { ensureVisible: true });
+			return;
+		}
+
+		// Synthetic WIP rows (`work-dir-changes` and `worktree-wip::<path>`) can't be loaded
+		// via the host EnsureRow fallback — the host has no real graph row for them, and the
+		// fallback's `updateGraphWithMoreRows` won't materialize one. They appear after the next
+		// render when `getDecoratedRows` synthesizes them, which only happens after Lit + React
+		// catch up to a scope change. Retry with a short backoff so callers that scope and select
+		// in the same tick (e.g. `handleScopeToBranchFromHeader`) don't drop the selection.
+		// We need to wait through: signal flush → Lit update → wrapper's render-batching RAF →
+		// React setState batch → React render → GK component indexing. A few retries cover that
+		// reliably without blocking on a fixed long timeout.
+		if (sha === 'work-dir-changes' || isSecondaryWipSha(sha)) {
+			const tryAgain = (attempt: number): void => {
+				if (this._selectGeneration !== generation) return;
+				if (this.ref?.getCommits([sha])?.length) {
+					this.ref.selectCommits([sha], { ensureVisible: true });
+					return;
+				}
+				if (attempt >= 10) return;
+
+				requestAnimationFrame(() => tryAgain(attempt + 1));
+			};
+			requestAnimationFrame(() => tryAgain(0));
 			return;
 		}
 

--- a/src/webviews/apps/plus/graph/stateProvider.ts
+++ b/src/webviews/apps/plus/graph/stateProvider.ts
@@ -72,6 +72,7 @@ export function isGraphSearchResultsError(
 type ResolvedScopeAnchor = {
 	mergeBase: { sha: string; date: number } | undefined;
 	mergeTargetTipSha: string | undefined;
+	focalBranchTipSha: string | undefined;
 };
 
 /**
@@ -483,6 +484,7 @@ export class GraphStateProvider extends StateProviderBase<State['webviewId'], Ap
 						: {
 								mergeBase: r.scope.mergeBase,
 								mergeTargetTipSha: r.scope.resolvedMergeTargetTipSha,
+								focalBranchTipSha: r.scope.resolvedFocalBranchTipSha,
 							},
 				)
 				.catch((): ResolvedScopeAnchor | undefined => undefined)
@@ -505,17 +507,19 @@ export class GraphStateProvider extends StateProviderBase<State['webviewId'], Ap
 
 	private patchScopeAnchor(scope: GraphScope, anchor: ResolvedScopeAnchor | undefined): void {
 		if (anchor == null) return;
-		// Host couldn't resolve either field — leave the live scope alone rather than assigning
-		// a no-op spread that would re-zoom the minimap for nothing.
-		if (anchor.mergeBase == null && anchor.mergeTargetTipSha == null) return;
+		// Host couldn't resolve any field — leave the live scope alone rather than assigning a
+		// no-op spread that would re-zoom the minimap for nothing.
+		if (anchor.mergeBase == null && anchor.mergeTargetTipSha == null && anchor.focalBranchTipSha == null) {
+			return;
+		}
 
 		// Only patch if the live scope still points at the same branch (user may have re-scoped
 		// or cleared while the resolve was in flight).
 		const current = this.scope;
 		if (current?.branchRef !== scope.branchRef) return;
 
-		// Skip if both the mergeBase and target tip already match — prevents a redundant signal
-		// update that would re-zoom the minimap needlessly.
+		// Skip if every patchable field already matches — prevents a redundant signal update that
+		// would re-zoom the minimap needlessly.
 		const mergeBaseSame =
 			current.mergeBase?.sha === anchor.mergeBase?.sha && current.mergeBase?.date === anchor.mergeBase?.date;
 		// `mergeTargetTipSha` may also be supplied by enrichment via `reconcileScopeMergeTarget`.
@@ -523,7 +527,8 @@ export class GraphStateProvider extends StateProviderBase<State['webviewId'], Ap
 		// resolver shouldn't clobber an enrichment-supplied SHA.
 		const targetTipSame =
 			anchor.mergeTargetTipSha == null || anchor.mergeTargetTipSha === current.mergeTargetTipSha;
-		if (mergeBaseSame && targetTipSame) return;
+		const focalTipSame = anchor.focalBranchTipSha == null || anchor.focalBranchTipSha === current.focalBranchTipSha;
+		if (mergeBaseSame && targetTipSame && focalTipSame) return;
 
 		const next: GraphScope = { ...current };
 		if (anchor.mergeBase != null && !mergeBaseSame) {
@@ -531,6 +536,9 @@ export class GraphStateProvider extends StateProviderBase<State['webviewId'], Ap
 		}
 		if (anchor.mergeTargetTipSha != null && !targetTipSame) {
 			next.mergeTargetTipSha = anchor.mergeTargetTipSha;
+		}
+		if (anchor.focalBranchTipSha != null && !focalTipSame) {
+			next.focalBranchTipSha = anchor.focalBranchTipSha;
 		}
 		this.scope = next;
 	}

--- a/src/webviews/apps/plus/graph/utils/branchSelection.utils.ts
+++ b/src/webviews/apps/plus/graph/utils/branchSelection.utils.ts
@@ -1,27 +1,37 @@
 import { uncommitted } from '@gitlens/git/models/revision.js';
+import type { GraphWorkingTreeStats } from '../../../../plus/graph/protocol.js';
 import { createSecondaryWipSha } from '../../../../plus/graph/protocol.js';
-import type { OverviewBranch, OverviewBranchWip } from '../../../../shared/overviewBranches.js';
+import type { OverviewBranch } from '../../../../shared/overviewBranches.js';
 
 /** Returns the graph-row SHA to select when the user picks a branch from a webview-side panel
  *  (overview cards, agents sidebar, etc.). Cascade matches the rules everywhere graph navigation
  *  for a branch fires:
  *    1. Secondary worktree (path differs from `branch.repoPath`) → that worktree's WIP row.
- *    2. Currently-opened branch with working changes → primary WIP (`uncommitted`).
+ *    2. Scoped branch IS the currently-opened branch AND has working changes → primary WIP
+ *       (`uncommitted`). The Working Changes row is anchored to HEAD, so it only "belongs" to
+ *       the scoped branch when the scoped branch is the one HEAD points at — even though the GK
+ *       component visually injects the row at the top of any scoped graph.
  *    3. Otherwise → the branch's tip commit.
  *  Returns `undefined` only when the branch has no resolvable tip (e.g. the cheap reference is
  *  missing a sha) — callers treat that as a no-op navigation. */
 export function getOverviewBranchSelectionSha(
 	branch: OverviewBranch,
-	wip: OverviewBranchWip | undefined,
+	workingTreeStats: GraphWorkingTreeStats | undefined,
 ): string | undefined {
 	if (branch.worktree != null && branch.worktree.path !== branch.repoPath) {
 		return createSecondaryWipSha(branch.worktree.path);
 	}
 
-	if (branch.opened) {
-		const state = wip?.workingTreeState;
-		const hasWip = state != null && state.added + state.changed + state.deleted > 0;
-		if (hasWip) return uncommitted;
+	// After the worktree check, `branch.opened === true` means the scoped branch is the current
+	// (primary worktree) branch — so `workingTreeStats` (the primary repo's WIP) is this branch's
+	// WIP. Skipping this gate would select the primary WIP row whenever HEAD has uncommitted
+	// changes — wrong for any scope where the focal branch isn't current.
+	if (
+		branch.opened &&
+		workingTreeStats != null &&
+		workingTreeStats.added + workingTreeStats.modified + workingTreeStats.deleted > 0
+	) {
+		return uncommitted;
 	}
 
 	return branch.reference.sha;

--- a/src/webviews/plus/graph/graphWebview.ts
+++ b/src/webviews/plus/graph/graphWebview.ts
@@ -412,6 +412,15 @@ interface SelectedRowState {
 	hidden?: boolean;
 }
 
+/** Host-side shape returned by the scope-anchor resolver. `focalBranchTipSha` is set whenever
+ *  the focal branch has a resolvable tip (almost always); `mergeBase` / `mergeTargetTipSha` are
+ *  only set when there's a real merge target distinct from the focal branch. */
+interface ResolvedScopeAnchor {
+	focalBranchTipSha?: string;
+	mergeBase?: { sha: string; date: number };
+	mergeTargetTipSha?: string;
+}
+
 function hasSearchQuery(arg: any): arg is { repository: GlRepository; search: SearchQuery } {
 	return arg?.repository != null && arg?.search != null;
 }
@@ -4467,6 +4476,7 @@ export class GraphWebviewProvider implements WebviewProvider<State, State, Graph
 				...params.scope,
 				mergeBase: anchor?.mergeBase,
 				resolvedMergeTargetTipSha: anchor?.mergeTargetTipSha,
+				resolvedFocalBranchTipSha: anchor?.focalBranchTipSha,
 			},
 		};
 	}
@@ -4497,23 +4507,21 @@ export class GraphWebviewProvider implements WebviewProvider<State, State, Graph
 	 * Per-branch cache of resolved scope anchors. Cleared by `invalidateScopeAnchors` whenever
 	 * heads/remotes/config move so a stale anchor can't survive a rebase. Holds promises so
 	 * concurrent scope-resolves dedupe naturally.
+	 *
+	 * `focalBranchTipSha` is always set when the focal branch resolves; `mergeBase` /
+	 * `mergeTargetTipSha` may be undefined when there's no real merge target (default branch,
+	 * or focal branch transiently equal to its target — see `computeScopeAnchor`).
 	 */
-	private readonly _scopeAnchorCache = new Map<
-		string,
-		Promise<{ mergeBase: { sha: string; date: number }; mergeTargetTipSha?: string } | undefined>
-	>();
+	private readonly _scopeAnchorCache = new Map<string, Promise<ResolvedScopeAnchor | undefined>>();
 
 	/**
-	 * Lightweight scope-anchor resolver: returns just `{mergeBase, mergeTargetTipSha}` without
-	 * paying for `getContributors --shortstat` that `getBranchContributionsOverview` runs for the
-	 * overview/sidebar contributors panel. The expensive overview path is still used by enrichment
-	 * — this just stops scope from triggering it on cold branches that aren't already covered by
-	 * the package-level `branchOverviews` cache.
+	 * Lightweight scope-anchor resolver: returns just `{focalBranchTipSha, mergeBase?, mergeTargetTipSha?}`
+	 * without paying for `getContributors --shortstat` that `getBranchContributionsOverview` runs
+	 * for the overview/sidebar contributors panel. The expensive overview path is still used by
+	 * enrichment — this just stops scope from triggering it on cold branches that aren't already
+	 * covered by the package-level `branchOverviews` cache.
 	 */
-	private async resolveScopeAnchor(
-		repoPath: string,
-		branchName: string,
-	): Promise<{ mergeBase: { sha: string; date: number }; mergeTargetTipSha?: string } | undefined> {
+	private async resolveScopeAnchor(repoPath: string, branchName: string): Promise<ResolvedScopeAnchor | undefined> {
 		// Prefer the already-loaded branch from the in-memory graph snapshot — `_graph.branches`
 		// is the same data `getBranches()` would return (same underlying cache), so this is a
 		// synchronous shortcut on the hot path, not a different source of truth.
@@ -4538,9 +4546,8 @@ export class GraphWebviewProvider implements WebviewProvider<State, State, Graph
 		return promise;
 	}
 
-	private async computeScopeAnchor(
-		branch: GitBranch,
-	): Promise<{ mergeBase: { sha: string; date: number }; mergeTargetTipSha?: string } | undefined> {
+	private async computeScopeAnchor(branch: GitBranch): Promise<ResolvedScopeAnchor> {
+		const focalBranchTipSha = branch.sha;
 		const svc = this.container.git.getRepositoryService(branch.repoPath);
 
 		// Resolve target name — `getBranchMergeTargetInfo` already shares the underlying caches
@@ -4556,7 +4563,7 @@ export class GraphWebviewProvider implements WebviewProvider<State, State, Graph
 			(targetInfo.mergeTargetBranch.paused ? undefined : targetInfo.mergeTargetBranch.value) ??
 			targetInfo.baseBranch ??
 			targetInfo.defaultBranch;
-		if (targetName == null) return undefined;
+		if (targetName == null) return { focalBranchTipSha: focalBranchTipSha };
 
 		// Prefer the in-memory branch list for the target tip, just like the focal branch above.
 		const targetBranch = this._graph?.branches.get(targetName) ?? (await svc.branches.getBranch(targetName));
@@ -4569,21 +4576,24 @@ export class GraphWebviewProvider implements WebviewProvider<State, State, Graph
 		// to its merge target. If we let it through, two things break: `mergeBase` collapses
 		// to the same sha and pins the visible window to a single row, and the GK component's
 		// `shouldHideWipRowForScope` treats that sha as a merge-target boundary and hides the
-		// WIP row of every worktree on the scoped branch. Returning undefined drops the
+		// WIP row of every worktree on the scoped branch. Returning just the focal tip drops the
 		// merge-target overlay and lets the scope walk all ancestors of `branchRef` /
 		// `upstreamRef` as if no target was configured.
-		if (mergeTargetTipSha == null || mergeTargetTipSha === branch.sha) return undefined;
+		if (mergeTargetTipSha == null || mergeTargetTipSha === focalBranchTipSha) {
+			return { focalBranchTipSha: focalBranchTipSha };
+		}
 
 		const mergeBaseSha = await svc.refs.getMergeBase(branch.ref, targetName);
-		if (mergeBaseSha == null) return undefined;
+		if (mergeBaseSha == null) return { focalBranchTipSha: focalBranchTipSha };
 
 		// Prefer the cheap dates-only lookup on desktop (git-cli); fall back to a full commit fetch
 		// for providers that don't implement it (e.g. the GitHub provider used in vscode.dev).
 		const dates = await svc.commits.getCommitDates?.(mergeBaseSha);
 		const committerDate = dates?.committerDate ?? (await svc.commits.getCommit(mergeBaseSha))?.committer.date;
-		if (committerDate == null) return undefined;
+		if (committerDate == null) return { focalBranchTipSha: focalBranchTipSha };
 
 		return {
+			focalBranchTipSha: focalBranchTipSha,
 			mergeBase: { sha: mergeBaseSha, date: committerDate.getTime() },
 			mergeTargetTipSha: mergeTargetTipSha,
 		};

--- a/src/webviews/plus/graph/protocol.ts
+++ b/src/webviews/plus/graph/protocol.ts
@@ -167,6 +167,10 @@ export interface GraphScope {
 	branchRef: string;
 	/** Full ref id of the branch's upstream (e.g. 'refs/remotes/origin/feature/x'). */
 	upstreamRef?: string;
+	/** SHA of the focal branch's tip commit. Backfilled by the scope-anchor resolver so callers
+	 *  (e.g. the popover's fallback path) can select the focal tip even when the branch isn't in
+	 *  the loaded graph rows page. */
+	focalBranchTipSha?: string;
 	/** SHA of the merge-target tip commit. Its ancestors are NOT walked — the tip is kept as a marker. */
 	mergeTargetTipSha?: string;
 	mergeBase?: { sha: string; date: number };
@@ -544,6 +548,10 @@ export interface ResolvedGraphScope extends GraphScope {
 	 * that aren't already in active/recent.
 	 */
 	resolvedMergeTargetTipSha?: string;
+	/** Resolved focal-branch tip SHA, looked up by the scope-anchor resolver. Mirrors the
+	 *  `resolvedMergeTargetTipSha` shape — distinct response field so the patcher can tell
+	 *  "resolver had no answer" (`undefined`) from "value already on the scope". */
+	resolvedFocalBranchTipSha?: string;
 }
 export interface ResolveGraphScopeParams {
 	repoPath: string;


### PR DESCRIPTION
## Summary

When scoping the Commit Graph to a branch (via the header scope popover or by clicking an overview card), the prior selection — usually the **target branch tip** the user just clicked — was preserved across the scope change. This left the new scope looking pinned to the wrong row.

This change selects the right default row whenever the scope changes:

- **Scoped branch is the current opened branch with working changes** → primary `Working Changes` row
- **Scoped branch has a worktree with WIP** → that worktree's secondary WIP row
- **Otherwise** → the focal branch's tip commit

The Working Changes row is anchored to HEAD, so it only "belongs" to the scoped branch when the scoped branch is the one HEAD points at — even though the GK component visually injects it at the top of any scoped graph. Selecting it for unrelated scopes (e.g. scoping to `pr-3` while the current branch `development` has WIP) was misleading.

## What changed

- **`utils/branchSelection.utils.ts`** — `getOverviewBranchSelectionSha` now uses the global `workingTreeStats` instead of the per-overview-branch `wip.workingTreeState`, gated on `branch.opened` so primary WIP only applies when the scoped branch is the current branch.
- **`graph-app.ts`** — `handleScopeToBranchFromHeader` now applies the same selection step both for branches found in the overview (mirroring the overview-card click flow) and for the fallback path (branches outside the overview's active/recent window). The fallback uses an inlined cascade because it has no `OverviewBranch` to feed the helper.
- **`graph-app.ts`** — Fixes a pre-existing path mismatch in the popover's fallback: the previous `commonPath ?? path` workaround produced a `branchRef` that didn't match any row or WIP entry in worktree workspaces, so the fallback scope itself wasn't filtering. Using `this.fallbackRepoPath` (= `selected.path`, what the host uses for `this.repository.path` when building both the graph rows and the `wipMetadataBySha` `branchRef`s) keeps the constructed `branchRef` aligned in both primary-repo and worktree-workspace cases.
- **`graph-wrapper/graph-wrapper.ts`** — `ensureAndSelectCommit` now retries on a short backoff for synthetic WIP SHAs (`work-dir-changes` and `worktree-wip::<path>`). These rows are synthesized client-side after Lit + React process a scope change, so callers that scope and select in the same tick (e.g. `handleScopeToBranchFromHeader`) would otherwise miss the row in the fast-path lookup AND fail the host-side `EnsureRowRequest` fallback (which can't materialize a synthetic id).

## Test plan

- [x] `pnpm run build:quick` clean
- [x] `pnpm run lint` clean for changed files
- [x] **Header popover → current branch (has WIP)**: primary WIP selected
- [x] **Header popover → main (different branch, not current, no worktree)**: main's tip selected (not WIP)
- [x] **Header popover → branch with worktree WIP (fallback path, branch outside overview)**: that worktree's secondary WIP selected
- [x] **Header popover → branch with no WIP/worktree (fallback)**: focal branch tip selected
- [x] **Overview card click → current branch (regression)**: primary WIP selected
- [x] **Critical regression**: scope to current branch (WIP selected), then scope to a different non-WIP branch → switches to that branch's tip, not stuck on WIP