### PR TITLE
Fixes primary WIP row leaking into descendant-branch scope

### DIFF
--- a/src/webviews/apps/plus/graph/__tests__/stateProvider.test.ts
+++ b/src/webviews/apps/plus/graph/__tests__/stateProvider.test.ts
@@ -3,6 +3,7 @@ import type { emptySetMarker } from '@gitkraken/gitkraken-components';
 import type {
 	GraphIncludeOnlyRef,
 	GraphIncludeOnlyRefs,
+	GraphScope,
 	GraphWipMetadataBySha,
 } from '../../../../plus/graph/protocol.js';
 import type { GetOverviewEnrichmentResponse } from '../../../../shared/overviewBranches.js';
@@ -377,27 +378,39 @@ suite('shouldShowPrimaryWipRow', () => {
 	const currentBranchId = '/repo|heads/feature';
 
 	test("returns true when branchesVisibility is 'all'", () => {
-		assert.strictEqual(shouldShowPrimaryWipRow('all', refsFor('/repo|heads/other'), currentBranchId), true);
+		assert.strictEqual(
+			shouldShowPrimaryWipRow('all', refsFor('/repo|heads/other'), currentBranchId, undefined),
+			true,
+		);
 	});
 
 	test('returns true when branchesVisibility is undefined', () => {
-		assert.strictEqual(shouldShowPrimaryWipRow(undefined, refsFor('/repo|heads/other'), currentBranchId), true);
+		assert.strictEqual(
+			shouldShowPrimaryWipRow(undefined, refsFor('/repo|heads/other'), currentBranchId, undefined),
+			true,
+		);
 	});
 
 	test('returns true when includeOnlyRefs is undefined', () => {
-		assert.strictEqual(shouldShowPrimaryWipRow('agents', undefined, currentBranchId), true);
+		assert.strictEqual(shouldShowPrimaryWipRow('agents', undefined, currentBranchId, undefined), true);
 	});
 
 	test('returns true when includeOnlyRefs is empty {} (no-filter sentinel)', () => {
-		assert.strictEqual(shouldShowPrimaryWipRow('smart', {}, currentBranchId), true);
+		assert.strictEqual(shouldShowPrimaryWipRow('smart', {}, currentBranchId, undefined), true);
 	});
 
 	test('returns true when currentBranchId is in the include set', () => {
-		assert.strictEqual(shouldShowPrimaryWipRow('agents', refsFor(currentBranchId), currentBranchId), true);
+		assert.strictEqual(
+			shouldShowPrimaryWipRow('agents', refsFor(currentBranchId), currentBranchId, undefined),
+			true,
+		);
 	});
 
 	test('returns false when currentBranchId is not in the include set (agents mode w/ no agent on current)', () => {
-		assert.strictEqual(shouldShowPrimaryWipRow('agents', refsFor('/repo|heads/other'), currentBranchId), false);
+		assert.strictEqual(
+			shouldShowPrimaryWipRow('agents', refsFor('/repo|heads/other'), currentBranchId, undefined),
+			false,
+		);
 	});
 
 	test('returns false when only the empty-set marker is present', () => {
@@ -406,13 +419,59 @@ suite('shouldShowPrimaryWipRow', () => {
 				'agents',
 				{ ['gk.empty-set-marker' satisfies typeof emptySetMarker]: {} as unknown as GraphIncludeOnlyRef },
 				currentBranchId,
+				undefined,
 			),
 			false,
 		);
 	});
 
 	test('returns true when currentBranchId is unknown (detached HEAD fallback)', () => {
-		assert.strictEqual(shouldShowPrimaryWipRow('agents', refsFor('/repo|heads/other'), undefined), true);
+		assert.strictEqual(shouldShowPrimaryWipRow('agents', refsFor('/repo|heads/other'), undefined, undefined), true);
+	});
+
+	test("returns false when scope's focal branch isn't HEAD (descendant scope leak repro)", () => {
+		// Pin with branchesVisibility === 'all' so a regression in guard ordering re-introduces
+		// the leak Eric reported (primary WIP appearing under a descendant branch's scope).
+		assert.strictEqual(
+			shouldShowPrimaryWipRow('all', undefined, currentBranchId, scopeFor('/repo|heads/descendant')),
+			false,
+		);
+	});
+
+	test('returns true when scope is undefined (no scope active)', () => {
+		assert.strictEqual(shouldShowPrimaryWipRow('all', undefined, currentBranchId, undefined), true);
+	});
+
+	test('returns true when scope.branchRef equals currentBranchId', () => {
+		assert.strictEqual(shouldShowPrimaryWipRow('all', undefined, currentBranchId, scopeFor(currentBranchId)), true);
+	});
+
+	test('returns false when scope is active and HEAD is detached', () => {
+		assert.strictEqual(
+			shouldShowPrimaryWipRow('all', undefined, undefined, scopeFor('/repo|heads/anything')),
+			false,
+		);
+	});
+
+	test('returns false when current is in scope.additionalBranchRefs but not scope.branchRef', () => {
+		// Pins the "additionalBranchRefs doesn't count" convention so a future broadening fails
+		// loudly — primary WIP attributes only to the focal branch (`scope.branchRef`).
+		assert.strictEqual(
+			shouldShowPrimaryWipRow(
+				'all',
+				undefined,
+				currentBranchId,
+				scopeFor('/repo|heads/focal', { additionalBranchRefs: [currentBranchId] }),
+			),
+			false,
+		);
+	});
+
+	test('scope guard precedes branchesVisibility — agents mode with off-scope focal still hides', () => {
+		assert.strictEqual(
+			shouldShowPrimaryWipRow('agents', refsFor(currentBranchId), currentBranchId, scopeFor('/repo|heads/other')),
+			false,
+		);
 	});
 });
 
@@ -429,4 +488,17 @@ function refsFor(...ids: string[]): GraphIncludeOnlyRefs {
 		result[id] = { id: id, name: name, type: type };
 	}
 	return result;
+}
+
+function scopeFor(branchRef: string, opts?: { additionalBranchRefs?: string[] }): GraphScope {
+	// `branchName` is required on GraphScope; derive a sensible default from the ref id's tail
+	// (mirrors how the host populates it). The tests don't read this field — `shouldShowPrimaryWipRow`
+	// only consults `branchRef` — but it must be present to type-check.
+	const slash = branchRef.lastIndexOf('/');
+	const branchName = slash >= 0 ? branchRef.slice(slash + 1) : branchRef;
+	return {
+		branchName: branchName,
+		branchRef: branchRef,
+		...(opts?.additionalBranchRefs ? { additionalBranchRefs: opts.additionalBranchRefs } : {}),
+	};
 }

--- a/src/webviews/apps/plus/graph/graph-wrapper/graph-wrapper.ts
+++ b/src/webviews/apps/plus/graph/graph-wrapper/graph-wrapper.ts
@@ -238,11 +238,12 @@ export class GlGraphWrapper extends SignalWatcher(LitElement) {
 
 	// Cache keyed by (rows, wipMetadataBySha, workingTreeStats, scope, branchesVisibility,
 	// includeOnlyRefs, branch.id) — any reference change invalidates. Scope must be in the key
-	// because `filterSecondariesForScope` reads `scope.branchRef`/`upstreamRef`/`additionalBranchRefs`;
-	// `branchesVisibility` + `includeOnlyRefs` + `currentBranchId` must also be in the key
-	// because the WIP-visibility helpers below
-	// (`filterSecondariesForIncludeOnlyRefs`, `shouldShowPrimaryWipRow`) read them when the
-	// scope picker is in a non-`all` mode (current/smart/favorited/agents).
+	// because `filterSecondariesForScope` reads `scope.branchRef`/`upstreamRef`/`additionalBranchRefs`
+	// AND `shouldShowPrimaryWipRow` reads `scope.branchRef` to enforce the "primary WIP belongs
+	// only to the focal branch when focal === current" convention; `branchesVisibility` +
+	// `includeOnlyRefs` + `currentBranchId` must also be in the key because the WIP-visibility
+	// helpers below (`filterSecondariesForIncludeOnlyRefs`, `shouldShowPrimaryWipRow`) read them
+	// when the scope picker is in a non-`all` mode (current/smart/favorited/agents).
 	private _decoratedRowsCache?: {
 		rows: GraphRow[] | undefined;
 		wipMetadataBySha: GraphWipMetadataBySha | undefined;
@@ -281,7 +282,7 @@ export class GlGraphWrapper extends SignalWatcher(LitElement) {
 			return cached.result;
 		}
 
-		const showPrimary = shouldShowPrimaryWipRow(branchesVisibility, includeOnlyRefs, currentBranchId);
+		const showPrimary = shouldShowPrimaryWipRow(branchesVisibility, includeOnlyRefs, currentBranchId, scope);
 
 		const filteredMetadata = filterSecondariesForIncludeOnlyRefs(
 			filterSecondariesForScope(wipMetadataBySha, scope),

--- a/src/webviews/apps/plus/graph/utils/wip.utils.ts
+++ b/src/webviews/apps/plus/graph/utils/wip.utils.ts
@@ -48,24 +48,43 @@ export function filterSecondariesForScope(
 
 /**
  * Determines whether the primary "Working Changes" row (for the current worktree's branch)
- * should render under the active `branchesVisibility` filter.
+ * should render under the active scope + `branchesVisibility` filters.
  *
+ * Scope check (runs first): when a scope is active and its focal branch (`scope.branchRef`)
+ * isn't the branch HEAD points at, the primary WIP is hidden. The Working Changes row is
+ * anchored to HEAD, so it only "belongs" to the scoped branch when the scoped branch is the
+ * one HEAD points at — see `getOverviewBranchSelectionSha` for the matching selection-side
+ * convention. `additionalBranchRefs` deliberately does NOT count: the primary WIP only
+ * attributes to the focal branch. In a detached-HEAD-plus-scope state this returns false —
+ * with no current branch there's nothing to attribute the WIP to.
+ *
+ * `branchesVisibility` check (runs after scope):
  * - `'all'` (and absent): always show.
- * - `'current'`, `'smart'`, `'favorited'`: these scopes always include the current branch by
+ * - `'current'`, `'smart'`, `'favorited'`: these modes always include the current branch by
  *   construction, so this returns true in normal cases.
  * - `'agents'`: only shows if the current branch is in the host-computed include set
  *   (i.e. an active agent is running on the current branch's worktree).
  *
  * Empty `{}` is treated as "no filter" — same convention as `filterSecondariesForIncludeOnlyRefs`.
- * If the current branch id is unknown (detached HEAD with a non-`'all'` scope), defaults to
- * showing the primary — the user's local WIP still matters even when there's no branch to
- * match against.
+ * If the current branch id is unknown (detached HEAD under a non-`'all'` `branchesVisibility`
+ * filter with no `scope` active), defaults to showing the primary — the user's local WIP
+ * still matters even when there's no branch to match against.
  */
 export function shouldShowPrimaryWipRow(
 	branchesVisibility: GraphBranchesVisibility | undefined,
 	includeOnlyRefs: GraphIncludeOnlyRefs | undefined,
 	currentBranchId: string | undefined,
+	scope: GraphScope | undefined,
 ): boolean {
+	// Scope guard runs first — the Working Changes row is anchored to HEAD, so it only
+	// "belongs" to the scoped branch when the scoped branch is the one HEAD points at.
+	// Without this gate, the GK component keeps the primary WIP in any descendant-branch
+	// scope (HEAD's sha is in the visible ancestor set) and surfaces the current branch's
+	// WIP under a branch it doesn't belong to. `additionalBranchRefs` deliberately does
+	// NOT count — convention is "focal branch only" (matches `getOverviewBranchSelectionSha`).
+	// Detached HEAD under an active scope returns false too — no branch to attribute WIP to.
+	if (scope != null && scope.branchRef !== currentBranchId) return false;
+
 	if (branchesVisibility == null || branchesVisibility === 'all') return true;
 	if (includeOnlyRefs == null) return true;
 	if (currentBranchId == null) return true; // detached HEAD fallback — keep primary visible


### PR DESCRIPTION
## Summary

- Adds a scope-aware guard to `shouldShowPrimaryWipRow` so the primary "Working Changes" row only renders when the scoped branch is the one HEAD points at — matching the convention already enforced for row selection in `getOverviewBranchSelectionSha`
- Fixes a regression after `e93aac585` (Fixes missing WIP rows when branch tips match), where the current branch's WIP leaked into any descendant branch's scoped view because the gitkraken-components scope filter kept the row whenever HEAD's sha was in the scope's visible ancestor set
- Threads the existing `scope` through to the helper at the single `graph-wrapper.ts` call site; the cache key already includes scope by identity, so no cache change is needed
- Detached HEAD under an active scope returns false too (no branch to attribute WIP to); without scope, the existing detached-HEAD passthrough is preserved

## Test plan

- [x] `pnpm run test` — 14 cases in the `shouldShowPrimaryWipRow` suite (8 existing + 6 new) cover descendant-scope leak (pinned with `branchesVisibility === 'all'` to catch guard-ordering regressions), scope === current, detached HEAD, `additionalBranchRefs` doesn't count, and guard ordering vs. agents mode
- [x] Manual repro in `~/dev/test/dummy-repo-private`:
  - `git stash && git checkout main && echo wip >> README.md`
  - Open Commit Graph, scope to `rebase-conflict-test-all` → Working Changes row **hidden** ✓
  - Scope back to `main` → Working Changes row **visible** ✓
  - Restore: `git checkout -- README.md && git checkout rebase-conflict-test-all && git stash pop`
- [x] Manual: worktree branch scope with current WIP → primary WIP **hidden**, secondary WIP for the scoped worktree still **visible** (confirms `filterSecondariesForScope` is untouched)
- [x] Manual: detached HEAD + scope → primary WIP **hidden**; clear scope → primary **visible**