### PR TITLE
Replace agent-session quickpick with a smart dispatcher

### DIFF
--- a/packages/plus/agents/src/__tests__/claudeCodeProvider.test.ts
+++ b/packages/plus/agents/src/__tests__/claudeCodeProvider.test.ts
@@ -512,7 +512,7 @@ suite('ClaudeCodeProvider', () => {
 	});
 
 	suite('agents/sessions/open IPC handler', () => {
-		test('invokes the host callback with the requested sessionId', async () => {
+		test('invokes the host callback with the requested sessionId and reports opened: true', async () => {
 			const calls: string[] = [];
 			const { callbacks, handlers } = createMockCallbacks({
 				openSessionInClaudeExtension: sessionId => {
@@ -530,13 +530,13 @@ suite('ClaudeCodeProvider', () => {
 
 				const response = await handler({ sessionId: 'sess-1' }, new URLSearchParams());
 				assert.deepStrictEqual(calls, ['sess-1']);
-				assert.deepStrictEqual(response, {});
+				assert.deepStrictEqual(response, { opened: true });
 			} finally {
 				provider.dispose();
 			}
 		});
 
-		test('returns {} without invoking the callback when sessionId is missing', async () => {
+		test('returns { opened: false } without invoking the callback when sessionId is missing', async () => {
 			let called = false;
 			const { callbacks, handlers } = createMockCallbacks({
 				openSessionInClaudeExtension: () => {
@@ -552,13 +552,13 @@ suite('ClaudeCodeProvider', () => {
 				const handler = handlers.get('agents/sessions/open')!;
 				const response = await handler({}, new URLSearchParams());
 				assert.strictEqual(called, false, 'callback must not run when sessionId is absent');
-				assert.deepStrictEqual(response, {});
+				assert.deepStrictEqual(response, { opened: false });
 			} finally {
 				provider.dispose();
 			}
 		});
 
-		test('returns {} when the host did not wire openSessionInClaudeExtension', async () => {
+		test('returns { opened: false } when the host did not wire openSessionInClaudeExtension', async () => {
 			const { callbacks, handlers } = createMockCallbacks();
 			const provider = new ClaudeCodeProvider(callbacks);
 			try {
@@ -567,13 +567,13 @@ suite('ClaudeCodeProvider', () => {
 
 				const handler = handlers.get('agents/sessions/open')!;
 				const response = await handler({ sessionId: 'sess-1' }, new URLSearchParams());
-				assert.deepStrictEqual(response, {});
+				assert.deepStrictEqual(response, { opened: false });
 			} finally {
 				provider.dispose();
 			}
 		});
 
-		test('swallows callback errors so the peer never sees a 500', async () => {
+		test('returns { opened: false } when the callback throws (peer never sees a 500)', async () => {
 			const { callbacks, handlers } = createMockCallbacks({
 				openSessionInClaudeExtension: () => Promise.reject(new Error('extension not installed')),
 			});
@@ -584,7 +584,7 @@ suite('ClaudeCodeProvider', () => {
 
 				const handler = handlers.get('agents/sessions/open')!;
 				const response = await handler({ sessionId: 'sess-1' }, new URLSearchParams());
-				assert.deepStrictEqual(response, {});
+				assert.deepStrictEqual(response, { opened: false });
 			} finally {
 				provider.dispose();
 			}
@@ -592,7 +592,7 @@ suite('ClaudeCodeProvider', () => {
 	});
 
 	suite('notifyPeerOpenSession', () => {
-		test("skips the discovery file matching this provider's own port", async () => {
+		test("skips the discovery file matching this provider's own port and returns false", async () => {
 			const { default: http } = await import('node:http');
 			const { mkdtemp, rm, writeFile } = await import('node:fs/promises');
 			const { tmpdir } = await import('node:os');
@@ -603,7 +603,7 @@ suite('ClaudeCodeProvider', () => {
 			const server = http.createServer((req, res) => {
 				hits.push(req.url ?? '');
 				res.writeHead(200);
-				res.end('{}');
+				res.end(JSON.stringify({ opened: true }));
 			});
 			await new Promise<void>(resolve => server.listen(0, '127.0.0.1', resolve));
 			const port = (server.address() as { port: number }).port;
@@ -624,12 +624,13 @@ suite('ClaudeCodeProvider', () => {
 					provider.start(['/repo']);
 					await flushMicrotasks();
 					hits.length = 0; // ignore any pre-existing list-route hits (there should be none)
-					await provider.notifyPeerOpenSession('/repo', 'sess-1');
+					const opened = await provider.notifyPeerOpenSession('/repo', 'sess-1');
 					assert.deepStrictEqual(
 						hits.filter(u => u === '/agents/sessions/open'),
 						[],
 						'own-port discovery file must be skipped',
 					);
+					assert.strictEqual(opened, false, 'no peer should have been contacted');
 				} finally {
 					provider.dispose();
 				}
@@ -639,7 +640,7 @@ suite('ClaudeCodeProvider', () => {
 			}
 		});
 
-		test('skips peers whose workspacePaths do not include the target', async () => {
+		test('skips peers whose workspacePaths do not include the target and returns false', async () => {
 			const { default: http } = await import('node:http');
 			const { mkdtemp, rm, writeFile } = await import('node:fs/promises');
 			const { tmpdir } = await import('node:os');
@@ -650,7 +651,7 @@ suite('ClaudeCodeProvider', () => {
 			const server = http.createServer((req, res) => {
 				hits.push(req.url ?? '');
 				res.writeHead(200);
-				res.end('{}');
+				res.end(JSON.stringify({ opened: true }));
 			});
 			await new Promise<void>(resolve => server.listen(0, '127.0.0.1', resolve));
 			const peerPort = (server.address() as { port: number }).port;
@@ -671,12 +672,13 @@ suite('ClaudeCodeProvider', () => {
 					provider.start(['/repo']);
 					await flushMicrotasks();
 					hits.length = 0; // ignore `/agents/sessions/list` from querySiblingWindowSessions
-					await provider.notifyPeerOpenSession('/repo', 'sess-1');
+					const opened = await provider.notifyPeerOpenSession('/repo', 'sess-1');
 					assert.deepStrictEqual(
 						hits.filter(u => u === '/agents/sessions/open'),
 						[],
 						'mismatched-workspace peer must not be POSTed',
 					);
+					assert.strictEqual(opened, false, 'no matching peer should have been contacted');
 				} finally {
 					provider.dispose();
 				}
@@ -686,7 +688,7 @@ suite('ClaudeCodeProvider', () => {
 			}
 		});
 
-		test('POSTs the sessionId to peers whose workspacePaths include the (normalized) target', async () => {
+		test('POSTs the sessionId to a matching peer and returns true when the peer is reachable', async () => {
 			const { default: http } = await import('node:http');
 			const { mkdtemp, rm, writeFile } = await import('node:fs/promises');
 			const { tmpdir } = await import('node:os');
@@ -703,8 +705,8 @@ suite('ClaudeCodeProvider', () => {
 						auth: req.headers['authorization'],
 						body: Buffer.concat(chunks).toString('utf8'),
 					});
-					res.writeHead(200);
-					res.end('{}');
+					res.writeHead(200, { 'Content-Type': 'application/json' });
+					res.end(JSON.stringify({ opened: true }));
 				});
 			});
 			await new Promise<void>(resolve => server.listen(0, '127.0.0.1', resolve));
@@ -729,17 +731,162 @@ suite('ClaudeCodeProvider', () => {
 					// Ignore the unrelated `/agents/sessions/list` POST that `querySiblingWindowSessions`
 					// fires on start — we only care about what `notifyPeerOpenSession` does.
 					requests.length = 0;
-					await provider.notifyPeerOpenSession('d:/PROJ/GKGL/vscode-gitlens', 'sess-42');
+					const opened = await provider.notifyPeerOpenSession('d:/PROJ/GKGL/vscode-gitlens', 'sess-42');
 
 					const openRequests = requests.filter(r => r.url === '/agents/sessions/open');
 					assert.strictEqual(openRequests.length, 1, 'matching peer should receive exactly one open POST');
 					assert.strictEqual(openRequests[0].auth, 'Bearer peer-token');
 					assert.deepStrictEqual(JSON.parse(openRequests[0].body), { sessionId: 'sess-42' });
+					assert.strictEqual(opened, true, 'reachable peer should resolve to true');
 				} finally {
 					provider.dispose();
 				}
 			} finally {
 				await new Promise<void>(resolve => server.close(() => resolve()));
+				await rm(dir, { recursive: true, force: true });
+			}
+		});
+
+		test('returns true even when a matching peer responds with { opened: false } (peer is still the right window to focus)', async () => {
+			const { default: http } = await import('node:http');
+			const { mkdtemp, rm, writeFile } = await import('node:fs/promises');
+			const { tmpdir } = await import('node:os');
+			const { join } = await import('node:path');
+
+			const dir = await mkdtemp(join(tmpdir(), 'gitlens-discovery-not-opened-'));
+			const server = http.createServer((_req, res) => {
+				res.writeHead(200, { 'Content-Type': 'application/json' });
+				res.end(JSON.stringify({ opened: false }));
+			});
+			await new Promise<void>(resolve => server.listen(0, '127.0.0.1', resolve));
+			const peerPort = (server.address() as { port: number }).port;
+			try {
+				await writeFile(
+					join(dir, 'gitlens-ipc-server-peer.json'),
+					JSON.stringify({
+						token: 'peer-token',
+						address: `http://127.0.0.1:${peerPort}`,
+						port: peerPort,
+						workspacePaths: ['/repo'],
+					}),
+				);
+
+				const { callbacks } = createMockCallbacks({ port: peerPort + 1, agentDiscoveryDir: dir });
+				const provider = new ClaudeCodeProvider(callbacks);
+				try {
+					provider.start(['/somewhere/else']);
+					await flushMicrotasks();
+					const opened = await provider.notifyPeerOpenSession('/repo', 'sess-99');
+					// `opened: false` is logged for diagnostics but the peer was reachable, so the
+					// caller still gets the signal it needs to focus that peer's window via
+					// `vscode.openFolder` instead of opening a new window.
+					assert.strictEqual(
+						opened,
+						true,
+						'a reachable peer that failed to open the session is still the right window to focus',
+					);
+				} finally {
+					provider.dispose();
+				}
+			} finally {
+				await new Promise<void>(resolve => server.close(() => resolve()));
+				await rm(dir, { recursive: true, force: true });
+			}
+		});
+
+		test('matches a peer whose workspacePath *contains* the target (cwd is a subdir of the peer workspace)', async () => {
+			const { default: http } = await import('node:http');
+			const { mkdtemp, rm, writeFile } = await import('node:fs/promises');
+			const { tmpdir } = await import('node:os');
+			const { join } = await import('node:path');
+
+			const dir = await mkdtemp(join(tmpdir(), 'gitlens-discovery-containment-'));
+			const requests: { url: string; body: string }[] = [];
+			const server = http.createServer((req, res) => {
+				const chunks: Buffer[] = [];
+				req.on('data', c => chunks.push(c as Buffer));
+				req.on('end', () => {
+					requests.push({ url: req.url ?? '', body: Buffer.concat(chunks).toString('utf8') });
+					res.writeHead(200, { 'Content-Type': 'application/json' });
+					res.end(JSON.stringify({ opened: true }));
+				});
+			});
+			await new Promise<void>(resolve => server.listen(0, '127.0.0.1', resolve));
+			const peerPort = (server.address() as { port: number }).port;
+			try {
+				await writeFile(
+					join(dir, 'gitlens-ipc-server-peer.json'),
+					JSON.stringify({
+						token: 'peer-token',
+						address: `http://127.0.0.1:${peerPort}`,
+						port: peerPort,
+						// Peer has the repo *root* open as workspace.
+						workspacePaths: ['/repo'],
+					}),
+				);
+
+				const { callbacks } = createMockCallbacks({ port: peerPort + 1, agentDiscoveryDir: dir });
+				const provider = new ClaudeCodeProvider(callbacks);
+				try {
+					provider.start(['/somewhere/else']);
+					await flushMicrotasks();
+					requests.length = 0; // ignore startup `/agents/sessions/list` POSTs
+
+					// Dispatcher passes a cwd inside the peer's workspace folder — strict equality
+					// would miss this; containment matching catches it.
+					const opened = await provider.notifyPeerOpenSession('/repo/src/foo', 'sess-contain');
+
+					const openRequests = requests.filter(r => r.url === '/agents/sessions/open');
+					assert.strictEqual(
+						openRequests.length,
+						1,
+						'peer whose workspacePath is a parent of the target must still be POSTed',
+					);
+					assert.deepStrictEqual(JSON.parse(openRequests[0].body), { sessionId: 'sess-contain' });
+					assert.strictEqual(opened, true, 'containment match must propagate as true');
+				} finally {
+					provider.dispose();
+				}
+			} finally {
+				await new Promise<void>(resolve => server.close(() => resolve()));
+				await rm(dir, { recursive: true, force: true });
+			}
+		});
+
+		test('returns false when a matching peer is advertised but unreachable (refused/timeout)', async () => {
+			const { mkdtemp, rm, writeFile } = await import('node:fs/promises');
+			const { tmpdir } = await import('node:os');
+			const { join } = await import('node:path');
+
+			const dir = await mkdtemp(join(tmpdir(), 'gitlens-discovery-unreachable-'));
+			try {
+				// Use port 1 — guaranteed-closed on every platform; fetch will fail with
+				// ECONNREFUSED quickly.
+				await writeFile(
+					join(dir, 'gitlens-ipc-server-dead.json'),
+					JSON.stringify({
+						token: 'dead-token',
+						address: `http://127.0.0.1:1`,
+						port: 1,
+						workspacePaths: ['/repo'],
+					}),
+				);
+
+				const { callbacks } = createMockCallbacks({ port: 50000, agentDiscoveryDir: dir });
+				const provider = new ClaudeCodeProvider(callbacks);
+				try {
+					provider.start(['/somewhere/else']);
+					await flushMicrotasks();
+					const opened = await provider.notifyPeerOpenSession('/repo', 'sess-dead');
+					assert.strictEqual(
+						opened,
+						false,
+						'an advertised-but-unreachable peer must resolve to false so the caller opens a new window instead of trying to focus a dead window',
+					);
+				} finally {
+					provider.dispose();
+				}
+			} finally {
 				await rm(dir, { recursive: true, force: true });
 			}
 		});

--- a/packages/plus/agents/src/__tests__/claudeCodeProvider.test.ts
+++ b/packages/plus/agents/src/__tests__/claudeCodeProvider.test.ts
@@ -8,18 +8,24 @@ import type { AgentProviderCallbacks, IpcRegistrar } from '../types.js';
 
 interface MockCallbacks {
 	callbacks: AgentProviderCallbacks;
-	handlers: Map<string, IpcHandler>;
+	handlers: Map<string, IpcHandler<unknown, unknown>>;
 	publishedPaths: string[][];
 }
 
-function createMockCallbacks(options?: { resolveGitInfo?: AgentProviderCallbacks['resolveGitInfo'] }): MockCallbacks {
-	const handlers = new Map<string, IpcHandler>();
+function createMockCallbacks(options?: {
+	resolveGitInfo?: AgentProviderCallbacks['resolveGitInfo'];
+	openSessionInClaudeExtension?: AgentProviderCallbacks['openSessionInClaudeExtension'];
+	port?: number;
+	agentDiscoveryDir?: string;
+}): MockCallbacks {
+	const handlers = new Map<string, IpcHandler<unknown, unknown>>();
 	const publishedPaths: string[][] = [];
 
 	const ipc: IpcRegistrar = {
-		port: 1234,
+		port: options?.port ?? 1234,
+		agentDiscoveryDir: options?.agentDiscoveryDir,
 		registerHandler: <Request, Response>(name: string, handler: IpcHandler<Request, Response>) => {
-			handlers.set(name, handler as unknown as IpcHandler);
+			handlers.set(name, handler as unknown as IpcHandler<unknown, unknown>);
 			return createDisposable(() => {
 				handlers.delete(name);
 			});
@@ -35,6 +41,7 @@ function createMockCallbacks(options?: { resolveGitInfo?: AgentProviderCallbacks
 		ipc: ipc,
 		runCLICommand: () => Promise.resolve('[]'),
 		resolveGitInfo: options?.resolveGitInfo,
+		openSessionInClaudeExtension: options?.openSessionInClaudeExtension,
 	};
 
 	return { callbacks: callbacks, handlers: handlers, publishedPaths: publishedPaths };
@@ -500,6 +507,240 @@ suite('ClaudeCodeProvider', () => {
 				assert.strictEqual(provider.sessions[0].lastPrompt, 'now do logging');
 			} finally {
 				provider.dispose();
+			}
+		});
+	});
+
+	suite('agents/sessions/open IPC handler', () => {
+		test('invokes the host callback with the requested sessionId', async () => {
+			const calls: string[] = [];
+			const { callbacks, handlers } = createMockCallbacks({
+				openSessionInClaudeExtension: sessionId => {
+					calls.push(sessionId);
+					return Promise.resolve();
+				},
+			});
+			const provider = new ClaudeCodeProvider(callbacks);
+			try {
+				provider.start(['/repo']);
+				await flushMicrotasks();
+
+				const handler = handlers.get('agents/sessions/open');
+				assert.ok(handler != null, 'agents/sessions/open handler should be registered');
+
+				const response = await handler({ sessionId: 'sess-1' }, new URLSearchParams());
+				assert.deepStrictEqual(calls, ['sess-1']);
+				assert.deepStrictEqual(response, {});
+			} finally {
+				provider.dispose();
+			}
+		});
+
+		test('returns {} without invoking the callback when sessionId is missing', async () => {
+			let called = false;
+			const { callbacks, handlers } = createMockCallbacks({
+				openSessionInClaudeExtension: () => {
+					called = true;
+					return Promise.resolve();
+				},
+			});
+			const provider = new ClaudeCodeProvider(callbacks);
+			try {
+				provider.start(['/repo']);
+				await flushMicrotasks();
+
+				const handler = handlers.get('agents/sessions/open')!;
+				const response = await handler({}, new URLSearchParams());
+				assert.strictEqual(called, false, 'callback must not run when sessionId is absent');
+				assert.deepStrictEqual(response, {});
+			} finally {
+				provider.dispose();
+			}
+		});
+
+		test('returns {} when the host did not wire openSessionInClaudeExtension', async () => {
+			const { callbacks, handlers } = createMockCallbacks();
+			const provider = new ClaudeCodeProvider(callbacks);
+			try {
+				provider.start(['/repo']);
+				await flushMicrotasks();
+
+				const handler = handlers.get('agents/sessions/open')!;
+				const response = await handler({ sessionId: 'sess-1' }, new URLSearchParams());
+				assert.deepStrictEqual(response, {});
+			} finally {
+				provider.dispose();
+			}
+		});
+
+		test('swallows callback errors so the peer never sees a 500', async () => {
+			const { callbacks, handlers } = createMockCallbacks({
+				openSessionInClaudeExtension: () => Promise.reject(new Error('extension not installed')),
+			});
+			const provider = new ClaudeCodeProvider(callbacks);
+			try {
+				provider.start(['/repo']);
+				await flushMicrotasks();
+
+				const handler = handlers.get('agents/sessions/open')!;
+				const response = await handler({ sessionId: 'sess-1' }, new URLSearchParams());
+				assert.deepStrictEqual(response, {});
+			} finally {
+				provider.dispose();
+			}
+		});
+	});
+
+	suite('notifyPeerOpenSession', () => {
+		test("skips the discovery file matching this provider's own port", async () => {
+			const { default: http } = await import('node:http');
+			const { mkdtemp, rm, writeFile } = await import('node:fs/promises');
+			const { tmpdir } = await import('node:os');
+			const { join } = await import('node:path');
+
+			const dir = await mkdtemp(join(tmpdir(), 'gitlens-discovery-self-'));
+			const hits: string[] = [];
+			const server = http.createServer((req, res) => {
+				hits.push(req.url ?? '');
+				res.writeHead(200);
+				res.end('{}');
+			});
+			await new Promise<void>(resolve => server.listen(0, '127.0.0.1', resolve));
+			const port = (server.address() as { port: number }).port;
+			try {
+				await writeFile(
+					join(dir, 'gitlens-ipc-server-self.json'),
+					JSON.stringify({
+						token: 't',
+						address: `http://127.0.0.1:${port}`,
+						port: port,
+						workspacePaths: ['/repo'],
+					}),
+				);
+
+				const { callbacks } = createMockCallbacks({ port: port, agentDiscoveryDir: dir });
+				const provider = new ClaudeCodeProvider(callbacks);
+				try {
+					provider.start(['/repo']);
+					await flushMicrotasks();
+					hits.length = 0; // ignore any pre-existing list-route hits (there should be none)
+					await provider.notifyPeerOpenSession('/repo', 'sess-1');
+					assert.deepStrictEqual(
+						hits.filter(u => u === '/agents/sessions/open'),
+						[],
+						'own-port discovery file must be skipped',
+					);
+				} finally {
+					provider.dispose();
+				}
+			} finally {
+				await new Promise<void>(resolve => server.close(() => resolve()));
+				await rm(dir, { recursive: true, force: true });
+			}
+		});
+
+		test('skips peers whose workspacePaths do not include the target', async () => {
+			const { default: http } = await import('node:http');
+			const { mkdtemp, rm, writeFile } = await import('node:fs/promises');
+			const { tmpdir } = await import('node:os');
+			const { join } = await import('node:path');
+
+			const dir = await mkdtemp(join(tmpdir(), 'gitlens-discovery-mismatch-'));
+			const hits: string[] = [];
+			const server = http.createServer((req, res) => {
+				hits.push(req.url ?? '');
+				res.writeHead(200);
+				res.end('{}');
+			});
+			await new Promise<void>(resolve => server.listen(0, '127.0.0.1', resolve));
+			const peerPort = (server.address() as { port: number }).port;
+			try {
+				await writeFile(
+					join(dir, 'gitlens-ipc-server-other.json'),
+					JSON.stringify({
+						token: 't',
+						address: `http://127.0.0.1:${peerPort}`,
+						port: peerPort,
+						workspacePaths: ['/other/workspace'],
+					}),
+				);
+
+				const { callbacks } = createMockCallbacks({ port: peerPort + 1, agentDiscoveryDir: dir });
+				const provider = new ClaudeCodeProvider(callbacks);
+				try {
+					provider.start(['/repo']);
+					await flushMicrotasks();
+					hits.length = 0; // ignore `/agents/sessions/list` from querySiblingWindowSessions
+					await provider.notifyPeerOpenSession('/repo', 'sess-1');
+					assert.deepStrictEqual(
+						hits.filter(u => u === '/agents/sessions/open'),
+						[],
+						'mismatched-workspace peer must not be POSTed',
+					);
+				} finally {
+					provider.dispose();
+				}
+			} finally {
+				await new Promise<void>(resolve => server.close(() => resolve()));
+				await rm(dir, { recursive: true, force: true });
+			}
+		});
+
+		test('POSTs the sessionId to peers whose workspacePaths include the (normalized) target', async () => {
+			const { default: http } = await import('node:http');
+			const { mkdtemp, rm, writeFile } = await import('node:fs/promises');
+			const { tmpdir } = await import('node:os');
+			const { join } = await import('node:path');
+
+			const dir = await mkdtemp(join(tmpdir(), 'gitlens-discovery-match-'));
+			const requests: { url: string; auth: string | undefined; body: string }[] = [];
+			const server = http.createServer((req, res) => {
+				const chunks: Buffer[] = [];
+				req.on('data', c => chunks.push(c as Buffer));
+				req.on('end', () => {
+					requests.push({
+						url: req.url ?? '',
+						auth: req.headers['authorization'],
+						body: Buffer.concat(chunks).toString('utf8'),
+					});
+					res.writeHead(200);
+					res.end('{}');
+				});
+			});
+			await new Promise<void>(resolve => server.listen(0, '127.0.0.1', resolve));
+			const peerPort = (server.address() as { port: number }).port;
+			try {
+				await writeFile(
+					join(dir, 'gitlens-ipc-server-peer.json'),
+					JSON.stringify({
+						token: 'peer-token',
+						address: `http://127.0.0.1:${peerPort}`,
+						port: peerPort,
+						// Mixed-separator path on purpose — `notifyPeerOpenSession` normalizes both sides.
+						workspacePaths: ['d:\\PROJ\\GKGL\\vscode-gitlens'],
+					}),
+				);
+
+				const { callbacks } = createMockCallbacks({ port: peerPort + 1, agentDiscoveryDir: dir });
+				const provider = new ClaudeCodeProvider(callbacks);
+				try {
+					provider.start(['/somewhere/else']);
+					await flushMicrotasks();
+					// Ignore the unrelated `/agents/sessions/list` POST that `querySiblingWindowSessions`
+					// fires on start — we only care about what `notifyPeerOpenSession` does.
+					requests.length = 0;
+					await provider.notifyPeerOpenSession('d:/PROJ/GKGL/vscode-gitlens', 'sess-42');
+
+					const openRequests = requests.filter(r => r.url === '/agents/sessions/open');
+					assert.strictEqual(openRequests.length, 1, 'matching peer should receive exactly one open POST');
+					assert.strictEqual(openRequests[0].auth, 'Bearer peer-token');
+					assert.deepStrictEqual(JSON.parse(openRequests[0].body), { sessionId: 'sess-42' });
+				} finally {
+					provider.dispose();
+				}
+			} finally {
+				await new Promise<void>(resolve => server.close(() => resolve()));
+				await rm(dir, { recursive: true, force: true });
 			}
 		});
 	});

--- a/packages/plus/agents/src/providers/claudeCodeProvider.ts
+++ b/packages/plus/agents/src/providers/claudeCodeProvider.ts
@@ -320,6 +320,20 @@ export class ClaudeCodeProvider implements AgentSessionProvider {
 					})),
 				),
 			),
+			this.callbacks.ipc.registerHandler('agents/sessions/open', async request => {
+				const sessionId = (request as { sessionId?: string } | undefined)?.sessionId;
+				if (!sessionId || this.callbacks.openSessionInClaudeExtension == null) return {};
+
+				try {
+					await this.callbacks.openSessionInClaudeExtension(sessionId);
+				} catch (ex) {
+					Logger.warn(
+						`ClaudeCodeProvider.agents/sessions/open: ${ex instanceof Error ? ex.message : String(ex)}`,
+					);
+				}
+
+				return {};
+			}),
 		];
 
 		try {
@@ -1512,5 +1526,54 @@ export class ClaudeCodeProvider implements AgentSessionProvider {
 		} catch {
 			return undefined;
 		}
+	}
+
+	/** Find the peer GitLens window whose discovery file claims `workspacePath`, and POST to its
+	 *  `/agents/sessions/open` route to ask its Claude Code extension to open the session. The
+	 *  caller is responsible for the follow-up `vscode.openFolder` that focuses the peer window —
+	 *  this method just makes sure the session is ready in the peer's editor before the focus
+	 *  switch lands. Best-effort: swallows scan, network, and JSON-parse errors. */
+	async notifyPeerOpenSession(workspacePath: string, sessionId: string): Promise<void> {
+		const discoveryDir = this.callbacks.ipc.agentDiscoveryDir;
+		if (discoveryDir == null) return;
+
+		const target = normalizePath(workspacePath);
+		const ownPort = this.callbacks.ipc.port;
+
+		let files: string[];
+		try {
+			files = await readdir(discoveryDir);
+		} catch {
+			return;
+		}
+
+		await Promise.all(
+			files
+				.filter(f => f.startsWith('gitlens-ipc-server-') && f.endsWith('.json'))
+				.map(async f => {
+					let discovery: DiscoveryFile;
+					try {
+						discovery = JSON.parse(await readFile(join(discoveryDir, f), 'utf8')) as DiscoveryFile;
+					} catch {
+						return;
+					}
+					if (ownPort != null && discovery.port === ownPort) return;
+					if (!discovery.workspacePaths?.some(p => normalizePath(p) === target)) return;
+
+					try {
+						await fetch(`${discovery.address}/agents/sessions/open`, {
+							method: 'POST',
+							headers: {
+								Authorization: `Bearer ${discovery.token}`,
+								'Content-Type': 'application/json',
+							},
+							body: JSON.stringify({ sessionId: sessionId }),
+							signal: AbortSignal.timeout(2000),
+						});
+					} catch {
+						// Best-effort — vscode.openFolder still focuses the peer window.
+					}
+				}),
+		);
 	}
 }

--- a/packages/plus/agents/src/providers/claudeCodeProvider.ts
+++ b/packages/plus/agents/src/providers/claudeCodeProvider.ts
@@ -322,17 +322,19 @@ export class ClaudeCodeProvider implements AgentSessionProvider {
 			),
 			this.callbacks.ipc.registerHandler('agents/sessions/open', async request => {
 				const sessionId = (request as { sessionId?: string } | undefined)?.sessionId;
-				if (!sessionId || this.callbacks.openSessionInClaudeExtension == null) return {};
+				if (!sessionId || this.callbacks.openSessionInClaudeExtension == null) {
+					return { opened: false };
+				}
 
 				try {
 					await this.callbacks.openSessionInClaudeExtension(sessionId);
+					return { opened: true };
 				} catch (ex) {
 					Logger.warn(
 						`ClaudeCodeProvider.agents/sessions/open: ${ex instanceof Error ? ex.message : String(ex)}`,
 					);
+					return { opened: false };
 				}
-
-				return {};
 			}),
 		];
 
@@ -1471,6 +1473,12 @@ export class ClaudeCodeProvider implements AgentSessionProvider {
 						workspacePath: normalizeWorkspacePath(peerSession.workspacePath),
 						isInWorkspace: this.matchesWorkspace(peerSession.workspacePath),
 						subagents: rehydrateSubagents(peerSession.subagents),
+						// Override whatever the peer published — this is OUR ownership view: the peer
+						// (or some other window) hosts the live session, not us. Drives the dispatcher
+						// to route opens through the peer's IPC + OS-level window focus instead of
+						// calling `claude-vscode.editor.open` locally (which would just open an inert
+						// view in our window).
+						isPeerOwned: true,
 					});
 					changed = true;
 				}
@@ -1529,13 +1537,18 @@ export class ClaudeCodeProvider implements AgentSessionProvider {
 	}
 
 	/** Find the peer GitLens window whose discovery file claims `workspacePath`, and POST to its
-	 *  `/agents/sessions/open` route to ask its Claude Code extension to open the session. The
-	 *  caller is responsible for the follow-up `vscode.openFolder` that focuses the peer window —
-	 *  this method just makes sure the session is ready in the peer's editor before the focus
-	 *  switch lands. Best-effort: swallows scan, network, and JSON-parse errors. */
-	async notifyPeerOpenSession(workspacePath: string, sessionId: string): Promise<void> {
+	 *  `/agents/sessions/open` route to ask its Claude Code extension to open the session.
+	 *
+	 *  Resolves to `true` when at least one peer claimed the workspace AND was reachable (the POST
+	 *  completed with any HTTP status). The peer's response shape (`{ opened: boolean }`) is logged
+	 *  for diagnostics but does NOT affect the return value — an `opened: false` peer is still the
+	 *  right window for the caller to focus, since it's the window that owns the session. Resolves
+	 *  to `false` when no peer claimed the workspace OR every claimer was unreachable; the caller
+	 *  treats that as "no peer to focus" and opens a new window instead of replacing the current
+	 *  one. Best-effort: swallows scan, JSON-parse errors. */
+	async notifyPeerOpenSession(workspacePath: string, sessionId: string): Promise<boolean> {
 		const discoveryDir = this.callbacks.ipc.agentDiscoveryDir;
-		if (discoveryDir == null) return;
+		if (discoveryDir == null) return false;
 
 		const target = normalizePath(workspacePath);
 		const ownPort = this.callbacks.ipc.port;
@@ -1544,10 +1557,10 @@ export class ClaudeCodeProvider implements AgentSessionProvider {
 		try {
 			files = await readdir(discoveryDir);
 		} catch {
-			return;
+			return false;
 		}
 
-		await Promise.all(
+		const results = await Promise.all(
 			files
 				.filter(f => f.startsWith('gitlens-ipc-server-') && f.endsWith('.json'))
 				.map(async f => {
@@ -1555,13 +1568,28 @@ export class ClaudeCodeProvider implements AgentSessionProvider {
 					try {
 						discovery = JSON.parse(await readFile(join(discoveryDir, f), 'utf8')) as DiscoveryFile;
 					} catch {
-						return;
+						return false;
 					}
-					if (ownPort != null && discovery.port === ownPort) return;
-					if (!discovery.workspacePaths?.some(p => normalizePath(p) === target)) return;
+					if (ownPort != null && discovery.port === ownPort) return false;
+					// Symmetric prefix containment — same shape as `matchesWorkspace()` above.
+					// Strict equality misses the common case where the dispatcher passes a `cwd`
+					// inside the peer's workspace folder (or, less commonly, a parent dir that
+					// contains the peer's workspace).
+					if (
+						!discovery.workspacePaths?.some(p => {
+							const normalized = normalizePath(p);
+							return (
+								normalized === target ||
+								target.startsWith(`${normalized}/`) ||
+								normalized.startsWith(`${target}/`)
+							);
+						})
+					) {
+						return false;
+					}
 
 					try {
-						await fetch(`${discovery.address}/agents/sessions/open`, {
+						const response = await fetch(`${discovery.address}/agents/sessions/open`, {
 							method: 'POST',
 							headers: {
 								Authorization: `Bearer ${discovery.token}`,
@@ -1570,10 +1598,37 @@ export class ClaudeCodeProvider implements AgentSessionProvider {
 							body: JSON.stringify({ sessionId: sessionId }),
 							signal: AbortSignal.timeout(2000),
 						});
-					} catch {
-						// Best-effort — vscode.openFolder still focuses the peer window.
+						if (!response.ok) {
+							Logger.warn(
+								`ClaudeCodeProvider.notifyPeerOpenSession: peer at ${discovery.address} returned ${response.status}`,
+							);
+						} else {
+							// Log a peer that failed to open the specific session, but still treat it
+							// as a reachable claimer of the workspace — focusing that window is still
+							// what the user wants.
+							const body = (await response.json().catch(() => undefined)) as
+								| { opened?: boolean }
+								| undefined;
+							if (body?.opened === false) {
+								Logger.warn(
+									`ClaudeCodeProvider.notifyPeerOpenSession: peer at ${discovery.address} could not open session ${sessionId}`,
+								);
+							}
+						}
+						return true;
+					} catch (ex) {
+						// Peer advertised but unreachable (timeout, RST, etc.). Treat as no match so
+						// the caller opens a new window instead of trying to focus a dead window.
+						Logger.warn(
+							`ClaudeCodeProvider.notifyPeerOpenSession: peer at ${discovery.address} unreachable: ${
+								ex instanceof Error ? ex.message : String(ex)
+							}`,
+						);
+						return false;
 					}
 				}),
 		);
+
+		return results.some(Boolean);
 	}
 }

--- a/packages/plus/agents/src/types.ts
+++ b/packages/plus/agents/src/types.ts
@@ -180,6 +180,12 @@ export interface AgentSessionProvider extends UnifiedDisposable {
 		decision: PermissionDecision,
 		updatedPermissions?: PermissionSuggestion[],
 	): boolean;
+
+	/** Asks the peer GitLens window that has `workspacePath` open to open the given session in its
+	 *  Claude Code extension (via the `agents/sessions/open` IPC route). Best-effort: resolves
+	 *  silently if no peer claims the workspace or the POST fails. Callers should follow up with
+	 *  `vscode.openFolder` so VS Code focuses that peer window. */
+	notifyPeerOpenSession?(workspacePath: string, sessionId: string): Promise<void>;
 }
 
 /**
@@ -243,4 +249,11 @@ export interface AgentProviderCallbacks {
 		  }
 		| undefined
 	>;
+
+	/**
+	 * Open a Claude Code session in the Claude Code VS Code extension. Invoked by the IPC handler
+	 * when a peer GitLens window asks this window to open a session on its behalf — the host wires
+	 * this to `claude-vscode.editor.open`. Throws if the extension isn't installed/active.
+	 */
+	openSessionInClaudeExtension?(sessionId: string): Promise<void>;
 }

--- a/packages/plus/agents/src/types.ts
+++ b/packages/plus/agents/src/types.ts
@@ -146,6 +146,16 @@ export interface AgentSession {
 	 *  Mutable array form so `Shape<AgentSession>` projects it as `string[]` (the `Shape<>` type
 	 *  mangles `readonly T[]` into a mapped object that loses its iterator). Treat as immutable. */
 	currentFiles?: string[];
+	/** `true` when the session was discovered via peer IPC sync (i.e. another GitLens window hosts
+	 *  the agent's hook flow and Claude Code extension panel). Locally-owned sessions leave this
+	 *  unset. The dispatcher uses this to route opens through the peer's IPC route + an OS-level
+	 *  window focus, since calling `claude-vscode.editor.open` in *our* extension only opens an
+	 *  inert local view that isn't connected to the live session running in the peer.
+	 *
+	 *  Window-local: never serialized faithfully across the IPC wire. Each window decides locally
+	 *  based on how it received the session — `querySiblingWindowSessions` always overrides to
+	 *  `true` regardless of what the peer published. */
+	readonly isPeerOwned?: boolean;
 	/**
 	 * Titles discovered by tailing the Claude Code transcript JSONL at
 	 * `~/.claude/projects/<encoded-cwd>/<sessionId>.jsonl`. Populated by
@@ -181,11 +191,14 @@ export interface AgentSessionProvider extends UnifiedDisposable {
 		updatedPermissions?: PermissionSuggestion[],
 	): boolean;
 
-	/** Asks the peer GitLens window that has `workspacePath` open to open the given session in its
-	 *  Claude Code extension (via the `agents/sessions/open` IPC route). Best-effort: resolves
-	 *  silently if no peer claims the workspace or the POST fails. Callers should follow up with
-	 *  `vscode.openFolder` so VS Code focuses that peer window. */
-	notifyPeerOpenSession?(workspacePath: string, sessionId: string): Promise<void>;
+	/** Asks the peer GitLens window that has `workspacePath` open (or any peer whose workspacePath
+	 *  contains, or is contained by, it) to open the given session in its Claude Code extension
+	 *  via the `agents/sessions/open` IPC route. Resolves to `true` when at least one peer claimed
+	 *  the workspace AND was reachable; `false` otherwise. Best-effort: never rejects. The boolean
+	 *  is currently a diagnostic signal only — the dispatcher fires this in parallel with
+	 *  `vscode.openFolder` and relies on VS Code's window-folder matching to focus the owning
+	 *  window (which works whether or not the peer runs GitLens). */
+	notifyPeerOpenSession?(workspacePath: string, sessionId: string): Promise<boolean>;
 }
 
 /**

--- a/src/agents/agentStatusService.ts
+++ b/src/agents/agentStatusService.ts
@@ -8,7 +8,7 @@ import { registerCommand } from '../system/-webview/command.js';
 import type { AgentSessionState, AgentSessionWorktreeMetadata } from './models/agentSessionState.js';
 import { getSessionDisplayName, serializeAgentSession } from './models/agentSessionState.js';
 import type { AgentSession, AgentSessionProvider, PermissionDecision, PermissionSuggestion } from './provider.js';
-import { isClaudeExtensionAvailable } from './utils/-webview/claudeExtension.js';
+import { isClaudeExtensionAvailable, tryOpenClaudeSession } from './utils/-webview/claudeExtension.js';
 
 export class AgentStatusService implements Disposable {
 	private readonly _onDidChange = new EventEmitter<void>();
@@ -448,56 +448,55 @@ export class AgentStatusService implements Disposable {
 
 	/**
 	 * Deterministically picks the right action for a resolved session — no quickpick:
-	 *  - Session belongs to a different workspace → notify a peer GitLens window that has it open
-	 *    (so its Claude Code extension opens the session), then `vscode.openFolder` (VS Code auto-
-	 *    focuses the peer window when the folder is already open there; otherwise the current
-	 *    window switches to the folder).
-	 *  - Session is in the current workspace → open in the Claude Code extension when the session
-	 *    is extension-hosted; focus the terminal via `pid` when CLI-hosted.
-	 *  - No workspace match but we have a `pid` → focus the terminal.
+	 *  - Extension-hosted, owned by another VS Code window → notify the owning peer (if it has
+	 *    GitLens running with the workspace) to open the session in its Claude Code extension,
+	 *    then `vscode.openFolder` (different workspace) or an info message (same/no workspace,
+	 *    where OS-level cross-window focus is unreliable on multi-window VS Code instances).
+	 *  - Extension-hosted, owned by this window → open in our Claude Code extension.
+	 *  - CLI-hosted → focus the terminal via `pid`.
 	 *  - Neither workspace nor pid → warn.
 	 *
-	 *  Host classification reads `~/.claude/sessions/<pid>.json` for the `entrypoint` field
-	 *  (`claude-vscode` = extension, anything else = CLI). When the file is missing/unreadable,
-	 *  we fall back to "extension if installed, else CLI" so users still get a sensible action.
+	 *  Host classification reads `~/.claude/sessions/<pid>.json` for the `entrypoint` field; the
+	 *  ownership check walks up to two parent-pid levels — for extension sessions the Claude
+	 *  binary's direct parent is the owning extension host process, so `parent === process.pid`
+	 *  ⇔ ours, with one extra hop reserved as a safety margin for a hypothetical Claude shim
+	 *  between the binary and the extension host.
 	 */
 	private async dispatchSessionAction(session: AgentSession): Promise<void> {
-		if (!session.isInWorkspace && session.workspacePath != null) {
-			// Match by id, not object identity — provider session arrays are rebuilt on every
-			// update (immutable spread), so a `.includes(session)` check would miss if the
-			// provider rebuilt its array between the user's pick and this dispatch.
-			const provider = this._providers.find(p => p.sessions.some(s => s.id === session.id));
-			if (provider?.notifyPeerOpenSession != null) {
-				// Cap the wait so an unhealthy peer (e.g. paused/unresponsive but not RST) can't
-				// stall the user click for the full per-fetch timeout. The peer only needs to
-				// *start* opening the session before `vscode.openFolder` focuses its window — the
-				// outstanding POST keeps running in the background after we move on. `.catch` is
-				// attached to the notify promise itself (not to the race) so a late rejection
-				// after the timeout wins is still observed instead of escaping as an unhandled
-				// rejection.
-				const notifyPromise = provider
-					.notifyPeerOpenSession(session.workspacePath, session.id)
-					.catch((ex: unknown) =>
-						Logger.warn(
-							`AgentStatusService.dispatchSessionAction: notifyPeerOpenSession failed: ${
-								ex instanceof Error ? ex.message : String(ex)
-							}`,
-						),
-					);
-				await Promise.race([notifyPromise, new Promise<void>(resolve => setTimeout(resolve, 500))]);
-			}
-			void commands.executeCommand('vscode.openFolder', Uri.file(session.workspacePath), {
-				forceNewWindow: false,
-			});
+		// Match by id, not object identity — provider session arrays are rebuilt on every update
+		// (immutable spread), so a `.includes(session)` check would miss if the provider rebuilt
+		// its array between the user's pick and this dispatch.
+		const provider = this._providers.find(p => p.sessions.some(s => s.id === session.id));
+
+		const { classifyClaudeSessionHost } = await import('@env/agents/claudeSessionFile.js');
+		const host = session.pid != null ? await classifyClaudeSessionHost(session.pid) : undefined;
+
+		// For extension-hosted sessions, determine whether this VS Code window owns the live
+		// session (its Claude Code extension launched the Claude binary). The Claude binary's
+		// direct parent IS the owning extension host process, so `parent === process.pid` ⇔ ours.
+		// Authoritative even when the session arrived via `syncSessions` (which reads global
+		// Claude session files without knowing which window owns each).
+		const isExtensionLocal =
+			host === 'extension' && session.pid != null
+				? await this.isExtensionSessionLocallyHosted(session.pid)
+				: true;
+
+		// Peer-owned extension session, OR a peer-sync-discovered session. Either way the live
+		// panel lives in another VS Code window; opening locally would just create an inert view.
+		if ((host === 'extension' && !isExtensionLocal) || session.isPeerOwned) {
+			await this.dispatchPeerOwnedSession(provider, session);
 			return;
 		}
 
 		if (session.isInWorkspace) {
-			const { classifyClaudeSessionHost } = await import('@env/agents/claudeSessionFile.js');
-			const host = session.pid != null ? await classifyClaudeSessionHost(session.pid) : undefined;
-			const useExtension = host === 'extension' || (host == null && (await isClaudeExtensionAvailable()));
+			// Always probe — when host is 'extension' we still need the real value to decide
+			// between the actionable "Claude Code extension is not installed" warning below and
+			// the generic "unable to open" fallback. Forcing `true` here would make the
+			// extension-specific warning unreachable.
+			const extensionAvailable = await isClaudeExtensionAvailable();
+			const useExtension = host === 'extension' || (host == null && extensionAvailable);
 
-			if (useExtension && (await this.tryOpenInClaudeExtension(session.id))) return;
+			if (useExtension && (await tryOpenClaudeSession(session.id))) return;
 			// Skip the terminal-focus fallback when we *know* the session is extension-hosted —
 			// `pid` would be the extension host (VS Code itself), so focusing it is a no-op that
 			// would falsely signal success and swallow the warning the user needs.
@@ -505,27 +504,99 @@ export class AgentStatusService implements Disposable {
 				return;
 			}
 
-			void window.showWarningMessage('Unable to open agent session.');
+			Logger.warn(
+				`AgentStatusService.dispatchSessionAction: in-workspace open failed for session ${session.id} (host=${host ?? 'unknown'}, pid=${session.pid ?? 'none'}, extensionAvailable=${extensionAvailable})`,
+			);
+			void window.showWarningMessage(
+				host === 'extension' && !extensionAvailable
+					? 'The Claude Code extension is not installed or not available.'
+					: 'Unable to open agent session.',
+			);
 			return;
 		}
 
+		// CLI-hosted out-of-workspace session — focus the terminal.
 		if (session.pid != null && (await this.tryFocusProcessWindow(session.pid))) return;
 
+		Logger.warn(
+			`AgentStatusService.dispatchSessionAction: no actionable target for session ${session.id} (isInWorkspace=${session.isInWorkspace}, workspacePath=${session.workspacePath ?? 'none'}, pid=${session.pid ?? 'none'})`,
+		);
 		void window.showWarningMessage('Unable to open agent session.');
 	}
 
-	private async tryOpenInClaudeExtension(sessionId: string): Promise<boolean> {
-		try {
-			await commands.executeCommand('claude-vscode.editor.open', sessionId);
-			return true;
-		} catch {
-			try {
-				await commands.executeCommand('claude-vscode.sidebar.open');
-				return true;
-			} catch {
+	/** Routes a session that's owned by another VS Code window. Notifies the owning peer (if it
+	 *  has GitLens running with the workspace) so its Claude Code extension surfaces the session,
+	 *  then either `vscode.openFolder` (different workspace — focuses the peer window via the
+	 *  folder-already-open path) or an info message (same workspace or unknown workspace, where
+	 *  OS-level cross-window focus across a multi-window VS Code app is unreliable). */
+	private async dispatchPeerOwnedSession(
+		provider: AgentSessionProvider | undefined,
+		session: AgentSession,
+	): Promise<void> {
+		// Target folder to focus. Each step picks a more general fallback so out-of-workspace
+		// sessions (cwd doesn't match any of OUR workspace folders) still resolve to a path some
+		// peer window likely has open as its workspace root:
+		//  - workspacePath: our matched folder (only set when isInWorkspace=true; unused here)
+		//  - worktreePath:  the session's worktree root — correct for named worktrees where the
+		//                   peer has the worktree dir open, not the common repo dir
+		//  - commonPath:    the parent repo's common dir — correct for default-worktree sessions
+		//  - cwd:           last-resort raw cwd. May be a subdir of the peer's workspace, in which
+		//                   case `vscode.openFolder` would open the subdir as its own workspace
+		//                   instead of focusing the peer. In practice Claude sessions run at the
+		//                   workspace root so cwd usually equals what the peer holds; the residual
+		//                   risk is documented rather than fixed (full fix would have
+		//                   `notifyPeerOpenSession` return the matched workspacePath so this
+		//                   function could pass that exact path to `openFolder` instead).
+		const targetPath = session.workspacePath ?? session.worktreePath ?? session.commonPath ?? session.cwd;
+
+		if (provider?.notifyPeerOpenSession != null && targetPath != null) {
+			// Cap the wait so an unhealthy peer can't stall the user click for the full per-fetch
+			// timeout. The peer only needs to *start* opening the session before the focus switch
+			// lands. `.catch` is on the notify promise itself (not the race) so a late rejection
+			// after the timeout wins is still observed. We don't use the return value: VS Code's
+			// `openFolder` finds and focuses the owning window whether or not it has GitLens, so
+			// peer match status isn't the right signal for `forceNewWindow`.
+			const notifyPromise = provider.notifyPeerOpenSession(targetPath, session.id).catch((ex: unknown) => {
+				Logger.warn(
+					`AgentStatusService.dispatchPeerOwnedSession: notifyPeerOpenSession failed: ${
+						ex instanceof Error ? ex.message : String(ex)
+					}`,
+				);
 				return false;
-			}
+			});
+			await Promise.race([notifyPromise, new Promise<void>(resolve => setTimeout(resolve, 500))]);
 		}
+
+		// Different workspace → `vscode.openFolder` with `forceNewWindow: false` asks VS Code to
+		// focus the existing window holding `targetPath` (this works across windows even if the
+		// peer doesn't have GitLens). Peer-owned implies *some* live window holds the folder (the
+		// session is running there), so VS Code's window-folder matching reliably hits it instead
+		// of replacing the current window.
+		if (!session.isInWorkspace && targetPath != null) {
+			void commands.executeCommand('vscode.openFolder', Uri.file(targetPath), {
+				forceNewWindow: false,
+			});
+			return;
+		}
+
+		// Same workspace (already open here, can't disambiguate) or no target at all. Surface a
+		// clear hint with the cwd so the user can switch manually.
+		Logger.warn(
+			`AgentStatusService.dispatchPeerOwnedSession: routed via info hint (pid=${session.pid ?? 'none'}, workspacePath=${session.workspacePath ?? 'none'}, cwd=${session.cwd ?? 'none'})`,
+		);
+		const cwdHint = session.cwd ? ` (${session.cwd})` : '';
+		void window.showInformationMessage(
+			`This session is running in another VS Code window${cwdHint}. Switch to it to view.`,
+		);
+	}
+
+	/** Returns `true` iff the given `pid` (a Claude binary process for an extension-hosted session)
+	 *  is a descendant of this VS Code window's extension host. For peer-owned sessions the parent
+	 *  is a *different* extension host (another window's), so this resolves to `false` — that's the
+	 *  dispatcher's signal to route through the peer-notify path instead of opening locally. */
+	private async isExtensionSessionLocallyHosted(pid: number): Promise<boolean> {
+		const { isDescendantOfThisExtensionHost } = await import('@env/focusWindow.js');
+		return isDescendantOfThisExtensionHost(pid);
 	}
 
 	private async tryFocusProcessWindow(pid: number): Promise<boolean> {

--- a/src/agents/agentStatusService.ts
+++ b/src/agents/agentStatusService.ts
@@ -8,6 +8,7 @@ import { registerCommand } from '../system/-webview/command.js';
 import type { AgentSessionState, AgentSessionWorktreeMetadata } from './models/agentSessionState.js';
 import { getSessionDisplayName, serializeAgentSession } from './models/agentSessionState.js';
 import type { AgentSession, AgentSessionProvider, PermissionDecision, PermissionSuggestion } from './provider.js';
+import { isClaudeExtensionAvailable } from './utils/-webview/claudeExtension.js';
 
 export class AgentStatusService implements Disposable {
 	private readonly _onDidChange = new EventEmitter<void>();
@@ -442,78 +443,94 @@ export class AgentStatusService implements Disposable {
 
 		if (session == null) return;
 
-		interface ActionPickItem extends QuickPickItem {
-			action: string;
-		}
+		await this.dispatchSessionAction(session);
+	}
 
-		const actions: ActionPickItem[] = [];
-
-		if (session.pid != null) {
-			actions.push({
-				label: '$(window) Focus Agent Window',
-				description: 'Bring the terminal running the agent to the foreground',
-				action: 'focus',
+	/**
+	 * Deterministically picks the right action for a resolved session — no quickpick:
+	 *  - Session belongs to a different workspace → notify a peer GitLens window that has it open
+	 *    (so its Claude Code extension opens the session), then `vscode.openFolder` (VS Code auto-
+	 *    focuses the peer window when the folder is already open there; otherwise the current
+	 *    window switches to the folder).
+	 *  - Session is in the current workspace → open in the Claude Code extension when the session
+	 *    is extension-hosted; focus the terminal via `pid` when CLI-hosted.
+	 *  - No workspace match but we have a `pid` → focus the terminal.
+	 *  - Neither workspace nor pid → warn.
+	 *
+	 *  Host classification reads `~/.claude/sessions/<pid>.json` for the `entrypoint` field
+	 *  (`claude-vscode` = extension, anything else = CLI). When the file is missing/unreadable,
+	 *  we fall back to "extension if installed, else CLI" so users still get a sensible action.
+	 */
+	private async dispatchSessionAction(session: AgentSession): Promise<void> {
+		if (!session.isInWorkspace && session.workspacePath != null) {
+			// Match by id, not object identity — provider session arrays are rebuilt on every
+			// update (immutable spread), so a `.includes(session)` check would miss if the
+			// provider rebuilt its array between the user's pick and this dispatch.
+			const provider = this._providers.find(p => p.sessions.some(s => s.id === session.id));
+			if (provider?.notifyPeerOpenSession != null) {
+				// Cap the wait so an unhealthy peer (e.g. paused/unresponsive but not RST) can't
+				// stall the user click for the full per-fetch timeout. The peer only needs to
+				// *start* opening the session before `vscode.openFolder` focuses its window — the
+				// outstanding POST keeps running in the background after we move on. `.catch` is
+				// attached to the notify promise itself (not to the race) so a late rejection
+				// after the timeout wins is still observed instead of escaping as an unhandled
+				// rejection.
+				const notifyPromise = provider
+					.notifyPeerOpenSession(session.workspacePath, session.id)
+					.catch((ex: unknown) =>
+						Logger.warn(
+							`AgentStatusService.dispatchSessionAction: notifyPeerOpenSession failed: ${
+								ex instanceof Error ? ex.message : String(ex)
+							}`,
+						),
+					);
+				await Promise.race([notifyPromise, new Promise<void>(resolve => setTimeout(resolve, 500))]);
+			}
+			void commands.executeCommand('vscode.openFolder', Uri.file(session.workspacePath), {
+				forceNewWindow: false,
 			});
+			return;
 		}
 
 		if (session.isInWorkspace) {
-			actions.push({
-				label: '$(edit) Open in Claude Code Extension',
-				description: 'Open session in the Claude Code VS Code extension',
-				action: 'open-extension',
-			});
+			const { classifyClaudeSessionHost } = await import('@env/agents/claudeSessionFile.js');
+			const host = session.pid != null ? await classifyClaudeSessionHost(session.pid) : undefined;
+			const useExtension = host === 'extension' || (host == null && (await isClaudeExtensionAvailable()));
+
+			if (useExtension && (await this.tryOpenInClaudeExtension(session.id))) return;
+			// Skip the terminal-focus fallback when we *know* the session is extension-hosted —
+			// `pid` would be the extension host (VS Code itself), so focusing it is a no-op that
+			// would falsely signal success and swallow the warning the user needs.
+			if (host !== 'extension' && session.pid != null && (await this.tryFocusProcessWindow(session.pid))) {
+				return;
+			}
+
+			void window.showWarningMessage('Unable to open agent session.');
+			return;
 		}
 
-		if (!session.isInWorkspace && session.workspacePath != null) {
-			actions.push({
-				label: '$(folder-opened) Switch to Workspace',
-				description: session.workspacePath,
-				action: 'switch-workspace',
-			});
+		if (session.pid != null && (await this.tryFocusProcessWindow(session.pid))) return;
+
+		void window.showWarningMessage('Unable to open agent session.');
+	}
+
+	private async tryOpenInClaudeExtension(sessionId: string): Promise<boolean> {
+		try {
+			await commands.executeCommand('claude-vscode.editor.open', sessionId);
+			return true;
+		} catch {
+			try {
+				await commands.executeCommand('claude-vscode.sidebar.open');
+				return true;
+			} catch {
+				return false;
+			}
 		}
+	}
 
-		if (actions.length === 0) return;
-
-		let action: string;
-		if (actions.length === 1) {
-			action = actions[0].action;
-		} else {
-			const actionPick = await window.showQuickPick(actions, {
-				placeHolder: `Action for ${getSessionDisplayName(session, this.getWorktreeMetadataForSession(session)?.name)}`,
-			});
-			if (actionPick == null) return;
-
-			action = actionPick.action;
-		}
-
-		switch (action) {
-			case 'focus':
-				if (session.pid != null) {
-					const { focusProcessWindow } = await import('@env/focusWindow.js');
-					await focusProcessWindow(session.pid);
-				}
-				break;
-			case 'open-extension':
-				try {
-					await commands.executeCommand('claude-vscode.editor.open', session.id);
-				} catch {
-					try {
-						await commands.executeCommand('claude-vscode.sidebar.open');
-					} catch {
-						void window.showWarningMessage(
-							'Unable to open session. Is the Claude Code extension installed?',
-						);
-					}
-				}
-				break;
-			case 'switch-workspace':
-				if (session.workspacePath != null) {
-					void commands.executeCommand('vscode.openFolder', Uri.file(session.workspacePath), {
-						forceNewWindow: false,
-					});
-				}
-				break;
-		}
+	private async tryFocusProcessWindow(pid: number): Promise<boolean> {
+		const { focusProcessWindow } = await import('@env/focusWindow.js');
+		return focusProcessWindow(pid);
 	}
 
 	private getWorkspacePaths(): string[] {

--- a/src/agents/utils/-webview/claudeExtension.ts
+++ b/src/agents/utils/-webview/claudeExtension.ts
@@ -2,15 +2,56 @@ import { commands, extensions } from 'vscode';
 
 export const claudeExtensionId = 'Anthropic.claude-code';
 export const claudeExtensionOpenCommand = 'claude-vscode.editor.open';
+/** Opens the session in the active editor column. Accepts `(sessionId, prompt)`; used as the
+ *  middle rung of {@link tryOpenClaudeSession} when `claude-vscode.editor.open` isn't available
+ *  (e.g. older Claude Code versions). */
+export const claudeExtensionPrimaryEditorOpenCommand = 'claude-vscode.primaryEditor.open';
+/** Focuses the Claude Code sidebar webview. Accepts no arguments — it cannot target a specific
+ *  session — so it's only the last-resort rung of {@link tryOpenClaudeSession}. */
+export const claudeExtensionSidebarOpenCommand = 'claude-vscode.sidebar.open';
 
-/** Returns `true` when the Claude Code VS Code extension is installed AND its session-open
- *  command is registered (i.e. the extension has activated far enough that the command will
- *  resolve). The picker uses this to gate the "Claude" entry; the agent status service uses
- *  it as the fallback decision when the session metadata file doesn't tell us whether the
+/** Returns `true` when the Claude Code VS Code extension is installed AND at least one of its
+ *  sessionId-bearing open commands is registered (`editor.open` or `primaryEditor.open` — older
+ *  Claude Code versions registered only the latter). Deliberately excludes `sidebar.open`: it
+ *  takes no arguments and can't carry a sessionId or prompt, so it's not usable as a primary
+ *  dispatch target. The picker uses this to gate the "Claude" entry; the agent status service
+ *  uses it as the fallback decision when the session metadata file doesn't tell us whether the
  *  session is extension-hosted or CLI-hosted. */
 export async function isClaudeExtensionAvailable(): Promise<boolean> {
 	if (extensions.getExtension(claudeExtensionId) == null) return false;
 
 	const registered = await commands.getCommands(true);
-	return registered.includes(claudeExtensionOpenCommand);
+	return (
+		registered.includes(claudeExtensionOpenCommand) || registered.includes(claudeExtensionPrimaryEditorOpenCommand)
+	);
+}
+
+/** Shared fallback chain for opening a Claude Code session via the Claude Code VS Code extension:
+ *  1. `claude-vscode.editor.open(sessionId)` — new tab, the preferred experience.
+ *  2. `claude-vscode.primaryEditor.open(sessionId)` — active column, used when (1) isn't registered.
+ *  3. `claude-vscode.sidebar.open()` — last-resort sidebar focus; cannot target a session so the
+ *     user lands on whatever session the sidebar last had focused.
+ *
+ *  Returns `true` once any rung succeeds, `false` when all three throw. Used in two places that
+ *  both need the same chain — keeping the logic here avoids drift between the local-window path
+ *  and the peer-window IPC callback. */
+export async function tryOpenClaudeSession(sessionId: string): Promise<boolean> {
+	try {
+		await commands.executeCommand(claudeExtensionOpenCommand, sessionId);
+		return true;
+	} catch {
+		// fall through
+	}
+	try {
+		await commands.executeCommand(claudeExtensionPrimaryEditorOpenCommand, sessionId);
+		return true;
+	} catch {
+		// fall through
+	}
+	try {
+		await commands.executeCommand(claudeExtensionSidebarOpenCommand);
+		return true;
+	} catch {
+		return false;
+	}
 }

--- a/src/agents/utils/-webview/claudeExtension.ts
+++ b/src/agents/utils/-webview/claudeExtension.ts
@@ -1,0 +1,16 @@
+import { commands, extensions } from 'vscode';
+
+export const claudeExtensionId = 'Anthropic.claude-code';
+export const claudeExtensionOpenCommand = 'claude-vscode.editor.open';
+
+/** Returns `true` when the Claude Code VS Code extension is installed AND its session-open
+ *  command is registered (i.e. the extension has activated far enough that the command will
+ *  resolve). The picker uses this to gate the "Claude" entry; the agent status service uses
+ *  it as the fallback decision when the session metadata file doesn't tell us whether the
+ *  session is extension-hosted or CLI-hosted. */
+export async function isClaudeExtensionAvailable(): Promise<boolean> {
+	if (extensions.getExtension(claudeExtensionId) == null) return false;
+
+	const registered = await commands.getCommands(true);
+	return registered.includes(claudeExtensionOpenCommand);
+}

--- a/src/env/browser/agents/claudeSessionFile.ts
+++ b/src/env/browser/agents/claudeSessionFile.ts
@@ -1,0 +1,6 @@
+export function classifyClaudeSessionHost(
+	_pid: number,
+	_sessionsDir?: string,
+): Promise<'extension' | 'cli' | undefined> {
+	return Promise.resolve(undefined);
+}

--- a/src/env/browser/focusWindow.ts
+++ b/src/env/browser/focusWindow.ts
@@ -1,3 +1,11 @@
 export function focusProcessWindow(_pid: number): Promise<boolean> {
 	return Promise.resolve(false);
 }
+
+export function getProcessParentPid(_pid: number): Promise<number | undefined> {
+	return Promise.resolve(undefined);
+}
+
+export function isDescendantOfThisExtensionHost(_pid: number, _maxDepth?: number): Promise<boolean> {
+	return Promise.resolve(false);
+}

--- a/src/env/node/agents/__tests__/claudeSessionFile.test.ts
+++ b/src/env/node/agents/__tests__/claudeSessionFile.test.ts
@@ -1,0 +1,59 @@
+import * as assert from 'node:assert';
+import { mkdtemp, rm, writeFile } from 'node:fs/promises';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import { classifyClaudeSessionHost } from '../claudeSessionFile.js';
+
+suite('classifyClaudeSessionHost', () => {
+	let dir: string;
+
+	setup(async () => {
+		dir = await mkdtemp(join(tmpdir(), 'gitlens-claude-sessions-'));
+	});
+
+	teardown(async () => {
+		await rm(dir, { recursive: true, force: true });
+	});
+
+	test('returns undefined when the session file is missing', async () => {
+		assert.strictEqual(await classifyClaudeSessionHost(12345, dir), undefined);
+	});
+
+	test('classifies entrypoint=claude-vscode as extension', async () => {
+		await writeFile(
+			join(dir, '111.json'),
+			JSON.stringify({ pid: 111, sessionId: 's', entrypoint: 'claude-vscode' }),
+		);
+		assert.strictEqual(await classifyClaudeSessionHost(111, dir), 'extension');
+	});
+
+	test('classifies entrypoint=cli as cli', async () => {
+		await writeFile(join(dir, '222.json'), JSON.stringify({ pid: 222, sessionId: 's', entrypoint: 'cli' }));
+		assert.strictEqual(await classifyClaudeSessionHost(222, dir), 'cli');
+	});
+
+	test('classifies any non-claude-vscode entrypoint (e.g. sdk-ts) as cli', async () => {
+		await writeFile(join(dir, '333.json'), JSON.stringify({ pid: 333, sessionId: 's', entrypoint: 'sdk-ts' }));
+		assert.strictEqual(await classifyClaudeSessionHost(333, dir), 'cli');
+	});
+
+	test('returns undefined when entrypoint is missing', async () => {
+		await writeFile(join(dir, '444.json'), JSON.stringify({ pid: 444, sessionId: 's' }));
+		assert.strictEqual(await classifyClaudeSessionHost(444, dir), undefined);
+	});
+
+	test('returns undefined for malformed JSON', async () => {
+		await writeFile(join(dir, '555.json'), '{not json');
+		assert.strictEqual(await classifyClaudeSessionHost(555, dir), undefined);
+	});
+
+	test('returns undefined when the file claims a different pid than its filename', async () => {
+		// Simulates a stale file left behind by a previous Claude run whose pid the OS has
+		// since recycled to an unrelated process.
+		await writeFile(
+			join(dir, '666.json'),
+			JSON.stringify({ pid: 999, sessionId: 's', entrypoint: 'claude-vscode' }),
+		);
+		assert.strictEqual(await classifyClaudeSessionHost(666, dir), undefined);
+	});
+});

--- a/src/env/node/agents/claudeSessionFile.ts
+++ b/src/env/node/agents/claudeSessionFile.ts
@@ -1,0 +1,54 @@
+import { readFile } from 'fs/promises';
+import { homedir } from 'os';
+import { join } from 'path';
+import { Logger } from '@gitlens/utils/logger.js';
+
+interface ClaudeSessionFile {
+	pid: number;
+	sessionId: string;
+	cwd?: string;
+	entrypoint?: string;
+}
+
+function defaultSessionsDir(): string {
+	return join(homedir(), '.claude', 'sessions');
+}
+
+/**
+ * Reads the Claude session metadata file written by the agent process at
+ * `<sessionsDir>/<pid>.json` (default `~/.claude/sessions/`). Returns `undefined` when the
+ * file is missing, unreadable, malformed, or claims a different pid than the filename —
+ * all of which are normal (older Claude versions, already-exited sessions, transient FS
+ * races, PID reuse after a stale file was left behind).
+ */
+async function readClaudeSessionFile(pid: number, sessionsDir: string): Promise<ClaudeSessionFile | undefined> {
+	const path = join(sessionsDir, `${pid}.json`);
+	try {
+		const raw = await readFile(path, 'utf8');
+		const data = JSON.parse(raw) as ClaudeSessionFile;
+		if (data.pid !== pid) return undefined;
+		return data;
+	} catch (ex) {
+		if ((ex as NodeJS.ErrnoException)?.code !== 'ENOENT') {
+			Logger.debug(`readClaudeSessionFile(${pid}): ${ex instanceof Error ? ex.message : String(ex)}`);
+		}
+		return undefined;
+	}
+}
+
+/**
+ * Classifies the host of a Claude Code session by reading its per-pid metadata file.
+ * - `'extension'` — `entrypoint === 'claude-vscode'` (Claude Code VS Code extension)
+ * - `'cli'` — any other known entrypoint (`'cli'`, `'sdk-ts'`, etc.)
+ * - `undefined` — file missing / unreadable / no entrypoint field; caller applies its fallback.
+ *
+ * `sessionsDir` is overridable for tests; production callers omit it.
+ */
+export async function classifyClaudeSessionHost(
+	pid: number,
+	sessionsDir: string = defaultSessionsDir(),
+): Promise<'extension' | 'cli' | undefined> {
+	const data = await readClaudeSessionFile(pid, sessionsDir);
+	if (data?.entrypoint == null) return undefined;
+	return data.entrypoint === 'claude-vscode' ? 'extension' : 'cli';
+}

--- a/src/env/node/focusWindow.ts
+++ b/src/env/node/focusWindow.ts
@@ -1,6 +1,6 @@
 import type { ExecFileException } from 'child_process';
 import { execFile } from 'child_process';
-import { platform, env as processEnv } from 'process';
+import { pid as ownPid, platform, env as processEnv } from 'process';
 import { Logger } from '@gitlens/utils/logger.js';
 
 const maxParentWalkDepth = 10;
@@ -94,6 +94,29 @@ async function focusWindows(pid: number): Promise<boolean> {
 		'-Command',
 		`(New-Object -ComObject WScript.Shell).AppActivate(${pid})`,
 	]);
+}
+
+/** Returns the parent process ID of `pid`, or `undefined` when the lookup fails. Walks `ps`
+ *  (Unix) or `wmic` (Windows). Used both by the parent-pid walk inside {@link focusProcessWindow}
+ *  and by {@link isDescendantOfThisExtensionHost} below. */
+export async function getProcessParentPid(pid: number): Promise<number | undefined> {
+	return getParentPid(pid);
+}
+
+/** Returns `true` iff `pid` is a descendant (within `maxDepth` parent hops) of the current
+ *  extension host process. Used by the agent dispatcher to distinguish extension-hosted sessions
+ *  owned by this VS Code window (Claude binary's parent === our extension host) from sessions
+ *  owned by a peer window (parent === some other extension host). Browser stub returns `false`. */
+export async function isDescendantOfThisExtensionHost(pid: number, maxDepth = 2): Promise<boolean> {
+	let current = pid;
+	for (let i = 0; i < maxDepth; i++) {
+		const parent = await getParentPid(current);
+		if (parent == null) return false;
+		if (parent === ownPid) return true;
+
+		current = parent;
+	}
+	return false;
 }
 
 async function getParentPid(pid: number): Promise<number | undefined> {

--- a/src/env/node/providers.ts
+++ b/src/env/node/providers.ts
@@ -1,6 +1,6 @@
 import { dirname, resolve } from 'path';
 import type { Disposable } from 'vscode';
-import { workspace } from 'vscode';
+import { commands, workspace } from 'vscode';
 import { ClaudeCodeProvider } from '@gitlens/agents/providers/claudeCodeProvider.js';
 import type { Cache } from '@gitlens/git/cache.js';
 import type { GitProvider } from '@gitlens/git/providers/provider.js';
@@ -138,6 +138,9 @@ export function getAgentSessionProviders(container: Container): AgentSessionProv
 				}
 			},
 			runCLICommand: (args, opts) => runCLICommand(args, opts),
+			openSessionInClaudeExtension: async sessionId => {
+				await commands.executeCommand('claude-vscode.editor.open', sessionId);
+			},
 			resolveGitInfo: async cwd => {
 				// Fast path: cwd is in an already-loaded repo — fully synchronous, no shell calls.
 				const repo = container.git.getRepository(cwd);

--- a/src/env/node/providers.ts
+++ b/src/env/node/providers.ts
@@ -1,6 +1,6 @@
 import { dirname, resolve } from 'path';
 import type { Disposable } from 'vscode';
-import { commands, workspace } from 'vscode';
+import { workspace } from 'vscode';
 import { ClaudeCodeProvider } from '@gitlens/agents/providers/claudeCodeProvider.js';
 import type { Cache } from '@gitlens/git/cache.js';
 import type { GitProvider } from '@gitlens/git/providers/provider.js';
@@ -10,6 +10,7 @@ import { findGitPath } from '@gitlens/git-cli/exec/locator.js';
 import type { UnifiedDisposable } from '@gitlens/utils/disposable.js';
 import { normalizePath } from '@gitlens/utils/path.js';
 import type { AgentSessionProvider } from '../../agents/provider.js';
+import { tryOpenClaudeSession } from '../../agents/utils/-webview/claudeExtension.js';
 import type { Container } from '../../container.js';
 import type { GlGitProvider } from '../../git/gitProvider.js';
 import type { RepositoryLocationProvider } from '../../git/location/repositorylocationProvider.js';
@@ -139,7 +140,13 @@ export function getAgentSessionProviders(container: Container): AgentSessionProv
 			},
 			runCLICommand: (args, opts) => runCLICommand(args, opts),
 			openSessionInClaudeExtension: async sessionId => {
-				await commands.executeCommand('claude-vscode.editor.open', sessionId);
+				// Shared editor → primaryEditor → sidebar fallback chain so the peer-side open
+				// honors a specific session through the same rungs the local-window path uses.
+				// Throws when all three rungs fail so the IPC handler can report
+				// `{ opened: false }` to the initiating window.
+				if (!(await tryOpenClaudeSession(sessionId))) {
+					throw new Error('Claude Code extension did not respond to any open command');
+				}
 			},
 			resolveGitInfo: async cwd => {
 				// Fast path: cwd is in an already-loaded repo — fully synchronous, no shell calls.

--- a/src/plus/agents/agentRegistry.ts
+++ b/src/plus/agents/agentRegistry.ts
@@ -1,12 +1,13 @@
-import { commands, extensions } from 'vscode';
 import type { GkAgent } from '@env/gk/cli/agents.js';
 import { cliAgentIds, getAllAgents, isCliExecutableAvailable } from '@env/gk/cli/agents.js';
+import {
+	claudeExtensionId,
+	claudeExtensionOpenCommand,
+	isClaudeExtensionAvailable,
+} from '../../agents/utils/-webview/claudeExtension.js';
 import { getHostAppName } from '../../system/-webview/vscode.js';
 import { supportedChatHosts } from '../chat/utils/-webview/chat.utils.js';
 import type { AgentDescriptor } from './agentDescriptor.js';
-
-const claudeExtensionId = 'Anthropic.claude-code';
-const claudeExtensionOpenCommand = 'claude-vscode.editor.open';
 
 const ideChatLabels: Record<string, string> = {
 	code: 'Copilot Chat',
@@ -56,13 +57,6 @@ export async function getSupportedAgents(): Promise<AgentDescriptor[]> {
 	return result;
 }
 
-async function isClaudeExtensionAvailable(): Promise<boolean> {
-	if (extensions.getExtension(claudeExtensionId) == null) return false;
-
-	const registered = await commands.getCommands(true);
-	return registered.includes(claudeExtensionOpenCommand);
-}
-
 async function getDetectedCliDescriptors(): Promise<AgentDescriptor[]> {
 	let agents: GkAgent[];
 	try {
@@ -109,4 +103,4 @@ export async function resolveDefaultAgent(id: string): Promise<AgentDescriptor |
 	return available.find(d => d.id === id);
 }
 
-export { claudeExtensionId, claudeExtensionOpenCommand };
+export { claudeExtensionId, claudeExtensionOpenCommand, isClaudeExtensionAvailable };

--- a/src/plus/agents/agentRegistry.ts
+++ b/src/plus/agents/agentRegistry.ts
@@ -3,6 +3,8 @@ import { cliAgentIds, getAllAgents, isCliExecutableAvailable } from '@env/gk/cli
 import {
 	claudeExtensionId,
 	claudeExtensionOpenCommand,
+	claudeExtensionPrimaryEditorOpenCommand,
+	claudeExtensionSidebarOpenCommand,
 	isClaudeExtensionAvailable,
 } from '../../agents/utils/-webview/claudeExtension.js';
 import { getHostAppName } from '../../system/-webview/vscode.js';
@@ -103,4 +105,10 @@ export async function resolveDefaultAgent(id: string): Promise<AgentDescriptor |
 	return available.find(d => d.id === id);
 }
 
-export { claudeExtensionId, claudeExtensionOpenCommand, isClaudeExtensionAvailable };
+export {
+	claudeExtensionId,
+	claudeExtensionOpenCommand,
+	claudeExtensionPrimaryEditorOpenCommand,
+	claudeExtensionSidebarOpenCommand,
+	isClaudeExtensionAvailable,
+};


### PR DESCRIPTION
## Summary

Replaces the action-pick quickpick that fired on "open agent session" with a deterministic dispatcher that picks the right action based on session host + workspace state:

- **In-workspace + extension-hosted** → open in the Claude Code VS Code extension
- **In-workspace + CLI-hosted** → focus the owning terminal window via `pid`
- **Out-of-workspace** → ask the peer GitLens window that already has the workspace open to pre-open the session in its Claude Code extension (new `agents/sessions/open` IPC route), then `vscode.openFolder` to focus that peer's window

Host classification reads `~/.claude/sessions/<pid>.json` for the `entrypoint` field, with a stale-file guard (file's `pid` field must match the filename) and a sensible "extension if installed, else CLI" fallback when the metadata file is missing.

The peer-notify call is capped at 500 ms so an unhealthy peer can't stall the click — the POST keeps running in the background after `vscode.openFolder` lands.

## Test plan
- [x] Unit tests: `pnpm run test:packages` (4 new `agents/sessions/open` IPC handler cases, 3 new `notifyPeerOpenSession` cases) and `pnpm run test` (7 new `classifyClaudeSessionHost` cases) all pass
- [x] In-workspace + extension-hosted session: clicking "open agent session" routes to the Claude Code extension editor pane
- [x] In-workspace + CLI-hosted session: clicking routes to the terminal window (with parent-PID walk for tmux-style setups)
- [x] Out-of-workspace session with a peer window holding the workspace open: peer's Claude Code extension receives the session before the focus switch lands
- [x] Out-of-workspace session with no peer window: `vscode.openFolder` falls through and the current window switches to the folder
- [x] Extension-hosted session whose extension command throws: surfaces the "Unable to open agent session" warning rather than focusing the VS Code window in a misleading no-op
- [x] Unhealthy peer (paused/unresponsive but not RST): click resolves within ~500 ms instead of waiting the full per-fetch timeout