### PR TITLE
Fixes agent session name showing system prompt preamble (#5260)

### DIFF
--- a/packages/plus/agents/src/__tests__/sanitizePrompt.test.ts
+++ b/packages/plus/agents/src/__tests__/sanitizePrompt.test.ts
@@ -167,6 +167,85 @@ suite('sanitizeAgentPrompt', () => {
 		});
 	});
 
+	suite('dispatch preamble', () => {
+		const startWorkPrompt = (issueJson: string) =>
+			'You are an advanced AI programming assistant tasked with helping a developer start work on a new issue. ' +
+			'Your goal is to analyze the issue details and provide a clear plan of action, estimate, and implement a solution.\n\n' +
+			'First, examine the following JSON object containing the issue details:\n\n' +
+			`<issue>\n${issueJson}\n</issue>\n\n` +
+			'Now, proceed with your analysis.';
+
+		const startReviewPrompt = (prJson: string) =>
+			'You are an advanced AI programming assistant tasked with reviewing a pull request (PR). ' +
+			'Your goal is to analyze the PR details and provide a comprehensive review.\n\n' +
+			'First, examine the following JSON object containing the PR details:\n\n' +
+			`<prData>\n${prJson}\n</prData>\n\n` +
+			'Now, proceed with your analysis.';
+
+		test('extracts issue title from a Start Work dispatch prompt', () => {
+			const input = startWorkPrompt(
+				JSON.stringify({ id: '123', title: 'Fix GitLab PR approval 405 Method Not Allowed error' }),
+			);
+			assert.strictEqual(sanitizeAgentPrompt(input), 'Fix GitLab PR approval 405 Method Not Allowed error');
+		});
+
+		test('extracts PR title from a Start Review dispatch prompt', () => {
+			const input = startReviewPrompt(JSON.stringify({ id: 'pr-1', title: 'Improve graph view updates' }));
+			assert.strictEqual(sanitizeAgentPrompt(input), 'Improve graph view updates');
+		});
+
+		test('trims whitespace around the extracted title', () => {
+			const input = startWorkPrompt(JSON.stringify({ title: '   Padded title   ' }));
+			assert.strictEqual(sanitizeAgentPrompt(input), 'Padded title');
+		});
+
+		test('falls through when block JSON is malformed', () => {
+			const input = startWorkPrompt('this is not json');
+			// Falls through to normal sanitization — neither preamble nor JSON gets stripped, so
+			// the full prompt comes back trimmed.
+			assert.strictEqual(sanitizeAgentPrompt(input), input.trim());
+		});
+
+		test('falls through when title field is missing', () => {
+			const input = startWorkPrompt(JSON.stringify({ id: '123', body: 'no title here' }));
+			assert.strictEqual(sanitizeAgentPrompt(input), input.trim());
+		});
+
+		test('falls through when title is an empty string', () => {
+			const input = startWorkPrompt(JSON.stringify({ id: '123', title: '   ' }));
+			assert.strictEqual(sanitizeAgentPrompt(input), input.trim());
+		});
+
+		test('falls through when title is not a string', () => {
+			const input = startWorkPrompt(JSON.stringify({ id: '123', title: 42 }));
+			assert.strictEqual(sanitizeAgentPrompt(input), input.trim());
+		});
+
+		test('rewrite wins over a trailing harness wrapper', () => {
+			const dispatched = startWorkPrompt(JSON.stringify({ title: 'Wire up the new pill' }));
+			const input = `${dispatched}\n<task-notification><status>completed</status></task-notification>`;
+			assert.strictEqual(sanitizeAgentPrompt(input), 'Wire up the new pill');
+		});
+
+		test('handles CRLF line endings inside the dispatch block', () => {
+			const issueJson = JSON.stringify({ title: 'CRLF-safe title' });
+			const input = startWorkPrompt(issueJson).replace(/\n/g, '\r\n');
+			assert.strictEqual(sanitizeAgentPrompt(input), 'CRLF-safe title');
+		});
+
+		test('ignores a dispatch block embedded inside a harness wrapper', () => {
+			// Realistic scenario: a developer working on GitLens itself selects code that contains
+			// our own dispatch template. The IDE wraps the selection in <ide_selection>…</ide_selection>
+			// and appends the user's real question. The harness wrapper must be stripped first so
+			// the embedded `<issue>` block doesn't hijack the session name.
+			const trap = JSON.stringify({ title: 'should not surface' });
+			const input =
+				`<ide_selection>here is the dispatch template:\n<issue>${trap}</issue>\nend of selection</ide_selection>\n` +
+				'why does this not work?';
+			assert.strictEqual(sanitizeAgentPrompt(input), 'why does this not work?');
+		});
+	});
+
 	suite('user content passes through', () => {
 		test('preserves <details>/<summary>', () => {
 			const input = '<details><summary>Click</summary>hidden body</details>';

--- a/packages/plus/agents/src/sanitizePrompt.ts
+++ b/packages/plus/agents/src/sanitizePrompt.ts
@@ -2,6 +2,14 @@ import { truncate } from '@gitlens/utils/string.js';
 
 const maxStoredPromptLength = 500;
 
+// Marker blocks GitLens itself embeds when dispatching Start Work / Start Review prompts to an
+// agent (see `start-work-issue` / `start-review-pullRequest` templates in
+// `packages/plus/ai/src/prompts.ts`). The surrounding template begins with a long
+// "You are an advanced AI programming assistant…" preamble that would otherwise become the
+// session's display name; matching on the block delimiters lets us pull the issue/PR title out
+// of the embedded JSON instead.
+const dispatchBlockRegex = /<(issue|prData)>([\s\S]*?)<\/\1>/;
+
 // Wrappers the Claude Code harness or its VS Code extension prepend to the `prompt` field of
 // `UserPromptSubmit` hook events. These are synthetic context blocks, not user-typed content,
 // and shouldn't appear verbatim in GitLens agent status UI.
@@ -41,6 +49,7 @@ export function sanitizeAgentPrompt(prompt: string | undefined): string | undefi
 	// Normalize CRLF up-front so the harness-block and whitespace-collapse regexes (which target
 	// `\n`) behave identically for Windows-originated prompts.
 	let result = prompt.replace(/\r\n/g, '\n');
+
 	let stripped = false;
 	for (const pattern of harnessBlockPatterns) {
 		const next = result.replace(pattern, '');
@@ -49,6 +58,15 @@ export function sanitizeAgentPrompt(prompt: string | undefined): string | undefi
 			result = next;
 		}
 	}
+
+	// GitLens-dispatched Start Work / Start Review prompts: replace the template body with just
+	// the issue/PR title so the session name doesn't surface the "You are an advanced AI…"
+	// preamble. Runs AFTER harness stripping so that an `<ide_selection>` (or other wrapper)
+	// containing an `<issue>…</issue>` block doesn't get rewritten to the embedded title — the
+	// wrapper is stripped first and only a genuine dispatch template body triggers the rewrite.
+	// Anything that doesn't yield a usable title falls through to normal sanitization.
+	const dispatchTitle = extractDispatchTitle(result);
+	if (dispatchTitle != null) return dispatchTitle;
 
 	// Only collapse the whitespace runs around stripped blocks. Untouched user prompts pass
 	// through with their internal whitespace intact (the final trim still removes the outer
@@ -68,4 +86,24 @@ export function sanitizeAgentPrompt(prompt: string | undefined): string | undefi
 export function prepareStoredPrompt(prompt: string | undefined): string | undefined {
 	const cleaned = sanitizeAgentPrompt(prompt);
 	return cleaned ? truncate(cleaned, maxStoredPromptLength) : undefined;
+}
+
+/**
+ * Looks for a GitLens-dispatch marker block (`<issue>…</issue>` or `<prData>…</prData>`) and
+ * returns the embedded `title` field. Both `IssueShape` and `PullRequestShape` carry `title`, so
+ * a single accessor covers Start Work and Start Review. Returns `undefined` when the block is
+ * absent, the JSON fails to parse, or `title` is missing/empty — those cases fall through to the
+ * regular sanitization path.
+ */
+function extractDispatchTitle(prompt: string): string | undefined {
+	const match = dispatchBlockRegex.exec(prompt);
+	if (match == null) return undefined;
+
+	try {
+		const parsed = JSON.parse(match[2]) as { title?: unknown };
+		const title = typeof parsed.title === 'string' ? parsed.title.trim() : '';
+		return title.length > 0 ? title : undefined;
+	} catch {
+		return undefined;
+	}
 }


### PR DESCRIPTION
## Summary

Closes #5260.

Fixes the agent session name surfacing the long "You are an advanced AI programming assistant…" preamble in Home → Agents, the status pill popover, and the Graph sidebar when a session is started via **Start Work in an Agent** or **Start Review in an Agent**.

The Claude Code provider captures the dispatched prompt verbatim into `session.firstPrompt`. Until the transcript-derived AI title arrives, `getSessionDisplayName` falls back to `deriveNameFromPrompt(firstPrompt)` — which takes the first non-empty line, i.e. the system-prompt preamble. The reporter's screenshot shows the preamble still in place after Claude had generated an AI title, so the symptom can persist even past that window.

This change recognizes the `<issue>…</issue>` / `<prData>…</prData>` marker blocks GitLens itself embeds when dispatching, parses the embedded JSON, and rewrites the stored prompt to the issue/PR `title`. The rewrite sits inside `sanitizeAgentPrompt`, so every prompt-capture path (hook events, CLI session-state syncs) benefits without changes to the dispatch wiring. The transcript-derived `titles.ai` still outranks the prompt-derived name in the cascade, so Claude's nuanced title can override later when it lands.

## Test plan

- [x] Unit tests pass (`pnpm test` in `packages/plus/agents`; 102 passing including 9 new dispatch-preamble cases covering Start Work, Start Review, whitespace, malformed JSON, missing/empty/non-string title, trailing harness wrapper, and CRLF)
- [x] `pnpm run build` succeeds (no lint / type errors)
- [x] Live verification — **Start Work in an Agent** against a real issue → Home → Agents card title shows the issue title (not the preamble); status-pill popover and Graph sidebar entries match
- [x] Live verification — **Start Review in an Agent** against a real PR → same surfaces show the PR title
- [x] Regression — sessions started via the normal CLI (no dispatch preamble) still derive their name from the free-typed prompt