### PR TITLE
Fix walkthrough Compare CTA passing uncommitted sentinel as rightRef

### DIFF
--- a/src/webviews/apps/plus/graph/components/gl-graph-details-panel.ts
+++ b/src/webviews/apps/plus/graph/components/gl-graph-details-panel.ts
@@ -511,7 +511,7 @@ export class GlGraphDetailsPanel extends SignalWatcher(LitElement) {
 	 *  overrides. */
 	openCompareMode(params: {
 		repoPath: string;
-		leftRef: string;
+		leftRef?: string;
 		leftRefType?: 'branch' | 'tag' | 'commit';
 		rightRef: string;
 		rightRefType?: 'branch' | 'tag' | 'commit';

--- a/src/webviews/apps/plus/graph/components/gl-graph-details-panel.ts
+++ b/src/webviews/apps/plus/graph/components/gl-graph-details-panel.ts
@@ -222,6 +222,10 @@ export class GlGraphDetailsPanel extends SignalWatcher(LitElement) {
 	private _workflow!: DetailsWorkflowController;
 
 	private _servicesResolved = false;
+	private _pendingCompare?: {
+		params: Parameters<GlGraphDetailsPanel['openCompareMode']>[0];
+		onReady?: () => void;
+	};
 
 	private _lastPushedWip?: unknown;
 	private _lastBranchState?: unknown;
@@ -509,14 +513,25 @@ export class GlGraphDetailsPanel extends SignalWatcher(LitElement) {
 	 *  explicit left/right refs (e.g. from a sidebar tree compare action). The current graph
 	 *  selection is left untouched; both sides of the comparison are driven by the supplied
 	 *  overrides. */
-	openCompareMode(params: {
-		repoPath: string;
-		leftRef?: string;
-		leftRefType?: 'branch' | 'tag' | 'commit';
-		rightRef: string;
-		rightRefType?: 'branch' | 'tag' | 'commit';
-		includeWorkingTree?: boolean;
-	}): void {
+	openCompareMode(
+		params: {
+			repoPath: string;
+			leftRef?: string;
+			leftRefType?: 'branch' | 'tag' | 'commit';
+			rightRef: string;
+			rightRefType?: 'branch' | 'tag' | 'commit';
+			includeWorkingTree?: boolean;
+		},
+		onReady?: () => void,
+	): boolean {
+		if (this._workflow == null) {
+			this._pendingCompare = { params: params, onReady: onReady };
+			return false;
+		}
+
+		if (onReady != null) {
+			onReady();
+		}
 		const selection: DetailsSelection = {
 			...this.currentSelection(),
 			repoPath: params.repoPath,
@@ -528,6 +543,7 @@ export class GlGraphDetailsPanel extends SignalWatcher(LitElement) {
 			rightRefType: params.rightRefType,
 			includeWorkingTree: params.includeWorkingTree,
 		});
+		return true;
 	}
 
 	/** Entry point for the WIP-row agent indicator. Expands the agents section.
@@ -1462,6 +1478,12 @@ export class GlGraphDetailsPanel extends SignalWatcher(LitElement) {
 		// fires `hostConnected` immediately (since we're already connected), which sets up
 		// the repo-change subscription without an extra call here.
 		this._workflow = new DetailsWorkflowController(this, this._actions);
+
+		if (this._pendingCompare != null) {
+			const { params, onReady } = this._pendingCompare;
+			this._pendingCompare = undefined;
+			this.openCompareMode(params, onReady);
+		}
 
 		void this._actions.fetchCapabilities();
 		// Fetched eagerly (not gated on isWip) because resolveServices runs once on

--- a/src/webviews/apps/plus/graph/graph-app.ts
+++ b/src/webviews/apps/plus/graph/graph-app.ts
@@ -636,12 +636,21 @@ export class GraphApp extends SignalWatcher(LitElement) {
 		if (action === 'enter-review' || action === 'enter-compose') {
 			this.detailsPanelEl?.enterModeForWip(action === 'enter-review' ? 'review' : 'compose', repoPath, sha);
 		} else if (action === 'open-compare') {
-			this.detailsPanelEl?.openCompareMode({
-				repoPath: repoPath,
-				leftRef: this.graphState.branch?.name ?? 'HEAD',
-				rightRef: sha,
-				includeWorkingTree: true,
-			});
+			if (target != null) {
+				this.detailsPanelEl?.openCompareMode({
+					repoPath: repoPath,
+					leftRef: this.graphState.branch?.name ?? 'HEAD',
+					rightRef: sha,
+					includeWorkingTree: true,
+				});
+			} else {
+				this.detailsPanelEl?.openCompareMode({
+					repoPath: repoPath,
+					rightRef: this.graphState.branch?.name ?? 'HEAD',
+					rightRefType: 'branch',
+					includeWorkingTree: true,
+				});
+			}
 		}
 
 		// Seed the WIP details commit input AFTER the panel has reconciled to the target row —

--- a/src/webviews/apps/plus/graph/graph-app.ts
+++ b/src/webviews/apps/plus/graph/graph-app.ts
@@ -629,28 +629,35 @@ export class GraphApp extends SignalWatcher(LitElement) {
 		this._selectedCommit = { sha: sha, repoPath: repoPath };
 		this._selectedCommits = undefined;
 
-		this.setDetailsVisible(true, 'request-mode');
-		this.ensureDetailsPosition();
+		const showDetails = () => {
+			this.setDetailsVisible(true, 'request-mode');
+			this.ensureDetailsPosition();
+		};
 
+		if (action === 'open-compare') {
+			await this.updateComplete;
+			const compareParams =
+				target != null
+					? {
+							repoPath: repoPath,
+							leftRef: this.graphState.branch?.name ?? 'HEAD',
+							rightRef: sha,
+							includeWorkingTree: true,
+						}
+					: {
+							repoPath: repoPath,
+							rightRef: this.graphState.branch?.name ?? 'HEAD',
+							rightRefType: 'branch' as const,
+							includeWorkingTree: true,
+						};
+			this.detailsPanelEl?.openCompareMode(compareParams, showDetails);
+			return;
+		}
+
+		showDetails();
 		await this.updateComplete;
 		if (action === 'enter-review' || action === 'enter-compose') {
 			this.detailsPanelEl?.enterModeForWip(action === 'enter-review' ? 'review' : 'compose', repoPath, sha);
-		} else if (action === 'open-compare') {
-			if (target != null) {
-				this.detailsPanelEl?.openCompareMode({
-					repoPath: repoPath,
-					leftRef: this.graphState.branch?.name ?? 'HEAD',
-					rightRef: sha,
-					includeWorkingTree: true,
-				});
-			} else {
-				this.detailsPanelEl?.openCompareMode({
-					repoPath: repoPath,
-					rightRef: this.graphState.branch?.name ?? 'HEAD',
-					rightRefType: 'branch',
-					includeWorkingTree: true,
-				});
-			}
 		}
 
 		// Seed the WIP details commit input AFTER the panel has reconciled to the target row —


### PR DESCRIPTION
## Summary

- Fixes the Open Compare Mode walkthrough CTA passing the uncommitted sentinel SHA (0000...0000) as rightRef, which caused the Compare panel to display an unresolvable commit reference
- When no graph row target is provided (walkthrough CTA), passes the current branch name from graphState as rightRef with rightRefType: branch, and omits leftRef so initCompareDefaults resolves the merge target asynchronously
- Fixes compare not opening reliably on first click -- uses graphState.branch directly (always available when the graph renders) instead of depending on async WIP state
- Fixes compare not activating on cold start (new window + add repo) -- the details panel workflow controller is created asynchronously in resolveServices; openCompareMode now queues the request and drains it once the workflow is ready
- Fixes double animation on cold start -- consumePendingAction was eagerly opening the details panel (showing WIP content) before openCompareMode, which on cold start had to queue. When the pending compare drained later, the compare sheet animated in on top of the already-visible panel. Now passes a showDetails callback to openCompareMode that fires atomically with the compare open, either immediately (workflow ready) or deferred (workflow pending)
- Preserves the existing openCompareMode path for targeted invocations (context-menu on a specific graph row)

Closes #5273

## Test plan

- [ ] Reset onboarding, open the Commit Graph, click See what is new, find Compare any refs from your Graph selection step, click Open Compare Mode -- verify compare opens with branch refs (not 0000...0000)
- [ ] Verify compare opens on the first click (not requiring a second click)
- [ ] Cold start: open new VS Code window without a repo, add a repo, open Home walkthrough, click Open Compare Mode -- verify compare activates on first click with a single animation
- [ ] Verify the compare refs are sensible: current branch as Compare side, merge target (e.g. origin/main) as Base side
- [ ] Right-click a WIP row in the graph, trigger open-compare from context menu -- verify it still opens with the correct commit SHA
- [ ] Verify no console errors related to Not a valid commit name
- [ ] Verify the compare sheet animation still plays normally on subsequent opens (close compare, reopen via the compare button)