### PR TITLE
Update upgrade notification toast for v18 and add action to open walkthrough

### DIFF
--- a/src/messages.ts
+++ b/src/messages.ts
@@ -309,21 +309,35 @@ export function showIntegrationRequestTimedOutWarningMessage(providerName: strin
 export async function showWhatsNewMessage(majorVersion: string): Promise<void> {
 	const confirm = { title: 'OK', isCloseAffordance: true };
 	const releaseNotes = { title: 'View Release Notes' };
-	const result = await showMessage(
-		'info',
-		`GitLens upgraded to ${majorVersion}${
-			majorVersion === '17'
-				? ' with the all new [GitKraken AI](https://gitkraken.com/solutions/gitkraken-ai?source=gitlens&product=gitlens&utm_source=gitlens-extension&utm_medium=in-app-links) access included in GitLens Pro, AI changelog and pull request creation, and Bitbucket integration.'
-				: " — see what's new."
-		}`,
-		undefined,
-		null,
-		releaseNotes,
-		confirm,
-	);
+	const openWalkthrough = { title: 'Open Walkthrough' };
+
+	let message: string;
+	switch (majorVersion) {
+		case '18':
+			message =
+				'GitLens upgraded to 18 — the Commit Graph is all new with agent integration, multi-worktree WIP rows, AI-powered Review and Compose modes, and more.';
+			break;
+		case '17':
+			message =
+				'GitLens upgraded to 17 with the all new [GitKraken AI](https://gitkraken.com/solutions/gitkraken-ai?source=gitlens&product=gitlens&utm_source=gitlens-extension&utm_medium=in-app-links) access included in GitLens Pro, AI changelog and pull request creation, and Bitbucket integration.';
+			break;
+		default:
+			message = `GitLens upgraded to ${majorVersion} — see what's new.`;
+			break;
+	}
+
+	const actions: MessageItem[] = [releaseNotes];
+	if (majorVersion === '18') {
+		actions.push(openWalkthrough);
+	}
+	actions.push(confirm);
+
+	const result = await showMessage('info', message, undefined, null, ...actions);
 
 	if (result === releaseNotes) {
 		void openUrl(urls.releaseNotes);
+	} else if (result === openWalkthrough) {
+		void executeCommand('gitlens.showWelcomeView', { mode: 'graph' });
 	}
 }
 


### PR DESCRIPTION
# Description

Update the messaging in the toast notification when upgrading to version 18 and adds a button to open the 'What's new in GitLens 18' walkthrough in the Welcome View.

<img width="505" height="223" alt="Screenshot 2026-05-26 at 9 10 47 AM" src="https://github.com/user-attachments/assets/1e136386-38f2-4eab-a262-edc023dd9b15" />


# Checklist

<!-- Please check off the following -->

- [x] I have followed the guidelines in the Contributing document
- [x] My changes follow the coding style of this project
- [x] My changes build without any errors or warnings
- [x] My changes have been formatted and linted
- [x] My changes include any required corresponding changes to the documentation (including CHANGELOG.md and README.md)
- [x] My changes have been rebased and squashed to the minimal number (typically 1) of relevant commits
- [x] My changes have a descriptive commit message with a short title, including a `Fixes $XXX -` or `Closes #XXX -` prefix to auto-close the issue that your PR addresses
