### PR TITLE
Fixes unable to stash unstaged files when it includes a untracked file 

### DIFF
--- a/README.md
+++ b/README.md
@@ -448,6 +448,7 @@ A big thanks to the people that have contributed to this project 🙏❤️:
 - JounQin ([@JounQin](https://github.com/JounQin)) &mdash; [contributions](https://github.com/gitkraken/vscode-gitlens/commits?author=JounQin)
 - Noritaka Kobayashi ([@noritaka1166](https://github.com/noritaka1166)) &mdash; [contributions](https://github.com/gitkraken/vscode-gitlens/commits?author=noritaka1166)
 - Daniel Asher ([@danielasher115](https://github.com/danielasher115)) &mdash; [contributions](https://github.com/gitkraken/vscode-gitlens/commits?author=danielasher115)
+- Awais Isane ([@AwaisIsane](https://github.com/AwaisIsane)) &mdash; [contributions](https://github.com/gitkraken/vscode-gitlens/commits?author=AwaisIsane)
 
 Also special thanks to the people that have provided support, testing, brainstorming, etc:
 

--- a/packages/git-cli/src/providers/stash.ts
+++ b/packages/git-cli/src/providers/stash.ts
@@ -390,7 +390,7 @@ export class StashGitSubProvider implements GitStashSubProvider {
 			params.push('--include-untracked');
 		}
 
-		if (options?.keepIndex && !options?.includeUntracked) {
+		if (options?.keepIndex) {
 			params.push('--keep-index');
 		}
 


### PR DESCRIPTION
## ❤ Thank you for contributing to GitLens! ❤

### 🚨 IMPORTANT 🚨
Fixes #5281


---

# Description

 the if condition always prevented the command  git stash push --include-untracked --keep-index from running

# Checklist

<!-- Please check off the following -->

- [x] I have followed the guidelines in the Contributing document
- [x] My changes follow the coding style of this project
- [x] My changes build without any errors or warnings
- [x] My changes have been formatted and linted
- [x] My changes include any required corresponding changes to the documentation (including CHANGELOG.md and README.md)
- [x] My changes have been rebased and squashed to the minimal number (typically 1) of relevant commits
- [x] My changes have a descriptive commit message with a short title, including a `Fixes $XXX -` or `Closes #XXX -` prefix to auto-close the issue that your PR addresses
