### PR TITLE
Add Open File inline action to WIP file rows in Graph

### DIFF
--- a/src/git/actions/commit.ts
+++ b/src/git/actions/commit.ts
@@ -670,7 +670,8 @@ export async function openFile(
 		// An untracked file in a stash typically has no working-tree copy to open. Mirror the
 		// warning surfaced by `gitlens.openWorkingFile:command` for the same case so the click
 		// isn't a silent no-op; users wanting the stashed content can pick "Open File at Revision".
-		if (typeof fileOrUri !== 'string' && fileOrUri.status === '?') {
+		// Skip this guard for WIP refs — untracked files in the working tree are real files.
+		if (typeof fileOrUri !== 'string' && fileOrUri.status === '?' && !isUncommitted(ref.ref)) {
 			void window.showWarningMessage('Unable to open working file. File could not be found in the working tree');
 			return;
 		}

--- a/src/webviews/apps/commitDetails/components/gl-details-wip-panel.ts
+++ b/src/webviews/apps/commitDetails/components/gl-details-wip-panel.ts
@@ -65,6 +65,7 @@ const discardUnstagedAction: TreeItemAction = {
 	label: 'Discard Unstaged Changes',
 	action: 'file-discard',
 };
+const openFileAction: TreeItemAction = { icon: 'go-to-file', label: 'Open File', action: 'file-open' };
 // `file-compare-wip-staged` is bridged by gl-wip-tree-pane into `file-compare-wip` with
 // `staged: true` overridden so the diff resolves to staged ↔ HEAD even though the deduped
 // row carries `staged: false` (preferred-unstaged precedence from the tree pane dedup).
@@ -74,12 +75,16 @@ const openStagedChangesAction: TreeItemAction = {
 	action: 'file-compare-wip-staged',
 };
 
-const conflictedCheckboxActions: TreeItemAction[] = [openCurrentChangesAction, openIncomingChangesAction];
+const conflictedCheckboxActions: TreeItemAction[] = [
+	openFileAction,
+	openCurrentChangesAction,
+	openIncomingChangesAction,
+];
 const conflictedActions: TreeItemAction[] = [...conflictedCheckboxActions, stageConflictAction];
-const checkboxDiscardOnly: TreeItemAction[] = [discardAction];
-const checkboxMixedActions: TreeItemAction[] = [openStagedChangesAction, discardUnstagedAction];
-const stagedActions: TreeItemAction[] = [unstageAction, discardAction];
-const unstagedActions: TreeItemAction[] = [stageAction, discardAction];
+const checkboxDiscardOnly: TreeItemAction[] = [openFileAction, discardAction];
+const checkboxMixedActions: TreeItemAction[] = [openFileAction, openStagedChangesAction, discardUnstagedAction];
+const stagedActions: TreeItemAction[] = [openFileAction, unstageAction, discardAction];
+const unstagedActions: TreeItemAction[] = [openFileAction, stageAction, discardAction];
 
 @customElement('gl-details-wip-panel')
 export class GlDetailsWipPanel extends GlDetailsBase {
@@ -687,7 +692,6 @@ export class GlDetailsWipPanel extends GlDetailsBase {
 			return this.checkboxMode ? conflictedCheckboxActions : conflictedActions;
 		}
 
-		// Non-conflicted files: row click opens, so no Open File button.
 		if (this.checkboxMode) {
 			// Mixed (deduped) gets an extra "Open Staged Changes" view button alongside Discard.
 			return options?.mixed ? checkboxMixedActions : checkboxDiscardOnly;


### PR DESCRIPTION
## Summary

- Adds an "Open File" inline icon button to WIP (working changes) file rows in the Commit Graph file list panel, matching the existing behavior on committed file rows
- The button uses the same go-to-file icon, tooltip, and placement (leftmost position) as the committed file row action
- Appears across all WIP file states: staged, unstaged, checkbox mode, and conflict entries

<img width="800" alt="image" src="https://github.com/user-attachments/assets/68366091-8c0c-4341-b453-c9415222aab5" />


Follow-up to #5207 and #5202.

## Test plan

- [ ] Open the Commit Graph, make a working change — verify Open File icon appears as the leftmost inline button on the file row
- [ ] Stage the file — verify the button persists (before Unstage and Discard)
- [ ] Click the button — file opens in the editor (not a diff)
- [ ] Right-click a WIP file row — verify Open File appears in the context menu
- [ ] Test in checkbox mode (staging checkboxes enabled)
- [ ] Test with a merge conflict — verify Open File appears alongside conflict actions