### PR TITLE
feat: offer AI credit add-ons when reaching weekly usage limit

### DIFF
--- a/docs/telemetry-events.md
+++ b/docs/telemetry-events.md
@@ -182,6 +182,26 @@ routed its hook events here — so don't treat every event as a dropped IPC sign
 }
 ```
 
+### ai/credits/addOnClicked
+
+> Sent when the user clicks "Get More Credits" on the weekly AI usage-limit notification
+
+```typescript
+{
+  'organization.role': 'owner' | 'admin' | 'billing' | 'user'
+}
+```
+
+### ai/credits/addOnDismissed
+
+> Sent when the user dismisses the weekly AI usage-limit notification
+
+```typescript
+{
+  'organization.role': 'owner' | 'admin' | 'billing' | 'user'
+}
+```
+
 ### ai/enabled
 
 > Sent when AI is enabled

--- a/src/constants.telemetry.ts
+++ b/src/constants.telemetry.ts
@@ -3,6 +3,7 @@ import type { AIActionType } from '@gitlens/ai/models/model.js';
 import type { GitContributionTiers } from '@gitlens/git/models/contributor.js';
 import type { Flatten } from '@gitlens/utils/object.js';
 import type { Config, GraphBranchesVisibility, GraphConfig } from './config.js';
+import type { OrganizationRole } from './plus/gk/models/organization.js';
 import type { GlCommands, GlCommandsDeprecated } from './constants.commands.js';
 import type { IntegrationIds, SupportedCloudIntegrationIds } from './constants.integrations.js';
 import type { WalkthroughSteps } from './constants.js';
@@ -87,6 +88,11 @@ export interface TelemetryEvents extends WebviewShowAbortedEvents, WebviewShownE
 
 	/** Sent when a user provides feedback (rating and optional details) for an AI feature */
 	'ai/feedback': AIFeedbackEvent;
+
+	/** Sent when the user clicks "Get More Credits" on the weekly AI usage-limit notification */
+	'ai/credits/addOnClicked': AICreditsNotificationEvent;
+	/** Sent when the user dismisses the weekly AI usage-limit notification */
+	'ai/credits/addOnDismissed': AICreditsNotificationEvent;
 
 	/** Sent when user dismisses the AI All Access banner */
 	'aiAllAccess/bannerDismissed': void;
@@ -698,6 +704,10 @@ export interface AIFeedbackEvent extends AIEventDataBase {
 	'unhelpful.reasons'?: string;
 	/** Custom feedback provided (if any) */
 	'unhelpful.custom'?: string;
+}
+
+interface AICreditsNotificationEvent {
+	'organization.role': OrganizationRole | undefined;
 }
 
 export interface CLIInstallStartedEvent {

--- a/src/plus/ai/aiProviderService.ts
+++ b/src/plus/ai/aiProviderService.ts
@@ -67,6 +67,7 @@ import { configuration } from '../../system/-webview/configuration.js';
 import { getContext } from '../../system/-webview/context.js';
 import { loadChunk } from '../../system/-webview/loadChunk.js';
 import type { Storage } from '../../system/-webview/storage.js';
+import { openUrl } from '../../system/-webview/vscode/uris.js';
 import type { Serialized } from '../../system/serialize.js';
 import type { ServerConnection } from '../gk/serverConnection.js';
 import { ensureFeatureAccess } from '../gk/utils/-webview/acount.utils.js';
@@ -1461,14 +1462,56 @@ export class AIProviderService implements AIService, Disposable {
 									return undefined;
 								}
 								case AIErrorReason.UserQuotaExceeded: {
-									const increaseLimit: MessageItem = { title: 'Increase Limit' };
-									const result = await window.showErrorMessage(
-										"Your request could not be completed because you've reached the weekly AI usage limit for your current plan. Upgrade to unlock more AI-powered actions.",
-										increaseLimit,
-									);
+									const sub = await this.container.subscription.getSubscription();
+									const role = sub.activeOrganization?.role;
+									const canPurchase =
+										role == null || role === 'owner' || role === 'admin' || role === 'billing';
 
-									if (result === increaseLimit) {
-										void this.container.subscription.manageSubscription(source);
+									if (canPurchase) {
+										const getMoreCredits: MessageItem = {
+											title: 'Get More Credits',
+										};
+										const dismiss: MessageItem = {
+											title: 'Dismiss',
+											isCloseAffordance: true,
+										};
+										const result = await window.showErrorMessage(
+											"Your request could not be completed because you've reached the weekly usage included in your plan. Purchase additional AI credits to keep using GitKraken AI.",
+											getMoreCredits,
+											dismiss,
+										);
+
+										if (result === getMoreCredits) {
+											this.container.telemetry.sendEvent(
+												'ai/credits/addOnClicked',
+												{ 'organization.role': role },
+												source,
+											);
+											void openUrl(
+												await this.container.urls.getGkDevUrl('subscription/credit-add-on'),
+											);
+										} else {
+											this.container.telemetry.sendEvent(
+												'ai/credits/addOnDismissed',
+												{ 'organization.role': role },
+												source,
+											);
+										}
+									} else {
+										const ok: MessageItem = {
+											title: 'OK',
+											isCloseAffordance: true,
+										};
+										await window.showErrorMessage(
+											"Your request could not be completed because you've reached the weekly usage included in your plan. Contact your organization admin or owner to request more AI credits.",
+											ok,
+										);
+
+										this.container.telemetry.sendEvent(
+											'ai/credits/addOnDismissed',
+											{ 'organization.role': role },
+											source,
+										);
 									}
 
 									if (options?.throwAIErrors) throw error;


### PR DESCRIPTION
## Summary

- Shows role-aware notification when users hit their weekly AI credit limit
  - **Admins/owners/billing/solo users**: "Get More Credits" button → opens credit add-on purchase page
  - **Regular members**: "Contact your organization admin" message with "OK" to dismiss
- Adds telemetry events (`ai/credits/addOnClicked`, `ai/credits/addOnDismissed`) with org role
- Includes a self-cleaning merge guard workflow that blocks merge before June 9, 2026

Closes gitkraken/vscode-gitlens-private#87

## Warning

1. Remove the merge guard workflow before merging
2. Do not merge before June 9

## Test plan

- [ ] Simulate Paid subscription + AI error mode → verify admin path shows "Get More Credits" + "Dismiss"
- [ ] Verify solo user (no org) sees the same purchase-capable notification
- [ ] Verify `user` role sees "Contact your organization admin" with "OK" button
- [ ] Verify "Get More Credits" opens `gitkraken.dev/subscription/credit-add-on`
- [ ] Verify merge guard workflow fails in CI before June 9

🤖 Generated with [Claude Code](https://claude.com/claude-code)