### PR TITLE
Fix push to use upstream tracking branch when names differ

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -27,6 +27,7 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/) and this p
 
 ### Fixed
 
+- Fixes push from the _Commit Graph_ silently pushing to a wrong remote branch when the local branch tracks a differently-named upstream (e.g., `feature/foo` tracking `origin/main`) &mdash; now correctly pushes to the configured upstream branch instead of creating a new remote branch ([#5304](https://github.com/gitkraken/vscode-gitlens/issues/5304))
 - Fixes the working changes (WIP) _Generate Commit Message_ in the _Commit Graph_ losing its result when the selection changes while a message is generating &mdash; the generation now continues and the message lands in the originating worktree's commit input (or its saved draft if you've navigated away) ([#5295](https://github.com/gitkraken/vscode-gitlens/issues/5295))
 - Fixes the commit details metadata bar in the _Commit Graph_ and _Inspect_ view not surfacing a reachable tag when a commit is contained only in tags (and not any branch) &mdash; now shows the most relevant tag with a tag icon and color, matching how branches are shown ([#5293](https://github.com/gitkraken/vscode-gitlens/issues/5293))
 - Fixes incorrect GitLab avatars being shown when multiple GitLab users share the same name ([#2205](https://github.com/gitkraken/vscode-gitlens/issues/2205))

--- a/packages/git-cli/src/providers/__tests__/integration/operations.test.ts
+++ b/packages/git-cli/src/providers/__tests__/integration/operations.test.ts
@@ -1,11 +1,12 @@
 import * as assert from 'assert';
 import { execFileSync } from 'node:child_process';
-import { writeFileSync } from 'node:fs';
+import { mkdtempSync, rmSync, writeFileSync } from 'node:fs';
+import { tmpdir } from 'node:os';
 import { join } from 'node:path';
 import type { SigningErrorReason } from '@gitlens/git/errors.js';
 import { CommitError, MergeError, SigningError } from '@gitlens/git/errors.js';
 import type { SigningFormat } from '@gitlens/git/models/signature.js';
-import { addCommit, createBranch, createTestRepo } from './helpers.js';
+import { addCommit, createBranch, createTestRepo, getHeadSha } from './helpers.js';
 
 suite('OperationsGitSubProvider.merge', () => {
 	test('returns { conflicted: false } on clean fast-forward merge', async () => {
@@ -249,6 +250,73 @@ suite('OperationsGitSubProvider signing', () => {
 				'Expected CommitError with reason nothingToCommit',
 			);
 			assert.strictEqual(calls.length, 0, 'onSigningFailed must not fire for non-signing failures');
+		} finally {
+			r.cleanup();
+		}
+	});
+});
+
+suite('OperationsGitSubProvider.push', () => {
+	function createRepoWithRemote() {
+		const r = createTestRepo();
+		const bareDir = mkdtempSync(join(tmpdir(), 'gitlens-test-bare-'));
+		execFileSync('git', ['clone', '--bare', r.path, bareDir], { stdio: 'pipe' });
+		execFileSync('git', ['remote', 'add', 'origin', bareDir], { cwd: r.path, stdio: 'pipe' });
+		execFileSync('git', ['fetch', 'origin'], { cwd: r.path, stdio: 'pipe' });
+		execFileSync('git', ['branch', '--set-upstream-to', 'origin/main', 'main'], { cwd: r.path, stdio: 'pipe' });
+		const origCleanup = r.cleanup;
+		return {
+			...r,
+			cleanup: () => {
+				origCleanup();
+				rmSync(bareDir, { recursive: true, force: true });
+			},
+		};
+	}
+
+	function getRemoteRef(repoPath: string, ref: string): string {
+		const output = execFileSync('git', ['ls-remote', 'origin', ref], {
+			cwd: repoPath,
+			encoding: 'utf-8',
+		}).trim();
+		return output.split('\t')[0] ?? '';
+	}
+
+	test('pushes to matching upstream branch', async () => {
+		const r = createRepoWithRemote();
+		try {
+			addCommit(r.path, 'file.txt', 'content\n', 'Add file');
+			const localSha = getHeadSha(r.path);
+
+			await r.provider.ops?.push(r.path);
+
+			const remoteSha = getRemoteRef(r.path, 'refs/heads/main');
+			assert.strictEqual(remoteSha, localSha, 'Remote main should match local HEAD after push');
+		} finally {
+			r.cleanup();
+		}
+	});
+
+	test('pushes to differently-named upstream branch using refspec', async () => {
+		const r = createRepoWithRemote();
+		try {
+			execFileSync('git', ['checkout', '-b', 'feature/foo'], { cwd: r.path, stdio: 'pipe' });
+			execFileSync('git', ['branch', '--set-upstream-to', 'origin/main', 'feature/foo'], {
+				cwd: r.path,
+				stdio: 'pipe',
+			});
+			addCommit(r.path, 'feature.txt', 'feature\n', 'Add feature');
+			const localSha = getHeadSha(r.path);
+
+			await r.provider.ops?.push(r.path);
+
+			// Should have pushed to origin/main, not created origin/feature/foo
+			const remoteSha = getRemoteRef(r.path, 'refs/heads/main');
+			assert.strictEqual(remoteSha, localSha, 'Remote main should have the feature commit');
+
+			// Verify no remote branch was created for feature/foo
+			const featureRef = getRemoteRef(r.path, 'refs/heads/feature/foo');
+			assert.strictEqual(featureRef, '', 'Remote should not have feature/foo branch');
 		} finally {
 			r.cleanup();
 		}

--- a/packages/git-cli/src/providers/operations.ts
+++ b/packages/git-cli/src/providers/operations.ts
@@ -469,12 +469,17 @@ export class OperationsGitSubProvider implements GitOperationsSubProvider {
 			const branch = await this.provider.branches.getBranch(repoPath);
 			if (branch == null) return;
 
-			branchName =
-				options?.reference != null
-					? `${options.reference.ref}:${
-							options?.publish != null ? 'refs/heads/' : ''
-						}${branch.nameWithoutRemote}`
-					: branch.name;
+			if (options?.reference != null) {
+				branchName = `${options.reference.ref}:${
+					options?.publish != null ? 'refs/heads/' : ''
+				}${branch.nameWithoutRemote}`;
+			} else {
+				const tracking = options?.publish == null ? branch.trackingWithoutRemote : undefined;
+				branchName =
+					tracking != null && tracking !== branch.nameWithoutRemote
+						? `${branch.name}:${tracking}`
+						: branch.name;
+			}
 			remoteName = branch.remoteName ?? options?.publish?.remote;
 			upstreamName = options?.reference == null && options?.publish != null ? branch.name : undefined;
 

--- a/src/commands/git/push.ts
+++ b/src/commands/git/push.ts
@@ -1,5 +1,4 @@
 import type { GitBranchReference, GitReference } from '@gitlens/git/models/reference.js';
-import { getRemoteNameFromBranchName } from '@gitlens/git/utils/branch.utils.js';
 import { getReferenceLabel, isBranchReference } from '@gitlens/git/utils/reference.utils.js';
 import { isStringArray } from '@gitlens/utils/array.js';
 import { fromNow } from '@gitlens/utils/date.js';
@@ -377,12 +376,10 @@ export class PushGitCommand extends QuickCommand<State> {
 							[],
 							createDirectiveQuickPickItem(Directive.Cancel, true, {
 								label: 'OK',
-								detail: `No commits ahead of ${getRemoteNameFromBranchName(status.upstream?.name)}`,
+								detail: `No commits ahead of ${status.upstream?.name}`,
 							}),
 							{
-								placeholder: `Nothing to push; No commits ahead of ${getRemoteNameFromBranchName(
-									status.upstream?.name,
-								)}`,
+								placeholder: `Nothing to push; No commits ahead of ${status.upstream?.name}`,
 							},
 						);
 					}
@@ -402,11 +399,11 @@ export class PushGitCommand extends QuickCommand<State> {
 										label: false,
 									})}`
 								: ''
-						}${status?.upstream ? ` to ${getRemoteNameFromBranchName(status.upstream?.name)}` : ''}`;
+						}${status?.upstream ? ` to ${status.upstream.name}` : ''}`;
 					} else {
 						pushDetails = `${
 							status?.upstream?.state.ahead ? ` ${pluralize('commit', status.upstream.state.ahead)}` : ''
-						}${status?.upstream ? ` to ${getRemoteNameFromBranchName(status.upstream?.name)}` : ''}`;
+						}${status?.upstream ? ` to ${status.upstream.name}` : ''}`;
 					}
 
 					step = this.createConfirmStep(
@@ -442,9 +439,7 @@ export class PushGitCommand extends QuickCommand<State> {
 								} ${pushDetails}${
 									status?.upstream?.state.behind
 										? `, overwriting ${pluralize('commit', status.upstream.state.behind)}${
-												status?.upstream
-													? ` on ${getRemoteNameFromBranchName(status.upstream?.name)}`
-													: ''
+												status?.upstream ? ` on ${status.upstream.name}` : ''
 											}`
 										: ''
 								}`,
@@ -454,7 +449,7 @@ export class PushGitCommand extends QuickCommand<State> {
 							? createDirectiveQuickPickItem(Directive.Cancel, true, {
 									label: `Cancel ${this.title}`,
 									detail: `Cannot push; ${getReferenceLabel(branch)} is behind${
-										status?.upstream ? ` ${getRemoteNameFromBranchName(status.upstream?.name)}` : ''
+										status?.upstream ? ` ${status.upstream.name}` : ''
 									} by ${pluralize('commit', status.upstream.state.behind)}`,
 								})
 							: undefined,


### PR DESCRIPTION
Fixes #5304

## Summary

<img width="800" alt="image" src="https://github.com/user-attachments/assets/3e64d655-8c8d-4274-9044-a1a59baedf59" />


- When a branch tracks a differently-named upstream (e.g., `feature/foo` → `origin/main`), the push operation now constructs a refspec `feature/foo:main` so git pushes to the correct remote branch
- Previously, `git push origin feature/foo` was executed, which created a new `origin/feature/foo` branch instead of pushing to `origin/main` — leaving the upstream tracking unchanged and the Graph still showing unpushed commits

## Test plan

- [ ] Create a branch tracking a differently-named remote: `git checkout -b feature/test origin/master`
- [ ] Commit a change
- [ ] Open the Commit Graph and click any of the 3 push buttons (header toolbar, WIP details header, or "Next Actions" panel)
- [ ] Verify push goes to `origin/master`, not `origin/feature/test`
- [ ] Verify the "Push N↑" indicator disappears after push
- [ ] Regression: push a branch with matching upstream name (e.g., `main` → `origin/main`) — should work as before

🤖 Generated with [Claude Code](https://claude.com/claude-code)
