### PR TITLE
Fix conflict button not working when graph is scoped to another branch

### DIFF
--- a/src/webviews/apps/plus/graph/context.ts
+++ b/src/webviews/apps/plus/graph/context.ts
@@ -87,6 +87,20 @@ export interface AppState extends State {
 	deferScopeClear(): void;
 
 	/**
+	 * Cancel any in-flight `setScope` publish and clean up all associated transient state
+	 * (`_pendingScope`, `_scopeClearDeferred`, `scopeLoading`). Lower-level primitive used by
+	 * {@link clearScope} — prefer `clearScope()` unless you need to separate the cancel from
+	 * the scope assignment (e.g. the deferred-clear path).
+	 */
+	cancelPendingScope(): void;
+
+	/**
+	 * Immediately clear the active scope, cancel any in-flight resolve, clean up transient
+	 * state, and emit `graph/scope/cleared` telemetry. No-op when no scope is active.
+	 */
+	clearScope(): void;
+
+	/**
 	 * Seed the per-repo WIP cache with an optimistically-edited `Wip` (e.g. after a local stage/
 	 * unstage). The entry is flagged so subsequent `getWipState` calls report `isLive: false`
 	 * until the host's watcher reconciles. The host-driven push paths (`DidChangeWorkingTree` /

--- a/src/webviews/apps/plus/graph/graph-app.ts
+++ b/src/webviews/apps/plus/graph/graph-app.ts
@@ -87,6 +87,7 @@ import { getOverviewBranchSelectionSha } from './utils/branchSelection.utils.js'
 import { getSelectedRepoPath } from './utils/repository.utils.js';
 import { getCommitDateFromRow } from './utils/row.utils.js';
 import { serializeWipContext } from './utils/rowContext.utils.js';
+import { shouldShowPrimaryWipRow } from './utils/wip.utils.js';
 import './gate.js';
 import './graph-header.js';
 import './graph-wrapper/graph-wrapper.js';
@@ -1208,6 +1209,7 @@ export class GraphApp extends SignalWatcher(LitElement) {
 					@toggle-details=${this.handleToggleDetails}
 					@show-details=${this.handleShowDetails}
 					@toggle-minimap=${this.handleToggleMinimap}
+					@jump-to-wip=${this.handleJumpToWip}
 					@gl-graph-scope-to-branch=${this.handleScopeToBranchFromHeader}
 				></gl-graph-header>
 				<div class="graph__workspace">
@@ -1830,6 +1832,25 @@ export class GraphApp extends SignalWatcher(LitElement) {
 			this.setDetailsVisible(true, 'toggle');
 			this.ensureDetailsPosition();
 		}
+	};
+
+	private handleJumpToWip = (): void => {
+		if (this.effectiveDisplayMode !== 'graph') return;
+
+		const scope = this.graphState.scope;
+		if (scope != null && scope.branchRef !== this.graphState.branch?.id) {
+			const wouldShow = shouldShowPrimaryWipRow(
+				this.graphState.branchesVisibility,
+				this.graphState.includeOnlyRefs,
+				this.graphState.branch?.id,
+				undefined,
+			);
+			if (!wouldShow) return;
+
+			this.graphState.clearScope();
+		}
+
+		this.graph?.ensureAndSelectCommit(uncommitted);
 	};
 
 	private handleToggleDetails(e: CustomEvent<{ altKey?: boolean } | void>) {

--- a/src/webviews/apps/plus/graph/graph-header.ts
+++ b/src/webviews/apps/plus/graph/graph-header.ts
@@ -360,10 +360,6 @@ export class GlGraphHeader extends SignalWatcher(LitElement) {
 		}
 	}
 
-	private handleJumpToWip() {
-		this.selectCommits?.(['work-dir-changes'], { ensureVisible: true });
-	}
-
 	private async jumpToSha(sha: string) {
 		const id = await this.ensureSearchResultRow(sha);
 		if (id == null) return;
@@ -1113,7 +1109,6 @@ export class GlGraphHeader extends SignalWatcher(LitElement) {
 							.lastFetched=${lastFetched}
 							.workingTreeStats=${this.graphState.workingTreeStats}
 							.state=${this.graphState}
-							@jump-to-wip=${this.handleJumpToWip}
 						></gl-git-actions-buttons>
 					`,
 				)}

--- a/src/webviews/apps/plus/graph/stateProvider.ts
+++ b/src/webviews/apps/plus/graph/stateProvider.ts
@@ -537,6 +537,24 @@ export class GraphStateProvider extends StateProviderBase<State['webviewId'], Ap
 		this._scopeClearDeferred = true;
 	}
 
+	cancelPendingScope(): void {
+		this._pendingScope = undefined;
+		this._scopeClearDeferred = false;
+		this.scopeLoading = false;
+	}
+
+	clearScope(): void {
+		if (this.scope == null) return;
+
+		this.cancelPendingScope();
+		this.scope = undefined;
+
+		emitTelemetrySentEvent<'graph/scope/cleared'>(this.host, {
+			name: 'graph/scope/cleared',
+			data: {},
+		});
+	}
+
 	/**
 	 * Merge a lazily-fetched merge-target into `overviewEnrichment` for the given branchId. The graph
 	 * overview's enrichment IPC opts out of eager merge-target fetching (`skipMergeTarget: true`); the
@@ -1003,18 +1021,7 @@ export class GraphStateProvider extends StateProviderBase<State['webviewId'], Ap
 			case DidChangeRefsVisibilityNotification.is(msg):
 				if (this._scopeClearDeferred) {
 					this._scopeClearDeferred = false;
-					const wasScoped = this.scope != null;
-					// Coalesce with the visibility update so the minimap and graph re-render once.
-					this.scope = undefined;
-					// Drop any in-flight `setScope` publish — otherwise a cache-miss resolve could
-					// re-publish a scope the user just cleared by switching visibility modes.
-					this._pendingScope = undefined;
-					if (wasScoped) {
-						emitTelemetrySentEvent<'graph/scope/cleared'>(this.host, {
-							name: 'graph/scope/cleared',
-							data: {},
-						});
-					}
+					this.clearScope();
 				}
 				this.updateState({
 					branchesVisibility: msg.params.branchesVisibility,


### PR DESCRIPTION
Fixes #5283

## Summary
- When the graph is scoped to another branch, the primary WIP row (`work-dir-changes`) is filtered out by design — it belongs to the current branch, not the scoped one
- Clicking the conflict/WIP button in the header tried to select that row, but it didn't exist in the scoped graph, so nothing happened
- The fix clears the scope before jumping to WIP when the scoped branch differs from the current branch, then retries selecting the WIP row via RAF until it appears in the re-rendered graph

## Test plan
- [ ] Open a repo with a merge conflict on the current branch
- [ ] Open the Commit Graph and scope to a different branch (via Focus Branch in the scope popover)
- [ ] Click the conflict/WIP button in the header toolbar
- [ ] Verify the scope clears, the WIP row appears and is selected, and the details panel shows the conflict info
- [ ] Verify clicking the WIP button when NOT scoped still works as before (no regression)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
