### PR TITLE
Reduces GK CLI list-sessions polling and adds sync-drift telemetry

### DIFF
--- a/docs/telemetry-events.md
+++ b/docs/telemetry-events.md
@@ -160,6 +160,28 @@
 }
 ```
 
+### agents/session/syncDiscrepancy
+
+> Sent when a reconciliation poll (`list-sessions`) finds the polled session set differs from
+what the live IPC hook path had already tracked. In a single window this should be rare and
+usually means a hook event was dropped; a nonzero `sync.discovered` is expected in multi-window
+setups, where the machine-wide poll can surface a session owned by another window that never
+routed its hook events here — so don't treat every event as a dropped IPC signal
+
+```typescript
+{
+  'agent.provider': string,
+  // Sessions the poll reported alive that the live IPC path had not tracked.
+  'sync.discovered': number,
+  // Tracked sessions the poll no longer reports alive (teardown the live path missed).
+  'sync.missing': number,
+  // Total alive sessions reported by the poll.
+  'sync.polled': number,
+  // Total sessions tracked (from the live path) before the poll reconciled.
+  'sync.tracked': number
+}
+```
+
 ### ai/enabled
 
 > Sent when AI is enabled

--- a/packages/plus/agents/src/__tests__/claudeCodeProvider.test.ts
+++ b/packages/plus/agents/src/__tests__/claudeCodeProvider.test.ts
@@ -6,10 +6,17 @@ import type { TranscriptTitles } from '../providers/claudeCodeTranscript.js';
 import { ClaudeCodeTranscriptReader } from '../providers/claudeCodeTranscript.js';
 import type { AgentProviderCallbacks, IpcRegistrar } from '../types.js';
 
+type SyncDiscrepancy = { provider: string; discovered: number; missing: number; polled: number; tracked: number };
+
 interface MockCallbacks {
 	callbacks: AgentProviderCallbacks;
 	handlers: Map<string, IpcHandler<unknown, unknown>>;
 	publishedPaths: string[][];
+	/** Every `runCLICommand` invocation's args, in order. Use {@link listSessionsCalls} to count
+	 *  the `list-sessions` reconciliation calls specifically. */
+	cliCalls: string[][];
+	/** Every `onSyncDiscrepancy` report, in order. */
+	syncDiscrepancies: SyncDiscrepancy[];
 }
 
 function createMockCallbacks(options?: {
@@ -17,9 +24,12 @@ function createMockCallbacks(options?: {
 	openSessionInClaudeExtension?: AgentProviderCallbacks['openSessionInClaudeExtension'];
 	port?: number;
 	agentDiscoveryDir?: string;
+	cliResponse?: string;
 }): MockCallbacks {
 	const handlers = new Map<string, IpcHandler<unknown, unknown>>();
 	const publishedPaths: string[][] = [];
+	const cliCalls: string[][] = [];
+	const syncDiscrepancies: SyncDiscrepancy[] = [];
 
 	const ipc: IpcRegistrar = {
 		port: options?.port ?? 1234,
@@ -39,16 +49,45 @@ function createMockCallbacks(options?: {
 
 	const callbacks: AgentProviderCallbacks = {
 		ipc: ipc,
-		runCLICommand: () => Promise.resolve('[]'),
+		runCLICommand: (args: string[]) => {
+			cliCalls.push([...args]);
+			return Promise.resolve(options?.cliResponse ?? '[]');
+		},
 		resolveGitInfo: options?.resolveGitInfo,
 		openSessionInClaudeExtension: options?.openSessionInClaudeExtension,
+		onSyncDiscrepancy: info => {
+			syncDiscrepancies.push(info);
+		},
 	};
 
-	return { callbacks: callbacks, handlers: handlers, publishedPaths: publishedPaths };
+	return {
+		callbacks: callbacks,
+		handlers: handlers,
+		publishedPaths: publishedPaths,
+		cliCalls: cliCalls,
+		syncDiscrepancies: syncDiscrepancies,
+	};
+}
+
+/** Counts the `list-sessions` reconciliation calls within recorded CLI invocations. */
+function listSessionsCalls(cliCalls: string[][]): number {
+	return cliCalls.filter(args => args.includes('list-sessions')).length;
 }
 
 function sessionStart(sessionId: string, cwd: string): Record<string, unknown> {
 	return { event: 'SessionStart', sessionId: sessionId, cwd: cwd, pid: process.pid };
+}
+
+/** A `list-sessions` poll entry (SessionFileData shape) for an alive session, used to exercise
+ *  the reconciliation poll / discrepancy detection. `pid: process.pid` so it passes `isProcessAlive`. */
+function sessionFileData(sessionId: string, cwd: string): Record<string, unknown> {
+	return {
+		sessionId: sessionId,
+		event: 'UserPromptSubmit',
+		cwd: cwd,
+		pid: process.pid,
+		updatedAt: '2024-01-01T00:00:00.000Z',
+	};
 }
 
 /** Yield to the microtask queue so `void this.ensureIpcServer()` can finish its awaits
@@ -921,3 +960,242 @@ class TestProvider extends ClaudeCodeProvider {
 		this._transcriptReader = reader;
 	}
 }
+
+/** Provider variant that lets tests drive a gated reconciliation tick deterministically, instead
+ *  of waiting for the real 15-minute `staleCheckTimer` interval. */
+class GateTestProvider extends ClaudeCodeProvider {
+	runGatedSync(): Promise<void> {
+		return this.syncSessions({ gate: true });
+	}
+}
+
+suite('ClaudeCodeProvider reconciliation poll gating (list-sessions)', () => {
+	const workspace = '/home/user/projectA';
+
+	test('skips the CLI on a gated tick when there are no sessions and hooks are not installed', async () => {
+		const { callbacks, cliCalls } = createMockCallbacks();
+		const provider = new GateTestProvider(callbacks);
+		try {
+			provider.start([workspace]);
+			await flushMicrotasks();
+			provider.setClaudeHooksInstalled(false);
+			cliCalls.length = 0; // ignore the ungated bootstrap call
+
+			await provider.runGatedSync();
+			await provider.runGatedSync();
+
+			assert.strictEqual(listSessionsCalls(cliCalls), 0);
+		} finally {
+			provider.dispose();
+		}
+	});
+
+	test('still polls when hooks are installed even with no sessions', async () => {
+		const { callbacks, cliCalls } = createMockCallbacks();
+		const provider = new GateTestProvider(callbacks);
+		try {
+			provider.start([workspace]);
+			await flushMicrotasks();
+			provider.setClaudeHooksInstalled(true);
+			cliCalls.length = 0;
+
+			await provider.runGatedSync();
+
+			assert.ok(listSessionsCalls(cliCalls) >= 1, 'a window with installed hooks must keep polling');
+		} finally {
+			provider.dispose();
+		}
+	});
+
+	test('still polls when sessions exist even if hooks are reported as not installed', async () => {
+		const { callbacks, handlers, cliCalls } = createMockCallbacks();
+		const provider = new GateTestProvider(callbacks);
+		try {
+			provider.start([workspace]);
+			await flushMicrotasks();
+			provider.setClaudeHooksInstalled(false);
+
+			const handler = handlers.get('agents/session')!;
+			await handler(sessionStart('sess-1', workspace), new URLSearchParams());
+			assert.strictEqual(provider.sessions.length, 1);
+			cliCalls.length = 0;
+
+			await provider.runGatedSync();
+
+			assert.ok(
+				listSessionsCalls(cliCalls) >= 1,
+				'a non-empty session list must keep polling (prune backstop + robustness to stale hook detection)',
+			);
+		} finally {
+			provider.dispose();
+		}
+	});
+
+	test('resumes polling on the next gated tick once a session is pushed', async () => {
+		const { callbacks, handlers, cliCalls } = createMockCallbacks();
+		const provider = new GateTestProvider(callbacks);
+		try {
+			provider.start([workspace]);
+			await flushMicrotasks();
+			provider.setClaudeHooksInstalled(false);
+			cliCalls.length = 0;
+
+			// Empty + hooks-off → skipped.
+			await provider.runGatedSync();
+			assert.strictEqual(listSessionsCalls(cliCalls), 0);
+
+			// A push makes the list non-empty → the next tick polls again, with no timer rebuild.
+			const handler = handlers.get('agents/session')!;
+			await handler(sessionStart('sess-1', workspace), new URLSearchParams());
+			cliCalls.length = 0;
+			await provider.runGatedSync();
+
+			assert.ok(listSessionsCalls(cliCalls) >= 1, 'polling must resume once a session exists');
+		} finally {
+			provider.dispose();
+		}
+	});
+
+	test('defaults to fail-open (polls) before the host pushes any hooks state', async () => {
+		const { callbacks, cliCalls } = createMockCallbacks();
+		const provider = new GateTestProvider(callbacks);
+		try {
+			provider.start([workspace]);
+			await flushMicrotasks();
+			cliCalls.length = 0; // never call setClaudeHooksInstalled — exercise the default
+
+			await provider.runGatedSync();
+
+			assert.ok(
+				listSessionsCalls(cliCalls) >= 1,
+				'before the first host push the provider must assume hooks may be installed',
+			);
+		} finally {
+			provider.dispose();
+		}
+	});
+
+	test('an off→on hooks transition reconciles immediately without waiting for the interval', async () => {
+		const { callbacks, cliCalls } = createMockCallbacks();
+		const provider = new GateTestProvider(callbacks);
+		try {
+			provider.start([workspace]);
+			await flushMicrotasks();
+			provider.setClaudeHooksInstalled(false);
+			cliCalls.length = 0;
+
+			provider.setClaudeHooksInstalled(true); // eager resync fires an ungated syncSessions() (polls, reports no drift)
+			await flushMicrotasks();
+
+			assert.ok(listSessionsCalls(cliCalls) >= 1, 'installing hooks must trigger an immediate reconciliation');
+		} finally {
+			provider.dispose();
+		}
+	});
+});
+
+suite('ClaudeCodeProvider live/poll sync discrepancy telemetry', () => {
+	const workspace = '/home/user/projectA';
+
+	test('reports discovered drift when a gated poll finds a session the live path never tracked', async () => {
+		const { callbacks, syncDiscrepancies } = createMockCallbacks({
+			cliResponse: JSON.stringify([sessionFileData('poll-only', workspace)]),
+		});
+		const provider = new GateTestProvider(callbacks);
+		try {
+			await provider.runGatedSync();
+
+			assert.strictEqual(provider.sessions.length, 1);
+			assert.strictEqual(syncDiscrepancies.length, 1);
+			assert.deepStrictEqual(syncDiscrepancies[0], {
+				provider: 'claudeCode',
+				discovered: 1,
+				missing: 0,
+				polled: 1,
+				tracked: 0,
+			});
+		} finally {
+			provider.dispose();
+		}
+	});
+
+	test('does not report drift once the discovered session is tracked', async () => {
+		const { callbacks, syncDiscrepancies } = createMockCallbacks({
+			cliResponse: JSON.stringify([sessionFileData('poll-only', workspace)]),
+		});
+		const provider = new GateTestProvider(callbacks);
+		try {
+			await provider.runGatedSync(); // discovers + reports
+			syncDiscrepancies.length = 0;
+
+			await provider.runGatedSync(); // already tracked → no drift
+
+			assert.strictEqual(syncDiscrepancies.length, 0);
+		} finally {
+			provider.dispose();
+		}
+	});
+
+	test('reports missing drift when a live-tracked session is absent from the poll', async () => {
+		const { callbacks, handlers, syncDiscrepancies } = createMockCallbacks(); // poll returns '[]'
+		const provider = new GateTestProvider(callbacks);
+		try {
+			provider.start([workspace]);
+			await flushMicrotasks();
+			const handler = handlers.get('agents/session')!;
+			await handler(sessionStart('live-1', workspace), new URLSearchParams());
+			assert.strictEqual(provider.sessions.length, 1);
+			syncDiscrepancies.length = 0;
+
+			await provider.runGatedSync();
+
+			assert.strictEqual(syncDiscrepancies.length, 1);
+			assert.deepStrictEqual(syncDiscrepancies[0], {
+				provider: 'claudeCode',
+				discovered: 0,
+				missing: 1,
+				polled: 0,
+				tracked: 1,
+			});
+		} finally {
+			provider.dispose();
+		}
+	});
+
+	test('does not report drift on the ungated bootstrap discovery', async () => {
+		const { callbacks, syncDiscrepancies } = createMockCallbacks({
+			cliResponse: JSON.stringify([sessionFileData('boot', workspace)]),
+		});
+		const provider = new ClaudeCodeProvider(callbacks);
+		try {
+			provider.start([workspace]);
+			await flushMicrotasks();
+
+			assert.strictEqual(provider.sessions.length, 1);
+			assert.strictEqual(syncDiscrepancies.length, 0, 'cold-start discovery is expected, not drift');
+		} finally {
+			provider.dispose();
+		}
+	});
+
+	test('the off→on eager resync discovers pre-existing sessions without reporting drift', async () => {
+		const { callbacks, syncDiscrepancies } = createMockCallbacks({
+			cliResponse: JSON.stringify([sessionFileData('preexisting', workspace)]),
+		});
+		const provider = new ClaudeCodeProvider(callbacks);
+		try {
+			provider.setClaudeHooksInstalled(false); // true(default)→false: no resync
+			provider.setClaudeHooksInstalled(true); // false→true: eager resync polls (ungated)
+			await flushMicrotasks();
+
+			assert.strictEqual(provider.sessions.length, 1, 'eager resync should pick up the already-running session');
+			assert.strictEqual(
+				syncDiscrepancies.length,
+				0,
+				'installing hooks mid-session is expected discovery, not drift',
+			);
+		} finally {
+			provider.dispose();
+		}
+	});
+});

--- a/packages/plus/agents/src/providers/claudeCodeProvider.ts
+++ b/packages/plus/agents/src/providers/claudeCodeProvider.ts
@@ -100,7 +100,7 @@ interface SessionBookkeeping {
 	priorPhase?: { phase: AgentSessionPhase; phaseSince: Date };
 }
 
-const staleCheckIntervalMs = 60 * 1000; // 1 minute
+const staleCheckIntervalMs = 15 * 60 * 1000; // 15 minutes
 /** Cooldown between PostToolUse and dropping the file from `currentFiles`. Held long enough that
  *  surfaces consuming the list (WIP file decoration, treemap activity overlay) keep showing a file
  *  the agent just touched well past the moment the tool call completed — a single edit reads as a
@@ -207,6 +207,10 @@ export class ClaudeCodeProvider implements AgentSessionProvider {
 	private readonly _pendingIdleTimers = new Map<string, NodeJS.Timeout>();
 	private _workspacePaths: string[] = [];
 	private _staleCheckTimer: UnifiedDisposable | undefined;
+	/** Whether Claude hooks are installed, pushed by the host via {@link setClaudeHooksInstalled}.
+	 *  Fail-open (`true`) until the first push lands so a fresh window with real hooks isn't
+	 *  suppressed on its first ticks. Gates the reconciliation poll in {@link syncSessions}. */
+	private _claudeHooksInstalled = true;
 	protected _transcriptReader: ClaudeCodeTranscriptReader = new ClaudeCodeTranscriptReader();
 
 	constructor(private readonly callbacks: AgentProviderCallbacks) {}
@@ -268,6 +272,20 @@ export class ClaudeCodeProvider implements AgentSessionProvider {
 				.catch((ex: unknown) =>
 					Logger.error(ex, 'ClaudeCodeProvider.updateWorkspacePaths: publishAgents failed'),
 				);
+		}
+	}
+
+	setClaudeHooksInstalled(installed: boolean): void {
+		const wasOff = !this._claudeHooksInstalled;
+		this._claudeHooksInstalled = installed;
+		// On a fresh off→on transition, reconcile immediately rather than waiting up to a full
+		// interval — picks up any session that was already running before hooks were installed.
+		// This is a deliberate discovery pass (like the cold-start bootstrap), not a routine tick:
+		// hooks were just off, so the live path couldn't have seen these sessions and anything we
+		// find here is expected, not drift. Run it ungated so it neither skips nor reports drift
+		// telemetry (an ungated `syncSessions()` always polls and never emits `onSyncDiscrepancy`).
+		if (installed && wasOff) {
+			void this.syncSessions();
 		}
 	}
 
@@ -386,7 +404,10 @@ export class ClaudeCodeProvider implements AgentSessionProvider {
 			void this.querySiblingWindowSessions();
 
 			this._staleCheckTimer?.dispose();
-			this._staleCheckTimer = disposableInterval(() => void this.syncSessions(), staleCheckIntervalMs);
+			this._staleCheckTimer = disposableInterval(
+				() => void this.syncSessions({ gate: true }),
+				staleCheckIntervalMs,
+			);
 		} catch (ex) {
 			Logger.error(ex, 'ClaudeCodeProvider.ensureIpcServer');
 		}
@@ -1449,7 +1470,15 @@ export class ClaudeCodeProvider implements AgentSessionProvider {
 		return true;
 	}
 
-	private async syncSessions(): Promise<void> {
+	protected async syncSessions(options?: { gate?: boolean }): Promise<void> {
+		// Recurring (gated) calls skip the CLI spawn when there's nothing to reconcile: no tracked
+		// sessions AND no installed hooks. Sessions only ever appear via the IPC push path or a peer,
+		// so an empty list with hooks off means no agents are reachable here. We still poll whenever
+		// sessions exist — that's the only local backstop for pruning agents that die without firing
+		// `SessionEnd`, and it keeps us correct even if hook detection is stale/wrong. The bootstrap
+		// call in `ensureIpcServer` passes no options, so cold-start discovery always runs.
+		if (options?.gate && this._sessions.length === 0 && !this._claudeHooksInstalled) return;
+
 		let sessions: SessionFileData[];
 		try {
 			const output = await this.callbacks.runCLICommand(['ai', 'hook', 'list-sessions', '--json']);
@@ -1461,14 +1490,29 @@ export class ClaudeCodeProvider implements AgentSessionProvider {
 			return;
 		}
 
+		// Snapshot what the live IPC path had already tracked, so we can detect drift between it and
+		// what the poll returns. Ideally they match exactly — any difference means the live push path
+		// missed an add (poll discovers it) or a teardown (poll no longer reports a session we track).
+		const trackedBefore = new Set(this._sessions.map(s => s.id));
+		const polledAlive = new Set<string>();
+		// Mutable copy of `trackedBefore` that also accumulates ids added during this poll, so the
+		// membership check below is O(1) and duplicate ids within a single poll response are only
+		// added once. `trackedBefore` itself stays the pre-poll snapshot used by the `missing` calc.
+		const known = new Set(trackedBefore);
+
 		let changed = false;
+		let discovered = 0;
 
 		for (const data of sessions) {
 			if (!data.sessionId || !data.pid || !isProcessAlive(data.pid)) {
 				continue;
 			}
 
-			if (this._sessions.some(s => s.id === data.sessionId)) continue;
+			polledAlive.add(data.sessionId);
+
+			if (known.has(data.sessionId)) continue;
+
+			known.add(data.sessionId);
 
 			const workspacePath = this.resolveWorkspacePath(data.cwd);
 			const isInWorkspace = workspacePath != null;
@@ -1510,6 +1554,7 @@ export class ClaudeCodeProvider implements AgentSessionProvider {
 				subagents: subagents,
 			});
 			changed = true;
+			discovered++;
 
 			if (data.cwd) {
 				void this.resolveGitInfo(data.sessionId, data.cwd);
@@ -1523,6 +1568,29 @@ export class ClaudeCodeProvider implements AgentSessionProvider {
 
 		if (changed) {
 			this._onDidChangeSessions.fire();
+		}
+
+		// Report any drift between the live-synced set and the poll. Only on the recurring (gated)
+		// poll — the ungated bootstrap call runs before the live path has had a chance to receive
+		// any events, so its discoveries are expected cold-start state, not drift. `missing` counts
+		// sessions we still track that the poll no longer reports alive (a teardown the live path
+		// missed, e.g. an agent killed without firing `SessionEnd`).
+		if (options?.gate) {
+			let missing = 0;
+			for (const id of trackedBefore) {
+				if (!polledAlive.has(id)) {
+					missing++;
+				}
+			}
+			if (discovered > 0 || missing > 0) {
+				this.callbacks.onSyncDiscrepancy?.({
+					provider: this.id,
+					discovered: discovered,
+					missing: missing,
+					polled: polledAlive.size,
+					tracked: trackedBefore.size,
+				});
+			}
 		}
 	}
 

--- a/packages/plus/agents/src/types.ts
+++ b/packages/plus/agents/src/types.ts
@@ -186,6 +186,11 @@ export interface AgentSessionProvider extends UnifiedDisposable {
 	stop(): void;
 	updateWorkspacePaths?(workspacePaths: string[]): void;
 
+	/** Pushed by the host from its cached agent detection. Lets the provider gate its reconciliation
+	 *  poll (the CLI `list-sessions` call) so an idle window with no sessions and no installed hooks
+	 *  doesn't spawn the CLI every interval. */
+	setClaudeHooksInstalled?(installed: boolean): void;
+
 	/** Resolves a pending permission. Returns `true` when the resolve was routed (the local IPC
 	 *  owns the session's pending entry); `false` when no local entry exists (typically a peer-
 	 *  discovered session owned by another GitLens window). Callers use this to give the user
@@ -239,6 +244,18 @@ export interface AgentProviderCallbacks {
 
 	/** Report that a permission request was resolved. No-op if the host has no telemetry. */
 	onPermissionResolved?(info: { provider: string; tool: string; decision: PermissionDecision }): void;
+
+	/** Report that a reconciliation poll found the polled session set drift from what the live IPC
+	 *  path had already tracked — `discovered` sessions the poll saw but we weren't tracking,
+	 *  `missing` sessions we track that the poll no longer reports alive. Ideally always zero. No-op
+	 *  if the host has no telemetry. */
+	onSyncDiscrepancy?(info: {
+		provider: string;
+		discovered: number;
+		missing: number;
+		polled: number;
+		tracked: number;
+	}): void;
 
 	/** Notify the host that a branch has agent activity. */
 	onBranchAgentActivity?(cwd: string): void;

--- a/src/agents/agentStatusService.ts
+++ b/src/agents/agentStatusService.ts
@@ -109,6 +109,9 @@ export class AgentStatusService implements Disposable {
 		);
 
 		this.startProviders();
+		// Resolve hooks-installed state once (async, off the providers' poll interval) and push it
+		// down so providers can gate their reconciliation poll from the start.
+		void this.pushHooksInstalledToProviders();
 	}
 
 	dispose(): void {
@@ -125,15 +128,40 @@ export class AgentStatusService implements Disposable {
 	}
 
 	private async invalidateHooksState(): Promise<void> {
+		// Drop the stale agent cache, re-read, and push the fresh state to providers (the re-read
+		// also warms the cache so the next webview read returns the new state without a delay).
+		await this.pushHooksInstalledToProviders({ invalidate: true });
+		this._onDidChangeHooksInstallState.fire();
+	}
+
+	/** Resolves the host's Claude hooks-installed state and pushes it to all providers so they can
+	 *  gate their reconciliation poll (the CLI `list-sessions` call). Resolves to `false` when the
+	 *  agent can't be detected (e.g. the browser stub's `getClaudeAgent()` returns `undefined`); fails
+	 *  *open* (`installed = true`) only if env resolution throws unexpectedly, so a transient failure
+	 *  never wrongly suppresses polling. The browser has no providers to receive the push regardless.
+	 *  Pass `invalidate` after an install/uninstall so the stale agent cache is dropped before re-reading.
+	 *
+	 *  Note: an external `gk ai hook install` (run outside GitLens) isn't observed here until
+	 *  something else re-reads — acceptable per the staleness window documented in
+	 *  `src/env/node/gk/cli/agents.ts`, and the poll gate opens anyway the moment any session
+	 *  appears (a non-empty session list always polls). */
+	private async pushHooksInstalledToProviders(options?: { invalidate?: boolean }): Promise<void> {
+		let installed = true;
 		try {
 			const env = await import('@env/providers.js');
-			env.invalidateAgentsCache();
-			// Warm the cache so the next read returns the new state without a delay.
-			await env.getClaudeAgent();
+			if (options?.invalidate) {
+				env.invalidateAgentsCache();
+			}
+			const claude = await env.getClaudeAgent();
+			installed = claude?.hooksInstalled ?? false;
 		} catch {
-			// Browser build: silently skip — webviews will refresh on the next state pull.
+			// Unexpected env-resolution/detection failure — leave fail-open (assume installed) so a
+			// transient error doesn't wrongly suppress polling. (The browser stub doesn't throw; it
+			// returns undefined above, yielding installed=false, and has no providers anyway.)
 		}
-		this._onDidChangeHooksInstallState.fire();
+		for (const provider of this._providers) {
+			provider.setClaudeHooksInstalled?.(installed);
+		}
 	}
 
 	get sessions(): readonly AgentSession[] {

--- a/src/constants.telemetry.ts
+++ b/src/constants.telemetry.ts
@@ -107,6 +107,12 @@ export interface TelemetryEvents extends WebviewShowAbortedEvents, WebviewShownE
 	'agents/session/ended': AgentProviderEvent;
 	/** Sent when a permission request is resolved */
 	'agents/permission/resolved': AgentPermissionResolvedEvent;
+	/** Sent when a reconciliation poll (`list-sessions`) finds the polled session set differs from
+	 *  what the live IPC hook path had already tracked. In a single window this should be rare and
+	 *  usually means a hook event was dropped; a nonzero `sync.discovered` is expected in multi-window
+	 *  setups, where the machine-wide poll can surface a session owned by another window that never
+	 *  routed its hook events here — so don't treat every event as a dropped IPC signal */
+	'agents/session/syncDiscrepancy': AgentSyncDiscrepancyEvent;
 
 	/** Sent when a CLI install attempt is started */
 	'cli/install/started': CLIInstallStartedEvent;
@@ -544,6 +550,18 @@ interface AgentPermissionResolvedEvent {
 	'agent.provider': string;
 	'permission.tool': string;
 	'permission.decision': string;
+}
+
+interface AgentSyncDiscrepancyEvent {
+	'agent.provider': string;
+	/** Sessions the poll reported alive that the live IPC path had not tracked. */
+	'sync.discovered': number;
+	/** Tracked sessions the poll no longer reports alive (teardown the live path missed). */
+	'sync.missing': number;
+	/** Total alive sessions reported by the poll. */
+	'sync.polled': number;
+	/** Total sessions tracked (from the live path) before the poll reconciled. */
+	'sync.tracked': number;
 }
 
 interface ActivateEvent extends ConfigEventData {

--- a/src/env/node/providers.ts
+++ b/src/env/node/providers.ts
@@ -140,6 +140,14 @@ export function getAgentSessionProviders(container: Container): AgentSessionProv
 					'permission.tool': info.tool,
 					'permission.decision': info.decision,
 				}),
+			onSyncDiscrepancy: info =>
+				container.telemetry.sendEvent('agents/session/syncDiscrepancy', {
+					'agent.provider': info.provider,
+					'sync.discovered': info.discovered,
+					'sync.missing': info.missing,
+					'sync.polled': info.polled,
+					'sync.tracked': info.tracked,
+				}),
 			onBranchAgentActivity: cwd => {
 				const repo = container.git.getRepository(cwd);
 				if (repo != null) {


### PR DESCRIPTION
## Summary

The GK CLI `gk ai hook list-sessions --json` command was being invoked far more than necessary. A fixed 60s timer in `ClaudeCodeProvider` spawned a fresh `gk` process **every minute, per VS Code window**, for the life of the window — even with zero agent sessions, while unfocused, and even when Claude Code hooks weren't installed at all. With multiple windows open this multiplied linearly.

Session data actually arrives via the IPC push path (hooks → `handleSessionEvent` → `ensureSession`); the poll is only a reconciliation/prune fallback. This PR makes the poll skip when there's nothing to reconcile, slows its cadence, and adds telemetry to verify the live path is genuinely complete.

## Changes

- **Gate the recurring poll.** It now skips the CLI spawn when there are no tracked sessions **and** Claude hooks aren't installed. It still polls whenever sessions exist (the only local backstop for pruning agents that die without firing `SessionEnd`, and robust to stale/incorrect hook detection) or when hooks are installed. The one-time bootstrap poll stays ungated so cold-start discovery is unaffected.
- **Push hooks-installed state into the provider.** Mirrors the existing `updateWorkspacePaths` host→provider push: the host resolves `getClaudeAgent().hooksInstalled` once (off the interval) and pushes it, re-pushing on install/uninstall. An off→on transition triggers an eager resync so installing hooks reconciles immediately instead of waiting for the next interval.
- **Interval 60s → 15 minutes.**
- **Sync-drift telemetry.** New `agents/session/syncDiscrepancy` event fires (gated calls only) when the poll's session set diverges from what the live IPC path already tracked — `discovered` (poll saw a session we weren't tracking) and `missing` (we track a session the poll no longer reports alive), plus `polled`/`tracked` denominators. Ideally always zero; a nonzero value signals the live push path dropped an event.

## Testing

- `pnpm run check` — clean
- `pnpm run pretty:check` — clean
- `pnpm --filter @gitlens/agents test` — 122 passing, including new gate + telemetry tests (the network-bound peer-discovery tests pass with network access)

## Notes

- Desktop-only — the browser build has no session providers, so no browser changes were needed.
- In multi-window setups a nonzero `discovered` can legitimately reflect a session owned by another window rather than a dropped event; worth keeping in mind when reading the telemetry.
