### PR TITLE
Fixes Commit Graph squash/drop/reword/modify edge cases (#5161)

### DIFF
--- a/contributions.json
+++ b/contributions.json
@@ -3356,7 +3356,7 @@
 			"menus": {
 				"webview/context": [
 					{
-						"when": "webviewItems =~ /gitlens:commit\\b(?=.*?\\b\\+current\\b)(?!.*?\\b\\+rebase\\b)/ && listMultiSelection && !gitlens:readonly && !gitlens:untrusted && !gitlens:hasVirtualFolders",
+						"when": "webviewItems =~ /gitlens:commit\\b(?=.*?\\b\\+rewriteable\\b)(?!.*?\\b\\+rebase\\b)/ && listMultiSelection && !gitlens:readonly && !gitlens:untrusted && !gitlens:hasVirtualFolders",
 						"group": "1_gitlens_actions",
 						"order": 3
 					}
@@ -3442,7 +3442,7 @@
 			"menus": {
 				"webview/context": [
 					{
-						"when": "webviewItem =~ /gitlens:commit\\b(?=.*?\\b\\+current\\b)(?!.*?\\b\\+rebase\\b)/ && !listMultiSelection && !gitlens:readonly && !gitlens:untrusted && !gitlens:hasVirtualFolders",
+						"when": "webviewItem =~ /gitlens:commit\\b(?=.*?\\b\\+rewriteable\\b)(?!.*?\\b\\+rebase\\b)/ && !listMultiSelection && !gitlens:readonly && !gitlens:untrusted && !gitlens:hasVirtualFolders",
 						"group": "1_gitlens_actions",
 						"order": 5
 					}
@@ -3455,7 +3455,7 @@
 			"menus": {
 				"webview/context": [
 					{
-						"when": "webviewItems =~ /gitlens:commit\\b(?=.*?\\b\\+current\\b)(?!.*?\\b\\+rebase\\b)/ && listMultiSelection && !gitlens:readonly && !gitlens:untrusted && !gitlens:hasVirtualFolders",
+						"when": "webviewItems =~ /gitlens:commit\\b(?=.*?\\b\\+rewriteable\\b)(?!.*?\\b\\+rebase\\b)/ && listMultiSelection && !gitlens:readonly && !gitlens:untrusted && !gitlens:hasVirtualFolders",
 						"group": "1_gitlens_actions",
 						"order": 5
 					}
@@ -3886,7 +3886,7 @@
 			"menus": {
 				"webview/context": [
 					{
-						"when": "webviewItem =~ /gitlens:commit\\b(?=.*?\\b\\+current\\b)(?!.*?\\b\\+rebase\\b)/ && !listMultiSelection && !gitlens:readonly && !gitlens:untrusted && !gitlens:hasVirtualFolders",
+						"when": "webviewItem =~ /gitlens:commit\\b(?=.*?\\b\\+rewriteable\\b)(?!.*?\\b\\+rebase\\b)/ && !listMultiSelection && !gitlens:readonly && !gitlens:untrusted && !gitlens:hasVirtualFolders",
 						"group": "1_gitlens_actions",
 						"order": 4
 					}
@@ -4138,7 +4138,7 @@
 			"menus": {
 				"webview/context": [
 					{
-						"when": "webviewItems =~ /gitlens:commit\\b(?=.*?\\b\\+current\\b)(?!.*?\\b\\+rebase\\b)/ && listMultiSelection && !gitlens:readonly && !gitlens:untrusted && !gitlens:hasVirtualFolders && listContiguousSelection",
+						"when": "webviewItems =~ /gitlens:commit\\b(?=.*?\\b\\+rewriteable\\b)(?!.*?\\b\\+rebase\\b)/ && listMultiSelection && !gitlens:readonly && !gitlens:untrusted && !gitlens:hasVirtualFolders && listContiguousSelection",
 						"group": "1_gitlens_actions",
 						"order": 2
 					}

--- a/package.json
+++ b/package.json
@@ -26786,12 +26786,12 @@
 				},
 				{
 					"command": "gitlens.graph.rewordCommit",
-					"when": "webviewItem =~ /gitlens:commit\\b(?=.*?\\b\\+current\\b)(?!.*?\\b\\+rebase\\b)/ && !listMultiSelection && !gitlens:readonly && !gitlens:untrusted && !gitlens:hasVirtualFolders",
+					"when": "webviewItem =~ /gitlens:commit\\b(?=.*?\\b\\+rewriteable\\b)(?!.*?\\b\\+rebase\\b)/ && !listMultiSelection && !gitlens:readonly && !gitlens:untrusted && !gitlens:hasVirtualFolders",
 					"group": "1_gitlens_actions@4"
 				},
 				{
 					"command": "gitlens.graph.modifyCommits",
-					"when": "webviewItem =~ /gitlens:commit\\b(?=.*?\\b\\+current\\b)(?!.*?\\b\\+rebase\\b)/ && !listMultiSelection && !gitlens:readonly && !gitlens:untrusted && !gitlens:hasVirtualFolders",
+					"when": "webviewItem =~ /gitlens:commit\\b(?=.*?\\b\\+rewriteable\\b)(?!.*?\\b\\+rebase\\b)/ && !listMultiSelection && !gitlens:readonly && !gitlens:untrusted && !gitlens:hasVirtualFolders",
 					"group": "1_gitlens_actions@5"
 				},
 				{
@@ -27638,17 +27638,17 @@
 				},
 				{
 					"command": "gitlens.graph.squashCommits.multi",
-					"when": "webviewItems =~ /gitlens:commit\\b(?=.*?\\b\\+current\\b)(?!.*?\\b\\+rebase\\b)/ && listMultiSelection && !gitlens:readonly && !gitlens:untrusted && !gitlens:hasVirtualFolders && listContiguousSelection",
+					"when": "webviewItems =~ /gitlens:commit\\b(?=.*?\\b\\+rewriteable\\b)(?!.*?\\b\\+rebase\\b)/ && listMultiSelection && !gitlens:readonly && !gitlens:untrusted && !gitlens:hasVirtualFolders && listContiguousSelection",
 					"group": "1_gitlens_actions@2"
 				},
 				{
 					"command": "gitlens.graph.dropCommits.multi",
-					"when": "webviewItems =~ /gitlens:commit\\b(?=.*?\\b\\+current\\b)(?!.*?\\b\\+rebase\\b)/ && listMultiSelection && !gitlens:readonly && !gitlens:untrusted && !gitlens:hasVirtualFolders",
+					"when": "webviewItems =~ /gitlens:commit\\b(?=.*?\\b\\+rewriteable\\b)(?!.*?\\b\\+rebase\\b)/ && listMultiSelection && !gitlens:readonly && !gitlens:untrusted && !gitlens:hasVirtualFolders",
 					"group": "1_gitlens_actions@3"
 				},
 				{
 					"command": "gitlens.graph.modifyCommits.multi",
-					"when": "webviewItems =~ /gitlens:commit\\b(?=.*?\\b\\+current\\b)(?!.*?\\b\\+rebase\\b)/ && listMultiSelection && !gitlens:readonly && !gitlens:untrusted && !gitlens:hasVirtualFolders",
+					"when": "webviewItems =~ /gitlens:commit\\b(?=.*?\\b\\+rewriteable\\b)(?!.*?\\b\\+rebase\\b)/ && listMultiSelection && !gitlens:readonly && !gitlens:untrusted && !gitlens:hasVirtualFolders",
 					"group": "1_gitlens_actions@5"
 				},
 				{

--- a/packages/git-cli/src/providers/graph.ts
+++ b/packages/git-cli/src/providers/graph.ts
@@ -147,6 +147,13 @@ export class GraphGitSubProvider implements GitGraphSubProvider {
 		const avatars = new Map<string, string>();
 		const ids = new Set<string>();
 		const reachableFromHEAD = new Set<string>();
+		// SHAs on the first-parent chain from HEAD up to (excluding) the first merge commit — the only
+		// commits a plain (non-`--rebase-merges`) interactive rebase can safely rewrite. `headSha` seeds
+		// the chain; `rewriteableNextSha` tracks the next sha expected on it. Outer scope so they persist
+		// across `more()` pagination, like `reachableFromHEAD`.
+		const rewriteableFromHEAD = new Set<string>();
+		let headSha: string | undefined;
+		let rewriteableNextSha: string | undefined;
 		// Undo Commit is offered only on a worktree HEAD that is a LEAF (nothing is built on it) —
 		// undoing a commit other work is stacked on is unsafe. The leaf check is only needed for the
 		// undo-eligible tips (the active HEAD + each worktree's HEAD), so track just those shas rather
@@ -275,6 +282,7 @@ export class GraphGitSubProvider implements GitGraphSubProvider {
 								branchIdOfMainWorktree: branchIdOfMainWorktree,
 								stashes: gitStash?.stashes,
 								reachableFromHEAD: reachableFromHEAD,
+								rewriteableFromHEAD: rewriteableFromHEAD,
 								tipShasWithChildren: tipShasWithChildren,
 								// `undefined` when HEAD has no upstream, so the processor flags nothing as
 								// unpublished; otherwise the live set (mutated during the walk, read by ref).
@@ -344,6 +352,7 @@ export class GraphGitSubProvider implements GitGraphSubProvider {
 							if (tip.startsWith('HEAD')) {
 								head = true;
 								reachableFromHEAD.add(shaOrRemapped);
+								headSha ??= shaOrRemapped;
 
 								if (tip !== 'HEAD') {
 									tip = tip.substring(8);
@@ -424,6 +433,22 @@ export class GraphGitSubProvider implements GitGraphSubProvider {
 					if (reachableFromHEAD.has(shaOrRemapped)) {
 						for (parent of parents) {
 							reachableFromHEAD.add(parent);
+						}
+					}
+
+					// First-parent rewriteable chain from HEAD: include each commit only while HEAD and
+					// every commit down to it has exactly one parent. Stops at (excludes) the first merge
+					// and the root — mirrors GitKraken's getDistinctCommitsFromHeadToFirstMergeCommit.
+					// Off-chain commits (a merge's other-parent ancestry, or anything below the first merge)
+					// are reachable-from-HEAD but NOT safely history-rewriteable by a plain interactive
+					// rebase. Relies on the same "commit emitted before its parents" ordering as above.
+					if (shaOrRemapped === headSha || shaOrRemapped === rewriteableNextSha) {
+						if (parents.length === 1) {
+							rewriteableFromHEAD.add(shaOrRemapped);
+							rewriteableNextSha = parents[0];
+						} else {
+							// A merge (>1 parents) or the root (0 parents) terminates the chain.
+							rewriteableNextSha = undefined;
 						}
 					}
 					if (reachableFromHeadUpstream.has(shaOrRemapped)) {
@@ -606,6 +631,7 @@ export class GraphGitSubProvider implements GitGraphSubProvider {
 					worktrees: worktrees,
 					worktreesByBranch: worktreesByBranch,
 					reachableFromHEAD: reachableFromHEAD,
+					rewriteableFromHEAD: rewriteableFromHEAD,
 					reachability: reachabilityBuilder.build(),
 					rows: rows,
 					id: sha ?? rev,

--- a/packages/git-cli/src/providers/operations.ts
+++ b/packages/git-cli/src/providers/operations.ts
@@ -660,6 +660,7 @@ export class OperationsGitSubProvider implements GitOperationsSubProvider {
 			branch?: string;
 			editor?: string;
 			interactive?: boolean;
+			programmaticEditor?: boolean;
 			messageEditor?: string;
 			onto?: string;
 			updateRefs?: boolean;
@@ -681,6 +682,13 @@ export class OperationsGitSubProvider implements GitOperationsSubProvider {
 
 			if (options.editor) {
 				configs.push('-c', `sequence.editor=${options.editor}`);
+			}
+
+			// A script-based sequence editor rewrites the todo by command word + SHA, so git must emit a
+			// plain, natural-order todo regardless of the user's rebase config: `rebase.autosquash` would
+			// reorder commits and rewrite `pick`→`fixup`, and `rebase.abbreviateCommands` would emit `p`.
+			if (options.programmaticEditor) {
+				configs.push('-c', 'rebase.autosquash=false', '-c', 'rebase.abbreviateCommands=false');
 			}
 		}
 

--- a/packages/git/src/models/graph.ts
+++ b/packages/git/src/models/graph.ts
@@ -57,6 +57,10 @@ export interface GitGraphRowTag {
  * child, to gate Undo Commit to leaf tips (undoing a commit other work is stacked on is unsafe). It is
  * NOT a general has-children signal: non-tip rows never carry it (the host only computes it for tips);
  * Bit 3: unpushed/ahead-of-upstream (`+unpublished`).
+ * Bit 4: history-rewriteable (`+rewriteable`) — on the first-parent chain from HEAD up to (excluding)
+ * the first merge commit, so a plain (non-`--rebase-merges`) interactive rebase can safely rewrite it;
+ * gates squash/drop/reword/modify. Strictly narrower than `+current` (reachable-from-HEAD includes a
+ * merge's other-parent ancestry, which is NOT safely rewriteable).
  * (`+HEAD` derives from `row.heads[].isCurrentHead`; contributor `+current` from `row.isCurrentUser`.)
  */
 export const enum GitGraphRowContextFlags {
@@ -65,6 +69,7 @@ export const enum GitGraphRowContextFlags {
 	UniqueToBranch = 1 << 1,
 	HasChildren = 1 << 2,
 	Unpublished = 1 << 3,
+	RewriteableFromHead = 1 << 4,
 }
 
 /**
@@ -163,6 +168,13 @@ export interface GitGraph {
 	readonly reachableFromHEAD?: ReadonlySet<string>;
 
 	/**
+	 * SHAs on the first-parent chain from HEAD up to (excluding) the first merge commit — i.e. the
+	 * commits a plain interactive rebase can safely rewrite. Empty when HEAD itself is a merge. Used by
+	 * the graph's history-rewriting commands (squash/drop/reword/modify) to validate selections.
+	 */
+	readonly rewriteableFromHEAD?: ReadonlySet<string>;
+
+	/**
 	 * Shared, append-only reachability table for the loaded rows (the primary representation — rows
 	 * carry only a {@link GitGraphRowContexts.reachabilityIndex} into it, not per-row ref arrays).
 	 * Grows monotonically across {@link more} pagination within a graph session: indices already
@@ -250,6 +262,10 @@ export interface GraphContext {
 	readonly branchIdOfMainWorktree: string | undefined;
 	readonly stashes: ReadonlyMap<string, GitStashCommit> | undefined;
 	readonly reachableFromHEAD: ReadonlySet<string>;
+	/** SHAs on the first-parent chain from HEAD up to (excluding) the first merge commit — the commits
+	 *  a plain interactive rebase can safely rewrite. Empty when HEAD is a merge. Sets the
+	 *  {@link GitGraphRowContextFlags.RewriteableFromHead} flag, gating squash/drop/reword/modify. */
+	readonly rewriteableFromHEAD: ReadonlySet<string>;
 	/** The subset of undo-eligible tip shas (active HEAD + worktree HEADs) that have at least one
 	 *  child — i.e. are NOT leaves. Scoped to tips (not all commits) for performance; do not treat as
 	 *  a general has-children signal. Sets the {@link GitGraphRowContextFlags.HasChildren} flag, which

--- a/packages/git/src/providers/operations.ts
+++ b/packages/git/src/providers/operations.ts
@@ -97,6 +97,14 @@ export interface GitOperationsSubProvider {
 			editor?: string;
 			interactive?: boolean;
 			/**
+			 * Set when the `editor` is a script that rewrites the todo by command word + SHA (e.g. the
+			 * Commit Graph's headless squash/drop/reword) rather than a human. Forces git to emit a plain,
+			 * natural-order todo by disabling `rebase.autosquash` (which would reorder commits and rewrite
+			 * `pick`→`fixup` for `fixup!`/`squash!` commits) and `rebase.abbreviateCommands` (which would
+			 * emit `p` instead of `pick`). Both honor the user's git config otherwise.
+			 */
+			programmaticEditor?: boolean;
+			/**
 			 * Command git uses to edit per-commit messages (the combined message a `squash` produces, or a
 			 * `reword`). Applied as `GIT_EDITOR` — which git's interactive-rebase `reword`/`squash` step honors,
 			 * unlike `core.editor` — with `core.editor` also set as a fallback. When omitted, git falls back to

--- a/src/git/__tests__/graphRowProcessor.test.ts
+++ b/src/git/__tests__/graphRowProcessor.test.ts
@@ -22,6 +22,7 @@ function createMockContext(overrides?: Partial<GraphContext>): GraphContext {
 		branchIdOfMainWorktree: undefined,
 		stashes: undefined,
 		reachableFromHEAD: new Set<string>(),
+		rewriteableFromHEAD: new Set<string>(),
 		tipShasWithChildren: new Set<string>(),
 		reachableFromHeadUpstream: undefined,
 		avatars: new Map<string, string>([['test@test.com', 'https://avatar']]),
@@ -247,6 +248,39 @@ suite('GlGraphRowProcessor', () => {
 			assert.ok(
 				(flags & GitGraphRowContextFlags.Unpublished) === 0,
 				`unexpected Unpublished bit on stash flags ${flags}`,
+			);
+		});
+	});
+
+	// The host ships `+rewriteable` as the `RewriteableFromHead` bit in `contexts.flags`; the webview
+	// turns the bit into the `+rewriteable` webview-item token (`buildRowCommitContext`) that gates the
+	// history-rewriting commands (squash/drop/reword/modify). A commit is rewriteable when it's on the
+	// first-parent chain from HEAD up to (excluding) the first merge — i.e. present in `rewriteableFromHEAD`.
+	suite('RewriteableFromHead flag on commit rows', () => {
+		test('sets the RewriteableFromHead bit when the commit is in rewriteableFromHEAD', () => {
+			const processor = new GlGraphRowProcessor(createMockContainer(), uri => uri);
+
+			const row = createRow();
+			processor.processRow(row, createMockContext({ rewriteableFromHEAD: new Set([row.sha]) }));
+
+			const flags = row.contexts?.flags ?? 0;
+			assert.ok(
+				(flags & GitGraphRowContextFlags.RewriteableFromHead) !== 0,
+				`expected RewriteableFromHead bit set in flags ${flags}`,
+			);
+		});
+
+		test('does not set the RewriteableFromHead bit when the commit is not in rewriteableFromHEAD', () => {
+			const processor = new GlGraphRowProcessor(createMockContainer(), uri => uri);
+
+			// Reachable from HEAD (e.g. an ancestor of a merge) but NOT on the first-parent rewriteable chain.
+			const row = createRow();
+			processor.processRow(row, createMockContext({ reachableFromHEAD: new Set([row.sha]) }));
+
+			const flags = row.contexts?.flags ?? 0;
+			assert.ok(
+				(flags & GitGraphRowContextFlags.RewriteableFromHead) === 0,
+				`unexpected RewriteableFromHead bit in flags ${flags}`,
 			);
 		});
 	});

--- a/src/git/graphRowProcessor.ts
+++ b/src/git/graphRowProcessor.ts
@@ -183,6 +183,7 @@ export class GlGraphRowProcessor implements GraphRowProcessor {
 				!context.reachableFromHeadUpstream.has(row.sha);
 			contexts.flags =
 				(context.reachableFromHEAD.has(row.sha) ? GitGraphRowContextFlags.ReachableFromHead : 0) |
+				(context.rewriteableFromHEAD.has(row.sha) ? GitGraphRowContextFlags.RewriteableFromHead : 0) |
 				(localBranches?.length === 1 ? GitGraphRowContextFlags.UniqueToBranch : 0) |
 				(context.tipShasWithChildren.has(row.sha) ? GitGraphRowContextFlags.HasChildren : 0) |
 				(isUnpublished ? GitGraphRowContextFlags.Unpublished : 0);

--- a/src/git/utils/__tests__/rebaseTodo.test.ts
+++ b/src/git/utils/__tests__/rebaseTodo.test.ts
@@ -89,4 +89,42 @@ suite('applyRebaseActionToTodo', () => {
 		assert.strictEqual(lines[2], 'reword c1b2c3d Commit C', 'selected C becomes reword');
 		assert.strictEqual(lines[1], 'pick b1b2c3d Commit B', 'unselected B stays pick');
 	});
+
+	// Git abbreviates the `pick` command to `p` when `rebase.abbreviateCommands=true`.
+	const abbreviatedTodo = [
+		'p a1b2c3d Commit A',
+		'p b1b2c3d Commit B',
+		'p c1b2c3d Commit C',
+		'p d1b2c3d Commit D',
+	].join('\n');
+
+	test('squashes an abbreviated (`p`) todo, rewriting to the full action word', () => {
+		const result = applyRebaseActionToTodo(abbreviatedTodo, [B, C], 'squash');
+		const lines = result.split('\n');
+		assert.strictEqual(lines[0], 'p a1b2c3d Commit A', 'unselected A stays untouched');
+		assert.strictEqual(lines[1], 'p b1b2c3d Commit B', 'oldest selected (B) stays the abbreviated pick target');
+		assert.strictEqual(lines[2], 'squash c1b2c3d Commit C', 'later selected (C) becomes full `squash`');
+		assert.strictEqual(lines[3], 'p d1b2c3d Commit D', 'unselected D stays untouched');
+	});
+
+	test('drops selected commits in an abbreviated (`p`) todo', () => {
+		const result = applyRebaseActionToTodo(abbreviatedTodo, [B, C], 'drop');
+		const lines = result.split('\n');
+		assert.strictEqual(lines[1], 'drop b1b2c3d Commit B', 'selected B becomes full `drop`');
+		assert.strictEqual(lines[2], 'drop c1b2c3d Commit C', 'selected C becomes full `drop`');
+		assert.strictEqual(lines[3], 'p d1b2c3d Commit D', 'unselected D stays untouched');
+	});
+
+	test('rewords the selected commit in an abbreviated (`p`) todo', () => {
+		const result = applyRebaseActionToTodo(abbreviatedTodo, [C], 'reword');
+		assert.strictEqual(result.split('\n')[2], 'reword c1b2c3d Commit C', 'selected C becomes full `reword`');
+	});
+
+	test('matches both `pick` and abbreviated `p` lines in a mixed todo', () => {
+		const mixedTodo = ['pick a1b2c3d Commit A', 'p b1b2c3d Commit B', 'p c1b2c3d Commit C'].join('\n');
+		const result = applyRebaseActionToTodo(mixedTodo, [B, C], 'squash');
+		const lines = result.split('\n');
+		assert.strictEqual(lines[1], 'p b1b2c3d Commit B', 'oldest selected (B) stays the abbreviated pick target');
+		assert.strictEqual(lines[2], 'squash c1b2c3d Commit C', 'later selected (C) becomes squash');
+	});
 });

--- a/src/git/utils/rebaseTodo.ts
+++ b/src/git/utils/rebaseTodo.ts
@@ -10,6 +10,9 @@ export type RebaseTodoAction = 'squash' | 'fixup' | 'drop' | 'reword';
  * Non-selected commits and non-`pick` lines (comments, `update-ref`, blanks) are left untouched.
  * `selectedShas` are full SHAs; todo lines carry abbreviated SHAs, so matching is prefix-based.
  *
+ * Git abbreviates the `pick` command to `p` when `rebase.abbreviateCommands` is enabled, so both forms
+ * are matched. The rewritten line uses the full action word, which git accepts regardless of that setting.
+ *
  * Pure and free of `vscode`/Node imports so the bundled `rebaseTodoEditor.ts` entry — git's
  * `sequence.editor` for headless squash/drop/reword — can import it directly, and so it can be
  * unit tested.
@@ -25,14 +28,14 @@ export function applyRebaseActionToTodo(
 	return todo
 		.split('\n')
 		.map(line => {
-			const match = /^pick\s+([0-9a-f]+)\b/.exec(line);
+			const match = /^(?:pick|p)\s+([0-9a-f]+)\b/.exec(line);
 			if (match == null) return line;
 			if (!selectedShas.some(sha => sha.startsWith(match[1]))) return line;
 			if (keepsFirst && !seenFirst) {
 				seenFirst = true;
 				return line;
 			}
-			return line.replace(/^pick(\s)/, `${action}$1`);
+			return line.replace(/^(?:pick|p)(\s)/, `${action}$1`);
 		})
 		.join('\n');
 }

--- a/src/webviews/apps/plus/graph/utils/rowContext.utils.ts
+++ b/src/webviews/apps/plus/graph/utils/rowContext.utils.ts
@@ -58,7 +58,7 @@ export function isUnpublishedRow(row: RowContextSource): boolean {
 /**
  * Builds the `gitlens:commit…` webview-item context for a commit row from its fields + `contexts.flags`.
  * Mirrors exactly what the host serialized pre-strip: `+HEAD`/`+worktreeHEAD` from `row.heads`,
- * `+current`/`+unique`/`+unpublished` from the flag bits. `message` is intentionally OMITTED — the wire
+ * `+current`/`+rewriteable`/`+unique`/`+unpublished` from the flag bits. `message` is intentionally OMITTED — the wire
  * `row.message` is emojified, and `Copy Message` refetches the raw message when `ref.message` is absent,
  * so omitting it preserves the original raw-message behavior instead of copying emojified text.
  *
@@ -75,8 +75,8 @@ export function buildRowCommitContext(row: RowContextSource, repoPath: string): 
 	const webviewItem = `gitlens:commit${currentHead != null ? '+HEAD' : ''}${
 		worktreeHead != null ? '+worktreeHEAD' : ''
 	}${flags & ContextFlags.ReachableFromHead ? '+current' : ''}${
-		flags & ContextFlags.UniqueToBranch ? '+unique' : ''
-	}${flags & ContextFlags.Unpublished ? '+unpublished' : ''}`;
+		flags & ContextFlags.RewriteableFromHead ? '+rewriteable' : ''
+	}${flags & ContextFlags.UniqueToBranch ? '+unique' : ''}${flags & ContextFlags.Unpublished ? '+unpublished' : ''}`;
 
 	return {
 		webviewItem: webviewItem,

--- a/src/webviews/plus/graph/graphWebview.ts
+++ b/src/webviews/plus/graph/graphWebview.ts
@@ -8965,6 +8965,9 @@ export class GraphWebviewProvider implements WebviewProvider<State, State, Graph
 				{
 					interactive: true,
 					editor: sequenceEditor.editor,
+					// The editor is a script that rewrites the todo by command + SHA, so force git to emit a
+					// plain, natural-order todo (no autosquash reordering, no abbreviated `p` commands).
+					programmaticEditor: true,
 					// squash (combined message) and reword (per-commit message) open a commit-message editor.
 					messageEditor:
 						action === 'squash' || action === 'reword' ? await getHostEditorCommand(true) : undefined,

--- a/src/webviews/plus/graph/graphWebview.ts
+++ b/src/webviews/plus/graph/graphWebview.ts
@@ -8872,6 +8872,28 @@ export class GraphWebviewProvider implements WebviewProvider<State, State, Graph
 	}
 
 	/**
+	 * Guards a history-rewriting rebase against commits that aren't safely rewriteable — i.e. not on the
+	 * first-parent chain from HEAD up to (excluding) the first merge (notably when HEAD itself is a merge,
+	 * or the selection is an ancestor of one). A plain interactive rebase (no `--rebase-merges`) would
+	 * flatten the merge. Uses the chain computed by the graph provider; when that set is unavailable,
+	 * returns `true` so the caller's per-commit parent checks still apply. Surfaces a warning and returns
+	 * `false` when the selection leaves the chain.
+	 */
+	private validateRewriteableSelection(
+		graph: GitGraph,
+		refs: readonly GitRevisionReference[],
+		verb: string,
+	): boolean {
+		const rewriteable = graph.rewriteableFromHEAD;
+		if (rewriteable == null || refs.every(ref => rewriteable.has(ref.ref))) return true;
+
+		void window.showWarningMessage(
+			`Unable to ${verb}: you can only rewrite commits on the current branch up to the first merge.`,
+		);
+		return false;
+	}
+
+	/**
 	 * Validates a multi-commit selection for a history-rewriting rebase (squash/fixup/drop): every commit
 	 * must be loaded in the graph, none may be a merge commit, and the oldest must have a parent to rebase
 	 * onto. Returns the selection ordered oldest-last plus whether any commit is already published, or
@@ -8922,6 +8944,10 @@ export class GraphWebviewProvider implements WebviewProvider<State, State, Graph
 			void window.showWarningMessage(`Unable to ${verb}: the selection includes a merge commit.`);
 			return undefined;
 		}
+
+		// Reject selections that leave the first-parent chain from HEAD before the first merge (e.g. HEAD
+		// is a merge, or the commits are an ancestor of one) — a plain interactive rebase would flatten it.
+		if (!this.validateRewriteableSelection(graph, ordered, verb)) return undefined;
 
 		const oldest = ordered.at(-1)!;
 		if ((graph.rows[rowIndexBySha.get(oldest.ref)!]?.parents.length ?? 0) === 0) {
@@ -9018,6 +9044,9 @@ export class GraphWebviewProvider implements WebviewProvider<State, State, Graph
 			void window.showWarningMessage('Unable to reword: cannot reword a merge commit.');
 			return;
 		}
+		// Also reject commits off the first-parent chain from HEAD before the first merge (e.g. HEAD is a
+		// merge, or this commit is an ancestor of one) — rewording rebases oldest..HEAD across the merge.
+		if (!this.validateRewriteableSelection(graph, [ref], 'reword')) return;
 
 		// Warn (don't block) when rewording an already-published commit — rewording requires a force push.
 		let published = false;
@@ -9071,6 +9100,10 @@ export class GraphWebviewProvider implements WebviewProvider<State, State, Graph
 			void window.showWarningMessage('Unable to modify: the selection includes a merge commit.');
 			return Promise.resolve();
 		}
+
+		// Reject selections that leave the first-parent chain from HEAD before the first merge (e.g. HEAD
+		// is a merge, or the commits are an ancestor of one) — the rebase spans oldest..HEAD across the merge.
+		if (!this.validateRewriteableSelection(graph, ordered, 'modify')) return Promise.resolve();
 
 		const oldest = ordered.at(-1);
 		const parentSha = oldest != null ? graph.rows[rowIndexBySha.get(oldest.ref)!]?.parents[0] : undefined;


### PR DESCRIPTION
Hardens the #5161 _Commit Graph_ history-rewriting commands — **Squash**, **Drop**, **Reword**, and **Modify Commits (Interactive Rebase)** — against two correctness issues.

## Fixes

### Squash/drop/reword silently doing nothing (`4a6a6e8f`)
The headless rebase rewrites the todo by matching `pick <sha>` lines, but git could emit a todo that didn't match what the editor expected (autosquash reordering / abbreviated `p` commands), so the rewrite was a no-op and the command appeared to do nothing. The sequence editor now forces a plain, natural-order todo (`programmaticEditor`) and the todo rewriter accepts the abbreviated `p` form.

### Rewrite commands offered across merge commits (`e0469aff`)
The commands were offered on commits that can't be safely rewritten by a plain interactive rebase — notably when **HEAD is a merge commit**, or when the selection is an **ancestor of a merge**. Running them rebases across the merge and flattens (destroys) it.

Obeys the following rule: commit is rewriteable only when it's on the **first-parent chain from HEAD up to (excluding) the first merge commit**.

- Computes that set (`rewriteableFromHEAD`) in the git-cli graph provider (a linear first-parent walk; empty when HEAD is a merge).
- Ships it as a new `RewriteableFromHead` row flag → `+rewriteable` webview-item marker that gates the commands' context-menu `when` clauses (a hard gate even for multi-select, via `reduceCommonWebviewItemsContext`).
- Adds an authoritative `validateRewriteableSelection` runtime guard in the command handlers, covering programmatic / command-palette invocation and mixed selections, with a safe fallback to the existing per-commit checks.

`+current` (reachable-from-HEAD) is intentionally left untouched — it still gates Revert / Push / Push to Commit / Rebase Onto, which legitimately want the broad meaning.