### PR TITLE
Updates feature gates

### DIFF
--- a/src/webviews/apps/plus/graph/gate.ts
+++ b/src/webviews/apps/plus/graph/gate.ts
@@ -46,7 +46,6 @@ export class GlGraphGate extends SignalWatcher(LitElement) {
 			featureRestriction="private-repos"
 			featureWithArticleIfNeeded="the Commit Graph"
 			?allowRepoSwitch=${this.graphState.allowRepoSwitch}
-			?hidden=${this.graphState.allowed !== false}
 			.source=${{ source: 'graph', detail: 'gate' } as const}
 			.state=${this.graphState.subscription?.state}
 			.webroot=${this.graphState.webroot}

--- a/src/webviews/apps/plus/graph/gate.ts
+++ b/src/webviews/apps/plus/graph/gate.ts
@@ -4,6 +4,9 @@ import { css, html, LitElement } from 'lit';
 import { customElement } from 'lit/decorators.js';
 import { ifDefined } from 'lit/directives/if-defined.js';
 import { createCommandLink } from '../../../../system/commands.js';
+import { ChooseRepositoryCommand } from '../../../plus/graph/protocol.js';
+import { featureGateContentStyles } from '../../shared/components/feature-gate.css.js';
+import { ipcContext } from '../../shared/contexts/ipc.js';
 import { linkStyles } from '../shared/components/vscode.css.js';
 import { graphStateContext } from './context.js';
 import '../../shared/components/code-icon.js';
@@ -14,87 +17,20 @@ import '../../shared/components/feature-gate.js';
 export class GlGraphGate extends SignalWatcher(LitElement) {
 	static override styles = [
 		linkStyles,
+		featureGateContentStyles,
 		css`
 			gl-feature-gate::part(section) {
 				width: 90vw;
 				max-width: 90rem;
-			}
-
-			.intro {
-				display: flex;
-				flex-direction: column;
-				gap: 1rem;
-				margin-block: 0.2rem 1.2rem;
-			}
-
-			.intro__title {
-				display: flex;
-				align-items: baseline;
-				flex-wrap: wrap;
-				gap: 0.6rem;
-				margin: 0;
-				font-size: 1.6rem;
-				font-weight: 600;
-				line-height: 1.2;
-			}
-
-			.intro__title gl-feature-badge {
-				margin: 0;
-				transform: translateY(-0.4rem);
-			}
-
-			.intro__lede {
-				margin: 0;
-				color: var(--color-foreground--85);
-				line-height: 1.5;
-			}
-
-			.intro__lede--sub {
-				display: inline-block;
-				margin: 0;
-				color: var(--color-foreground--85);
-				line-height: 1.5;
-				font-size: 1.1rem;
-			}
-
-			.intro__features {
-				list-style: none;
-				margin-block: 0.6rem;
-				margin-inline: 0;
-				padding: 1.2rem;
-				display: grid;
-				grid-template-columns: repeat(2, 1fr);
-				gap: 1.2rem;
-				background: color-mix(in srgb, #000 18%, transparent);
-				border-radius: 0.6rem;
-			}
-
-			.intro__feature {
-				display: flex;
-				align-items: flex-start;
-				gap: 0.8rem;
-				line-height: 1.5;
-				font-size: 1.1rem;
-				opacity: 0.9;
-			}
-
-			.intro__feature strong {
-				text-transform: uppercase;
-				margin-right: 0.4rem;
-				font-size: 1.2rem;
-				opacity: 1;
-			}
-
-			.intro__feature code-icon {
-				color: var(--vscode-textLink-foreground);
-				margin-top: 0.2rem;
-				flex-shrink: 0;
 			}
 		`,
 	];
 
 	@consume({ context: graphStateContext, subscribe: true })
 	graphState!: typeof graphStateContext.__context__;
+
+	@consume({ context: ipcContext })
+	private readonly _ipc!: typeof ipcContext.__context__;
 
 	override render() {
 		return html`<gl-feature-gate
@@ -109,77 +45,88 @@ export class GlGraphGate extends SignalWatcher(LitElement) {
 			appearance="alert"
 			featureRestriction="private-repos"
 			featureWithArticleIfNeeded="the Commit Graph"
+			?allowRepoSwitch=${this.graphState.allowRepoSwitch}
 			?hidden=${this.graphState.allowed !== false}
 			.source=${{ source: 'graph', detail: 'gate' } as const}
 			.state=${this.graphState.subscription?.state}
 			.webroot=${this.graphState.webroot}
+			@gl-switch-repos=${this.onSwitchRepos}
 		>
-			<div slot="feature" class="intro">
-				<h2 class="intro__title">
-					<span>Try the All-New Commit Graph</span>
-					<gl-feature-badge
-						.source=${{ source: 'graph', detail: 'badge' } as const}
-						subscription="{subscription}"
-					></gl-feature-badge>
-				</h2>
-				<p class="intro__lede">
-					Where your development and agentic workflows come together
-					<span class="intro__lede--sub"
-						>Parallelize your workflow—manage multiple active worktrees, orchestrate concurrent agents, and
-						execute your entire Git lifecycle without context-switching</span
-					>
+			<section slot="feature" class="feature">
+				<header class="feature__header">
+					<div class="icon-cube feature__feature-icon"><code-icon icon="gl-gitlens"></code-icon></div>
+					<hgroup>
+						<h2 class="feature__title">
+							<span>Try the All-New Commit Graph</span>
+							<gl-feature-badge
+								.source=${{ source: 'graph', detail: 'badge' } as const}
+								.subscription=${this.graphState.subscription}
+							></gl-feature-badge>
+						</h2>
+						<p class="feature__lede">Where your development and agentic workflows come together</p>
+					</hgroup>
+				</header>
+
+				<p class="feature__sub">
+					Parallelize your workflow—manage multiple active worktrees, orchestrate concurrent agents, and
+					execute your entire Git lifecycle without context-switching
 				</p>
-				<ul class="intro__features">
-					<li class="intro__feature">
-						<code-icon icon="layout"></code-icon>
-						<span
+
+				<ul class="list">
+					<li class="list__item">
+						<span class="icon-cube"><code-icon icon="layout"></code-icon></span>
+						<span class="list__copy"
 							><strong>Unified Workspace</strong> Centralize your workflow with the Side Bar and dockable
 							Details Panel. Detach the graph into a separate window to maximize your editor space</span
 						>
 					</li>
 
-					<li class="intro__feature">
-						<code-icon icon="robot"></code-icon>
-						<span
+					<li class="list__item">
+						<span class="icon-cube"><code-icon icon="robot"></code-icon></span>
+						<span class="list__copy"
 							><strong>Orchestrate Agents</strong> Launch, monitor, and interact with agents from the
 							graph, Agents Side Bar, or Kanban board to approve permissions and view execution plans
 							inline</span
 						>
 					</li>
-					<li class="intro__feature">
-						<code-icon icon="shield"></code-icon>
-						<span
+					<li class="list__item">
+						<span class="icon-cube"><code-icon icon="shield"></code-icon></span>
+						<span class="list__copy"
 							><strong>Command Center</strong> Review changes, stage files, create or compose commits, and
 							resolve conflicts. On a clean worktree the Details Panel guides your next steps—like
 							pulling, pushing, or drafting a PR</span
 						>
 					</li>
-					<li class="intro__feature">
-						<code-icon icon="arrow-swap"></code-icon>
-						<span
+					<li class="list__item">
+						<span class="icon-cube"><code-icon icon="arrow-swap"></code-icon></span>
+						<span class="list__copy"
 							><strong>Parallelize Work</strong> Juggle multiple active worktrees and agent sessions
 							within a single view. Focus the graph on specific changes instantly to review and track
 							where agents are working in real-time</span
 						>
 					</li>
-					<li class="intro__feature">
-						<code-icon icon="wand"></code-icon>
-						<span
+					<li class="list__item">
+						<span class="icon-cube"><code-icon icon="wand"></code-icon></span>
+						<span class="list__copy"
 							><strong>AI Compose & Review</strong> Bring order from chaos. Restructure changes into
 							clean, review-ready commits automatically. Catch issues early with severity-tagged reviews
 							that you can delegate directly to an agent</span
 						>
 					</li>
-					<li class="intro__feature">
-						<code-icon icon="pulse"></code-icon>
-						<span
+					<li class="list__item">
+						<span class="icon-cube"><code-icon icon="pulse"></code-icon></span>
+						<span class="list__copy"
 							><strong>Deep Visualizations</strong> Analyze repo evolution with the Visual History.
 							Pinpoint hotspots and trends or watch agent activity in real-time using the Files, Commits,
 							and Agent Activity treemaps</span
 						>
 					</li>
 				</ul>
-			</div>
+			</section>
 		</gl-feature-gate>`;
+	}
+
+	private onSwitchRepos(): void {
+		this._ipc.sendCommand(ChooseRepositoryCommand);
 	}
 }

--- a/src/webviews/apps/plus/graph/stateProvider.ts
+++ b/src/webviews/apps/plus/graph/stateProvider.ts
@@ -299,6 +299,9 @@ export class GraphStateProvider extends StateProviderBase<State['webviewId'], Ap
 	accessor allowed: State['allowed'] = false;
 
 	@signalState()
+	accessor allowRepoSwitch: State['allowRepoSwitch'];
+
+	@signalState()
 	accessor avatars: State['avatars'];
 
 	@signalState()

--- a/src/webviews/apps/plus/shared/components/feature-gate-plus-state.ts
+++ b/src/webviews/apps/plus/shared/components/feature-gate-plus-state.ts
@@ -93,6 +93,18 @@ export class GlFeatureGatePlusState extends LitElement {
 				white-space: nowrap;
 			}
 
+			/* Like .actions-row but center-aligned, for a row that mixes a text button with an
+			   icon-only button: their baselines don't match (a text baseline vs the synthesized
+			   bottom edge of the icon button's flex box), so centering the equal-height button
+			   boxes is what lines them up. */
+			.actions-row-center {
+				display: flex;
+				gap: 0.6em;
+				align-items: center;
+				justify-content: center;
+				white-space: nowrap;
+			}
+
 			.hint {
 				border-bottom: 1px dashed currentColor;
 			}
@@ -147,22 +159,18 @@ export class GlFeatureGatePlusState extends LitElement {
 		this.hidden = hidden;
 		if (hidden) return undefined;
 
-		const appearance = (this.appearance ?? 'alert') === 'alert' ? 'alert' : undefined;
-
 		switch (this.state) {
 			case SubscriptionState.VerificationRequired:
 				return html`
 					<slot name="feature"></slot>
-					<p class="centered">
+					<p class="actions-row-center">
 						<gl-button
 							class="inline"
-							appearance="${ifDefined(appearance)}"
 							href="${createCommandLink<Source>('gitlens.plus.resendVerification', this.source)}"
 							>Resend Email</gl-button
 						>
 						<gl-button
 							class="inline"
-							appearance="${ifDefined(appearance)}"
 							href="${createCommandLink<Source>('gitlens.plus.validate', this.source)}"
 							><code-icon icon="refresh"></code-icon
 						></gl-button>
@@ -185,7 +193,6 @@ export class GlFeatureGatePlusState extends LitElement {
 					<p class="actions-row">
 						<gl-button
 							class="inline"
-							appearance="${ifDefined(appearance)}"
 							href="${createCommandLink<Source>('gitlens.plus.signUp', this.source)}"
 							>&nbsp;Try GitLens Pro&nbsp;</gl-button
 						><span
@@ -213,7 +220,6 @@ export class GlFeatureGatePlusState extends LitElement {
 					<p class="actions-row">
 						<gl-button
 							class="inline"
-							appearance="${ifDefined(appearance)}"
 							href="${createCommandLink<SubscriptionUpgradeCommandArgs>('gitlens.plus.upgrade', {
 								plan: 'pro',
 								...(this.source ?? { source: 'feature-gate' }),
@@ -233,7 +239,6 @@ export class GlFeatureGatePlusState extends LitElement {
 					<p class="actions-row">
 						<gl-button
 							class="inline"
-							appearance="${ifDefined(appearance)}"
 							href="${createCommandLink<Source>('gitlens.plus.reactivateProTrial', this.source)}"
 							>Continue</gl-button
 						>
@@ -256,11 +261,7 @@ export class GlFeatureGatePlusState extends LitElement {
 		if (used === 0) {
 			return html`<slot name="feature"></slot>
 				<p class="actions-row">
-					<gl-button
-						.appearance=${ifDefined(appearance) ?? undefined}
-						href="${ifDefined(this.featurePreviewCommandLink)}"
-						>Continue</gl-button
-					>
+					<gl-button href="${ifDefined(this.featurePreviewCommandLink)}">Continue</gl-button>
 				</p>
 				<hr />
 				<p class="centered">
@@ -280,10 +281,7 @@ export class GlFeatureGatePlusState extends LitElement {
 		return html`
 			${this.renderFeaturePreviewStep(featurePreview, used)}
 			<p class="actions-row">
-				<gl-button
-					class="inline"
-					appearance="${ifDefined(appearance)}"
-					href="${ifDefined(this.featurePreviewCommandLink)}"
+				<gl-button class="inline" href="${ifDefined(this.featurePreviewCommandLink)}"
 					>Continue Preview</gl-button
 				><span
 					>or

--- a/src/webviews/apps/plus/timeline/actions.ts
+++ b/src/webviews/apps/plus/timeline/actions.ts
@@ -359,6 +359,7 @@ export class TimelineActions {
 					s.scope.set(result.scope);
 					s.repository.set(result.repository);
 					s.access.set(result.access);
+					s.allowRepoSwitch.set(result.allowRepoSwitch ?? false);
 					s.error.set(undefined);
 					// Start/switch WIP watch for the enriched repo so file saves refresh the pseudo-commit row
 					if (result.repository?.path) {

--- a/src/webviews/apps/plus/timeline/state.ts
+++ b/src/webviews/apps/plus/timeline/state.ts
@@ -43,6 +43,9 @@ export function createTimelineState(storage?: HostStorage) {
 	const repository = signal<(RepositoryShape & { ref: GitReference | undefined }) | undefined>(undefined);
 	const repositories = signal<{ count: number; openCount: number }>({ count: 0, openCount: 0 });
 	const access = signal<FeatureAccess | undefined>(undefined);
+	/** True when the workspace has both public and private repos — drives the gate's "Switch Repos"
+	 *  affordance. Set from the dataset result; only surfaced by the gate while it's shown. */
+	const allowRepoSwitch = signal<boolean>(false);
 
 	/** Currently-loaded history span (ms) for the dataset. `null` means "use period-derived
 	 *  span" (initial state and after period change). When the chart fires `gl-load-more`
@@ -101,6 +104,7 @@ export function createTimelineState(storage?: HostStorage) {
 		repository: repository,
 		repositories: repositories,
 		access: access,
+		allowRepoSwitch: allowRepoSwitch,
 		loadedSpanMs: loadedSpanMs,
 		visibleSpanMs: visibleSpanMs,
 		loadingMore: loadingMore,

--- a/src/webviews/apps/plus/timeline/timeline.ts
+++ b/src/webviews/apps/plus/timeline/timeline.ts
@@ -284,15 +284,24 @@ export class GlTimelineApp extends SignalWatcherWebviewApp {
 		this._actions?.changeScope(e.detail.type, e.detail.value ?? null, e.detail.detached);
 	};
 
+	private onSwitchRepos = (): void => {
+		void this._actions?.pickAndNavigateRepo();
+	};
+
 	private renderGate() {
 		const s = this._state;
+		// Mount the gate only while access is denied — mount/unmount drives the modal's open/teardown,
+		// the same way the Commit Graph gate is conditionally rendered.
+		if (s.allowed.get() !== false) return nothing;
+
 		const sub = s.access.get()?.subscription?.current;
 		if (this.placement === 'editor') {
 			return html`<gl-feature-gate
-				?hidden=${s.allowed.get() !== false}
+				?allowRepoSwitch=${s.allowRepoSwitch.get()}
 				featureRestriction="private-repos"
 				.source=${{ source: 'timeline' as const, detail: 'gate' }}
 				.state=${sub?.state}
+				@gl-switch-repos=${this.onSwitchRepos}
 				><p slot="feature">
 					<a href="https://help.gitkraken.com/gitlens/gitlens-features/#visual-file-history-pro"
 						>Visual History</a
@@ -306,10 +315,12 @@ export class GlTimelineApp extends SignalWatcherWebviewApp {
 		}
 
 		return html`<gl-feature-gate
+			?allowRepoSwitch=${s.allowRepoSwitch.get()}
 			?hidden=${s.allowed.get() !== false}
 			featureRestriction="private-repos"
 			.source=${{ source: 'timeline' as const, detail: 'gate' }}
 			.state=${sub?.state}
+			@gl-switch-repos=${this.onSwitchRepos}
 			><p slot="feature">
 				<a href="https://help.gitkraken.com/gitlens/gitlens-features/#visual-file-history-pro"
 					>Visual File History</a

--- a/src/webviews/apps/plus/timeline/timeline.ts
+++ b/src/webviews/apps/plus/timeline/timeline.ts
@@ -329,7 +329,6 @@ export class GlTimelineApp extends SignalWatcherWebviewApp {
 
 		return html`<gl-feature-gate
 			?allowRepoSwitch=${s.allowRepoSwitch.get()}
-			?hidden=${s.allowed.get() !== false}
 			featureRestriction="private-repos"
 			.source=${{ source: 'timeline' as const, detail: 'gate' }}
 			.state=${sub?.state}

--- a/src/webviews/apps/plus/timeline/timeline.ts
+++ b/src/webviews/apps/plus/timeline/timeline.ts
@@ -13,6 +13,7 @@ import type {
 import { periodToMs } from '../../../plus/timeline/utils/period.js';
 import { SignalWatcherWebviewApp } from '../../shared/appBase.js';
 import { compactBreadcrumbsConsumerStyles } from '../../shared/components/breadcrumbs.js';
+import { featureGateContentStyles } from '../../shared/components/feature-gate.css.js';
 import { getHost } from '../../shared/host/context.js';
 import { RpcController } from '../../shared/rpc/rpcController.js';
 import type { Resource } from '../../shared/state/resource.js';
@@ -40,6 +41,7 @@ export class GlTimelineApp extends SignalWatcherWebviewApp {
 	static override styles = [
 		linkStyles,
 		ruleStyles,
+		featureGateContentStyles,
 		timelineBaseStyles,
 		timelineStyles,
 		compactBreadcrumbsConsumerStyles,
@@ -302,16 +304,27 @@ export class GlTimelineApp extends SignalWatcherWebviewApp {
 				.source=${{ source: 'timeline' as const, detail: 'gate' }}
 				.state=${sub?.state}
 				@gl-switch-repos=${this.onSwitchRepos}
-				><p slot="feature">
-					<a href="https://help.gitkraken.com/gitlens/gitlens-features/#visual-file-history-pro"
-						>Visual History</a
-					>
-					<gl-feature-badge></gl-feature-badge>
-					&mdash; visualize the evolution of a repository, branch, folder, or file and identify when the most
-					impactful changes were made and by whom. Quickly see unmerged changes in files or folders, when
-					slicing by branch.
-				</p></gl-feature-gate
-			>`;
+				><section slot="feature" class="feature">
+					<header class="feature__header">
+						<div class="icon-cube feature__feature-icon"><code-icon icon="gl-gitlens"></code-icon></div>
+						<hgroup>
+							<h2 class="feature__title">
+								<span>Visual History</span>
+								<gl-feature-badge></gl-feature-badge>
+							</h2>
+							<p class="feature__lede">See how any file, folder, or branch evolved &mdash; at a glance</p>
+						</hgroup>
+					</header>
+					<p>
+						Visualize the evolution of a repository, branch, folder, or file and identify when the most
+						impactful changes were made and by whom. Quickly see unmerged changes in files or folders, when
+						slicing by branch.
+						<a href="https://help.gitkraken.com/gitlens/gitlens-features/#visual-file-history-pro"
+							>Learn More</a
+						>
+					</p>
+				</section>
+			</gl-feature-gate>`;
 		}
 
 		return html`<gl-feature-gate
@@ -321,14 +334,26 @@ export class GlTimelineApp extends SignalWatcherWebviewApp {
 			.source=${{ source: 'timeline' as const, detail: 'gate' }}
 			.state=${sub?.state}
 			@gl-switch-repos=${this.onSwitchRepos}
-			><p slot="feature">
-				<a href="https://help.gitkraken.com/gitlens/gitlens-features/#visual-file-history-pro"
-					>Visual File History</a
-				>
-				<gl-feature-badge></gl-feature-badge>
-				&mdash; visualize the evolution of a file and quickly identify when the most impactful changes were made
-				and by whom. Quickly see unmerged changes in files or folders, when slicing by branch.
-			</p></gl-feature-gate
+			><section slot="feature" class="feature">
+				<header class="feature__header">
+					<div class="icon-cube feature__feature-icon"><code-icon icon="gl-gitlens"></code-icon></div>
+					<hgroup>
+						<h2 class="feature__title">
+							<span>Visual History</span>
+							<gl-feature-badge></gl-feature-badge>
+						</h2>
+						<p class="feature__lede">See how any file, folder, or branch evolved &mdash; at a glance</p>
+					</hgroup>
+				</header>
+				<p>
+					Visualize the evolution of a repository, branch, folder, or file and identify when the most
+					impactful changes were made and by whom. Quickly see unmerged changes in files or folders, when
+					slicing by branch.
+					<a href="https://help.gitkraken.com/gitlens/gitlens-features/#visual-file-history-pro"
+						>Learn More</a
+					>
+				</p>
+			</section></gl-feature-gate
 		>`;
 	}
 

--- a/src/webviews/apps/shared/components/feature-gate.css.ts
+++ b/src/webviews/apps/shared/components/feature-gate.css.ts
@@ -1,0 +1,220 @@
+import { css } from 'lit';
+
+export const featureGateBaseStyles = css`
+	:host {
+		--gate-background: var(--vscode-editorWidget-background);
+		--gate-foreground: var(--vscode-editorWidget-foreground);
+		--gate-border: var(--vscode-editorWidget-border);
+		--gate-border-size: 0.2rem;
+
+		position: absolute;
+		inset: 0;
+
+		box-sizing: border-box;
+	}
+
+	::slotted(p) {
+		margin: revert !important;
+	}
+
+	::slotted(p:first-child) {
+		margin-top: 0 !important;
+	}
+
+	/* The gate renders as a native modal <dialog> promoted to the top layer (via showModal),
+			   so it covers the entire webview viewport. These rules reset the UA dialog styles. */
+	dialog {
+		--section-foreground: var(--gate-foreground);
+		--section-background: var(--gate-background);
+		--section-border-color: var(--gate-border);
+
+		--link-foreground: var(--vscode-textLink-foreground);
+		--link-foreground-active: var(--vscode-textLink-activeForeground);
+
+		position: fixed;
+		inset: 0;
+		width: 100%;
+		max-width: none;
+		height: 100%;
+		max-height: none;
+		margin: 0;
+		padding: 2.4rem 0;
+
+		display: flex;
+		flex-direction: column;
+		box-sizing: border-box;
+		overflow: hidden;
+
+		color: var(--section-foreground);
+		/* Gradient border that follows border-radius (border-image ignores radius): a transparent
+		   real border, a solid fill clipped to padding-box, and the brand gradient clipped to
+		   border-box so it only shows through the border ring. */
+		border: var(--gate-border-size) solid transparent;
+		border-radius: 1.2rem;
+		background:
+			linear-gradient(var(--section-background), var(--section-background)) padding-box,
+			var(--gl-gradient-brand) border-box;
+
+		box-shadow: 0 0 0 1px var(--section-border-color);
+	}
+
+	/* Background-painted borders are dropped in forced-colors mode — restore a solid border. */
+	@media (forced-colors: active) {
+		dialog {
+			border-color: var(--section-border-color);
+		}
+	}
+
+	dialog::backdrop {
+		background: transparent;
+		backdrop-filter: blur(3px) saturate(0.8);
+	}
+
+	.content {
+		padding-inline: 2.4rem;
+		flex: 1 1 auto;
+		min-height: 0;
+		overflow: auto;
+
+		display: flex;
+		flex-direction: column;
+	}
+
+	:host-context(body[data-placement='editor']) dialog,
+	:host([appearance='alert']) dialog {
+		--link-decoration-default: underline;
+		--link-foreground: color-mix(in srgb, var(--section-foreground) 50%, var(--vscode-textLink-foreground));
+		--link-foreground-active: color-mix(
+			in srgb,
+			var(--section-foreground) 50%,
+			var(--vscode-textLink-activeForeground)
+		);
+
+		inset: 0;
+		width: max-content;
+		max-width: 600px;
+		height: max-content;
+		max-height: calc(100% - 0.4rem);
+		margin: auto;
+	}
+
+	:host-context(body[data-placement='editor']) .content ::slotted(gl-button),
+	:host([appearance='alert']) .content ::slotted(gl-button) {
+		display: block;
+		margin-left: auto;
+		margin-right: auto;
+	}
+
+	.switch-repos {
+		position: absolute;
+		top: 0.6rem;
+		right: 0.6rem;
+		z-index: 1;
+
+		opacity: 0.6;
+	}
+
+	.switch-repos:hover,
+	.switch-repos:focus-within {
+		opacity: 1;
+	}
+`;
+
+export const featureGateContentStyles = css`
+	.icon-cube {
+		--icon-color: var(--vscode-textLink-foreground);
+		--icon-background: color-mix(in srgb, var(--icon-color) 10%, transparent);
+		--icon-size: 1.4em;
+
+		flex: none;
+		display: inline-flex;
+		align-items: center;
+		justify-content: center;
+		width: calc(var(--icon-size) * 1.6);
+		aspect-ratio: 1;
+		background: var(--icon-background);
+		border-radius: 0.6rem;
+
+		code-icon {
+			font-size: var(--icon-size);
+			color: var(--icon-color);
+		}
+	}
+
+	.feature {
+		display: flex;
+		flex-direction: column;
+		gap: 1rem;
+		margin-block-end: 1.2rem;
+		line-height: 1.5;
+		color: var(--color-foreground--65);
+	}
+
+	.feature__header {
+		display: flex;
+		align-items: flex-start;
+		gap: 1.2rem;
+	}
+
+	.feature__feature-icon {
+		/* Fixed light glyph: the brand gradient is dark in every theme, so a theme-driven foreground
+		   (near-black on light themes) would fail contrast against it. */
+		--icon-color: #fff;
+		--icon-background: var(--gl-gradient-brand);
+	}
+
+	.feature__title {
+		display: flex;
+		align-items: baseline;
+		flex-wrap: wrap;
+		gap: 0.6rem;
+		margin: 0;
+		font-size: 1.6rem;
+		font-weight: 600;
+		line-height: 1.2;
+		color: var(--color-foreground);
+	}
+
+	.feature__title gl-feature-badge {
+		margin: 0;
+		transform: translateY(-0.4rem);
+	}
+
+	.feature__lede {
+		margin: 0;
+	}
+
+	.feature__sub {
+		margin: 0;
+		font-size: 1.2rem;
+	}
+
+	.list {
+		list-style: none;
+		margin-block: 0.6rem;
+		margin-inline: 0;
+		padding-inline-start: 0;
+		display: grid;
+		grid-template-columns: repeat(2, 1fr);
+		gap: 1.6rem;
+	}
+
+	.list__item {
+		display: flex;
+		align-items: flex-start;
+		gap: 1.2rem;
+	}
+
+	.list__copy {
+		display: flex;
+		flex-direction: column;
+		gap: 0.2rem;
+		font-size: 1.1rem;
+		text-wrap: pretty;
+
+		strong {
+			font-size: 1.2rem;
+			color: var(--color-foreground);
+		}
+	}
+`;

--- a/src/webviews/apps/shared/components/feature-gate.css.ts
+++ b/src/webviews/apps/shared/components/feature-gate.css.ts
@@ -152,6 +152,7 @@ export const featureGateContentStyles = css`
 
 	.feature__header {
 		display: flex;
+		flex-direction: row;
 		align-items: flex-start;
 		gap: 1.2rem;
 	}

--- a/src/webviews/apps/shared/components/feature-gate.ts
+++ b/src/webviews/apps/shared/components/feature-gate.ts
@@ -74,7 +74,7 @@ export class GlFeatureGate extends LitElement {
 	}
 
 	override render(): unknown {
-		if (this.hidden || isSubscriptionTrialOrPaidFromState(this.state)) return undefined;
+		if (isSubscriptionTrialOrPaidFromState(this.state)) return undefined;
 
 		const appearance =
 			(this.appearance ?? (document.body.getAttribute('data-placement') ?? 'editor') === 'editor')

--- a/src/webviews/apps/shared/components/feature-gate.ts
+++ b/src/webviews/apps/shared/components/feature-gate.ts
@@ -1,10 +1,16 @@
-import { css, html, LitElement } from 'lit';
-import { customElement, property } from 'lit/decorators.js';
+import type { PropertyValues } from 'lit';
+import { html, LitElement, nothing } from 'lit';
+import { customElement, property, query } from 'lit/decorators.js';
 import type { SubscriptionState } from '../../../../constants.subscription.js';
 import type { Source } from '../../../../constants.telemetry.js';
 import type { FeaturePreview } from '../../../../features.js';
 import { isSubscriptionTrialOrPaidFromState } from '../../../../plus/gk/utils/subscription.utils.js';
 import { linkStyles } from '../../plus/shared/components/vscode.css.js';
+import { featureGateBaseStyles } from './feature-gate.css.js';
+import { focusableBaseStyles } from './styles/lit/a11y.css.js';
+import { scrollableBase } from './styles/lit/base.css.js';
+import './button.js';
+import './code-icon.js';
 import '../../plus/shared/components/feature-gate-plus-state.js';
 
 declare global {
@@ -12,93 +18,20 @@ declare global {
 		'gl-feature-gate': GlFeatureGate;
 	}
 
-	// interface GlobalEventHandlersEventMap {}
+	interface GlobalEventHandlersEventMap {
+		'gl-switch-repos': CustomEvent<void>;
+	}
 }
 
 @customElement('gl-feature-gate')
 export class GlFeatureGate extends LitElement {
-	static override styles = [
-		linkStyles,
-		css`
-			:host {
-				--background: var(--vscode-sideBar-background);
-				--foreground: var(--vscode-sideBar-foreground);
+	static override styles = [focusableBaseStyles, linkStyles, scrollableBase, featureGateBaseStyles];
 
-				position: absolute;
-				top: 0;
-				left: 0;
-				bottom: 0;
-				right: 0;
-				overflow: auto;
-				z-index: 1050;
+	@query('dialog')
+	private readonly dialogEl!: HTMLDialogElement | null;
 
-				box-sizing: border-box;
-			}
-
-			:host-context(body[data-placement='editor']),
-			:host([appearance='alert']) {
-				--background: transparent;
-				--foreground: var(--vscode-editor-foreground);
-
-				backdrop-filter: blur(3px) saturate(0.8);
-				padding: 0 2rem;
-			}
-
-			::slotted(p) {
-				margin: revert !important;
-			}
-
-			::slotted(p:first-child) {
-				margin-top: 0 !important;
-			}
-
-			section {
-				--section-foreground: var(--foreground);
-				--section-background: var(--background);
-				--section-border-color: transparent;
-
-				--link-foreground: var(--vscode-textLink-foreground);
-				--link-foreground-active: var(--vscode-textLink-activeForeground);
-
-				display: flex;
-				flex-direction: column;
-				padding: 0 2rem 1.3rem 2rem;
-				background: var(--section-background);
-				color: var(--section-foreground);
-				border: 1px solid var(--section-border-color);
-
-				height: min-content;
-			}
-
-			:host-context(body[data-placement='editor']) section,
-			:host([appearance='alert']) section {
-				--section-foreground: var(--color-alert-infoForeground);
-				--section-background: var(--color-alert-infoBackground);
-				--section-border-color: var(--color-alert-infoBorder);
-
-				--link-decoration-default: underline;
-				--link-foreground: color-mix(in srgb, var(--section-foreground) 50%, var(--vscode-textLink-foreground));
-				--link-foreground-active: color-mix(
-					in srgb,
-					var(--section-foreground) 50%,
-					var(--vscode-textLink-activeForeground)
-				);
-
-				border-radius: 0.3rem;
-				max-width: 600px;
-				max-height: min-content;
-				margin: 0.2rem auto;
-				padding: 1.3rem;
-			}
-
-			:host-context(body[data-placement='editor']) section ::slotted(gl-button),
-			:host([appearance='alert']) section ::slotted(gl-button) {
-				display: block;
-				margin-left: auto;
-				margin-right: auto;
-			}
-		`,
-	];
+	@property({ type: Boolean })
+	allowRepoSwitch = false;
 
 	@property({ reflect: true })
 	appearance?: 'alert' | 'default';
@@ -124,6 +57,22 @@ export class GlFeatureGate extends LitElement {
 	@property({ type: String })
 	webroot?: string;
 
+	override disconnectedCallback(): void {
+		// Defensively tear down the modal so an unmounted gate can never leave a stuck top-layer backdrop.
+		this.dialogEl?.close();
+		super.disconnectedCallback?.();
+	}
+
+	protected override updated(_changedProperties: PropertyValues): void {
+		// Promote the dialog into the top layer once it's rendered. Consumers mount the gate only while it
+		// should show, so the dialog opens here on mount; unmounting (or a Pro-state re-render that returns
+		// nothing) removes it from the DOM, which tears the modal back down.
+		const dialog = this.dialogEl;
+		if (dialog != null && !dialog.open) {
+			dialog.showModal();
+		}
+	}
+
 	override render(): unknown {
 		if (this.hidden || isSubscriptionTrialOrPaidFromState(this.state)) return undefined;
 
@@ -133,21 +82,53 @@ export class GlFeatureGate extends LitElement {
 				: 'default';
 
 		return html`
-			<section part="section">
-				<slot></slot>
-				<gl-feature-gate-plus-state
-					appearance=${appearance}
-					.featurePreview=${this.featurePreview}
-					.featurePreviewCommandLink=${this.featurePreviewCommandLink}
-					.featureRestriction=${this.featureRestriction}
-					.featureWithArticleIfNeeded=${this.featureWithArticleIfNeeded}
-					.source=${this.source}
-					.state=${this.state}
-					.webroot=${this.webroot}
-				>
-					<slot name="feature" slot="feature"></slot>
-				</gl-feature-gate-plus-state>
-			</section>
+			<dialog part="section" @cancel=${this.onCancel} @keydown=${this.onKeydown}>
+				<div class="content scrollable">
+					<slot></slot>
+					<gl-feature-gate-plus-state
+						appearance=${appearance}
+						.featurePreview=${this.featurePreview}
+						.featurePreviewCommandLink=${this.featurePreviewCommandLink}
+						.featureRestriction=${this.featureRestriction}
+						.featureWithArticleIfNeeded=${this.featureWithArticleIfNeeded}
+						.source=${this.source}
+						.state=${this.state}
+						.webroot=${this.webroot}
+					>
+						<slot name="feature" slot="feature"></slot>
+					</gl-feature-gate-plus-state>
+				</div>
+				${this.allowRepoSwitch
+					? html`<gl-button
+							class="switch-repos"
+							appearance="toolbar"
+							tooltip="Switch to a different repository"
+							@click=${this.onSwitchRepos}
+							><code-icon icon="gl-switch" slot="prefix"></code-icon> Switch Repos</gl-button
+						>`
+					: nothing}
+			</dialog>
 		`;
+	}
+
+	private onKeydown(e: KeyboardEvent): void {
+		// The gate is a hard access block, so Escape must not dismiss it. The `cancel` handler below
+		// isn't enough on its own: the gate opens via showModal() with no user gesture, which makes it a
+		// Chromium "free" close watcher — Escape closes it and cancel's preventDefault() is ignored (an
+		// anti-abuse measure against un-dismissable dialogs). Preventing the Escape keydown's default
+		// stops the close request from ever being generated, which holds regardless of user activation.
+		if (e.key === 'Escape') {
+			e.preventDefault();
+		}
+	}
+
+	private onCancel(e: Event): void {
+		// Defense-in-depth for non-keyboard close requests (e.g. a system back gesture) — only effective
+		// when the dialog has user activation; the keyboard path is handled in onKeydown above.
+		e.preventDefault();
+	}
+
+	private onSwitchRepos(): void {
+		this.dispatchEvent(new CustomEvent('gl-switch-repos', { bubbles: true, composed: true }));
 	}
 }

--- a/src/webviews/apps/shared/styles/theme.scss
+++ b/src/webviews/apps/shared/styles/theme.scss
@@ -10,6 +10,9 @@
 	--editor-font-size: var(--vscode-editor-font-size);
 	--editor-font-weight: var(--vscode-editor-font-weight);
 
+	// Brand accent gradient (GitKraken purple → blue) — Pro feature gates, promos, etc.
+	--gl-gradient-brand: linear-gradient(to right, #7900c9, #196fff);
+
 	--color-background: var(--vscode-editor-background);
 	// Computed variants in code
 	--color-background--lighten-05: color-mix(in srgb, #fff 5%, var(--color-background));

--- a/src/webviews/plus/graph/graphWebview.ts
+++ b/src/webviews/plus/graph/graphWebview.ts
@@ -7818,6 +7818,13 @@ export class GraphWebviewProvider implements WebviewProvider<State, State, Graph
 
 		const graphWalkthroughBanner = this.getGraphWalkthroughBannerState();
 
+		// `mixed` means the workspace has both public and private repos — so a gated (private) repo can
+		// offer switching to a public one. Only computed when access is denied (the only time the gate, and
+		// thus the switch affordance, is shown) to avoid an aggregate visibility() scan on the common
+		// allowed path. The result is cached on the provider.
+		const allowed = this.isGraphAccessAllowed(access, featurePreview);
+		const allowRepoSwitch = allowed === false ? (await this.container.git.visibility()) === 'mixed' : false;
+
 		const result: State = {
 			...this.host.baseWebviewState,
 			webroot: this.host.getWebRoot(),
@@ -7841,7 +7848,8 @@ export class GraphWebviewProvider implements WebviewProvider<State, State, Graph
 			lastFetched: new Date(getSettledValue(lastFetchedResult)!),
 			selectedRows: convertSelectedRows(this._selectedRows),
 			subscription: access?.subscription.current,
-			allowed: this.isGraphAccessAllowed(access, featurePreview), //(access?.allowed ?? false) !== false,
+			allowed: allowed,
+			allowRepoSwitch: allowRepoSwitch,
 			avatars: data != null ? Object.fromEntries(data.avatars) : undefined,
 			refsMetadata: this.resetRefsMetadata() === null ? null : {},
 			loading: deferRows === true,

--- a/src/webviews/plus/graph/protocol.ts
+++ b/src/webviews/plus/graph/protocol.ts
@@ -244,6 +244,9 @@ export interface State extends WebviewState<'gitlens.graph' | 'gitlens.views.gra
 	selectedRows?: GraphSelectedRows;
 	subscription?: Subscription;
 	allowed: boolean;
+	/** True when the workspace has both public and private repos, so a gated (private) repo can offer
+	 *  switching to a public one. Independent of `allowed` — the gate only surfaces it when shown. */
+	allowRepoSwitch?: boolean;
 	avatars?: GraphAvatars;
 	loading?: boolean;
 	refsMetadata?: GraphRefsMetadata | null;

--- a/src/webviews/plus/timeline/protocol.ts
+++ b/src/webviews/plus/timeline/protocol.ts
@@ -150,6 +150,9 @@ export interface TimelineDatasetResult {
 	repository: (RepositoryShape & { ref: GitReference | undefined }) | undefined;
 	/** Feature access for the scope's repo. */
 	access: FeatureAccess;
+	/** True when the workspace has both public and private repos, so a gated (private) scope can offer
+	 *  switching to a public repo. Independent of `access.allowed` — the gate only surfaces it when shown. */
+	allowRepoSwitch?: boolean;
 }
 
 /** View-specific service for Timeline operations. */

--- a/src/webviews/plus/timeline/timelineWebview.ts
+++ b/src/webviews/plus/timeline/timelineWebview.ts
@@ -402,11 +402,19 @@ export class TimelineWebviewProvider implements WebviewProvider<State, State, Ti
 			this.updateViewTitle(scope, repo);
 		}
 
+		// `mixed` means the workspace has both public and private repos — so a gated (private) scope can
+		// offer switching to a public one. Only computed when access is denied (the only time the gate, and
+		// thus the switch affordance, is shown) to avoid an aggregate visibility() scan on every (allowed)
+		// dataset fetch, including each load-more. The result is cached on the provider.
+		const allowRepoSwitch =
+			result.access.allowed === false ? (await this.container.git.visibility()) === 'mixed' : false;
+
 		return {
 			dataset: result.dataset,
 			scope: result.scope,
 			repository: result.repository,
 			access: result.access,
+			allowRepoSwitch: allowRepoSwitch,
 		};
 	}
 


### PR DESCRIPTION
Closes #5335

### Summary

Reworks the Pro feature gates — the access blocks shown when a Pro feature (Commit Graph, Visual History) is opened on a private repo without a paid or trial subscription — to render as native top-layer `<dialog>` modals instead of absolutely-positioned overlays. Adds a **Switch Repos** affordance so a user blocked on a private repo can jump to a public one (where the feature is free), and refreshes the gate content with a shared, modern layout.

### What changed

**Native `<dialog>` conversion** (shared `gl-feature-gate`)

- Converts the gate from an absolutely-positioned `<section>` overlay to a native `<dialog>` opened via `showModal()` and promoted into the browser's top layer, with a blurred backdrop and a brand-gradient border.
- Because the gate is a _hard access block_, Escape and cancel close requests are trapped so it can't be dismissed. (Escape is handled at the `keydown` level because a `showModal()` dialog opened without a user gesture is a Chromium "free" close watcher, where `cancel`'s `preventDefault()` is ignored.)
- Defensively tears the modal down on disconnect so an unmounted gate can never leave a stuck top-layer backdrop.

**Switch Repos affordance**

- New `allowRepoSwitch` property and `gl-switch-repos` event on the shared gate.
- The host computes `allowRepoSwitch` from Git visibility (`mixed` = the workspace has both public and private repos) — and only when access is denied, to avoid an aggregate visibility scan on the common allowed path (including every Timeline load-more).
- Commit Graph wires the switch to `ChooseRepositoryCommand`; Visual History wires it to `pickAndNavigateRepo()`.

**Redesigned gate content**

- New shared `featureGateContentStyles` (header icon cube, two-column feature grid, brand-gradient feature icon) and a `--gl-gradient-brand` theme token (GitKraken purple → blue) for Pro gates and promos.
- **Commit Graph:** restyled header and feature grid; fixed the Pro badge `.subscription` binding, which was passing the literal string `"{subscription}"` instead of the actual subscription.
- **Visual History:** redesigned with a header, lede, and "Learn More" link; the gate now mounts only while access is denied so mount/unmount cleanly drives the modal's open/teardown (matching the Commit Graph gate).

**Button alignment fix**

- The verification-required state put a text button ("Resend Email") next to an icon-only button in a centered paragraph, where mismatched baselines kept them from lining up. Switched the row to a center-aligned flex container so the equal-height buttons align regardless of content, and dropped the now-redundant `appearance` passthrough to the Pro-state buttons.

### Accessibility

- Background-painted gradient borders are dropped in `forced-colors` mode, so a solid border is restored there.
- The feature icon uses a fixed light glyph against the always-dark brand gradient to preserve contrast across themes.

### Screenshots

| Before | After |
| --- | --- |
|  <img width="1133" height="1193" alt="Screenshot 2026-06-05 at 2 36 04 PM" src="https://github.com/user-attachments/assets/47cd3a08-e2cb-43ca-b161-3aa7ddb6728f" /> | <img width="1133" height="1226" alt="Screenshot 2026-06-09 at 11 37 11 AM" src="https://github.com/user-attachments/assets/5686fa0c-f165-4390-a35e-7a122bbba88f" /> |



