### PR TITLE
Actualizes Commit Graph smoke E2E tests for the current panel UI

### DIFF
--- a/tests/e2e/pageObjects/gitLensPage.ts
+++ b/tests/e2e/pageObjects/gitLensPage.ts
@@ -201,8 +201,12 @@ export class GitLensPage extends VSCodePage {
 
 	/** Commit Graph tab in the panel */
 	get commitGraphViewSection(): Locator {
-		// The Graph view shows as a tab in the panel with text content "Graph"
-		return this.panel.locator.locator('text=Graph').first();
+		// When the Commit Graph view is open, its panel toolbar is labelled
+		// "GitLens: Commit Graph: <repo> actions" and stays visible in both the gated (Community)
+		// and loaded (Pro) states. Match that toolbar by accessible name — the panel title <h2>
+		// itself is sr-hidden, and a bare "Graph" text match resolved to the hidden generic
+		// "GitLens: Graph" header.
+		return this.panel.locator.getByRole('toolbar', { name: /Commit Graph/ }).first();
 	}
 
 	/** Commit Graph webview in the panel */

--- a/tests/e2e/pageObjects/gitLensPage.ts
+++ b/tests/e2e/pageObjects/gitLensPage.ts
@@ -199,7 +199,7 @@ export class GitLensPage extends VSCodePage {
 		return this.panel.getTab('GitLens', true);
 	}
 
-	/** Commit Graph tab in the panel */
+	/** Commit Graph view section in the panel (matched via its panel toolbar) */
 	get commitGraphViewSection(): Locator {
 		// When the Commit Graph view is open, its panel toolbar is labelled
 		// "GitLens: Commit Graph: <repo> actions" and stays visible in both the gated (Community)

--- a/tests/e2e/specs/smoke.test.ts
+++ b/tests/e2e/specs/smoke.test.ts
@@ -334,8 +334,7 @@ test.describe('Smoke Tests — Commit Graph view', () => {
 		const graphWebview = await vscode.gitlens.getGitLensWebview('Graph', 'webviewView', 30000);
 		expect(graphWebview).not.toBeNull();
 		// Graph may take longer to load and render
-		await expect(graphWebview!.getByText('BRANCH / TAG').first()).toBeVisible({ timeout: 30000 });
-		await expect(graphWebview!.getByText('COMMIT MESSAGE').first()).toBeVisible({ timeout: MaxTimeout });
+		await expect(graphWebview!.getByText('BRANCH / TAG').first()).toBeVisible({ timeout: MaxTimeout });
 
 		// Verify that the Pro gate is NOT visible
 		const featureGate = graphWebview!.locator('gl-feature-gate:not([hidden])');


### PR DESCRIPTION
# Description

Fixes the two Commit Graph smoke E2E tests (`tests/e2e/specs/smoke.test.ts`) that were red on `main`. Test-only — no product code touched (diff is limited to `tests/e2e/`).

**Root cause (confirmed via live DOM inspection):** the `commitGraphViewSection` page-object locator matched a bare `text=Graph`, which resolved to the hidden generic `GitLens: Graph` header. The visible panel title is now `GitLens: Commit Graph: <repo>` and its `<h2>` is sr-hidden, so the locator never found a visible element and test 305 failed before reaching its gate assertion.

**Changes:**

- `commitGraphViewSection` → `getByRole('toolbar', { name: /Commit Graph/ })`. The panel toolbar (labelled `GitLens: Commit Graph: <repo> actions`) is visible in both the gated (Community) and loaded (Pro) states, unlike the sr-hidden title `<h2>`.
- Dropped the obsolete `COMMIT MESSAGE` readiness wait in the Pro test — the `BRANCH / TAG` wait above already covers render-readiness (`@gitkraken/gitkraken-components` renamed the column).

**Note:** the Community gate assertion is unchanged and remains valid — live inspection confirms the in-webview `gl-feature-gate` (+ `Continue`) is still shown for the community state, i.e. #5335's native-dialog work did not remove the in-webview gate here.

**Verification (VS Code 1.124.0):** full `smoke.test.ts` — **13 passed**. (Test 322 flaked once on a transient `TypeError: fetch failed` during the Pro subscription simulation — environmental/network; passes in isolation and combined.)

# Checklist

- [x] My changes follow the coding style of this project
- [x] My changes have been formatted and linted
- [x] My changes have been rebased and squashed to a single commit
- [ ] CHANGELOG/README — not applicable (internal E2E test maintenance)