### PR TITLE
Actualizes Stash Push E2E test for the reversed wizard order

### DIFF
--- a/tests/e2e/specs/quickWizard.test.ts
+++ b/tests/e2e/specs/quickWizard.test.ts
@@ -608,27 +608,30 @@ test.describe('Quick Wizard — Tag Commands', () => {
 
 test.describe('Quick Wizard — Stash Commands', () => {
 	test.describe('Stash Push Flow', () => {
-		test('Complete flow: command → subcommand → message & reverse', async ({
+		test('Complete flow: command → subcommand → confirm → message & reverse', async ({
 			vscode,
 			vscode: {
 				gitlens: { quickPick },
 			},
 		}) => {
+			// The push wizard was reversed (commit "Reverses the stash push wizard"): the confirm
+			// step now precedes the message input to avoid back-navigation loops with confirm overrides.
 			await selectCommandSubcommandAndWaitForStepWithOptionalRepo(vscode, 'stash', 'push', {
-				title: /Push Stash/i,
-				placeholder: /Stash message/i,
+				title: /Confirm Push Stash/i,
+				placeholder: /Confirm Push Stash/i,
 			});
 
-			// Enter a stash message
-			await quickPick.enterTextAndSubmit('Test stash message');
+			// Select the default "Push Stash" confirmation option (first item)
+			await quickPick.selectItem(/Push Stash/i);
 
-			// Confirm step
-			await quickPick.waitForStep({ title: /Confirm Push Stash/i });
+			// Message step (placeholder distinguishes it from the still-matching "Confirm Push Stash" title)
+			await quickPick.waitForStep({ title: /Push Stash/i, placeholder: /Stash message/i });
 
 			// === REVERSE NAVIGATION ===
+			// Do not submit a message — submitting would execute the stash. Navigate back instead.
 
-			// Back from confirm → message
-			await quickPick.goBackAndWaitForStep({ title: /Push Stash/i, placeholder: /Stash message/i });
+			// Back from message → confirm
+			await quickPick.goBackAndWaitForStep({ title: /Confirm Push Stash/i, placeholder: /Confirm Push Stash/i });
 
 			await reverseCommandSubcommandAndRepo(vscode, 'stash');
 

--- a/tests/e2e/specs/quickWizard.test.ts
+++ b/tests/e2e/specs/quickWizard.test.ts
@@ -616,13 +616,18 @@ test.describe('Quick Wizard — Stash Commands', () => {
 		}) => {
 			// The push wizard was reversed (commit "Reverses the stash push wizard"): the confirm
 			// step now precedes the message input to avoid back-navigation loops with confirm overrides.
+			// The confirm step shows because launching via the menu (`gitlens.gitCommands`, no args) makes
+			// `startedFrom === 'menu'`, so the skip key is `stash-push:menu` — not the default-skipped
+			// `stash-push:command`. If `stash-push:menu` is ever added to `gitCommands.skipConfirmations`,
+			// the confirm step vanishes and this test would time out on the (now-absent) confirm step.
 			await selectCommandSubcommandAndWaitForStepWithOptionalRepo(vscode, 'stash', 'push', {
 				title: /Confirm Push Stash/i,
 				placeholder: /Confirm Push Stash/i,
 			});
 
-			// Select the default "Push Stash" confirmation option (first item)
-			await quickPick.selectItem(/Push Stash/i);
+			// Select the plain "Push Stash" confirmation option (negative lookahead excludes the
+			// "Snapshot" / "& …" variants, so this is order-independent rather than relying on `.first()`)
+			await quickPick.selectItem(/Push Stash(?! Snapshot| &)/);
 
 			// Message step (placeholder distinguishes it from the still-matching "Confirm Push Stash" title)
 			await quickPick.waitForStep({ title: /Push Stash/i, placeholder: /Stash message/i });


### PR DESCRIPTION
## Summary

Fixes the long-failing `Stash Push Flow` E2E test (`quickWizard.test.ts:611`).

The Stash Push test was failing with `None of the expected steps found` — it timed out waiting for the message-input step that never appeared first.

### Root cause (not a product bug)

The stash push wizard was **intentionally reversed** in commit `ed34a9fbd` *"Reverses the stash push wizard"* — the **confirm** step now precedes the **message** input, to prevent back-navigation loops where confirm overrides would trap users. The E2E test still assumed the old `message → confirm` order.

### Fix

Updates the test to the current order:
1. Reach the **Confirm Push Stash** step first.
2. Select the plain `Push Stash` confirmation option (order-independent selector that excludes the "Snapshot"/"& …" variants).
3. Assert the **message** step (placeholder `Stash message` distinguishes it from the still-matching `Confirm Push Stash` title).
4. Reverse-navigate back **without submitting** a message — submitting would execute the stash.

Also documents why the confirm step appears at all: launching via the menu yields `startedFrom === 'menu'`, so the skip key is `stash-push:menu` rather than the default-skipped `stash-push:command`.

### Verification

- `Stash Push Flow` — ✅ green (4.x s)
- Full `Stash Commands` block — **7/7 passed** (no neighbouring flow regressed)
- ESLint clean on the changed file

🤖 Generated with [Claude Code](https://claude.com/claude-code)