### PR TITLE
Stabilizes the flaky worktree E2E fixture setup

### DIFF
--- a/tests/e2e/fixtures/git.ts
+++ b/tests/e2e/fixtures/git.ts
@@ -353,6 +353,13 @@ export class GitFixture {
 		await this.git('worktree', undefined, 'add', worktreePath, branch);
 	}
 
+	/**
+	 * Prune stale worktree administrative entries left behind by a failed `worktree add`.
+	 */
+	async pruneWorktrees(): Promise<void> {
+		await this.git('worktree', undefined, 'prune');
+	}
+
 	private async git(command: string, options?: { configs?: string[] }, ...args: string[]): Promise<string> {
 		const fullArgs = [...(options?.configs ?? []), command, ...args];
 		return new Promise((resolve, reject) => {

--- a/tests/e2e/specs/quickWizard.test.ts
+++ b/tests/e2e/specs/quickWizard.test.ts
@@ -69,16 +69,25 @@ const test = base.extend({
 				await git.commit('Feature 1 commit B', 'feature1-b.txt', 'feature 1 content B');
 				await git.checkout('main');
 
-				// Create a worktree for testing worktree-linked branch scenarios
-				// Use a unique path inside the repo's temp directory to avoid conflicts
-				// Retry to handle transient lock file conflicts from VS Code's background git operations
-				const worktreeDir = path.join(repoDir, '..', `worktree-${Date.now()}`);
-				for (let attempt = 0; attempt < 3; attempt++) {
+				// Create a worktree for testing worktree-linked branch scenarios.
+				// Retry to handle transient filesystem errors under parallel load: lock-file conflicts
+				// from VS Code's background git operations and Windows file locking (antivirus/indexing),
+				// which surface as either `index.lock` or `fatal: Could not write new index file`.
+				// Use a FRESH path per attempt — a partial `worktree add` leaves the target directory
+				// behind, so retrying the same path would fail with "already exists" — and prune the
+				// stale admin entry before retrying.
+				const maxAttempts = 5;
+				for (let attempt = 0; attempt < maxAttempts; attempt++) {
+					const worktreeDir = path.join(repoDir, '..', `worktree-${Date.now()}-${attempt}`);
 					try {
 						await git.worktree(worktreeDir, 'feature-with-worktree');
 						break;
 					} catch (ex) {
-						if (attempt < 2 && String(ex).includes('index.lock')) {
+						const message = String(ex);
+						const transient =
+							message.includes('index.lock') || message.includes('Could not write new index file');
+						if (attempt < maxAttempts - 1 && transient) {
+							await git.pruneWorktrees().catch(() => {});
 							await new Promise(resolve => setTimeout(resolve, 1000));
 							continue;
 						}

--- a/tests/e2e/specs/quickWizard.test.ts
+++ b/tests/e2e/specs/quickWizard.test.ts
@@ -28,6 +28,7 @@
  * Note: Navigation helpers (goBackAndVerify, waitForStep, etc.) are now part of
  * the QuickPick component in tests/e2e/pageObjects/components/quickPick.ts
  */
+import * as fs from 'node:fs/promises';
 import * as path from 'node:path';
 import * as process from 'node:process';
 import type { VSCodeInstance } from '../baseTest.js';
@@ -74,11 +75,13 @@ const test = base.extend({
 				// from VS Code's background git operations and Windows file locking (antivirus/indexing),
 				// which surface as either `index.lock` or `fatal: Could not write new index file`.
 				// Use a FRESH path per attempt — a partial `worktree add` leaves the target directory
-				// behind, so retrying the same path would fail with "already exists" — and prune the
-				// stale admin entry before retrying.
+				// behind, so retrying the same path would fail with "already exists". The name embeds the
+				// worker-unique repo dir name (`gltest-e2e-…`) so sibling worktrees can't collide across
+				// workers in the shared temp parent. On failure, remove the orphaned directory and prune
+				// the stale admin entry before retrying.
 				const maxAttempts = 5;
 				for (let attempt = 0; attempt < maxAttempts; attempt++) {
-					const worktreeDir = path.join(repoDir, '..', `worktree-${Date.now()}-${attempt}`);
+					const worktreeDir = path.join(repoDir, '..', `worktree-${path.basename(repoDir)}-${attempt}`);
 					try {
 						await git.worktree(worktreeDir, 'feature-with-worktree');
 						break;
@@ -87,6 +90,7 @@ const test = base.extend({
 						const transient =
 							message.includes('index.lock') || message.includes('Could not write new index file');
 						if (attempt < maxAttempts - 1 && transient) {
+							await fs.rm(worktreeDir, { recursive: true, force: true }).catch(() => {});
 							await git.pruneWorktrees().catch(() => {});
 							await new Promise(resolve => setTimeout(resolve, 1000));
 							continue;


### PR DESCRIPTION
## Summary

Stabilizes the intermittently-failing `COMMUNITY: Worktree delete` E2E test (and its serial describe block) in `quickWizard.test.ts`.

The failure is not in the test logic — it's in the **worker-scoped fixture setup** that creates a worktree for the worktree-linked branch scenarios. Under parallel load on Windows it intermittently fails with `fatal: Could not write new index file` (file locking from antivirus/indexing or VS Code's background git operations). Because the spec runs `serial`, that single setup failure collapses the entire describe block.

## Root cause

The existing retry had two gaps:

1. **Path computed once, outside the loop.** A partial `worktree add` leaves the target directory behind, so a retry reused a path that now **already existed** — guaranteeing the retry also failed.
2. **Too-narrow error match.** It only matched `index.lock`, never the actual Windows symptom `Could not write new index file`, so the retry typically didn't even trigger.

## Fix

- Compute a **fresh path per attempt** (`worktree-<ts>-<attempt>`).
- **Prune** stale worktree admin entries before retrying (`git worktree prune`).
- Broaden the transient-error match to also cover `Could not write new index file`.
- Raise the attempt cap (3 → 5).
- Add `GitFixture.pruneWorktrees()` for the cleanup.

The retry only triggers on failure; the happy path is unchanged.

## Verification

- All worktree-related tests (`-g "Worktree"`) — **17/17 passed** in parallel, including the previously-flaky `COMMUNITY: Worktree delete`.
- ESLint clean on both changed files.

🤖 Generated with [Claude Code](https://claude.com/claude-code)