### PR TITLE
AI conflict resolution follow-ups

### DIFF
--- a/packages/plus/ai/src/models/provider.ts
+++ b/packages/plus/ai/src/models/provider.ts
@@ -47,6 +47,12 @@ export interface AIProvider<Provider extends AIProviders = AIProviders> extends 
 		model: AIModel<Provider>,
 		apiKey: string,
 		getMessages: (maxInputTokens: number, retries: number) => Promise<AIChatMessage[]>,
-		options: { signal: AbortSignal; modelOptions?: { outputTokens?: number; temperature?: number } },
+		options: {
+			signal: AbortSignal;
+			modelOptions?: { outputTokens?: number; temperature?: number };
+			/** Opaque session ID the GitKraken provider sends as `GK-Conversation-ID` so the backend
+			 *  charges its per-feature fee once per session; ignored by all other providers. */
+			conversationId?: string;
+		},
 	): Promise<AIProviderResponse<void> | undefined>;
 }

--- a/packages/plus/ai/src/providers/__tests__/gitkrakenProvider.test.ts
+++ b/packages/plus/ai/src/providers/__tests__/gitkrakenProvider.test.ts
@@ -1,0 +1,68 @@
+import * as assert from 'assert';
+import { gitKrakenProviderDescriptor } from '../../constants.js';
+import type { AIModel } from '../../models/model.js';
+import type { AIProviderContext } from '../context.js';
+import { GitKrakenProvider } from '../gitkrakenProvider.js';
+import { OpenAICompatibleProviderBase } from '../openAICompatibleProviderBase.js';
+
+const context: AIProviderContext = {
+	fetch: () => Promise.reject(new Error('not used by getHeaders')),
+	getApiKey: () => Promise.resolve(undefined),
+	getProviderConfig: () => ({ enabled: true }),
+	getOrPromptUrl: () => Promise.resolve(undefined),
+};
+
+const model: AIModel<typeof gitKrakenProviderDescriptor.id> = {
+	id: 'test-model',
+	name: 'Test Model',
+	maxTokens: { input: 1024, output: undefined },
+	provider: { id: gitKrakenProviderDescriptor.id, name: gitKrakenProviderDescriptor.name },
+};
+
+class TestGitKrakenProvider extends GitKrakenProvider {
+	headers(conversationId?: string): Record<string, string> {
+		return this.getHeaders('conflict-resolution', 'test-token', model, 'chat/completions', conversationId);
+	}
+}
+
+class TestBaseProvider extends OpenAICompatibleProviderBase<typeof gitKrakenProviderDescriptor.id> {
+	readonly id = gitKrakenProviderDescriptor.id;
+	readonly name = 'Test Base';
+	protected readonly descriptor = gitKrakenProviderDescriptor;
+	protected readonly config = {};
+
+	getModels(): Promise<readonly AIModel<typeof gitKrakenProviderDescriptor.id>[]> {
+		return Promise.resolve([]);
+	}
+
+	protected getUrl(_model: AIModel<typeof gitKrakenProviderDescriptor.id>): string | undefined {
+		return undefined;
+	}
+
+	headers(conversationId?: string): Record<string, string> | Promise<Record<string, string>> {
+		return this.getHeaders('conflict-resolution', 'test-token', model, 'https://example.com', conversationId);
+	}
+}
+
+suite('GitKrakenProvider getHeaders', () => {
+	test('includes GK-Conversation-ID when a conversation ID is provided', () => {
+		const headers = new TestGitKrakenProvider(context).headers('11111111-2222-3333-4444-555555555555');
+		assert.strictEqual(headers['GK-Conversation-ID'], '11111111-2222-3333-4444-555555555555');
+		assert.strictEqual(headers['GK-Action'], 'conflict-resolution');
+		assert.strictEqual(headers.Authorization, 'Bearer test-token');
+	});
+
+	test('omits GK-Conversation-ID when no conversation ID is provided', () => {
+		const headers = new TestGitKrakenProvider(context).headers();
+		assert.strictEqual('GK-Conversation-ID' in headers, false);
+		assert.strictEqual(headers['GK-Action'], 'conflict-resolution');
+	});
+});
+
+suite('OpenAICompatibleProviderBase getHeaders', () => {
+	test('never emits GK-Conversation-ID — the ID must not reach third-party APIs', async () => {
+		const headers = await new TestBaseProvider(context).headers('11111111-2222-3333-4444-555555555555');
+		assert.strictEqual('GK-Conversation-ID' in headers, false);
+		assert.strictEqual(headers.Authorization, 'Bearer test-token');
+	});
+});

--- a/packages/plus/ai/src/providers/gitkrakenProvider.ts
+++ b/packages/plus/ai/src/providers/gitkrakenProvider.ts
@@ -87,11 +87,15 @@ export class GitKrakenProvider extends OpenAICompatibleProviderBase<typeof provi
 		apiKey: string,
 		_model: AIModel<typeof provider.id>,
 		_url: string,
+		conversationId?: string,
 	): Record<string, string> {
 		return {
 			Accept: 'application/json',
 			Authorization: `Bearer ${apiKey}`,
 			'GK-Action': action,
+			// Scopes the backend's once-per-conversation feature fee — without it every request in a
+			// multi-call session (e.g. conflict resolution) is charged the full flat fee.
+			...(conversationId ? { 'GK-Conversation-ID': conversationId } : {}),
 		};
 	}
 

--- a/packages/plus/ai/src/providers/openAICompatibleProviderBase.ts
+++ b/packages/plus/ai/src/providers/openAICompatibleProviderBase.ts
@@ -61,6 +61,9 @@ export abstract class OpenAICompatibleProviderBase<T extends AIProviders> implem
 		apiKey: string,
 		_model: AIModel<T>,
 		_url: string,
+		// Deliberately unused here: only the GitKraken provider forwards the conversation ID (as
+		// `GK-Conversation-ID`); it must never reach third-party APIs.
+		_conversationId?: string,
 	): Record<string, string> | Promise<Record<string, string>> {
 		return {
 			Accept: 'application/json',
@@ -74,12 +77,24 @@ export abstract class OpenAICompatibleProviderBase<T extends AIProviders> implem
 		model: AIModel<T>,
 		apiKey: string,
 		getMessages: (maxInputTokens: number, retries: number) => Promise<AIChatMessage[]>,
-		options: { signal: AbortSignal; modelOptions?: { outputTokens?: number; temperature?: number } },
+		options: {
+			signal: AbortSignal;
+			modelOptions?: { outputTokens?: number; temperature?: number };
+			conversationId?: string;
+		},
 	): Promise<AIProviderResponse<void> | undefined> {
 		using scope = maybeStartScopedLogger(`${getLoggableName(this)}.sendRequest`);
 
 		try {
-			const result = await this.fetch(action, model, apiKey, getMessages, options.modelOptions, options.signal);
+			const result = await this.fetch(
+				action,
+				model,
+				apiKey,
+				getMessages,
+				options.modelOptions,
+				options.signal,
+				options.conversationId,
+			);
 			return result;
 		} catch (ex) {
 			if (isCancellationError(ex)) {
@@ -104,6 +119,7 @@ export abstract class OpenAICompatibleProviderBase<T extends AIProviders> implem
 		messages: (maxInputTokens: number, retries: number) => Promise<AIChatMessage[]>,
 		modelOptions?: { outputTokens?: number; temperature?: number },
 		signal?: AbortSignal,
+		conversationId?: string,
 	): Promise<AIProviderResponse<void>> {
 		let retries = 0;
 		let maxInputTokens = model.maxTokens.input;
@@ -123,7 +139,7 @@ export abstract class OpenAICompatibleProviderBase<T extends AIProviders> implem
 				),
 			};
 
-			const rsp = await this.fetchCore(action, model, apiKey, request, signal);
+			const rsp = await this.fetchCore(action, model, apiKey, request, signal, conversationId);
 			if (!rsp.ok) {
 				const result = await this.handleFetchFailure(rsp, action, model, retries, maxInputTokens);
 				if (result.retry) {
@@ -207,6 +223,7 @@ export abstract class OpenAICompatibleProviderBase<T extends AIProviders> implem
 		apiKey: string,
 		request: object,
 		signal: AbortSignal | undefined,
+		conversationId?: string,
 	): Promise<Response> {
 		const url = this.getUrl(model);
 		if (!url) {
@@ -215,7 +232,7 @@ export abstract class OpenAICompatibleProviderBase<T extends AIProviders> implem
 
 		try {
 			return await this.context.fetch(url, {
-				headers: await this.getHeaders(action, apiKey, model, url),
+				headers: await this.getHeaders(action, apiKey, model, url, conversationId),
 				method: 'POST',
 				body: JSON.stringify(request),
 				signal: signal,

--- a/src/plus/ai/aiProviderService.ts
+++ b/src/plus/ai/aiProviderService.ts
@@ -91,6 +91,8 @@ import {
 } from './utils/-webview/ai.utils.js';
 import type { ResolvePromptOptions } from './utils/-webview/prompt.utils.js';
 import { getLocalPromptTemplate, resolvePrompt } from './utils/-webview/prompt.utils.js';
+import type { BYOKUsage } from './utils/byokUsage.utils.js';
+import { aggregateBYOKUsage } from './utils/byokUsage.utils.js';
 
 export interface AIResponse<T = void> extends AIProviderResponse<T> {
 	readonly type: AIActionType;
@@ -413,6 +415,11 @@ export class AIProviderService implements AIService, Disposable {
 	// subscription change, and force.
 	private readonly _providerModelsCache = new Map<AIProviders, Promise<readonly AIModel[]>>();
 
+	// BYOK token usage accumulated per conversation (keyed by conversationId, then provider/model),
+	// reported as ONE usage report — and so one backend feature fee — when `flushBYOKUsage` is
+	// called at session end.
+	private readonly _pendingBYOKUsage = new Map<string, Map<string, BYOKUsage>>();
+
 	private _actions: AIActions | undefined;
 	get actions(): AIActions {
 		this._actions ??= new AIActions(this);
@@ -475,6 +482,12 @@ export class AIProviderService implements AIService, Disposable {
 	}
 
 	dispose(): void {
+		// Best-effort: report any BYOK usage still pending for unflushed conversations so it isn't
+		// silently dropped on shutdown/reload.
+		for (const conversationId of [...this._pendingBYOKUsage.keys()]) {
+			void this.flushBYOKUsage(conversationId);
+		}
+
 		this._disposable.dispose();
 		this._onDidChangeModel.dispose();
 		this._providerDisposable?.dispose();
@@ -1155,6 +1168,11 @@ export class AIProviderService implements AIService, Disposable {
 		source: Source,
 		options?: {
 			cancellation?: CancellationToken;
+			/** Session-scoped ID sent to the GitKraken backend (as `GK-Conversation-ID`) so its flat
+			 *  per-feature fee is charged once per session instead of once per request. Multi-call
+			 *  features should pass the same ID for every request in a user-facing session. Also defers
+			 *  BYOK usage reporting — the caller MUST call {@link flushBYOKUsage} when the session ends. */
+			conversationId?: string;
 			generating?: Deferred<AIModel>;
 			modelOptions?: { outputTokens?: number; temperature?: number };
 			progress?: ProgressOptions;
@@ -1294,7 +1312,11 @@ export class AIProviderService implements AIService, Disposable {
 							model,
 							apiKey,
 							provider.getMessages.bind(this, model, telementry.data, cancellation),
-							{ signal: controller.signal, modelOptions: options?.modelOptions },
+							{
+								signal: controller.signal,
+								modelOptions: options?.modelOptions,
+								conversationId: options?.conversationId,
+							},
 						);
 						if (!fulfilled) {
 							options?.generating?.fulfill(model);
@@ -1331,7 +1353,14 @@ export class AIProviderService implements AIService, Disposable {
 						);
 
 						if (result != null && supportedAIProviders.get(model.provider.id)?.requiresUserKey) {
-							void this.reportBYOKUsage(action, result);
+							// Within a conversation, defer reporting — each report is charged the flat
+							// per-feature fee, so the session's many calls are aggregated into ONE report
+							// sent by `flushBYOKUsage` when the session ends.
+							if (options?.conversationId != null) {
+								this.accumulateBYOKUsage(options.conversationId, action, result);
+							} else {
+								void this.reportBYOKUsage(action, result);
+							}
 						}
 
 						if (!isGkModel) {
@@ -1634,16 +1663,86 @@ export class AIProviderService implements AIService, Disposable {
 		// API requires total_tokens >= 1
 		if (totalTokens < 1) return;
 
+		await this.postBYOKUsageReport(model.provider.id, model.id, action, totalTokens, promptTokens);
+	}
+
+	/**
+	 * Accumulates a BYOK response's token usage under its conversation instead of reporting it
+	 * immediately — the backend charges a flat per-feature fee per report, so a multi-call session
+	 * reports once, via {@link flushBYOKUsage}, when it ends.
+	 */
+	private accumulateBYOKUsage(
+		conversationId: string,
+		action: AIActionType,
+		response: AIProviderResponse<void>,
+	): void {
+		const model = response.model;
+		const promptTokens = response.usage?.promptTokens;
+		const completionTokens = response.usage?.completionTokens;
+		const totalTokens = response.usage?.totalTokens ?? (promptTokens ?? 0) + (completionTokens ?? 0);
+		if (totalTokens < 1) return;
+
+		let buckets = this._pendingBYOKUsage.get(conversationId);
+		if (buckets == null) {
+			buckets = new Map();
+			this._pendingBYOKUsage.set(conversationId, buckets);
+		}
+
+		const key = `${model.provider.id}/${model.id}`;
+		const bucket = buckets.get(key);
+		if (bucket == null) {
+			buckets.set(key, {
+				provider: model.provider.id,
+				model: model.id,
+				action: action,
+				totalTokens: totalTokens,
+				inputTokens: promptTokens ?? 0,
+			});
+		} else {
+			bucket.totalTokens += totalTokens;
+			bucket.inputTokens += promptTokens ?? 0;
+		}
+	}
+
+	/**
+	 * Sends the single aggregated BYOK usage report for a conversation started via `sendRequest`'s
+	 * `conversationId` option. Call when the user-facing session ends (applied/discarded/disposed).
+	 * No-op when nothing was accumulated, so it's safe to call repeatedly (e.g. discard then dispose).
+	 */
+	async flushBYOKUsage(conversationId: string): Promise<void> {
+		const buckets = this._pendingBYOKUsage.get(conversationId);
+		this._pendingBYOKUsage.delete(conversationId);
+		if (buckets == null) return;
+
+		const usage = aggregateBYOKUsage(buckets.values());
+		if (usage == null) return;
+
+		await this.postBYOKUsageReport(
+			usage.provider,
+			usage.model,
+			usage.action,
+			usage.totalTokens,
+			usage.inputTokens > 0 ? usage.inputTokens : undefined,
+		);
+	}
+
+	private async postBYOKUsageReport(
+		provider: AIProviders,
+		model: string,
+		action: AIActionType,
+		totalTokens: number,
+		inputTokens?: number,
+	): Promise<void> {
 		try {
 			await this.connection.fetchGkApi('v1/ai-tasks/usage/reports', {
 				method: 'POST',
 				body: JSON.stringify({
-					provider: model.provider.id,
-					model: model.id,
+					provider: provider,
+					model: model,
 					task_type: 'message-prompt',
 					action: action,
 					total_tokens: totalTokens,
-					...(promptTokens != null && { input_tokens: promptTokens }),
+					...(inputTokens != null && { input_tokens: inputTokens }),
 				}),
 			});
 		} catch {}

--- a/src/plus/ai/utils/__tests__/byokUsage.utils.test.ts
+++ b/src/plus/ai/utils/__tests__/byokUsage.utils.test.ts
@@ -1,0 +1,52 @@
+import * as assert from 'assert';
+import type { BYOKUsage } from '../byokUsage.utils.js';
+import { aggregateBYOKUsage } from '../byokUsage.utils.js';
+
+function usage(overrides: Partial<BYOKUsage>): BYOKUsage {
+	return {
+		provider: 'openai',
+		model: 'test-model',
+		action: 'conflict-resolution',
+		totalTokens: 0,
+		inputTokens: 0,
+		...overrides,
+	};
+}
+
+suite('aggregateBYOKUsage', () => {
+	test('returns undefined for no buckets', () => {
+		assert.strictEqual(aggregateBYOKUsage([]), undefined);
+	});
+
+	test('returns undefined when the summed total is below the API minimum of 1', () => {
+		assert.strictEqual(aggregateBYOKUsage([usage({ totalTokens: 0, inputTokens: 0 })]), undefined);
+	});
+
+	test('passes a single bucket through unchanged', () => {
+		const result = aggregateBYOKUsage([usage({ totalTokens: 100, inputTokens: 60 })]);
+		assert.deepStrictEqual(result, usage({ totalTokens: 100, inputTokens: 60 }));
+	});
+
+	test('sums tokens across buckets and attributes to the dominant model', () => {
+		const result = aggregateBYOKUsage([
+			usage({ provider: 'openai', model: 'small', totalTokens: 100, inputTokens: 70 }),
+			usage({ provider: 'anthropic', model: 'large', totalTokens: 900, inputTokens: 500 }),
+			usage({ provider: 'openai', model: 'medium', totalTokens: 300, inputTokens: 200 }),
+		]);
+		assert.deepStrictEqual(result, {
+			provider: 'anthropic',
+			model: 'large',
+			action: 'conflict-resolution',
+			totalTokens: 1300,
+			inputTokens: 770,
+		});
+	});
+
+	test('keeps a zero-usage bucket from masking reportable usage', () => {
+		const result = aggregateBYOKUsage([
+			usage({ totalTokens: 0, inputTokens: 0 }),
+			usage({ model: 'used', totalTokens: 5, inputTokens: 2 }),
+		]);
+		assert.deepStrictEqual(result, usage({ model: 'used', totalTokens: 5, inputTokens: 2 }));
+	});
+});

--- a/src/plus/ai/utils/byokUsage.utils.ts
+++ b/src/plus/ai/utils/byokUsage.utils.ts
@@ -1,0 +1,40 @@
+import type { AIProviders } from '@gitlens/ai/constants.js';
+import type { AIActionType } from '@gitlens/ai/models/model.js';
+
+export interface BYOKUsage {
+	provider: AIProviders;
+	model: string;
+	action: AIActionType;
+	totalTokens: number;
+	inputTokens: number;
+}
+
+/**
+ * Folds a conversation's per-(provider/model) usage buckets into a single report: token counts are
+ * summed across buckets and attributed to the bucket with the most total tokens. A session rarely
+ * spans models (only when the user switches models mid-session), and one report per session is the
+ * point — each report is charged the backend's flat per-feature fee.
+ * Returns undefined when there's nothing reportable (no buckets, or the API-required minimum of
+ * 1 total token isn't met).
+ */
+export function aggregateBYOKUsage(usages: Iterable<BYOKUsage>): BYOKUsage | undefined {
+	let dominant: BYOKUsage | undefined;
+	let totalTokens = 0;
+	let inputTokens = 0;
+	for (const usage of usages) {
+		totalTokens += usage.totalTokens;
+		inputTokens += usage.inputTokens;
+		if (dominant == null || usage.totalTokens > dominant.totalTokens) {
+			dominant = usage;
+		}
+	}
+	if (dominant == null || totalTokens < 1) return undefined;
+
+	return {
+		provider: dominant.provider,
+		model: dominant.model,
+		action: dominant.action,
+		totalTokens: totalTokens,
+		inputTokens: inputTokens,
+	};
+}

--- a/src/plus/coretools/conflict/integration.ts
+++ b/src/plus/coretools/conflict/integration.ts
@@ -29,6 +29,9 @@ export interface ResolveSingleArgs {
 	config?: ResolverConfig;
 	signal?: AbortSignal;
 	onProgress?: (event: ConflictProgressEvent) => void;
+	/** Session-scoped conversation ID forwarded with every AI request so the backend charges its
+	 *  flat per-feature fee once per resolution session instead of once per request. */
+	conversationId?: string;
 }
 
 export interface ExtractArgs {
@@ -55,6 +58,9 @@ export interface ResolveAllParallelArgs {
 	onProgress?: (event: ConflictProgressEvent) => void;
 	/** Max resolutions in flight at once. Defaults to {@link ResolveConcurrency}. */
 	concurrency?: number;
+	/** Session-scoped conversation ID forwarded with every AI request so the backend charges its
+	 *  flat per-feature fee once per resolution session instead of once per request. */
+	conversationId?: string;
 }
 
 /** Default max in-flight AI resolutions for the parallel batch path — balances throughput against
@@ -82,7 +88,7 @@ export class ConflictToolsIntegration {
 
 	async resolveSingle(args: ResolveSingleArgs, telemetrySource: Source): Promise<Resolution> {
 		const git = createConflictGitPort(args.svc);
-		const model = createAiModelPort(this.container, telemetrySource);
+		const model = createAiModelPort(this.container, telemetrySource, args.conversationId);
 		return resolveConflict(args.conflict, args.context ?? {}, {
 			git: git,
 			model: model,
@@ -109,7 +115,7 @@ export class ConflictToolsIntegration {
 	 */
 	async resolveAllParallel(args: ResolveAllParallelArgs, telemetrySource: Source): Promise<StepResult> {
 		const git = createConflictGitPort(args.svc);
-		const model = createAiModelPort(this.container, telemetrySource);
+		const model = createAiModelPort(this.container, telemetrySource, args.conversationId);
 		const entries = [...args.entries];
 		const resolutions: Resolution[] = [];
 		const errors: { filePath: string; error: Error }[] = [];
@@ -292,7 +298,7 @@ function createConflictGitPort(svc: GitRepositoryService): ConflictGitPort {
 	};
 }
 
-function createAiModelPort(container: Container, source: Source): ConflictModelPort {
+function createAiModelPort(container: Container, source: Source, conversationId?: string): ConflictModelPort {
 	return {
 		generate: async (params: ConflictModelParams): Promise<ConflictModelResult> => {
 			const cancellationSource = new CancellationTokenSource();
@@ -353,6 +359,7 @@ function createAiModelPort(container: Container, source: Source): ConflictModelP
 					source,
 					{
 						cancellation: cancellationSource.token,
+						conversationId: conversationId,
 						modelOptions: {
 							outputTokens: params.maxTokens,
 							temperature: params.temperature,

--- a/src/webviews/apps/plus/graph/components/detailsWorkflowController.ts
+++ b/src/webviews/apps/plus/graph/components/detailsWorkflowController.ts
@@ -646,6 +646,11 @@ export class DetailsWorkflowController implements ReactiveController {
 			this.review.invalidateErrorRecovery();
 		} else if (exitingMode === 'compose') {
 			this.compose.invalidateErrorRecovery();
+		} else if (exitingMode === 'resolve') {
+			// The focused-file scope is an input of the engagement that set it (per-file/multi-select
+			// entry points) — clear it on exit so a later chip-initiated session defaults back to all
+			// conflicted files instead of silently re-scoping to the previous session's file(s).
+			this.actions.state.resolveFocusedFilePaths.set(undefined);
 		}
 		// On repo-switch, the caller (Trigger 1 in hostUpdate) will follow up with the new
 		// repo's selection arriving. Refetching here uses `host.currentSelection()` which is

--- a/src/webviews/apps/plus/graph/components/gl-details-resolve-mode-panel.ts
+++ b/src/webviews/apps/plus/graph/components/gl-details-resolve-mode-panel.ts
@@ -24,6 +24,10 @@ export interface ResolveViewDiffDetail {
 	filePath: string;
 }
 
+export interface ResolveOpenFileDetail {
+	filePath: string;
+}
+
 /** Friendly label + icon for each conflict-tools resolution strategy. `skipped` is a warning —
  *  the file was intentionally left conflicted and still needs manual attention. */
 const strategyDisplay: Record<ConflictResolutionStrategy, { label: string; icon: string; warn?: boolean }> = {
@@ -87,6 +91,42 @@ export class GlDetailsResolveModePanel extends LitElement {
 				text-overflow: ellipsis;
 				white-space: nowrap;
 				flex: 1;
+			}
+
+			/* Idle-state file link — opens the conflicted working-tree file. Mirrors the review
+			   panel's .review-area__file-link affordance (hover background + path underline). */
+			.resolve-file__link {
+				display: flex;
+				align-items: center;
+				gap: 0.4rem;
+				flex: 1;
+				min-width: 0;
+				margin: -0.2rem -0.4rem;
+				padding: 0.2rem 0.4rem;
+				font-size: inherit;
+				font-family: inherit;
+				color: var(--vscode-textLink-foreground);
+				background: transparent;
+				border: none;
+				cursor: pointer;
+				text-align: left;
+				border-radius: 0.2rem;
+			}
+
+			.resolve-file__link:hover {
+				background: var(--vscode-list-hoverBackground);
+			}
+
+			/* Underline only the path text on hover — without this scope, the rule applies to the
+			   whole button and the icon picks up a stray underline at its baseline. */
+			.resolve-file__link:hover .resolve-file__path {
+				text-decoration: underline;
+			}
+
+			.resolve-file__link code-icon {
+				color: var(--vscode-foreground);
+				opacity: 0.7;
+				flex: none;
 			}
 
 			.resolve-file__badge {
@@ -226,8 +266,15 @@ export class GlDetailsResolveModePanel extends LitElement {
 							f =>
 								html`<li class="resolve-file">
 									<div class="resolve-file__head">
-										<code-icon icon="git-merge"></code-icon>
-										<span class="resolve-file__path">${f.path}</span>
+										<button
+											class="resolve-file__link"
+											title="Open file"
+											aria-label="Open ${f.path}"
+											@click=${() => this.emit('resolve-open-file', { filePath: f.path })}
+										>
+											<code-icon icon="git-merge"></code-icon>
+											<span class="resolve-file__path">${f.path}</span>
+										</button>
 									</div>
 								</li>`,
 						)}

--- a/src/webviews/apps/plus/graph/components/gl-details-wip-header.ts
+++ b/src/webviews/apps/plus/graph/components/gl-details-wip-header.ts
@@ -282,8 +282,9 @@ export class GlDetailsWipHeader extends LitElement {
 	private computeWipModes(): ('review' | 'compose' | 'resolve')[] {
 		if (!this.aiEnabled) return [];
 		// Surface the Resolve toggle only when the WIP has conflicts (a paused merge/rebase) —
-		// resolve operates on the conflicted-file set, so it's meaningless otherwise.
-		return this.wip?.changes?.hasConflicts ? ['compose', 'review', 'resolve'] : ['compose', 'review'];
+		// resolve operates on the conflicted-file set, so it's meaningless otherwise. It leads
+		// the cluster when present: resolving is the primary action for a conflicted WIP.
+		return this.wip?.changes?.hasConflicts ? ['resolve', 'compose', 'review'] : ['compose', 'review'];
 	}
 
 	private renderBranchStateAction() {

--- a/src/webviews/apps/plus/graph/components/gl-graph-details-panel.ts
+++ b/src/webviews/apps/plus/graph/components/gl-graph-details-panel.ts
@@ -2569,6 +2569,8 @@ export class GlGraphDetailsPanel extends SignalWatcher(LitElement) {
 			}}
 			@resolve-view-diff=${(e: CustomEvent<{ filePath: string }>) =>
 				this.handleResolveViewDiff(e.detail.filePath)}
+			@resolve-open-file=${(e: CustomEvent<{ filePath: string }>) =>
+				this.handleResolveOpenFile(e.detail.filePath)}
 			@resolve-apply-all=${() => void this._workflow.resolve.applyResolutions()}
 			@resolve-discard=${() => this._workflow.resolve.discard()}
 			@resolve-cancel=${this.handleCancelMode}
@@ -2601,6 +2603,17 @@ export class GlGraphDetailsPanel extends SignalWatcher(LitElement) {
 		if (file == null) return;
 
 		this._actions.openResolutionDiff(file, resolution.virtualRef);
+	}
+
+	/** Open a conflicted file from the resolve panel's idle list — working tree, so the user can
+	 *  inspect the conflict markers before running an AI resolution. The explicit uncommitted ref
+	 *  routes the host through its WIP fast path (`makeWipRef`), which stays reliable for
+	 *  secondary worktrees where `getCommit(uncommitted)` may not be hydrated. */
+	private handleResolveOpenFile(filePath: string): void {
+		const file = this._state.wip.get()?.changes?.files?.find(f => f.path === filePath);
+		if (file == null) return;
+
+		this._actions.openFile(file, { ref: uncommitted });
 	}
 
 	private handleScopeChange(

--- a/src/webviews/apps/shared/components/details-header/gl-details-header.css.ts
+++ b/src/webviews/apps/shared/components/details-header/gl-details-header.css.ts
@@ -58,7 +58,8 @@ export const detailsHeaderStyles = css`
 	}
 
 	/* Mode-toggle label collapse, staggered right-to-left in display order: Compare yields
-	   first, then Resolve, then Review, then Compose.
+	   first, then Review, then Compose, then Resolve — the (conflict-only) Resolve chip leads
+	   the cluster as the primary action, so it keeps its label longest.
 	   The chip's slotted label is a normal child of <gl-action-chip> in this template,
 	   so we target it via descendant selectors. Hiding the slotted span with display:none
 	   cleanly removes the flex item and its surrounding gap inside the chip — yielding
@@ -66,9 +67,9 @@ export const detailsHeaderStyles = css`
 	   so the selected mode keeps its label visible. Breakpoints leave room for the title
 	   side's WIP stats pill, which takes priority over labels (see
 	   gl-details-wip-header.css.ts); secondary actions never hide.
-	   The (conflict-only) Resolve chip makes the cluster ~one labeled chip wider, so Compare
-	   yields sooner when it's present (the :has()-scoped rule); the later steps then line up
-	   with the 3-chip cascade, since each band holds the same number of labels either way. */
+	   The Resolve chip makes the cluster ~one labeled chip wider, so each step fires one
+	   band sooner when it's present (the :has()-scoped rules) — keeping the same number of
+	   visible labels per band as the 3-chip cascade. */
 	@container gl-action-chip-host (max-width: 560px) {
 		.details-header__actions:has(.mode-toggle--resolve) .mode-toggle--compare .mode-toggle__text {
 			display: none;
@@ -77,19 +78,25 @@ export const detailsHeaderStyles = css`
 
 	@container gl-action-chip-host (max-width: 500px) {
 		.mode-toggle--compare .mode-toggle__text,
-		.mode-toggle--resolve:not(.mode-toggle--active) .mode-toggle__text {
+		.details-header__actions:has(.mode-toggle--resolve)
+			.mode-toggle--review:not(.mode-toggle--active)
+			.mode-toggle__text {
 			display: none;
 		}
 	}
 
 	@container gl-action-chip-host (max-width: 440px) {
-		.mode-toggle--review:not(.mode-toggle--active) .mode-toggle__text {
+		.mode-toggle--review:not(.mode-toggle--active) .mode-toggle__text,
+		.details-header__actions:has(.mode-toggle--resolve)
+			.mode-toggle--compose:not(.mode-toggle--active)
+			.mode-toggle__text {
 			display: none;
 		}
 	}
 
 	@container gl-action-chip-host (max-width: 380px) {
-		.mode-toggle--compose:not(.mode-toggle--active) .mode-toggle__text {
+		.mode-toggle--compose:not(.mode-toggle--active) .mode-toggle__text,
+		.mode-toggle--resolve:not(.mode-toggle--active) .mode-toggle__text {
 			display: none;
 		}
 	}

--- a/src/webviews/plus/graph/graphWebview.ts
+++ b/src/webviews/plus/graph/graphWebview.ts
@@ -74,6 +74,7 @@ import { sortBranches, sortRemotes, sortTags, sortWorktrees } from '@gitlens/git
 import { filterMap } from '@gitlens/utils/array.js';
 import { CancellationError, isCancellationError } from '@gitlens/utils/cancellation.js';
 import { getScopedCounter } from '@gitlens/utils/counter.js';
+import { uuid } from '@gitlens/utils/crypto.js';
 import type { Deferrable } from '@gitlens/utils/debounce.js';
 import { debounce } from '@gitlens/utils/debounce.js';
 import { debug, trace } from '@gitlens/utils/decorators/log.js';
@@ -652,6 +653,12 @@ export class GraphWebviewProvider implements WebviewProvider<State, State, Graph
 		string,
 		{ resolutions: readonly ConflictToolsResolution[]; sessionId: string }
 	>();
+	/** Per-repo AI conversation ID for the active resolve session — sent with every AI request so
+	 *  the backend charges its flat per-feature fee once per session, across re-runs and per-file
+	 *  retries. Kept separate from {@link _activeResolveSessions} because it must exist before the
+	 *  first AI call and survive a cancelled/failed first run (so a re-run reuses it); cleared with
+	 *  the session in {@link discardResolveSession}. */
+	private readonly _resolveConversationIds = new Map<string, string>();
 	private _computeWorktreeChangesPromise?: Promise<void>;
 	private _pendingWorktreeChanges?: Parameters<typeof getWorktreeHasWorkingChanges>[1][];
 	private _hoverCache = new Map<string, Promise<string>>();
@@ -948,6 +955,12 @@ export class GraphWebviewProvider implements WebviewProvider<State, State, Graph
 			this._composeVirtual = undefined;
 		}
 		this._activeResolveSessions.clear();
+		// Flush each conversation's aggregated BYOK usage report (one feature fee per session) so a
+		// webview teardown mid-session doesn't drop it.
+		for (const conversationId of this._resolveConversationIds.values()) {
+			void this.container.ai.flushBYOKUsage(conversationId);
+		}
+		this._resolveConversationIds.clear();
 		if (this._resolveVirtual != null) {
 			this._resolveVirtual.provider.dispose();
 			this._resolveVirtual.registration.dispose();
@@ -996,8 +1009,27 @@ export class GraphWebviewProvider implements WebviewProvider<State, State, Graph
 		return this._conflictToolsForGraph;
 	}
 
+	/** Gets the repo's resolve-session AI conversation ID, minting one for a new session. */
+	private getOrCreateResolveConversationId(repoPath: string): string {
+		let conversationId = this._resolveConversationIds.get(repoPath);
+		if (conversationId == null) {
+			conversationId = uuid();
+			this._resolveConversationIds.set(repoPath, conversationId);
+		}
+		return conversationId;
+	}
+
 	/** Drops the cached resolve session for a repo and ends its virtual session (no disk writes). */
 	private discardResolveSession(repoPath: string): void {
+		// The conversation outlives the session entry (it exists from before the first AI call), so
+		// end it before the `session == null` return — a run cancelled before any session entry was
+		// created still needs its BYOK usage flushed (one aggregated report = one feature fee).
+		const conversationId = this._resolveConversationIds.get(repoPath);
+		if (conversationId != null) {
+			this._resolveConversationIds.delete(repoPath);
+			void this.container.ai.flushBYOKUsage(conversationId);
+		}
+
 		const session = this._activeResolveSessions.get(repoPath);
 		if (session == null) return;
 
@@ -2050,6 +2082,11 @@ export class GraphWebviewProvider implements WebviewProvider<State, State, Graph
 							};
 						}
 
+						// One conversation ID per resolve session — re-runs ("Refine") and per-file
+						// retries reuse it until apply/discard, so the backend's flat per-feature fee
+						// is charged once for the whole session instead of once per AI request.
+						const conversationId = this.getOrCreateResolveConversationId(repoPath);
+
 						// Resolve the conflicted files in a bounded-concurrency pool so one file's failure
 						// is isolated (recorded in `errors`) and the rest still resolve — and they run in
 						// parallel rather than one-at-a-time.
@@ -2060,6 +2097,7 @@ export class GraphWebviewProvider implements WebviewProvider<State, State, Graph
 								context: context,
 								signal: resolveSignal,
 								onProgress: onProgress,
+								conversationId: conversationId,
 							},
 							{
 								source: 'graph',
@@ -2198,6 +2236,9 @@ export class GraphWebviewProvider implements WebviewProvider<State, State, Graph
 								conflict: conflict,
 								context: { refs: refs, userGuidance: feedback },
 								signal: resolveSignal,
+								// Same conversation as the run being retried (an active session implies
+								// the ID exists; minting here is just a defensive fallback).
+								conversationId: this.getOrCreateResolveConversationId(repoPath),
 							},
 							{ source: 'graph', detail: 'resolveRetryFile' },
 						);


### PR DESCRIPTION
Follow-ups to the AI conflict resolution feature — relates to #5306.

### Changes

- **Fixes AI conflict resolution being charged the flat fee per request** — mints one conversation ID per resolve session (initial run, refines, and per-file retries) and sends it as `GK-Conversation-ID` so the backend charges its flat per-feature fee once per session instead of once per model call; BYOK providers report a single aggregated usage record per session.
- **Changes Resolve to lead the WIP details header actions** — when the WIP has conflicts, the Resolve chip renders first (Resolve, Compose, Review, Compare), with the label-collapse cascade reworked to match the new display order.
- **Adds open-file links to the resolve mode conflicted file list** — files in the resolve panel's idle state are now clickable links that open the working-tree file (with its conflict markers) so a conflict can be inspected before running an AI resolution.

### Verification

- `pnpm run check` passes
- Live-verified against a paused merge with conflicted files: chip order and responsive label collapse (both conflict and no-conflict cascades), and idle file links opening the working-tree file end-to-end