### PR TITLE
Fix graph avatars blocked by CORS (#5343)

### DIFF
--- a/package.json
+++ b/package.json
@@ -29124,7 +29124,7 @@
 		"@eamodio/supertalk-signals": "0.0.6",
 		"@gitkraken/compose-tools": "0.3.1",
 		"@gitkraken/conflict-tools": "0.2.0",
-		"@gitkraken/gitkraken-components": "13.0.0-vnext.36",
+		"@gitkraken/gitkraken-components": "13.0.0-vnext.38",
 		"@gitkraken/provider-apis": "0.40.0",
 		"@gitkraken/shared-tools": "0.2.0",
 		"@gitlens/agents": "workspace:*",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -62,8 +62,8 @@ importers:
         specifier: 0.2.0
         version: 0.2.0
       '@gitkraken/gitkraken-components':
-        specifier: 13.0.0-vnext.36
-        version: 13.0.0-vnext.36(dragula@3.7.3)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)
+        specifier: 13.0.0-vnext.38
+        version: 13.0.0-vnext.38(dragula@3.7.3)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)
       '@gitkraken/provider-apis':
         specifier: 0.40.0
         version: 0.40.0(encoding@0.1.13)
@@ -1053,8 +1053,8 @@ packages:
     resolution: {integrity: sha512-bX84gu1INsdx3bvft+pdc71F+o7UDbrs+KPFzTM65Y+bmMhwn+hPa6nB3bvxkFW/Vb3QVKQQKxVVyDyT3uMUVw==}
     engines: {node: '>= 22'}
 
-  '@gitkraken/gitkraken-components@13.0.0-vnext.36':
-    resolution: {integrity: sha512-gH5vxz6NbPfV9N4AUTdU6TJcBBmoat20DxOW7NPLr7D5Z7xkffANqbxR6ZyndVZLDxqkSGPrJ0JPtYlUBVN0GA==}
+  '@gitkraken/gitkraken-components@13.0.0-vnext.38':
+    resolution: {integrity: sha512-5f3JK6M/BDxtSu8QHaCgXCQ2M/EWjXdzzFhKPabgWaNQipc5Q80sEksZGzOHq9beZrOWEA7UOSQYDEiBDajkPA==}
     engines: {node: '>= 22.12.0', pnpm: '>= 10.0.0'}
     peerDependencies:
       dragula: 3.7.3
@@ -7703,7 +7703,7 @@ snapshots:
       '@gitkraken/shared-tools': 0.2.0
       picomatch: 4.0.4
 
-  '@gitkraken/gitkraken-components@13.0.0-vnext.36(dragula@3.7.3)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)':
+  '@gitkraken/gitkraken-components@13.0.0-vnext.38(dragula@3.7.3)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)':
     dependencies:
       '@axosoft/react-virtualized': 9.22.3-gitkraken.3(react-dom@19.2.6(react@19.2.6))(react@19.2.6)
       '@types/react': 19.2.14

--- a/src/avatars.ts
+++ b/src/avatars.ts
@@ -1,4 +1,5 @@
 import { EventEmitter, Uri } from 'vscode';
+import { fetch } from '@env/fetch.js';
 import type { CommitAuthor } from '@gitlens/git/models/author.js';
 import { getGitHubNoReplyAddressParts } from '@gitlens/git/remotes/github.js';
 import { base64 } from '@gitlens/utils/base64.js';
@@ -272,6 +273,45 @@ async function getAvatarUriFromRemoteProvider(
 		avatar.timestamp = Date.now();
 		avatar.retries++;
 
+		return undefined;
+	}
+}
+
+const maxAvatarProxyBytes = 512 * 1024; // 512 KB
+const rasterImageTypes = new Set(['image/png', 'image/jpeg', 'image/jpg', 'image/gif', 'image/webp']);
+
+export async function fetchAvatarImageAsDataUri(url: string): Promise<Uri | undefined> {
+	try {
+		if (!url.startsWith('https://')) return undefined;
+
+		const rsp = await fetch(url, { signal: AbortSignal.timeout(10_000) });
+		if (!rsp.ok) {
+			void rsp.body?.cancel();
+			return undefined;
+		}
+		if (!rsp.url.startsWith('https://')) {
+			void rsp.body?.cancel();
+			return undefined;
+		}
+
+		const contentType = rsp.headers.get('content-type')?.split(';')[0].trim().toLowerCase();
+		if (!rasterImageTypes.has(contentType ?? '')) {
+			void rsp.body?.cancel();
+			return undefined;
+		}
+
+		const contentLength = rsp.headers.get('content-length');
+		if (contentLength != null && parseInt(contentLength, 10) > maxAvatarProxyBytes) {
+			void rsp.body?.cancel();
+			return undefined;
+		}
+
+		const buffer = await rsp.arrayBuffer();
+		if (buffer.byteLength > maxAvatarProxyBytes) return undefined;
+
+		const data = base64(new Uint8Array(buffer));
+		return Uri.parse(`data:${contentType};base64,${data}`);
+	} catch {
 		return undefined;
 	}
 }

--- a/src/webviews/apps/plus/graph/graph-wrapper/gl-graph.react.tsx
+++ b/src/webviews/apps/plus/graph/graph-wrapper/gl-graph.react.tsx
@@ -430,16 +430,51 @@ export const GlGraphReact = memo((initProps: GraphWrapperInitProps) => {
 		[initProps.onMouseLeave, stopColumnResize],
 	);
 
+	const avatarErrorBatch = useRef<{
+		pending: Record<string, string>;
+		timer: ReturnType<typeof setTimeout> | undefined;
+	}>({ pending: Object.create(null) as Record<string, string>, timer: undefined });
+
+	useEffect(() => {
+		return () => {
+			if (avatarErrorBatch.current.timer != null) {
+				clearTimeout(avatarErrorBatch.current.timer);
+			}
+		};
+	}, []);
+
 	const avatarUrlSpecByEmail = useMemo(() => {
 		const avatars = props.avatars;
 		if (avatars == null || initProps.onAvatarLoadError == null) return avatars;
 
 		const onError = initProps.onAvatarLoadError;
+		const batch = avatarErrorBatch.current;
+
+		if (batch.timer != null) {
+			clearTimeout(batch.timer);
+			batch.timer = undefined;
+		}
+		batch.pending = Object.create(null) as Record<string, string>;
+
+		function flushErrors() {
+			batch.timer = undefined;
+			if (Object.keys(batch.pending).length === 0) return;
+
+			const failed = batch.pending;
+			batch.pending = Object.create(null) as Record<string, string>;
+			onError(failed);
+		}
+
+		function onAvatarError(email: string, failedUrl: string) {
+			batch.pending[email] = failedUrl;
+			batch.timer ??= setTimeout(flushErrors, 150);
+		}
+
 		const result: Record<string, { url: string; onError: (url: string, error: unknown) => void }> = {};
 		for (const [email, url] of Object.entries(avatars)) {
 			result[email] = {
 				url: url,
-				onError: (failedUrl, _error) => onError({ [email]: failedUrl }),
+				onError: (failedUrl, _error) => onAvatarError(email, failedUrl),
 			};
 		}
 		return result;

--- a/src/webviews/apps/plus/graph/graph-wrapper/gl-graph.react.tsx
+++ b/src/webviews/apps/plus/graph/graph-wrapper/gl-graph.react.tsx
@@ -139,6 +139,7 @@ export interface GraphWrapperEvents {
 	) => void;
 	onChangeVisibleDays?: (detail: { top: number; bottom: number }) => void;
 	onFilterColumn?: (detail: { zone: GraphZoneType }) => void;
+	onAvatarLoadError?: (emails: Record<string, string>) => void;
 	onMissingAvatars?: (emails: Record<string, string>) => void;
 	onMissingRefsMetadata?: (metadata: GraphMissingRefsMetadata) => void;
 	onMoreRows?: (id?: string) => void;
@@ -428,6 +429,21 @@ export const GlGraphReact = memo((initProps: GraphWrapperInitProps) => {
 		},
 		[initProps.onMouseLeave, stopColumnResize],
 	);
+
+	const avatarUrlSpecByEmail = useMemo(() => {
+		const avatars = props.avatars;
+		if (avatars == null || initProps.onAvatarLoadError == null) return avatars;
+
+		const onError = initProps.onAvatarLoadError;
+		const result: Record<string, { url: string; onError: (url: string, error: unknown) => void }> = {};
+		for (const [email, url] of Object.entries(avatars)) {
+			result[email] = {
+				url: url,
+				onError: (failedUrl, _error) => onError({ [email]: failedUrl }),
+			};
+		}
+		return result;
+	}, [props.avatars, initProps.onAvatarLoadError]);
 
 	const handleMissingAvatars = useCallback(
 		(emails: GraphAvatars) => {
@@ -1120,7 +1136,7 @@ export const GlGraphReact = memo((initProps: GraphWrapperInitProps) => {
 		<GraphContainer
 			ref={graphRef}
 			rowAdornmentProvider={rowAdornmentProvider}
-			avatarUrlByEmail={props.avatars}
+			avatarUrlByEmail={avatarUrlSpecByEmail}
 			columnsSettings={columnsSettings}
 			contexts={context}
 			formatCommitMessage={formatCommitMessage}
@@ -1254,6 +1270,7 @@ declare global {
 		'graph-doubleclickref': CustomEvent<{ ref: GraphRef; metadata?: GraphRefMetadataItem }>;
 		'graph-doubleclickrow': CustomEvent<{ row: GraphRow; preserveFocus?: boolean }>;
 		'graph-filtercolumn': CustomEvent<{ zone: GraphZoneType }>;
+		'graph-avatarloaderror': CustomEvent<GraphAvatars>;
 		'graph-missingavatars': CustomEvent<GraphAvatars>;
 		'graph-missingrefsmetadata': CustomEvent<GraphMissingRefsMetadata>;
 		'graph-morerows': CustomEvent<string | undefined>;

--- a/src/webviews/apps/plus/graph/graph-wrapper/gl-graph.ts
+++ b/src/webviews/apps/plus/graph/graph-wrapper/gl-graph.ts
@@ -231,6 +231,7 @@ export class GlGraph extends LitElement {
 				onChangeSelection: this.handleChangeSelection,
 				onChangeVisibleDays: this.handleChangeVisibleDays,
 				onFilterColumn: this.handleFilterColumn,
+				onAvatarLoadError: this.handleAvatarLoadError,
 				onMissingAvatars: this.handleMissingAvatars,
 				onMissingRefsMetadata: this.handleMissingRefsMetadata,
 				onMoreRows: this.handleMoreRows,
@@ -275,6 +276,10 @@ export class GlGraph extends LitElement {
 
 	private handleFilterColumn = (detail: { zone: GraphZoneType }): void => {
 		this.dispatchEvent(new CustomEvent('filtercolumn', { detail: detail }));
+	};
+
+	private handleAvatarLoadError = (emails: GraphAvatars): void => {
+		this.dispatchEvent(new CustomEvent('avatarloaderror', { detail: emails }));
 	};
 
 	private handleMissingAvatars = (emails: GraphAvatars): void => {
@@ -399,6 +404,7 @@ declare global {
 			state: GraphSelectionState;
 		}>;
 		changevisibledays: CustomEvent<{ top: number; bottom: number }>;
+		avatarloaderror: CustomEvent<GraphAvatars>;
 		missingavatars: CustomEvent<GraphAvatars>;
 		missingrefsmetadata: CustomEvent<GraphMissingRefsMetadata>;
 		morerows: CustomEvent<string | undefined>;

--- a/src/webviews/apps/plus/graph/graph-wrapper/graph-wrapper.ts
+++ b/src/webviews/apps/plus/graph/graph-wrapper/graph-wrapper.ts
@@ -40,6 +40,7 @@ import {
 	GetMoreRowsCommand,
 	GetWipStatsRequest,
 	isSecondaryWipSha,
+	ProxyAvatarsCommand,
 	RowActionCommand,
 	SyncWipWatchesCommand,
 	UpdateColumnsCommand,
@@ -819,6 +820,7 @@ export class GlGraphWrapper extends SignalWatcher(LitElement) {
 			@changeselection=${this.onSelectionChanged}
 			@changevisibledays=${this.onVisibleDaysChanged}
 			@filtercolumn=${this.onFilterColumn}
+			@avatarloaderror=${this.onAvatarLoadError}
 			@missingavatars=${this.onMissingAvatars}
 			@missingrefsmetadata=${this.onMissingRefsMetadata}
 			@morerows=${this.onGetMoreRows}
@@ -972,6 +974,10 @@ export class GlGraphWrapper extends SignalWatcher(LitElement) {
 
 	private onMouseLeave() {
 		this.dispatchEvent(new CustomEvent('gl-graph-mouse-leave'));
+	}
+
+	private onAvatarLoadError({ detail: emails }: CustomEventType<'graph-avatarloaderror'>) {
+		this._ipc.sendCommand(ProxyAvatarsCommand, { avatars: emails });
 	}
 
 	private onMissingAvatars({ detail: emails }: CustomEventType<'graph-missingavatars'>) {

--- a/src/webviews/plus/graph/graphWebview.ts
+++ b/src/webviews/plus/graph/graphWebview.ts
@@ -78,6 +78,7 @@ import { uuid } from '@gitlens/utils/crypto.js';
 import type { Deferrable } from '@gitlens/utils/debounce.js';
 import { debounce } from '@gitlens/utils/debounce.js';
 import { debug, trace } from '@gitlens/utils/decorators/log.js';
+import { DedupedAsyncCache } from '@gitlens/utils/dedupedAsyncCache.js';
 import { annotateDiffWithNewLineNumbers } from '@gitlens/utils/diff.js';
 import { createDisposable, disposableInterval } from '@gitlens/utils/disposable.js';
 import { fnv1aHash64 } from '@gitlens/utils/hash.js';
@@ -97,7 +98,7 @@ import { pluralize } from '@gitlens/utils/string.js';
 import type { AgentSessionState } from '../../../agents/models/agentSessionState.js';
 import { isActiveAgentPhase } from '../../../agents/provider.js';
 import type { CreatePullRequestActionContext, OpenPullRequestActionContext } from '../../../api/gitlens.d.js';
-import { getAvatarUri } from '../../../avatars.js';
+import { fetchAvatarImageAsDataUri, getAvatarUri } from '../../../avatars.js';
 import { parseCommandContext } from '../../../commands/commandContext.utils.js';
 import type { CopyDeepLinkCommandArgs } from '../../../commands/copyDeepLink.js';
 import type { CopyMessageToClipboardCommandArgs } from '../../../commands/copyMessageToClipboard.js';
@@ -209,6 +210,11 @@ import {
 	formatChangesContextForPrompt,
 	gatherContextForChanges,
 } from '../../../plus/ai/utils/-webview/changesContext.js';
+import type { ConflictToolsIntegration } from '../../../plus/coretools/conflict/integration.js';
+import type {
+	ConflictProgressEvent,
+	Resolution as ConflictToolsResolution,
+} from '../../../plus/coretools/conflict/types.js';
 import { showPatchesView } from '../../../plus/drafts/actions.js';
 import type { FeaturePreviewChangeEvent, SubscriptionChangeEvent } from '../../../plus/gk/subscriptionService.js';
 import { isHooksBannerEnabled, isMcpBannerEnabled } from '../../../plus/gk/utils/-webview/mcp.utils.js';
@@ -286,11 +292,6 @@ import * as branchRefCommands from '../shared/branchRefCommands.js';
 import type { ChoosePathParams, DidChoosePathParams } from '../timeline/protocol.js';
 import type { TimelineCommandArgs } from '../timeline/registration.js';
 import { buildTimelineDataset } from '../timeline/timelineDataset.js';
-import type { ConflictToolsIntegration } from '../../../plus/coretools/conflict/integration.js';
-import type {
-	ConflictProgressEvent,
-	Resolution as ConflictToolsResolution,
-} from '../../../plus/coretools/conflict/types.js';
 import type { GraphComposeIntegration } from './compose/integration.js';
 import { isComposeSimulatorActive, runSimulatedComposeChanges } from './compose/simulator.js';
 import {
@@ -460,6 +461,7 @@ import {
 	isSecondaryWipSha,
 	JumpToHeadRequest,
 	OpenPullRequestDetailsCommand,
+	ProxyAvatarsCommand,
 	ResetGraphFiltersCommand,
 	ResolveGraphScopeRequest,
 	RowActionCommand,
@@ -4679,6 +4681,45 @@ export class GraphWebviewProvider implements WebviewProvider<State, State, Graph
 		}
 	}
 
+	private readonly _avatarProxyCache = new DedupedAsyncCache<string, Uri | undefined>();
+	private readonly _avatarProxyFailed = new Set<string>();
+
+	@ipcCommand(ProxyAvatarsCommand)
+	private async onProxyAvatars(params: IpcParams<typeof ProxyAvatarsCommand>) {
+		if (this._graph == null) return;
+
+		const entries = Object.entries(params.avatars);
+		if (entries.length === 0) return;
+
+		let changed = false;
+		await Promise.allSettled(
+			entries.map(([email, url]) => {
+				if (url.startsWith('data:') || this._avatarProxyFailed.has(url)) return Promise.resolve();
+
+				return this._avatarProxyCache
+					.getOrResolve(url, () => fetchAvatarImageAsDataUri(url))
+					.then(uri => {
+						if (uri != null) {
+							if (this._graph?.avatars.get(email) !== url) return;
+
+							this._graph.avatars.set(email, uri.toString(true));
+							changed = true;
+						} else {
+							this._avatarProxyFailed.add(url);
+						}
+					});
+			}),
+		);
+
+		if (changed) {
+			// Proxy replaces values for existing keys (same email, new data URI), so the
+			// map size doesn't change. Reset the watermark to force notifyDidChangeAvatars
+			// to ship the update — see the comment there for the full invariant.
+			this._lastSentAvatarsSize = undefined;
+			this.updateAvatars();
+		}
+	}
+
 	@ipcCommand(GetMissingRefsMetadataCommand)
 	private async onGetMissingRefMetadata(params: IpcParams<typeof GetMissingRefsMetadataCommand>) {
 		if (this._graph == null || this._refsMetadata === null) {
@@ -6194,12 +6235,14 @@ export class GraphWebviewProvider implements WebviewProvider<State, State, Graph
 		if (this._graph == null) return;
 
 		const data = this._graph;
-		// Share the `_lastSentAvatarsSize` watermark with the rows-notification path: avatar values
-		// never change for existing keys (every write at graphRowProcessor is gated by
-		// `!context.avatars.has(row.email)`), so an unchanged size means the webview already has
-		// every avatar. Skip the `Object.fromEntries` + IPC in that case. Only advance the watermark
-		// on confirmed delivery — a failed `notify` is requeued by type and REPLACED by a later one,
-		// so a speculative advance could skip avatars the webview never received.
+		// Size-based watermark shared with the rows-notification path. Normally avatar values don't
+		// change for existing keys (graphRowProcessor gates on `!context.avatars.has(row.email)`),
+		// so an unchanged size means the webview already has every avatar. Exception: the avatar
+		// proxy replaces CORS-failing URLs with data URIs for the same key — callers must reset
+		// `_lastSentAvatarsSize` to force the notification through (see `onProxyAvatars`). Only
+		// advance the watermark on confirmed delivery — a failed `notify` is requeued by type and
+		// REPLACED by a later one, so a speculative advance could skip avatars the webview never
+		// received.
 		const avatarsSize = data.avatars.size;
 		if (avatarsSize === this._lastSentAvatarsSize) return;
 
@@ -8836,6 +8879,8 @@ export class GraphWebviewProvider implements WebviewProvider<State, State, Graph
 			this._lastSentWipDraftsInitialized = false;
 			this._lastSentWipNotificationParams = undefined;
 			this._graphLoading = undefined;
+			this._avatarProxyCache.clear();
+			this._avatarProxyFailed.clear();
 			this.resetHoverCache();
 			this.resetRefsMetadata();
 			this.resetSearchState();

--- a/src/webviews/plus/graph/protocol.ts
+++ b/src/webviews/plus/graph/protocol.ts
@@ -528,6 +528,11 @@ export interface GetMissingAvatarsParams {
 }
 export const GetMissingAvatarsCommand = new IpcCommand<GetMissingAvatarsParams>(scope, 'avatars/get');
 
+export interface ProxyAvatarsParams {
+	avatars: Record</*email*/ string, /*url*/ string>;
+}
+export const ProxyAvatarsCommand = new IpcCommand<ProxyAvatarsParams>(scope, 'avatars/proxy');
+
 export interface GetMissingRefsMetadataParams {
 	metadata: GraphMissingRefsMetadata;
 }


### PR DESCRIPTION
## Summary

- Proxies avatar images through the extension host (Node.js) when they fail to load in the graph webview due to CORS
- The graph component uses `crossOrigin="anonymous"` for canvas rendering, which blocks images from servers without `Access-Control-Allow-Origin` headers (e.g. GitLab `/uploads/` paths)
- On load error, the webview batches failed URLs and sends them to the extension host via IPC, which downloads them via `fetch` (no CORS in Node.js), converts to `data:` URIs, and sends them back
- The happy path (Gravatar, GitHub — URLs with CORS headers) is unchanged

Depends on gitkraken/GitKrakenComponents#387, which adds `AvatarUrlSpec` support to the `Avatar` component.

Fixes #5343

## Test plan

- [ ] Open a GitLab-connected repo in the Graph
- [ ] Verify GitLab avatars show (briefly as initials, then real avatar after proxy)
- [ ] Verify Gravatar/GitHub avatars still load immediately (no regression)
- [ ] Reset avatar cache + reload — verify avatars recover
- [ ] Check console for no `[object Object]` or infinite retry errors

🤖 Generated with [Claude Code](https://claude.com/claude-code)
