### PR TITLE
Fixes silent error handling in Graph commit message generation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -26,6 +26,7 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/) and this p
 
 ### Fixed
 
+- Fixes the _Commit Graph_ commit details _Generate Commit Message_ silently doing nothing when the AI provider fails with an untyped error (e.g. Copilot credit limit) &mdash; the failure is now surfaced as an error notification, matching the _Source Control_ panel
 - Fixes the _Commit Graph_ retaining outdated parent connections and file statistics after deepening a shallow clone or changing Git replacement refs
 - Fixes closing _Compose_ or _Review_ after restarting discarding the saved work, and restores _Resume_ when returning after navigating away
 - Fixes contextual tips already seen in one _Commit Graph_ view showing again after another view saves its seen tips

--- a/src/plus/ai/__debug__aiSimulator.ts
+++ b/src/plus/ai/__debug__aiSimulator.ts
@@ -207,6 +207,18 @@ class AISimulatorDebug {
 				iconPath: new ThemeIcon('blank'),
 				item: 'quota',
 			},
+			{
+				label: 'Provider Error',
+				description: 'Throws a generic Error (mimics Copilot credit-limit / VSCode provider failure)',
+				iconPath: new ThemeIcon('blank'),
+				item: 'provider-error',
+			},
+			{
+				label: 'Provider Unavailable',
+				description: 'Returns undefined (mimics unavailable Copilot model after credit exhaustion)',
+				iconPath: new ThemeIcon('blank'),
+				item: 'provider-unavailable',
+			},
 		];
 
 		if (this.active != null) {

--- a/src/plus/ai/__debug__aiSimulator.ts
+++ b/src/plus/ai/__debug__aiSimulator.ts
@@ -203,6 +203,18 @@ class AISimulatorDebug {
 				iconPath: new ThemeIcon('blank'),
 				item: 'quota',
 			},
+			{
+				label: 'Provider Error',
+				description: 'Throws a generic Error (mimics Copilot credit-limit / VSCode provider failure)',
+				iconPath: new ThemeIcon('blank'),
+				item: 'provider-error',
+			},
+			{
+				label: 'Provider Unavailable',
+				description: 'Returns undefined (mimics unavailable Copilot model after credit exhaustion)',
+				iconPath: new ThemeIcon('blank'),
+				item: 'provider-unavailable',
+			},
 		];
 
 		if (this.active != null) {

--- a/src/plus/ai/__debug__simulatorProvider.ts
+++ b/src/plus/ai/__debug__simulatorProvider.ts
@@ -46,6 +46,18 @@ const simulatorModels: readonly AIModel<'simulator'>[] = [
 		maxTokens: { input: 200000, output: 32000 },
 		provider: simulatorProviderDescriptor,
 	},
+	{
+		id: 'provider-error',
+		name: 'Simulator: Provider Error (generic)',
+		maxTokens: { input: 200000, output: 32000 },
+		provider: simulatorProviderDescriptor,
+	},
+	{
+		id: 'provider-unavailable',
+		name: 'Simulator: Provider Unavailable',
+		maxTokens: { input: 200000, output: 32000 },
+		provider: simulatorProviderDescriptor,
+	},
 ];
 
 export class SimulatorProvider implements AIProvider<'simulator'> {
@@ -105,6 +117,16 @@ export class SimulatorProvider implements AIProvider<'simulator'> {
 				AIErrorReason.UserQuotaExceeded,
 				new Error('(Simulator) Simulated weekly AI credit limit reached for verification'),
 			);
+		}
+
+		if (mode === 'provider-error') {
+			throw new Error(
+				"(Simulator) You've reached your credit limit. To continue working, please contact your organization's admin or wait until your credits reset.",
+			);
+		}
+
+		if (mode === 'provider-unavailable') {
+			return undefined;
 		}
 
 		if (mode === 'slow') {

--- a/src/plus/ai/__debug__simulatorProvider.ts
+++ b/src/plus/ai/__debug__simulatorProvider.ts
@@ -52,6 +52,18 @@ const simulatorModels: readonly AIModel<'simulator'>[] = [
 		maxTokens: { input: 200000, output: 32000 },
 		provider: simulatorProviderDescriptor,
 	},
+	{
+		id: 'provider-error',
+		name: 'Simulator: Provider Error (generic)',
+		maxTokens: { input: 200000, output: 32000 },
+		provider: simulatorProviderDescriptor,
+	},
+	{
+		id: 'provider-unavailable',
+		name: 'Simulator: Provider Unavailable',
+		maxTokens: { input: 200000, output: 32000 },
+		provider: simulatorProviderDescriptor,
+	},
 ];
 
 /**
@@ -162,6 +174,16 @@ export class SimulatorProvider implements AIProvider<'simulator'> {
 				AIErrorReason.UserQuotaExceeded,
 				new Error('(Simulator) Simulated weekly AI credit limit reached for verification'),
 			);
+		}
+
+		if (mode === 'provider-error') {
+			throw new Error(
+				"(Simulator) You've reached your credit limit. To continue working, please contact your organization's admin or wait until your credits reset.",
+			);
+		}
+
+		if (mode === 'provider-unavailable') {
+			return undefined;
 		}
 
 		if (mode === 'slow') {

--- a/src/plus/ai/__debug__simulatorState.ts
+++ b/src/plus/ai/__debug__simulatorState.ts
@@ -1,7 +1,15 @@
 import type { AIActionType } from '@gitlens/ai/models/model.js';
 import type { AIChatMessage } from '@gitlens/ai/models/provider.js';
 
-export type SimulatorMode = 'default' | 'slow' | 'invalid' | 'error' | 'cancel' | 'quota';
+export type SimulatorMode =
+	| 'default'
+	| 'slow'
+	| 'invalid'
+	| 'error'
+	| 'cancel'
+	| 'quota'
+	| 'provider-error'
+	| 'provider-unavailable';
 
 export interface SimulatorInject {
 	readonly action?: AIActionType;

--- a/src/plus/ai/__debug__simulatorState.ts
+++ b/src/plus/ai/__debug__simulatorState.ts
@@ -1,7 +1,15 @@
 import type { AIActionType } from '@gitlens/ai/models/model.js';
 import type { AIChatMessage, AIChatMessageRole } from '@gitlens/ai/models/provider.js';
 
-export type SimulatorMode = 'default' | 'slow' | 'invalid' | 'error' | 'cancel' | 'quota';
+export type SimulatorMode =
+	| 'default'
+	| 'slow'
+	| 'invalid'
+	| 'error'
+	| 'cancel'
+	| 'quota'
+	| 'provider-error'
+	| 'provider-unavailable';
 
 export interface SimulatorInject {
 	readonly action?: AIActionType;

--- a/src/webviews/plus/graph/graphInspectServices.ts
+++ b/src/webviews/plus/graph/graphInspectServices.ts
@@ -28,6 +28,7 @@ import type { GlRepository } from '../../../git/models/repository.js';
 import { getBranchMergeTargetName } from '../../../git/utils/-webview/branch.utils.js';
 import { getConflictFileInfos } from '../../../git/utils/-webview/conflictKind.utils.js';
 import { getChangesForChangelog } from '../../../git/utils/-webview/log.utils.js';
+import { showGenericErrorMessage } from '../../../messages.js';
 import { getSupportedAgents } from '../../../plus/agents/agentRegistry.js';
 import type { AIGenerateChangelogChanges } from '../../../plus/ai/actions/generateChangelog.js';
 import { shouldUseSinglePass } from '../../../plus/ai/actions/reviewChanges.js';
@@ -1438,8 +1439,10 @@ export class GraphInspectServices {
 
 			return result.result;
 		} catch (ex) {
-			// Surface the failure instead of silently returning so regressions are visible.
+			// Untyped provider errors (e.g. Copilot credit limit) arrive unnotified — surface
+			// them like the SCM command does
 			Logger.error(ex, 'graph.generateCommitMessage');
+			void showGenericErrorMessage(ex instanceof Error ? ex.message : String(ex));
 			return undefined;
 		} finally {
 			disposeCancellation();

--- a/src/webviews/plus/graph/graphWebview.ts
+++ b/src/webviews/plus/graph/graphWebview.ts
@@ -203,6 +203,7 @@ import {
 	getWorktreesByBranch,
 } from '../../../git/utils/-webview/worktree.utils.js';
 import type { RebaseTodoAction } from '../../../git/utils/rebaseTodo.js';
+import { showGenericErrorMessage } from '../../../messages.js';
 import type { OnboardingChangeEvent } from '../../../onboarding/onboardingService.js';
 import type { UsageChangeEvent } from '../../../onboarding/usageTracker.js';
 import { getSupportedAgents } from '../../../plus/agents/agentRegistry.js';
@@ -1861,8 +1862,8 @@ export class GraphWebviewProvider implements WebviewProvider<State, State, Graph
 
 						return result.result;
 					} catch (ex) {
-						// Surface the failure instead of silently returning so regressions are visible.
 						Logger.error(ex, 'graph.generateCommitMessage');
+						void showGenericErrorMessage(ex instanceof Error ? ex.message : String(ex));
 						return undefined;
 					} finally {
 						disposeCancellation();


### PR DESCRIPTION
## Summary

- Shows an error notification when the Graph details "Generate Commit Message" fails with an untyped provider error (e.g. Copilot credit limit)
- Adds `Provider Error` and `Provider Unavailable` AI simulator modes for reproducing untyped provider failures in debug builds

Closes gitkraken/vscode-gitlens-private#89

## Approach

**Implemented (Option A — targeted fix):** Added `showGenericErrorMessage()` to the Graph's `generateCommitMessage` catch block in `graphInspectServices.ts`, matching the existing SCM command behavior in `generateCommitMessage.ts`.

> Note: originally implemented in `graphWebview.ts`; the handler has since moved to `graphInspectServices.ts` (Home view removal relocated the Graph details services), so the fix now lands there.

**Alternative considered (Option B — systemic fix):** Add a fallback notification in `sendRequest()` (`aiProviderService.ts`) for all unclassified errors before rethrowing, so no caller has to handle it individually. This would cover all current and future AI surfaces (Graph, SCM, Composer, Review, etc.) but is a broader change in a critical path.

## Test plan

Verified live against a debug build (subscription simulator → Pro, AI simulator → the modes below):

- [x] Provider Error mode: Graph → select WIP → sparkle "Generate Commit Message" → error notification shown (previously: silent, error only in the output channel)
- [x] SCM "Generate Commit Message" with the same mode → same error notification (surfaces now match)
- [x] Cancel mode → no spurious error notification (cancellation is returned as `'cancelled'`, never rethrown)
- [x] Provider Unavailable mode → silent on both surfaces, no crash (expected — no error to report; the "AI is degraded" indicator is out of scope, tracked by the issue's remaining items)
- [x] Typed AIError modes (Error, Quota) still show their specific notifications from both surfaces — and only once on the Graph (typed errors are notified inside `sendRequest` and never reach the new catch, so no double notification)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
