### PR TITLE
Fixes Keep Staged dropping staged changes when stashing selected files

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,10 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/) and this p
 - Adds ConfigCat-based feature flag service for A/B testing and experimentation support ([#5092](https://github.com/gitkraken/vscode-gitlens/issues/5092))
 - Adds an optional `avatar` URL template to custom remotes in the `gitlens.remotes` setting &mdash; enables corporate and self-hosted setups to resolve commit-author avatars via a templated URL with `${email}`, `${emailName}`, `${domain}`, and `${size}` tokens; identity values are component-encoded before interpolation to keep attacker-controllable commit emails from injecting URL-structural characters, and templates configured via workspace settings require explicit user approval on first use in a trusted workspace (revocable via _GitLens: Reset > Approved Avatar URL Templates..._) ([#302](https://github.com/gitkraken/vscode-gitlens/issues/302), [#5155](https://github.com/gitkraken/vscode-gitlens/pull/5155)) &mdash; thanks to [PR #1636](https://github.com/gitkraken/vscode-gitlens/pull/1636) by Tmk ([@tmkx](https://github.com/tmkx))
 
+### Fixed
+
+- Fixes _Keep Staged_ not keeping staged changes when stashing selected files &mdash; choosing _Keep Staged_ while stashing specific tracked files no longer drops the `--keep-index` flag, so staged changes are correctly kept intact ([#5281](https://github.com/gitkraken/vscode-gitlens/issues/5281))
+
 ## [18.2.0] - 2026-06-15
 
 ### Added

--- a/packages/git-cli/src/providers/__tests__/integration/stash.test.ts
+++ b/packages/git-cli/src/providers/__tests__/integration/stash.test.ts
@@ -176,6 +176,57 @@ suite('StashSubProvider.saveStash', () => {
 			r.cleanup();
 		}
 	});
+
+	test('keeps staged changes when stashing tracked files by pathspec (#5281)', async () => {
+		// Regression for #5281 (file-selection path): selecting tracked files and choosing "Keep Staged"
+		// must keep the index intact. The selection has no untracked files (includeUntracked: false), so
+		// the git --keep-index pathspec bug doesn't apply and --keep-index must NOT be dropped. A prior
+		// bug dropped --keep-index for *every* pathspec push (because --include-untracked is auto-added as
+		// a safety net), stashing the staged changes too.
+		const r = createTestRepo();
+		try {
+			addCommit(r.path, 'both.txt', 'L1\nL2\n', 'add both.txt');
+
+			// Staged change to a tracked file...
+			writeFileSync(join(r.path, 'both.txt'), 'L1-staged\nL2\n');
+			execFileSync('git', ['add', 'both.txt'], { cwd: r.path, stdio: 'pipe' });
+			// ...plus a further unstaged change to the same file
+			writeFileSync(join(r.path, 'both.txt'), 'L1-staged\nL2-unstaged\n');
+			// Untracked file present but NOT part of the selection
+			writeFileSync(join(r.path, 'untracked.txt'), 'untracked\n');
+
+			// Stash only the tracked file, keeping the index — no untracked files in the selection
+			await r.provider.stash?.saveStash(r.path, 'tracked only, keep staged', [join(r.path, 'both.txt')], {
+				includeUntracked: false,
+				keepIndex: true,
+			});
+
+			// The staged change must remain staged (index kept intact)
+			assert.strictEqual(
+				execFileSync('git', ['show', ':both.txt'], { cwd: r.path, encoding: 'utf-8' }),
+				'L1-staged\nL2\n',
+				'Staged change must remain staged after stashing tracked files with keepIndex',
+			);
+			// The working tree must be reset to the staged state (the unstaged change was stashed)
+			assert.strictEqual(
+				readFileSync(join(r.path, 'both.txt'), 'utf-8'),
+				'L1-staged\nL2\n',
+				'Unstaged change should have been stashed',
+			);
+			// The unselected untracked file must be left untouched
+			assert.strictEqual(
+				readFileSync(join(r.path, 'untracked.txt'), 'utf-8'),
+				'untracked\n',
+				'Unselected untracked file should be left in the working tree',
+			);
+
+			// Exactly one stash entry should have been created
+			const stash = await r.provider.stash?.getStash(r.path);
+			assert.strictEqual(stash?.stashes.size, 1, 'Expected exactly one stash entry');
+		} finally {
+			r.cleanup();
+		}
+	});
 });
 
 suite('CommitsSubProvider.getLog with stashes after rebase', () => {

--- a/packages/git-cli/src/providers/__tests__/integration/stash.test.ts
+++ b/packages/git-cli/src/providers/__tests__/integration/stash.test.ts
@@ -227,6 +227,171 @@ suite('StashSubProvider.saveStash', () => {
 			r.cleanup();
 		}
 	});
+
+	test('stashes only staged changes, keeping unstaged changes intact (#2539, #5138)', async () => {
+		// Regression for #2539/#5138: "Stash Staged Changes" (onlyStaged) must stash only what's staged
+		// and leave unstaged changes in the working tree. Staged and unstaged edits are on *different*
+		// lines to avoid git's same-line --staged limitation.
+		const r = createTestRepo();
+		try {
+			addCommit(r.path, 'f.txt', 'L1\nL2\nL3\n', 'add f.txt');
+
+			// Staged change on line 1...
+			writeFileSync(join(r.path, 'f.txt'), 'L1-staged\nL2\nL3\n');
+			execFileSync('git', ['add', 'f.txt'], { cwd: r.path, stdio: 'pipe' });
+			// ...unstaged change on a different line (line 3)
+			writeFileSync(join(r.path, 'f.txt'), 'L1-staged\nL2\nL3-unstaged\n');
+
+			await r.provider.stash?.saveStash(r.path, 'staged only', undefined, { onlyStaged: true });
+
+			// The index is reset to HEAD — the staged change moved into the stash
+			assert.strictEqual(
+				execFileSync('git', ['show', ':f.txt'], { cwd: r.path, encoding: 'utf-8' }),
+				'L1\nL2\nL3\n',
+				'Index should be reset to HEAD after stashing only staged changes',
+			);
+			// The unstaged change is left untouched in the working tree
+			assert.strictEqual(
+				readFileSync(join(r.path, 'f.txt'), 'utf-8'),
+				'L1\nL2\nL3-unstaged\n',
+				'Unstaged changes should remain in the working tree',
+			);
+
+			const stash = await r.provider.stash?.getStash(r.path);
+			assert.strictEqual(stash?.stashes.size, 1, 'Expected exactly one stash entry');
+		} finally {
+			r.cleanup();
+		}
+	});
+
+	test('stashes only staged changes for a specific tracked file by pathspec (#4894)', async () => {
+		// Regression for #4894: "--staged" combined with a pathspec for a tracked file must not fail with
+		// "pathspec ... did not match any file(s) known to git".
+		const r = createTestRepo();
+		try {
+			addCommit(r.path, 't.txt', 'L1\nL2\n', 'add t.txt');
+			writeFileSync(join(r.path, 't.txt'), 'L1-staged\nL2\n');
+			execFileSync('git', ['add', 't.txt'], { cwd: r.path, stdio: 'pipe' });
+
+			await assert.doesNotReject(
+				() => r.provider.stash?.saveStash(r.path, 'staged file', [join(r.path, 't.txt')], { onlyStaged: true }),
+				'Stashing a staged tracked file by pathspec with --staged should not error',
+			);
+
+			// The staged change was stashed and the index reset to HEAD
+			assert.strictEqual(
+				execFileSync('git', ['show', ':t.txt'], { cwd: r.path, encoding: 'utf-8' }),
+				'L1\nL2\n',
+				'Index should be reset to HEAD',
+			);
+			const stash = await r.provider.stash?.getStash(r.path);
+			assert.strictEqual(stash?.stashes.size, 1, 'Expected exactly one stash entry');
+		} finally {
+			r.cleanup();
+		}
+	});
+});
+
+suite('StashSubProvider untracked files', () => {
+	test('lists and restores untracked files stashed with --include-untracked (#2033, #1890)', async () => {
+		// Regression for #2033/#1890: untracked files captured in a stash must be listed and restored on
+		// apply (git stores them in the stash's third parent).
+		const r = createTestRepo();
+		try {
+			writeFileSync(join(r.path, 'untracked.txt'), 'untracked content\n');
+			await r.provider.stash?.saveStash(r.path, 'with untracked', undefined, { includeUntracked: true });
+
+			// The untracked file was stashed away (removed from the working tree)
+			assert.throws(
+				() => readFileSync(join(r.path, 'untracked.txt'), 'utf-8'),
+				'Untracked file should have been stashed',
+			);
+
+			const stash = await r.provider.stash?.getStash(r.path);
+			const commit = [...(stash?.stashes.values() ?? [])][0];
+			const stashName = commit?.stashName;
+			assert.ok(stashName, 'Expected a stash entry with a name');
+
+			// The untracked file is listed among the stash's files
+			const files = await r.provider.stash?.getStashCommitFiles(r.path, stashName);
+			assert.ok(
+				files?.some(f => f.path === 'untracked.txt'),
+				'Untracked file should be listed in the stash',
+			);
+
+			// Applying the stash restores the untracked file to the working tree
+			const result = await r.provider.stash?.applyStash(r.path, stashName);
+			assert.strictEqual(result?.conflicted, false, 'Apply should not conflict');
+			assert.strictEqual(
+				readFileSync(join(r.path, 'untracked.txt'), 'utf-8'),
+				'untracked content\n',
+				'Untracked file should be restored on apply',
+			);
+		} finally {
+			r.cleanup();
+		}
+	});
+});
+
+suite('StashSubProvider.applyStash (pop)', () => {
+	test('pop removes the entry from the stash list (#3163)', async () => {
+		// Regression for #3163: applying with deleteAfter (pop) must drop the entry from the stash list.
+		const r = createTestRepo();
+		try {
+			writeFileSync(join(r.path, 'README.md'), '# changed\n');
+			await r.provider.stash?.saveStash(r.path, 'popme');
+
+			const stash = await r.provider.stash?.getStash(r.path);
+			const stashName = [...(stash?.stashes.values() ?? [])][0]?.stashName;
+			assert.ok(stashName, 'Expected a stash entry');
+
+			await r.provider.stash?.applyStash(r.path, stashName, { deleteAfter: true });
+
+			// Assert against git directly: the provider's cached getStash isn't invalidated without the
+			// cache-reset hooks the extension wires up, so it can return a stale entry here.
+			const remaining = execFileSync('git', ['stash', 'list'], { cwd: r.path, encoding: 'utf-8' })
+				.split('\n')
+				.filter(Boolean);
+			assert.strictEqual(remaining.length, 0, 'pop should drop the stash entry');
+			// The changes were applied to the working tree
+			assert.strictEqual(readFileSync(join(r.path, 'README.md'), 'utf-8'), '# changed\n');
+		} finally {
+			r.cleanup();
+		}
+	});
+});
+
+suite('StashSubProvider.deleteStash', () => {
+	test('drops the targeted entry by name + sha, leaving others intact (#1971)', async () => {
+		// Regression for #1971: dropping must target the exact entry (verified by sha), not be confused by
+		// stash-number/index shifts.
+		const r = createTestRepo();
+		try {
+			writeFileSync(join(r.path, 'README.md'), '# first\n');
+			await r.provider.stash?.saveStash(r.path, 'first');
+			writeFileSync(join(r.path, 'README.md'), '# second\n');
+			await r.provider.stash?.saveStash(r.path, 'second');
+
+			const stash = await r.provider.stash?.getStash(r.path);
+			const first = [...(stash?.stashes.values() ?? [])].find(c => c.message === 'first');
+			assert.ok(first?.stashName, 'Expected to find the "first" stash');
+
+			// Pass the sha so git drops the exact entry even if list indices have shifted
+			await r.provider.stash?.deleteStash(r.path, first.stashName, first.sha);
+
+			// Assert against git directly (the provider's cached getStash isn't invalidated in tests)
+			const remaining = execFileSync('git', ['stash', 'list'], { cwd: r.path, encoding: 'utf-8' }).trim();
+			assert.match(remaining, /second/, 'The "second" stash should remain');
+			assert.doesNotMatch(remaining, /first/, 'The "first" stash should have been dropped');
+			assert.strictEqual(
+				remaining.split('\n').filter(Boolean).length,
+				1,
+				'Exactly one stash should remain after dropping the other',
+			);
+		} finally {
+			r.cleanup();
+		}
+	});
 });
 
 suite('CommitsSubProvider.getLog with stashes after rebase', () => {

--- a/packages/git-cli/src/providers/stash.ts
+++ b/packages/git-cli/src/providers/stash.ts
@@ -390,8 +390,9 @@ export class StashGitSubProvider implements GitStashSubProvider {
 			params.push('--include-untracked');
 		}
 
-		// "--keep-index --include-untracked -- <pathspec>" hits a bug in git in some circumstances.
-		// Don't allow these flags together.
+		// `git stash push --keep-index --include-untracked -- <pathspec>` hits a bug in git when the
+		// pathspec names an untracked file: the restoring checkout can't match an untracked path in the
+		// index tree, so it fails and the staged changes are lost.
 		//
 		// $ mkdir stash-test && cd stash-test && git init
 		// $ echo a > a.txt
@@ -401,7 +402,13 @@ export class StashGitSubProvider implements GitStashSubProvider {
 		// $ git stash push --keep-index --include-untracked -- b.txt
 		// Saved working directory and index state WIP on main: 8a280fe init
 		// error: pathspec ':(prefix:0)b.txt' did not match any file(s) known to git
-		if (options?.keepIndex && !(params.includes('--include-untracked') && options?.pathspecs?.length)) {
+		//
+		// Only suppress --keep-index for that case — when the selection actually includes untracked
+		// files (`includeUntracked`) AND we're stashing by pathspec. Keying off `includeUntracked` (the
+		// caller's intent) rather than the `--include-untracked` flag is deliberate: we add
+		// `--include-untracked` to every pathspec push above as a safety net, but a tracked-only
+		// selection can — and must — still keep the index intact.
+		if (options?.keepIndex && !(options?.includeUntracked && options?.pathspecs?.length)) {
 			params.push('--keep-index');
 		}
 


### PR DESCRIPTION
## Summary

Fixes #5369 — stashing **selected files** with **Keep Staged** was dropping the staged changes instead of keeping the index intact.

`stashPushCore` adds `--include-untracked` to every pathspec push as a safety net, and the `--keep-index` guard keyed off whether `--include-untracked` was present in the params — so it dropped `--keep-index` for **every** file-selection push, even tracked-only selections where git's `--keep-index --include-untracked -- <pathspec>` bug doesn't apply.

This keys the guard off the caller's actual intent (`options.includeUntracked`) instead:

```ts
if (options?.keepIndex && !(options?.includeUntracked && options?.pathspecs?.length)) {
```

- Tracked-only selection → `--keep-index` kept, index preserved ✅
- Selection that includes untracked files → `--keep-index` still dropped to avoid the git bug

This is the file-selection counterpart to c4d86fe (18.1.0), which only fixed the no-pathspec _Stash Unstaged Changes_ SCM action.

## Tests

- New integration test for the fix (proven to fail without it).
- Plus regression tests hardening this high-activity area, mapped to past issues:
  - onlyStaged keeps unstaged changes (#2539, #5138)
  - onlyStaged + tracked-file pathspec doesn't hit the pathspec-match error (#4894)
  - untracked files listed in / restored from a stash (#2033, #1890)
  - pop drops the entry (#3163)
  - deleteStash targets the correct entry by name + sha (#1971)

Full stash suite: 15 passing. Typecheck, Prettier, oxlint clean.

Relates to #5281.