### PR TITLE
Closes #5364 - Fix git operations silently swallowing failures matching Git warnings

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,8 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/) and this p
 ### Fixed
 
 - Fixes _Keep Staged_ not keeping staged changes when stashing selected files &mdash; choosing _Keep Staged_ while stashing specific tracked files no longer drops the `--keep-index` flag, so staged changes are correctly kept intact ([#5281](https://github.com/gitkraken/vscode-gitlens/issues/5281))
+- Fixes pushing a branch that needs a force-push (e.g. after an amend or rebase) silently reporting success without updating the remote &mdash; a non-fast-forward (_tip of your current branch is behind_) rejection is now surfaced as an error instead of being swallowed as non-fatal ([#5364](https://github.com/gitkraken/vscode-gitlens/issues/5364))
+- Fixes _Fetch_, _Pull_, _Switch_, _Reset_, and _Restore_ operations silently reporting success when the underlying Git command failed with a message Git treats as a warning (e.g. an unreachable remote, or an invalid ref/revision) &mdash; these failures are now surfaced as errors instead of being swallowed as non-fatal
 
 ## [18.2.0] - 2026-06-15
 

--- a/packages/core/CHANGELOG.md
+++ b/packages/core/CHANGELOG.md
@@ -6,6 +6,10 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/) and this p
 
 ## [Unreleased]
 
+### Fixed
+
+- Fixes `push`, `fetch`, `pull`, `reset`, `checkout`, and `restore` resolving as success when the git command actually failed with output matching a `GitWarnings` pattern (e.g. a non-fast-forward `tipBehind` push rejection, an unreachable remote, or an invalid ref/revision) — the rejection was swallowed by the default handler and the typed-error mapping was unreachable; these now reject with the correct error (`PushError`/`FetchError`/`PullError`/`ResetError`/`CheckoutError`) (git-cli)
+
 ## [0.3.0] - 2026-05-27
 
 ## [0.2.0] - 2026-05-01

--- a/packages/git-cli/src/exec/__tests__/gitErrors.test.ts
+++ b/packages/git-cli/src/exec/__tests__/gitErrors.test.ts
@@ -2,6 +2,7 @@ import * as assert from 'assert';
 import { RunError } from '../exec.errors.js';
 import {
 	classifySigningError,
+	defaultExceptionHandler,
 	getGitCommandError,
 	GitError,
 	GitErrors,
@@ -443,6 +444,31 @@ suite('getGitCommandError() Test Suite', () => {
 	test('maps fetch stderr to "remoteConnectionFailed" reason', () => {
 		const ex = makeGitError('fatal: Could not read from remote repository.');
 		assert.strictEqual(captureReason('fetch', ex), 'remoteConnectionFailed');
+	});
+});
+
+suite('defaultExceptionHandler() Test Suite', () => {
+	// Documents the mechanism behind the requirement that mutating operations (push, etc.) pass
+	// `errors: 'throw'`: any rejection whose message matches a `GitWarnings` regex is treated as
+	// non-fatal and swallowed here, so it never reaches the operation's catch block. A push left to
+	// the default handler would resolve as if it succeeded on a non-fast-forward (`tipBehind`) rejection.
+	test('swallows tipBehind (non-fast-forward) rejections as non-fatal', () => {
+		const ex = makeGitError(
+			'hint: Updates were rejected because the tip of your current branch is behind\nhint: its remote counterpart.',
+		);
+		assert.doesNotThrow(() => defaultExceptionHandler(ex, '/repo'));
+	});
+
+	test('rethrows remoteAhead rejections (not a GitWarning)', () => {
+		const ex = makeGitError(
+			"error: failed to push some refs to 'origin'\nhint: Updates were rejected because the remote contains work that you do not have locally.",
+		);
+		assert.throws(() => defaultExceptionHandler(ex, '/repo'));
+	});
+
+	test('rethrows unrecognized errors', () => {
+		const ex = makeGitError('some unknown error happened');
+		assert.throws(() => defaultExceptionHandler(ex, '/repo'));
 	});
 });
 

--- a/packages/git-cli/src/providers/__tests__/operations.test.ts
+++ b/packages/git-cli/src/providers/__tests__/operations.test.ts
@@ -1,0 +1,166 @@
+import * as assert from 'assert';
+import * as sinon from 'sinon';
+import type { Cache } from '@gitlens/git/cache.js';
+import type { GitServiceContext } from '@gitlens/git/context.js';
+import { CheckoutError, FetchError, PullError, PushError, ResetError } from '@gitlens/git/errors.js';
+import type { GitBranchReference } from '@gitlens/git/models/reference.js';
+import type { GitResult, GitRunOptions } from '@gitlens/git/run.types.js';
+import type { CliGitProviderInternal } from '../../cliGitProvider.js';
+import { RunError } from '../../exec/exec.errors.js';
+import type { Git } from '../../exec/git.js';
+import { defaultExceptionHandler, GitError } from '../../exec/git.js';
+import { OperationsGitSubProvider } from '../operations.js';
+
+suite('OperationsGitSubProvider Test Suite', () => {
+	let sandbox: sinon.SinonSandbox;
+	let operations: OperationsGitSubProvider;
+	let gitStub: sinon.SinonStubbedInstance<Git>;
+
+	const repoPath = '/repo';
+
+	function branchRef(): GitBranchReference {
+		return {
+			refType: 'branch',
+			name: 'feature',
+			ref: 'feature',
+			remote: false,
+			upstream: { name: 'origin/feature', missing: false },
+			repoPath: repoPath,
+		};
+	}
+
+	function successResult(): GitResult {
+		return { stdout: '', stderr: undefined, exitCode: 0, cancelled: false };
+	}
+
+	/**
+	 * Stubs `git.run` to mirror the real {@link Git.runCore} error contract for a failing command:
+	 * with `errors: 'throw'` the rejection is thrown; otherwise it is routed through the real
+	 * {@link defaultExceptionHandler}, which swallows `GitWarnings` matches (resolving as success)
+	 * and rethrows everything else. This reproduces the production swallow behavior without spawning
+	 * a real git process, so the tests genuinely distinguish a push that surfaces a rejection from
+	 * one that silently swallows it.
+	 */
+	function stubRunFailure(stderr: string): void {
+		(gitStub.run as sinon.SinonStub).callsFake(
+			async (options: GitRunOptions, ...args: readonly (string | undefined)[]) => {
+				const ex = new GitError(
+					new RunError(
+						{ message: stderr, cmd: `git ${args.filter(a => a != null).join(' ')}`, code: 1 },
+						'',
+						stderr,
+					),
+				);
+				if (options.errors === 'throw') throw ex;
+
+				// Mirror Git.runCore: let the default handler decide fatal vs. non-fatal
+				defaultExceptionHandler(ex, options.cwd);
+				return successResult();
+			},
+		);
+	}
+
+	setup(() => {
+		sandbox = sinon.createSandbox();
+
+		class MockGit {
+			supports(_feature: string) {
+				return Promise.resolve(true);
+			}
+			run(..._args: any[]) {
+				return Promise.resolve(successResult());
+			}
+		}
+
+		gitStub = sandbox.createStubInstance(MockGit) as unknown as sinon.SinonStubbedInstance<Git>;
+		(gitStub.run as sinon.SinonStub).resolves(successResult());
+
+		const context = {} as unknown as GitServiceContext;
+		const cache = {} as unknown as Cache;
+		const provider = {} as unknown as CliGitProviderInternal;
+
+		operations = new OperationsGitSubProvider(context, gitStub, cache, provider);
+	});
+
+	teardown(() => {
+		sandbox.restore();
+	});
+
+	test('push passes `errors: throw` so rejections are not swallowed by the default handler', async () => {
+		await operations.push(repoPath, { reference: branchRef() });
+
+		const pushCall = (gitStub.run as sinon.SinonStub).getCalls().find(c => c.args.includes('push'));
+		assert.ok(pushCall, 'expected git.run to be invoked with a push command');
+		assert.strictEqual((pushCall.args[0] as GitRunOptions).errors, 'throw');
+	});
+
+	test('push surfaces a non-fast-forward (tipBehind) rejection as PushError', async () => {
+		stubRunFailure(
+			'To origin\n ! [rejected]        feature -> feature (non-fast-forward)\n' +
+				"error: failed to push some refs to 'origin'\n" +
+				'hint: Updates were rejected because the tip of your current branch is behind\n' +
+				'hint: its remote counterpart.',
+		);
+
+		await assert.rejects(operations.push(repoPath, { reference: branchRef() }), (ex: unknown) =>
+			PushError.is(ex, 'tipBehind'),
+		);
+	});
+
+	test('push surfaces a remoteAhead rejection as PushError', async () => {
+		stubRunFailure(
+			"error: failed to push some refs to 'origin'\n" +
+				'hint: Updates were rejected because the remote contains work that you do not have locally.',
+		);
+
+		await assert.rejects(operations.push(repoPath, { reference: branchRef() }), (ex: unknown) =>
+			PushError.is(ex, 'remoteAhead'),
+		);
+	});
+
+	test('fetch surfaces an unreachable-remote failure as FetchError', async () => {
+		// `remoteConnectionError` is a GitWarning, so without `errors: 'throw'` the default handler
+		// swallows it and the fetch resolves as if it succeeded.
+		stubRunFailure('fatal: Could not read from remote repository.');
+
+		await assert.rejects(operations.fetch(repoPath), (ex: unknown) => FetchError.is(ex, 'remoteConnectionFailed'));
+	});
+
+	test('pull surfaces an unreachable-remote failure as PullError', async () => {
+		// `remoteConnectionError` is a GitWarning, so without `errors: 'throw'` the default handler
+		// swallows it and the pull resolves as if it succeeded.
+		stubRunFailure('fatal: Could not read from remote repository.');
+
+		await assert.rejects(operations.pull(repoPath), (ex: unknown) => PullError.is(ex, 'remoteConnectionFailed'));
+	});
+
+	test('reset surfaces an invalid-revision failure as ResetError', async () => {
+		// `unknownRevision` is a GitWarning, so without `errors: 'throw'` the default handler swallows
+		// it and the reset resolves as if it succeeded (without resetting).
+		stubRunFailure("fatal: ambiguous argument 'badref': unknown revision or path not in the working tree.");
+
+		await assert.rejects(operations.reset(repoPath, 'badref'), (ex: unknown) =>
+			ResetError.is(ex, 'ambiguousArgument'),
+		);
+	});
+
+	test('checkout surfaces an invalid-ref failure as CheckoutError', async () => {
+		// `unknownRevision` is a GitWarning, so without `errors: 'throw'` the default handler swallows
+		// it and the checkout resolves as if it succeeded.
+		stubRunFailure("fatal: ambiguous argument 'badref': unknown revision or path not in the working tree.");
+
+		await assert.rejects(operations.checkout(repoPath, 'badref'), (ex: unknown) =>
+			CheckoutError.is(ex, 'pathspecNotFound'),
+		);
+	});
+
+	test('restore surfaces an invalid-ref failure as CheckoutError', async () => {
+		// restore is implemented via `git checkout`; `unknownRevision` is a GitWarning, so without
+		// `errors: 'throw'` the default handler swallows it and the restore resolves as if it succeeded.
+		stubRunFailure("fatal: ambiguous argument 'badref': unknown revision or path not in the working tree.");
+
+		await assert.rejects(operations.restore(repoPath, 'file.ts', { ref: 'badref' }), (ex: unknown) =>
+			CheckoutError.is(ex, 'pathspecNotFound'),
+		);
+	});
+});

--- a/packages/git-cli/src/providers/operations.ts
+++ b/packages/git-cli/src/providers/operations.ts
@@ -65,7 +65,7 @@ export class OperationsGitSubProvider implements GitOperationsSubProvider {
 		}
 
 		try {
-			await this.git.run({ cwd: repoPath, ...runOptions }, ...params);
+			await this.git.run({ cwd: repoPath, errors: 'throw', ...runOptions }, ...params);
 			this.context.hooks?.cache?.onReset?.(repoPath, 'branches', 'status');
 			this.context.hooks?.repository?.onChanged?.(repoPath, ['head', 'heads', 'index']);
 		} catch (ex) {
@@ -278,7 +278,7 @@ export class OperationsGitSubProvider implements GitOperationsSubProvider {
 		}
 
 		try {
-			await this.git.run({ cwd: repoPath, ...runOptions }, ...params);
+			await this.git.run({ cwd: repoPath, errors: 'throw', ...runOptions }, ...params);
 		} catch (ex) {
 			throw getGitCommandError(
 				'fetch',
@@ -425,7 +425,7 @@ export class OperationsGitSubProvider implements GitOperationsSubProvider {
 		}
 
 		try {
-			await this.git.run({ cwd: repoPath, configs: gitConfigsPull, ...runOptions }, ...params);
+			await this.git.run({ cwd: repoPath, configs: gitConfigsPull, errors: 'throw', ...runOptions }, ...params);
 		} catch (ex) {
 			await this.throwIfSigningError(repoPath, params, ex, options.source);
 			throw getGitCommandError(
@@ -590,7 +590,7 @@ export class OperationsGitSubProvider implements GitOperationsSubProvider {
 		}
 
 		try {
-			await this.git.run({ cwd: repoPath, ...runOptions }, ...params);
+			await this.git.run({ cwd: repoPath, errors: 'throw', ...runOptions }, ...params);
 		} catch (ex) {
 			const error = getGitCommandError(
 				'push',
@@ -779,7 +779,7 @@ export class OperationsGitSubProvider implements GitOperationsSubProvider {
 		params.push(rev, '--');
 
 		try {
-			await this.git.run({ cwd: repoPath, ...runOptions }, ...params);
+			await this.git.run({ cwd: repoPath, errors: 'throw', ...runOptions }, ...params);
 		} catch (ex) {
 			throw getGitCommandError(
 				'reset',
@@ -823,7 +823,10 @@ export class OperationsGitSubProvider implements GitOperationsSubProvider {
 					args.push(selector);
 				}
 				args.push('--pathspec-from-file=-', '--pathspec-file-nul');
-				await this.git.run({ cwd: repoPath, ...runOptions, stdin: normalized.join('\0') }, ...args);
+				await this.git.run(
+					{ cwd: repoPath, errors: 'throw', ...runOptions, stdin: normalized.join('\0') },
+					...args,
+				);
 			} else {
 				// Older git: pass pathspecs as args, one git invocation per chunk (collapsing N
 				// path-mode checkouts into ⌈N / chunk⌉ spawns). Reserve the command prefix length and
@@ -832,7 +835,7 @@ export class OperationsGitSubProvider implements GitOperationsSubProvider {
 				const perArgOverhead = 3;
 				const prefixLength = prefix.reduce((sum, arg) => sum + arg.length + perArgOverhead, 0);
 				for (const batch of chunkByStringLength(normalized, maxGitCliLength - prefixLength, perArgOverhead)) {
-					await this.git.run({ cwd: repoPath, ...runOptions }, ...prefix, ...batch);
+					await this.git.run({ cwd: repoPath, errors: 'throw', ...runOptions }, ...prefix, ...batch);
 				}
 			}
 			this.context.hooks?.cache?.onReset?.(repoPath, 'status');


### PR DESCRIPTION
# Description

Closes #5364

The mutating operations in the `git-cli` `OperationsGitSubProvider` — `push`, `fetch`, `pull`, `reset`, `checkout`, and `restore` — ran git **without** `errors: 'throw'`. As a result, any rejection whose message matched a `GitWarnings` regex was treated as non-fatal by `defaultExceptionHandler`, swallowed, and the operation **resolved as if it had succeeded** — leaving each method's `getGitCommandError(...)` → typed-error mapping unreachable.

The most visible case (reported in #5364, found while debugging a downstream Kepler issue): a normal `push` of a branch that needs a force-push (after an amend/rebase) is rejected as non-fast-forward with _"tip of your current branch is behind its remote counterpart"_. That message matches `GitWarnings.tipBehind`, so `ops.push()` resolved successfully while the remote was left unchanged — the caller couldn't tell a real push from a rejected one.

## Fix

Pass `errors: 'throw'` on each of the six operations so rejections reach the `catch` and surface as the correct typed error (`PushError` / `FetchError` / `PullError` / `ResetError` / `CheckoutError`), matching what `commit` / `merge` / `rebase` / `cherryPick` already do. Beyond `tipBehind`, this also covers other `GitWarnings` that overlap with these operations' real failures — e.g. `remoteConnectionError` (unreachable remote) for `fetch`/`pull`, and `unknownRevision` (invalid ref/revision) for `reset`/`checkout`/`restore`.

The alternative (moving `tipBehind` out of `GitWarnings`) was rejected as riskier, since `defaultExceptionHandler` uses that table for every command.

## Tests

- New `operations.test.ts` with a per-operation regression test. The harness stubs `git.run` to faithfully mirror the real `Git.runCore` error contract (delegating to the actual `defaultExceptionHandler`), so the tests reproduce the production swallow rather than bypassing it — verified that reverting the fix makes them fail.
- New `defaultExceptionHandler()` suite documenting the swallow mechanism (swallows `tipBehind`, rethrows `remoteAhead`/unrecognized).

## Changelog

- Root `CHANGELOG.md` — user-facing GitLens extension entry.
- `packages/core/CHANGELOG.md` — API-facing entry for the published `@gitkraken/core-gitlens` package (which bundles `git-cli`), since downstream consumers (e.g. Kepler) pick up the fix through a `core` release.
