### PR TITLE
Explain telemetry in graph

### DIFF
--- a/docs/telemetry-events.md
+++ b/docs/telemetry-events.md
@@ -3038,9 +3038,125 @@ background-upgraded the extension while the host kept running the old build
 }
 ```
 
+### graphDetails/commit/explain
+
+> Sent when the user runs AI explain on a single commit in Graph Details
+
+```typescript
+{
+  'context.repository.closed': boolean,
+  'context.repository.folder.scheme': string,
+  'context.repository.id': string,
+  'context.repository.provider.id': string,
+  'context.repository.scheme': string,
+  'context.webview.host': 'view' | 'editor' | 'panel',
+  'context.webview.id': string,
+  'context.webview.instanceId': string,
+  'context.webview.type': string,
+  // Whether the user supplied custom guidance
+  'hasCustomPrompt': boolean,
+  // Whether the target is a stash entry rather than a regular commit
+  'isStash': boolean
+}
+```
+
+### graphDetails/commit/explain/completed
+
+> Sent when a single-commit AI explain completes successfully in Graph Details
+
+```typescript
+{
+  'context.repository.closed': boolean,
+  'context.repository.folder.scheme': string,
+  'context.repository.id': string,
+  'context.repository.provider.id': string,
+  'context.repository.scheme': string,
+  'context.webview.host': 'view' | 'editor' | 'panel',
+  'context.webview.id': string,
+  'context.webview.instanceId': string,
+  'context.webview.type': string,
+  // Whether the user supplied custom guidance
+  'hasCustomPrompt': boolean,
+  // Whether the target is a stash entry rather than a regular commit
+  'isStash': boolean
+}
+```
+
+### graphDetails/commit/explain/failed
+
+> Sent when a single-commit AI explain fails in Graph Details
+
+```typescript
+{
+  'context.repository.closed': boolean,
+  'context.repository.folder.scheme': string,
+  'context.repository.id': string,
+  'context.repository.provider.id': string,
+  'context.repository.scheme': string,
+  'context.webview.host': 'view' | 'editor' | 'panel',
+  'context.webview.id': string,
+  'context.webview.instanceId': string,
+  'context.webview.type': string,
+  // Whether the user supplied custom guidance
+  'hasCustomPrompt': boolean,
+  // Whether the target is a stash entry rather than a regular commit
+  'isStash': boolean
+}
+```
+
 ### graphDetails/compare/explain
 
 > Sent when the user runs AI explain on a comparison in Graph Details
+
+```typescript
+{
+  'context.repository.closed': boolean,
+  'context.repository.folder.scheme': string,
+  'context.repository.id': string,
+  'context.repository.provider.id': string,
+  'context.repository.scheme': string,
+  'context.webview.host': 'view' | 'editor' | 'panel',
+  'context.webview.id': string,
+  'context.webview.instanceId': string,
+  'context.webview.type': string,
+  // Whether the user supplied custom guidance
+  'hasCustomPrompt': boolean,
+  'includeWorkingTree': boolean,
+  // Active tab driving the diff direction (branch-compare only; undefined otherwise)
+  'tab': 'all' | 'ahead' | 'behind',
+  // Single-commit/range compare vs branch-compare tabs
+  'variant': 'compare' | 'branchCompare'
+}
+```
+
+### graphDetails/compare/explain/completed
+
+> Sent when a comparison AI explain completes successfully in Graph Details
+
+```typescript
+{
+  'context.repository.closed': boolean,
+  'context.repository.folder.scheme': string,
+  'context.repository.id': string,
+  'context.repository.provider.id': string,
+  'context.repository.scheme': string,
+  'context.webview.host': 'view' | 'editor' | 'panel',
+  'context.webview.id': string,
+  'context.webview.instanceId': string,
+  'context.webview.type': string,
+  // Whether the user supplied custom guidance
+  'hasCustomPrompt': boolean,
+  'includeWorkingTree': boolean,
+  // Active tab driving the diff direction (branch-compare only; undefined otherwise)
+  'tab': 'all' | 'ahead' | 'behind',
+  // Single-commit/range compare vs branch-compare tabs
+  'variant': 'compare' | 'branchCompare'
+}
+```
+
+### graphDetails/compare/explain/failed
+
+> Sent when a comparison AI explain fails in Graph Details
 
 ```typescript
 {

--- a/src/constants.telemetry.ts
+++ b/src/constants.telemetry.ts
@@ -316,6 +316,17 @@ export interface TelemetryEvents extends WebviewShowAbortedEvents, WebviewShownE
 	/** Sent when the user generates an AI changelog for a comparison in Graph Details */
 	'graphDetails/compare/generateChangelog': GraphDetailsCompareGenerateChangelogEvent;
 
+	/** Sent when the user runs AI explain on a single commit in Graph Details */
+	'graphDetails/commit/explain': GraphDetailsCommitExplainEvent;
+	/** Sent when a single-commit AI explain completes successfully in Graph Details */
+	'graphDetails/commit/explain/completed': GraphDetailsCommitExplainEvent;
+	/** Sent when a single-commit AI explain fails in Graph Details */
+	'graphDetails/commit/explain/failed': GraphDetailsCommitExplainEvent;
+	/** Sent when a comparison AI explain completes successfully in Graph Details */
+	'graphDetails/compare/explain/completed': GraphDetailsCompareExplainEvent;
+	/** Sent when a comparison AI explain fails in Graph Details */
+	'graphDetails/compare/explain/failed': GraphDetailsCompareExplainEvent;
+
 	/** Sent when the user enters compose mode in the Graph Details panel */
 	'graphDetails/compose/opened': GraphDetailsComposeLifecycleEvent;
 	/** Sent when the user exits compose mode in the Graph Details panel (toggled off or destroyed) */
@@ -1425,6 +1436,13 @@ interface GraphDetailsCompareGenerateChangelogEvent extends GraphContextEventDat
 	variant: 'compare' | 'branchCompare';
 	tab: 'all' | 'ahead' | 'behind' | undefined;
 	includeWorkingTree: boolean;
+}
+
+interface GraphDetailsCommitExplainEvent extends GraphContextEventData {
+	/** Whether the user supplied custom guidance */
+	hasCustomPrompt: boolean;
+	/** Whether the target is a stash entry rather than a regular commit */
+	isStash: boolean;
 }
 
 interface GraphVirtualFileOpenedEvent extends GraphContextEventData {

--- a/src/webviews/apps/plus/graph/components/detailsActions.ts
+++ b/src/webviews/apps/plus/graph/components/detailsActions.ts
@@ -1327,19 +1327,34 @@ export class DetailsActions {
 		const commit = this.state.commit.get();
 		if (!commit) return;
 
+		const hasCustomPrompt = (prompt?.length ?? 0) > 0;
+		const isStash = commit.stashNumber != null;
+		const telemetryData = { hasCustomPrompt: hasCustomPrompt, isStash: isStash };
+		this.sendTelemetryEvent('graphDetails/commit/explain', telemetryData);
+
 		try {
 			const result = await this.services.graphInspect.explainCommit(commit.repoPath, commit.sha, prompt);
-			if (this.state.commit.get()?.sha !== commit.sha) return;
+			const isStale = this.state.commit.get()?.sha !== commit.sha;
 
 			if ('error' in result && result.error) {
-				this.state.explain.set({ error: result.error });
+				if (!isStale) {
+					this.state.explain.set({ error: result.error });
+				}
+				this.sendTelemetryEvent('graphDetails/commit/explain/failed', telemetryData);
 			} else if ('result' in result && result.result) {
-				this.state.explain.set({ result: result.result });
+				if (!isStale) {
+					this.state.explain.set({ result: result.result });
+				}
+				this.sendTelemetryEvent('graphDetails/commit/explain/completed', telemetryData);
 			}
 		} catch {
-			if (this.state.commit.get()?.sha !== commit.sha) return;
+			if (this.state.commit.get()?.sha !== commit.sha) {
+				this.sendTelemetryEvent('graphDetails/commit/explain/failed', telemetryData);
+				return;
+			}
 
 			this.state.explain.set({ error: { message: 'Failed to explain commit' } });
+			this.sendTelemetryEvent('graphDetails/commit/explain/failed', telemetryData);
 		}
 	}
 
@@ -1570,16 +1585,29 @@ export class DetailsActions {
 		const toSha = this.toSha(shas, swapped);
 		if (!fromSha || !toSha || !repoPath) return;
 
-		this.sendTelemetryEvent('graphDetails/compare/explain', {
-			variant: 'compare',
+		const telemetryData = {
+			variant: 'compare' as const,
 			hasCustomPrompt: (prompt?.length ?? 0) > 0,
-			tab: undefined,
+			tab: undefined as 'all' | 'ahead' | 'behind' | undefined,
 			includeWorkingTree: false,
-		});
+		};
+		this.sendTelemetryEvent('graphDetails/compare/explain', telemetryData);
 		this.state.compareExplainBusy.set(true);
-		void this.services.graphInspect.explainCompare(repoPath, fromSha, toSha, prompt).finally(() => {
-			this.state.compareExplainBusy.set(false);
-		});
+		void this.services.graphInspect
+			.explainCompare(repoPath, fromSha, toSha, prompt)
+			.then(
+				result => {
+					if ('error' in result && result.error) {
+						this.sendTelemetryEvent('graphDetails/compare/explain/failed', telemetryData);
+					} else {
+						this.sendTelemetryEvent('graphDetails/compare/explain/completed', telemetryData);
+					}
+				},
+				() => this.sendTelemetryEvent('graphDetails/compare/explain/failed', telemetryData),
+			)
+			.finally(() => {
+				this.state.compareExplainBusy.set(false);
+			});
 	}
 
 	compareGenerateChangelog(shas: string[] | undefined, repoPath: string | undefined): void {
@@ -1618,16 +1646,29 @@ export class DetailsActions {
 		const refs = this.getCompareAIRefs();
 		if (!repoPath || !refs) return;
 
-		this.sendTelemetryEvent('graphDetails/compare/explain', {
-			variant: 'branchCompare',
+		const telemetryData = {
+			variant: 'branchCompare' as const,
 			hasCustomPrompt: (prompt?.length ?? 0) > 0,
 			tab: this.state.branchCompareActiveTab.get(),
 			includeWorkingTree: this.state.branchCompareIncludeWorkingTree.get(),
-		});
+		};
+		this.sendTelemetryEvent('graphDetails/compare/explain', telemetryData);
 		this.state.compareExplainBusy.set(true);
-		void this.services.graphInspect.explainCompare(repoPath, refs.fromRef, refs.toRef, prompt).finally(() => {
-			this.state.compareExplainBusy.set(false);
-		});
+		void this.services.graphInspect
+			.explainCompare(repoPath, refs.fromRef, refs.toRef, prompt)
+			.then(
+				result => {
+					if ('error' in result && result.error) {
+						this.sendTelemetryEvent('graphDetails/compare/explain/failed', telemetryData);
+					} else {
+						this.sendTelemetryEvent('graphDetails/compare/explain/completed', telemetryData);
+					}
+				},
+				() => this.sendTelemetryEvent('graphDetails/compare/explain/failed', telemetryData),
+			)
+			.finally(() => {
+				this.state.compareExplainBusy.set(false);
+			});
 	}
 
 	branchCompareGenerateChangelog(repoPath: string | undefined): void {


### PR DESCRIPTION
Part of #5356 (Explain checkbox under WIP Details)

## Summary

- Adds `graphDetails/commit/explain` initiation + `completed`/`failed` outcome events for single-commit and stash explain in Graph Details (tracks `hasCustomPrompt`, `isStash`)
- Adds `graphDetails/compare/explain/completed` and `graphDetails/compare/explain/failed` outcome events for compare and branch-compare explain (reuses existing `GraphDetailsCompareExplainEvent` with `variant`, `hasCustomPrompt`, `tab`, `includeWorkingTree`)
- Telemetry docs auto-regenerated via `pnpm run generate:docs:telemetry`

### New events

| Event | When |
|---|---|
| `graphDetails/commit/explain` | User clicks Explain on a commit/stash in Graph Details |
| `graphDetails/commit/explain/completed` | Single-commit AI explain succeeds |
| `graphDetails/commit/explain/failed` | Single-commit AI explain fails |
| `graphDetails/compare/explain/completed` | Compare/branch-compare AI explain succeeds |
| `graphDetails/compare/explain/failed` | Compare/branch-compare AI explain fails |

### Out of scope

- Context menu commands (`explainCommit:graph`, `explainStash:graph`, `explainWip:graph`, `explainBranch:graph`) already propagate `source: 'graph'` to the cross-cutting `ai/explain` event
- WIP rows have no inline explain affordance in the details panel (only via context menu)

## Test plan

- [ ] Select a commit in Graph, click Explain — verify `graphDetails/commit/explain` fires with `hasCustomPrompt: false`, `isStash: false`
- [ ] Repeat with custom prompt text — verify `hasCustomPrompt: true`
- [ ] Select a stash, click Explain — verify `isStash: true`
- [ ] Select two commits, click Explain in compare panel — verify `graphDetails/compare/explain` fires with `variant: 'compare'`, then `graphDetails/compare/explain/completed` on success
- [ ] Enter branch compare, click Explain — verify `variant: 'branchCompare'` with correct `tab` and `includeWorkingTree`
- [ ] Verify busy states still clear correctly after explain completes or fails
- [ ] Run `npx tsc --noEmit` — passes cleanly

🤖 Generated with [Claude Code](https://claude.com/claude-code)