### PR TITLE
Committing telemetry in graph

### DIFF
--- a/docs/telemetry-events.md
+++ b/docs/telemetry-events.md
@@ -2958,6 +2958,68 @@ background-upgraded the extension while the host kept running the old build
 }
 ```
 
+### graph/wip/action
+
+> Sent when the user triggers a branch action from the WIP panel header or next-steps
+
+```typescript
+{
+  // Which action was triggered
+  'action': 'createPullRequest' | 'startReview' | 'startWork' | 'pull' | 'push' | 'fetch' | 'publishBranch' | 'forcePush' | 'switchBranch' | 'createBranch' | 'createPullRequestWithAI' | 'rebaseOntoMergeTarget' | 'mergeMergeTarget' | 'shareAsCloudPatch' | 'copyPatch' | 'stashSave' | 'stashSaveStaged' | 'stashSaveFiles' | 'applyStash' | 'createWorktree',
+  'context.repository.closed': boolean,
+  'context.repository.folder.scheme': string,
+  'context.repository.id': string,
+  'context.repository.provider.id': string,
+  'context.repository.scheme': string,
+  'context.webview.host': 'view' | 'editor' | 'panel',
+  'context.webview.id': string,
+  'context.webview.instanceId': string,
+  'context.webview.type': string
+}
+```
+
+### graph/wip/commit/amendToggled
+
+> Sent when the user toggles the "Amend Previous Commit" checkbox in the WIP panel
+
+```typescript
+{
+  'context.repository.closed': boolean,
+  'context.repository.folder.scheme': string,
+  'context.repository.id': string,
+  'context.repository.provider.id': string,
+  'context.repository.scheme': string,
+  'context.webview.host': 'view' | 'editor' | 'panel',
+  'context.webview.id': string,
+  'context.webview.instanceId': string,
+  'context.webview.type': string,
+  // New state of the amend toggle (true = amend on)
+  'enabled': boolean,
+  // Whether the commit box had text when toggled
+  'hasMessage': boolean
+}
+```
+
+### graph/wip/commit/coauthorsAdded
+
+> Sent when the user completes the co-author picker and trailers are appended to the commit message
+
+```typescript
+{
+  'context.repository.closed': boolean,
+  'context.repository.folder.scheme': string,
+  'context.repository.id': string,
+  'context.repository.provider.id': string,
+  'context.repository.scheme': string,
+  'context.webview.host': 'view' | 'editor' | 'panel',
+  'context.webview.id': string,
+  'context.webview.instanceId': string,
+  'context.webview.type': string,
+  // Number of co-authors selected
+  'count': number
+}
+```
+
 ### graph/wip/commit/failed
 
 > Sent when a commit from the Graph's WIP panel fails (e.g. a hook rejection or signing failure)
@@ -3022,6 +3084,108 @@ background-upgraded the extension while the host kept running the old build
   'message.length': number,
   // Whether the `git.enableSmartCommit` preference was on at commit time
   'smartCommit': boolean
+}
+```
+
+### graph/wip/generateMessage/cancelled
+
+> Sent when the user cancels an in-flight AI commit message generation
+
+```typescript
+{
+  'context.repository.closed': boolean,
+  'context.repository.folder.scheme': string,
+  'context.repository.id': string,
+  'context.repository.provider.id': string,
+  'context.repository.scheme': string,
+  'context.webview.host': 'view' | 'editor' | 'panel',
+  'context.webview.id': string,
+  'context.webview.instanceId': string,
+  'context.webview.type': string,
+  // Milliseconds from start to cancellation; undefined if startedAt was missing
+  'duration': number
+}
+```
+
+### graph/wip/generateMessage/failed
+
+> Sent when AI commit message generation fails or returns an empty message
+
+```typescript
+{
+  // Whether amend mode was on
+  'amend': boolean,
+  'context.repository.closed': boolean,
+  'context.repository.folder.scheme': string,
+  'context.repository.id': string,
+  'context.repository.provider.id': string,
+  'context.repository.scheme': string,
+  'context.webview.host': 'view' | 'editor' | 'panel',
+  'context.webview.id': string,
+  'context.webview.instanceId': string,
+  'context.webview.type': string,
+  // Milliseconds until failure; undefined if startedAt was missing
+  'duration': number,
+  // Whether there was prior text
+  'hasExistingMessage': boolean,
+  // Why the generation failed: 'error' = RPC/AI threw, 'empty' = AI returned an empty message
+  'reason': 'error' | 'empty'
+}
+```
+
+### graph/wip/generateMessage/started
+
+> Sent when the user clicks the sparkle button to generate an AI commit message
+
+```typescript
+{
+  // Whether amend mode was on at generation time
+  'amend': boolean,
+  'context.repository.closed': boolean,
+  'context.repository.folder.scheme': string,
+  'context.repository.id': string,
+  'context.repository.provider.id': string,
+  'context.repository.scheme': string,
+  'context.webview.host': 'view' | 'editor' | 'panel',
+  'context.webview.id': string,
+  'context.webview.instanceId': string,
+  'context.webview.type': string,
+  // Count of staged files
+  'files.staged.count': number,
+  // Total changed files in the working tree
+  'files.total.count': number,
+  // Whether the commit box already had text (AI refine vs. blank-slate)
+  'hasExistingMessage': boolean,
+  // Whether files were staged
+  'hasStagedFiles': boolean,
+  // Length of existing message (0 if blank)
+  'message.length': number
+}
+```
+
+### graph/wip/generateMessage/succeeded
+
+> Sent when AI commit message generation completes with a non-empty message
+
+```typescript
+{
+  // Whether amend mode was on
+  'amend': boolean,
+  'context.repository.closed': boolean,
+  'context.repository.folder.scheme': string,
+  'context.repository.id': string,
+  'context.repository.provider.id': string,
+  'context.repository.scheme': string,
+  'context.webview.host': 'view' | 'editor' | 'panel',
+  'context.webview.id': string,
+  'context.webview.instanceId': string,
+  'context.webview.type': string,
+  // Wall-clock milliseconds from start to settlement; undefined if startedAt was missing
+  'duration': number,
+  // Whether there was prior text (refine flow)
+  'hasExistingMessage': boolean,
+  // Character length of the generated message
+  'result.length': number
 }
 ```
 

--- a/src/constants.telemetry.ts
+++ b/src/constants.telemetry.ts
@@ -282,6 +282,22 @@ export interface TelemetryEvents extends WebviewShowAbortedEvents, WebviewShownE
 	'graph/wip/commit/succeeded': GraphWipCommitSucceededEvent;
 	/** Sent when a commit from the Graph's WIP panel fails (e.g. a hook rejection or signing failure) */
 	'graph/wip/commit/failed': GraphWipCommitFailedEvent;
+	/** Sent when the user toggles the "Amend Previous Commit" checkbox in the WIP panel */
+	'graph/wip/commit/amendToggled': GraphWipCommitAmendToggledEvent;
+	/** Sent when the user completes the co-author picker and trailers are appended to the commit message */
+	'graph/wip/commit/coauthorsAdded': GraphWipCommitCoauthorsAddedEvent;
+
+	/** Sent when the user clicks the sparkle button to generate an AI commit message */
+	'graph/wip/generateMessage/started': GraphWipGenerateMessageStartedEvent;
+	/** Sent when AI commit message generation completes with a non-empty message */
+	'graph/wip/generateMessage/succeeded': GraphWipGenerateMessageSucceededEvent;
+	/** Sent when AI commit message generation fails or returns an empty message */
+	'graph/wip/generateMessage/failed': GraphWipGenerateMessageFailedEvent;
+	/** Sent when the user cancels an in-flight AI commit message generation */
+	'graph/wip/generateMessage/cancelled': GraphWipGenerateMessageCancelledEvent;
+
+	/** Sent when the user triggers a branch action from the WIP panel header or next-steps */
+	'graph/wip/action': GraphWipActionEvent;
 
 	/** Sent when a virtual-FS-backed file (e.g. a Graph Compose proposed commit) is opened */
 	'graph/virtualFile/opened': GraphVirtualFileOpenedEvent;
@@ -1380,6 +1396,87 @@ interface GraphWipCommitFailedEvent extends GraphContextEventData, GraphWipCommi
 	reason: GraphWipCommitFailureReason;
 	/** Whether raw output (hook/git stderr) was captured and surfaced via "View Full Output" */
 	hasOutput: boolean;
+}
+
+interface GraphWipCommitAmendToggledEvent extends GraphContextEventData {
+	/** New state of the amend toggle (true = amend on) */
+	enabled: boolean;
+	/** Whether the commit box had text when toggled */
+	hasMessage: boolean;
+}
+
+interface GraphWipCommitCoauthorsAddedEvent extends GraphContextEventData {
+	/** Number of co-authors selected */
+	count: number;
+}
+
+interface GraphWipGenerateMessageStartedEvent extends GraphContextEventData {
+	/** Whether amend mode was on at generation time */
+	amend: boolean;
+	/** Whether the commit box already had text (AI refine vs. blank-slate) */
+	hasExistingMessage: boolean;
+	/** Length of existing message (0 if blank) */
+	'message.length': number;
+	/** Whether files were staged */
+	hasStagedFiles: boolean;
+	/** Count of staged files */
+	'files.staged.count': number;
+	/** Total changed files in the working tree */
+	'files.total.count': number;
+}
+
+interface GraphWipGenerateMessageSucceededEvent extends GraphContextEventData {
+	/** Whether amend mode was on */
+	amend: boolean | undefined;
+	/** Whether there was prior text (refine flow) */
+	hasExistingMessage: boolean | undefined;
+	/** Wall-clock milliseconds from start to settlement; undefined if startedAt was missing */
+	duration: number | undefined;
+	/** Character length of the generated message */
+	'result.length': number;
+}
+
+interface GraphWipGenerateMessageFailedEvent extends GraphContextEventData {
+	/** Whether amend mode was on */
+	amend: boolean | undefined;
+	/** Whether there was prior text */
+	hasExistingMessage: boolean | undefined;
+	/** Milliseconds until failure; undefined if startedAt was missing */
+	duration: number | undefined;
+	/** Why the generation failed: 'error' = RPC/AI threw, 'empty' = AI returned an empty message */
+	reason: 'error' | 'empty';
+}
+
+interface GraphWipGenerateMessageCancelledEvent extends GraphContextEventData {
+	/** Milliseconds from start to cancellation; undefined if startedAt was missing */
+	duration: number | undefined;
+}
+
+export type GraphWipAction =
+	| 'push'
+	| 'forcePush'
+	| 'pull'
+	| 'fetch'
+	| 'publishBranch'
+	| 'switchBranch'
+	| 'createBranch'
+	| 'createPullRequest'
+	| 'createPullRequestWithAI'
+	| 'rebaseOntoMergeTarget'
+	| 'mergeMergeTarget'
+	| 'shareAsCloudPatch'
+	| 'copyPatch'
+	| 'stashSave'
+	| 'stashSaveStaged'
+	| 'stashSaveFiles'
+	| 'applyStash'
+	| 'createWorktree'
+	| 'startWork'
+	| 'startReview';
+
+interface GraphWipActionEvent extends GraphContextEventData {
+	/** Which action was triggered */
+	action: GraphWipAction;
 }
 
 export type GraphDetailsFileAction =

--- a/src/webviews/apps/plus/graph/components/detailsActions.ts
+++ b/src/webviews/apps/plus/graph/components/detailsActions.ts
@@ -3195,6 +3195,8 @@ export class DetailsActions {
 		);
 		if (coauthors == null) return; // cancelled — leave the message untouched
 
+		this.sendTelemetryEvent('graph/wip/commit/coauthorsAdded', { count: coauthors.length });
+
 		// Append against the live message so text typed before opening the picker is preserved.
 		this.state.commitMessage.set(appendCoauthorsToMessage(this.state.commitMessage.get(), coauthors));
 		// User-authored edit — survives the HEAD-move auto-clear; the debounced WIP-draft flush persists it.

--- a/src/webviews/apps/plus/graph/components/detailsState.ts
+++ b/src/webviews/apps/plus/graph/components/detailsState.ts
@@ -115,7 +115,13 @@ export type RunningOperation =
 	| (RunningOperationBase & { kind: 'review'; result?: ReviewResult })
 	| (RunningOperationBase & { kind: 'compose'; result?: ComposeResult })
 	| (RunningOperationBase & { kind: 'resolve'; result?: ResolveResult })
-	| (RunningOperationBase & { kind: 'generateMessage' });
+	| (RunningOperationBase & {
+			kind: 'generateMessage';
+			/** Timestamp (`performance.now()`) when the generation was dispatched. Used to compute
+			 *  duration on cancel and settlement. */
+			startedAt?: number;
+			telemetryContext?: { amend: boolean; hasExistingMessage: boolean };
+	  });
 
 /** Per-anchor running-operation slot. An anchor may hold one of each kind concurrently. */
 export interface RunningOperationBucket {

--- a/src/webviews/apps/plus/graph/components/detailsWorkflowController.ts
+++ b/src/webviews/apps/plus/graph/components/detailsWorkflowController.ts
@@ -1995,7 +1995,12 @@ export class DetailsWorkflowController implements ReactiveController {
 		// generate-message routes to the WIP input/draft, not a resource, so it skips the review/compose
 		// `_disconnected` resource-write bail below (teardown aborts these runs; the guard above drops late settles).
 		if (kind === 'generateMessage') {
-			this.settleGenerateMessage(anchor, result as GenerateMessageResult | undefined, ex);
+			this.settleGenerateMessage(
+				anchor,
+				current as Extract<RunningOperation, { kind: 'generateMessage' }>,
+				result as GenerateMessageResult | undefined,
+				ex,
+			);
 			return;
 		}
 
@@ -2075,13 +2080,31 @@ export class DetailsWorkflowController implements ReactiveController {
 	 *  decides) and remove the entry. Ephemeral — nothing is stored; errors land nothing. */
 	private settleGenerateMessage(
 		anchor: RunningOperationAnchor,
+		entry: Extract<RunningOperation, { kind: 'generateMessage' }>,
 		result: GenerateMessageResult | undefined,
 		ex: unknown,
 	): void {
 		const message = ex == null ? (result?.message ?? '') : '';
+		const duration = entry.startedAt != null ? performance.now() - entry.startedAt : undefined;
+		const context = entry.telemetryContext;
+
 		if (message) {
 			this.host.applyGeneratedCommitMessage(anchor.repoPath, message);
+			this.actions.sendTelemetryEvent('graph/wip/generateMessage/succeeded', {
+				amend: context?.amend,
+				hasExistingMessage: context?.hasExistingMessage,
+				duration: duration,
+				'result.length': message.length,
+			});
+		} else {
+			this.actions.sendTelemetryEvent('graph/wip/generateMessage/failed', {
+				amend: context?.amend,
+				hasExistingMessage: context?.hasExistingMessage,
+				duration: duration,
+				reason: ex != null ? 'error' : 'empty',
+			});
 		}
+
 		this.removeRunningOperation(anchorKey(anchor), 'generateMessage');
 	}
 
@@ -2096,10 +2119,32 @@ export class DetailsWorkflowController implements ReactiveController {
 
 		const existing = this.host.crossPaneState.runningOperations.get().get(key)?.generateMessage;
 		if (existing?.execState === 'generating') {
+			const duration = existing.startedAt != null ? performance.now() - existing.startedAt : undefined;
 			existing.abortController?.abort();
 			this.removeRunningOperation(key, 'generateMessage');
+			this.actions.sendTelemetryEvent('graph/wip/generateMessage/cancelled', { duration: duration });
 			return;
 		}
+
+		const state = this.actions.state;
+		const wip = state.wip.get();
+		const files = wip?.changes?.files;
+		const currentMessage = state.commitMessage.get().trim();
+		const amend = state.amend.get();
+		const hasStagedFiles = files?.some(f => f.staged) ?? false;
+
+		const telemetryContext = {
+			amend: amend,
+			hasExistingMessage: currentMessage.length > 0,
+		};
+
+		this.actions.sendTelemetryEvent('graph/wip/generateMessage/started', {
+			...telemetryContext,
+			'message.length': currentMessage.length,
+			hasStagedFiles: hasStagedFiles,
+			'files.staged.count': files?.filter(f => f.staged).length ?? 0,
+			'files.total.count': files?.length ?? 0,
+		});
 
 		const controller = new AbortController();
 		const promise = this.startGenerateMessage(repoPath, controller.signal);
@@ -2109,6 +2154,8 @@ export class DetailsWorkflowController implements ReactiveController {
 			execState: 'generating',
 			abortController: controller,
 			promise: promise,
+			startedAt: performance.now(),
+			telemetryContext: telemetryContext,
 		});
 		promise.then(
 			result => this.onRunSettled('generateMessage', anchor, controller, result, undefined),

--- a/src/webviews/apps/plus/graph/components/gl-graph-details-panel.ts
+++ b/src/webviews/apps/plus/graph/components/gl-graph-details-panel.ts
@@ -10,7 +10,7 @@ import type { AgentSessionState } from '../../../../../agents/models/agentSessio
 import type { StashApplyCommandArgs } from '../../../../../commands/stashApply.js';
 import type { ViewFilesLayout } from '../../../../../config.js';
 import type { StoredGraphWipDraft } from '../../../../../constants.storage.js';
-import type { GraphDetailsMode } from '../../../../../constants.telemetry.js';
+import type { GraphDetailsMode, GraphWipAction } from '../../../../../constants.telemetry.js';
 import type { CommitDetails } from '../../../../commitDetails/protocol.js';
 import type { Wip } from '../../../../plus/graph/detailsProtocol.js';
 import type { ConflictSide, GraphServices, VirtualRefShape } from '../../../../plus/graph/graphService.js';
@@ -2979,33 +2979,71 @@ export class GlGraphDetailsPanel extends SignalWatcher(LitElement) {
 		void this._actions.refetchCommitQuiet(this.sha, repoPath, this.graphReachability, this.commitLite);
 	};
 
-	private handleSwitchBranch = () => this._actions.switchBranch(this.effectiveRepoPath);
+	private trackWipAction(action: GraphWipAction): void {
+		this._actions.sendTelemetryEvent('graph/wip/action', { action: action });
+	}
 
-	private handleCreateBranch = () => this._actions.createBranch(this.effectiveRepoPath);
+	private handleSwitchBranch = () => {
+		this.trackWipAction('switchBranch');
+		this._actions.switchBranch(this.effectiveRepoPath);
+	};
 
-	private handlePublishBranch = () => void this._actions.services.repository.publishBranch(this.effectiveRepoPath!);
+	private handleCreateBranch = () => {
+		this.trackWipAction('createBranch');
+		this._actions.createBranch(this.effectiveRepoPath);
+	};
 
-	private handlePull = () => void this._actions.services.repository.pull(this.effectiveRepoPath!);
+	private handlePublishBranch = () => {
+		this.trackWipAction('publishBranch');
+		void this._actions.services.repository.publishBranch(this.effectiveRepoPath!);
+	};
 
-	private handlePush = () => void this._actions.services.repository.push(this.effectiveRepoPath!);
+	private handlePull = () => {
+		this.trackWipAction('pull');
+		void this._actions.services.repository.pull(this.effectiveRepoPath!);
+	};
 
-	private handleForcePush = () => void this._actions.services.repository.push(this.effectiveRepoPath!, true);
+	private handlePush = () => {
+		this.trackWipAction('push');
+		void this._actions.services.repository.push(this.effectiveRepoPath!);
+	};
 
-	private handleFetch = () => void this._actions.services.repository.fetch(this.effectiveRepoPath!);
+	private handleForcePush = () => {
+		this.trackWipAction('forcePush');
+		void this._actions.services.repository.push(this.effectiveRepoPath!, true);
+	};
 
-	private handleCreatePullRequest = () => this._actions.createPullRequest(this.effectiveRepoPath);
+	private handleFetch = () => {
+		this.trackWipAction('fetch');
+		void this._actions.services.repository.fetch(this.effectiveRepoPath!);
+	};
 
-	private handleCreatePullRequestWithAI = () =>
+	private handleCreatePullRequest = () => {
+		this.trackWipAction('createPullRequest');
+		this._actions.createPullRequest(this.effectiveRepoPath);
+	};
+
+	private handleCreatePullRequestWithAI = () => {
+		this.trackWipAction('createPullRequestWithAI');
 		this._actions.createPullRequest(this.effectiveRepoPath, { describeWithAI: true });
+	};
 
-	private handleShareWipAsCloudPatch = () =>
+	private handleShareWipAsCloudPatch = () => {
+		this.trackWipAction('shareAsCloudPatch');
 		void this._actions.services.commands.executeScoped('gitlens.shareWipAsCloudPatch:graph', {
 			repoPath: this.effectiveRepoPath,
 		});
+	};
 
-	private handleRebaseOntoMergeTarget = () => this._actions.rebaseOntoMergeTarget();
+	private handleRebaseOntoMergeTarget = () => {
+		this.trackWipAction('rebaseOntoMergeTarget');
+		this._actions.rebaseOntoMergeTarget();
+	};
 
-	private handleMergeMergeTargetIntoCurrent = () => this._actions.mergeMergeTargetIntoCurrent();
+	private handleMergeMergeTargetIntoCurrent = () => {
+		this.trackWipAction('mergeMergeTarget');
+		this._actions.mergeMergeTargetIntoCurrent();
+	};
 
 	private handleReviewBranchChanges = () => this.enterBranchWorkMode('review');
 
@@ -3030,23 +3068,33 @@ export class GlGraphDetailsPanel extends SignalWatcher(LitElement) {
 		// Toolbar Stash with a multi-selection carries the selected files (same path as the inline
 		// `file-stash` batch action); otherwise it's the scope action (`onlyStaged` staged-vs-all).
 		if (e.detail?.files?.length) {
+			this.trackWipAction('stashSaveFiles');
 			this._actions.stashFiles([...e.detail.files]);
 		} else {
+			this.trackWipAction(e.detail?.onlyStaged ? 'stashSaveStaged' : 'stashSave');
 			this._actions.stashSave(this.effectiveRepoPath, e.detail?.onlyStaged);
 		}
 	};
 
-	private handleStartWork = (e: CustomEvent<{ showOpenInAgent?: 'ask' | 'manual' | 'agent' } | undefined>) =>
+	private handleStartWork = (e: CustomEvent<{ showOpenInAgent?: 'ask' | 'manual' | 'agent' } | undefined>) => {
+		this.trackWipAction('startWork');
 		this._actions.startWork(e.detail?.showOpenInAgent);
+	};
 
-	private handleStartReview = (e: CustomEvent<{ showOpenInAgent?: 'ask' | 'manual' | 'agent' } | undefined>) =>
+	private handleStartReview = (e: CustomEvent<{ showOpenInAgent?: 'ask' | 'manual' | 'agent' } | undefined>) => {
+		this.trackWipAction('startReview');
 		this._actions.startPRReview(e.detail?.showOpenInAgent);
+	};
 
-	private handleCreatePr = () => this._actions.createPullRequest(this.effectiveRepoPath);
+	private handleApplyStash = () => {
+		this.trackWipAction('applyStash');
+		this._actions.applyStash(this.effectiveRepoPath);
+	};
 
-	private handleApplyStash = () => this._actions.applyStash(this.effectiveRepoPath);
-
-	private handleNewWorktree = () => this._actions.createWorktree();
+	private handleNewWorktree = () => {
+		this.trackWipAction('createWorktree');
+		this._actions.createWorktree();
+	};
 
 	private handleRefreshLaunchpad = (): void => {
 		this._launchpadState?.refresh();
@@ -3075,6 +3123,10 @@ export class GlGraphDetailsPanel extends SignalWatcher(LitElement) {
 	};
 
 	private handleAmendChange = (e: CustomEvent<{ checked: boolean }>) => {
+		this._actions.sendTelemetryEvent('graph/wip/commit/amendToggled', {
+			enabled: e.detail.checked,
+			hasMessage: this._state.commitMessage.get().length > 0,
+		});
 		this._state.amend.set(e.detail.checked);
 		if (e.detail.checked) {
 			// Bind the amend intent to the HEAD it was authored against. If HEAD moves later
@@ -3320,6 +3372,7 @@ export class GlGraphDetailsPanel extends SignalWatcher(LitElement) {
 	};
 
 	private handleCopyWipPatch = (e: CustomEvent<CopyWipPatchEventDetail>) => {
+		this.trackWipAction('copyPatch');
 		this._actions.copyWipPatchToClipboard(e.detail.repoPath, e.detail.scope, e.detail.uris);
 	};
 


### PR DESCRIPTION
## Summary

- Adds comprehensive telemetry coverage to the Graph WIP panel committing workflow, as part of the "Committing" checklist item in #5356
- Instruments AI commit message generation lifecycle (graph/wip/generateMessage started/succeeded/failed/cancelled) with duration tracking and failure reason classification (error vs empty)
- Tracks commit box interactions: amend toggle (graph/wip/commit/amendToggled) and co-author picker completion (graph/wip/commit/coauthorsAdded)
- Adds unified graph/wip/action event for all 20 WIP panel header/next-steps actions (push, pull, fetch, create PR, stash, rebase, etc.)

## Test plan

- [ ] TypeScript compiles cleanly (npx tsc --noEmit)
- [ ] All existing unit tests pass (pnpm run test) -- especially detailsWorkflowController.test.ts generate-message tests
- [ ] AI sparkle button: click to generate -> started + succeeded events fire; click again while generating -> cancelled fires
- [ ] Toggle amend checkbox -> amendToggled fires with correct enabled state
- [ ] Add co-authors via picker -> coauthorsAdded fires with correct count (cancel should not fire)
- [ ] Push/Pull/Fetch/Create PR/Stash/etc. from WIP panel -> graph/wip/action fires with correct action discriminator
- [ ] All payloads are privacy-safe: no file paths, message text, or co-author names