### PR TITLE
Staging telemetry in Graph

### DIFF
--- a/docs/telemetry-events.md
+++ b/docs/telemetry-events.md
@@ -3189,6 +3189,140 @@ background-upgraded the extension while the host kept running the old build
 }
 ```
 
+### graph/wip/staging/discard
+
+> Sent when the user discards file changes from the Graph's WIP panel
+
+```typescript
+{
+  'context.repository.closed': boolean,
+  'context.repository.folder.scheme': string,
+  'context.repository.id': string,
+  'context.repository.provider.id': string,
+  'context.repository.scheme': string,
+  'context.webview.host': 'view' | 'editor' | 'panel',
+  'context.webview.id': string,
+  'context.webview.instanceId': string,
+  'context.webview.type': string,
+  // Number of files affected (available for file/files scope)
+  'files.count': number,
+  // Whether a single file, multi-select, discard-all-staged, or discard-all-unstaged
+  'scope': 'files' | 'file' | 'staged' | 'unstaged'
+}
+```
+
+### graph/wip/staging/failed
+
+> Sent when any staging operation fails in the Graph's WIP panel
+
+```typescript
+{
+  'context.repository.closed': boolean,
+  'context.repository.folder.scheme': string,
+  'context.repository.id': string,
+  'context.repository.provider.id': string,
+  'context.repository.scheme': string,
+  'context.webview.host': 'view' | 'editor' | 'panel',
+  'context.webview.id': string,
+  'context.webview.instanceId': string,
+  'context.webview.type': string,
+  // Which staging operation failed
+  'operation': 'stash' | 'stage' | 'unstage' | 'discard' | 'resolveConflict',
+  // Scope of the failed operation
+  'scope': string
+}
+```
+
+### graph/wip/staging/resolveConflict
+
+> Sent when the user resolves conflict(s) by taking a side in the Graph's WIP panel
+
+```typescript
+{
+  'context.repository.closed': boolean,
+  'context.repository.folder.scheme': string,
+  'context.repository.id': string,
+  'context.repository.provider.id': string,
+  'context.repository.scheme': string,
+  'context.webview.host': 'view' | 'editor' | 'panel',
+  'context.webview.id': string,
+  'context.webview.instanceId': string,
+  'context.webview.type': string,
+  // Whether a single-file side pick or resolve-all-conflicts
+  'scope': 'all' | 'file',
+  // Which side was chosen
+  'side': 'current' | 'incoming'
+}
+```
+
+### graph/wip/staging/stage
+
+> Sent when the user stages file(s) in the Graph's WIP panel
+
+```typescript
+{
+  'context.repository.closed': boolean,
+  'context.repository.folder.scheme': string,
+  'context.repository.id': string,
+  'context.repository.provider.id': string,
+  'context.repository.scheme': string,
+  'context.webview.host': 'view' | 'editor' | 'panel',
+  'context.webview.id': string,
+  'context.webview.instanceId': string,
+  'context.webview.type': string,
+  // Number of files being staged
+  'files.count': number,
+  // Whether the repo has conflicts at the time (stage-all prompts about conflict markers)
+  'hasConflicts': boolean,
+  // Whether a single file, multi-select batch, or stage-all
+  'scope': 'files' | 'all' | 'file'
+}
+```
+
+### graph/wip/staging/stash
+
+> Sent when the user stashes specific file(s) from the Graph's WIP panel
+
+```typescript
+{
+  'context.repository.closed': boolean,
+  'context.repository.folder.scheme': string,
+  'context.repository.id': string,
+  'context.repository.provider.id': string,
+  'context.repository.scheme': string,
+  'context.webview.host': 'view' | 'editor' | 'panel',
+  'context.webview.id': string,
+  'context.webview.instanceId': string,
+  'context.webview.type': string,
+  // Number of files being stashed
+  'files.count': number,
+  // Whether a single file or multi-select batch
+  'scope': 'files' | 'file'
+}
+```
+
+### graph/wip/staging/unstage
+
+> Sent when the user unstages file(s) in the Graph's WIP panel
+
+```typescript
+{
+  'context.repository.closed': boolean,
+  'context.repository.folder.scheme': string,
+  'context.repository.id': string,
+  'context.repository.provider.id': string,
+  'context.repository.scheme': string,
+  'context.webview.host': 'view' | 'editor' | 'panel',
+  'context.webview.id': string,
+  'context.webview.instanceId': string,
+  'context.webview.type': string,
+  // Number of files being unstaged
+  'files.count': number,
+  // Whether a single file, multi-select batch, or unstage-all
+  'scope': 'files' | 'all' | 'file'
+}
+```
+
 ### graphDetails/closed
 
 > Sent when the integrated graph details panel is collapsed

--- a/src/constants.telemetry.ts
+++ b/src/constants.telemetry.ts
@@ -299,6 +299,19 @@ export interface TelemetryEvents extends WebviewShowAbortedEvents, WebviewShownE
 	/** Sent when the user triggers a branch action from the WIP panel header or next-steps */
 	'graph/wip/action': GraphWipActionEvent;
 
+	/** Sent when the user stages file(s) in the Graph's WIP panel */
+	'graph/wip/staging/stage': GraphWipStagingStageEvent;
+	/** Sent when the user unstages file(s) in the Graph's WIP panel */
+	'graph/wip/staging/unstage': GraphWipStagingUnstageEvent;
+	/** Sent when the user discards file changes from the Graph's WIP panel */
+	'graph/wip/staging/discard': GraphWipStagingDiscardEvent;
+	/** Sent when the user stashes specific file(s) from the Graph's WIP panel */
+	'graph/wip/staging/stash': GraphWipStagingStashEvent;
+	/** Sent when the user resolves conflict(s) by taking a side in the Graph's WIP panel */
+	'graph/wip/staging/resolveConflict': GraphWipStagingResolveConflictEvent;
+	/** Sent when any staging operation fails in the Graph's WIP panel */
+	'graph/wip/staging/failed': GraphWipStagingFailedEvent;
+
 	/** Sent when a virtual-FS-backed file (e.g. a Graph Compose proposed commit) is opened */
 	'graph/virtualFile/opened': GraphVirtualFileOpenedEvent;
 	/** Sent when opening a virtual-FS-backed file fails (e.g. the compose session is no longer registered) */
@@ -1477,6 +1490,56 @@ export type GraphWipAction =
 interface GraphWipActionEvent extends GraphContextEventData {
 	/** Which action was triggered */
 	action: GraphWipAction;
+}
+
+export type GraphWipStagingScope = 'file' | 'files' | 'all';
+
+interface GraphWipStagingStageEvent extends GraphContextEventData {
+	/** Whether a single file, multi-select batch, or stage-all */
+	scope: GraphWipStagingScope;
+	/** Number of files being staged */
+	'files.count': number;
+	/** Whether the repo has conflicts at the time (stage-all prompts about conflict markers) */
+	hasConflicts: boolean;
+}
+
+interface GraphWipStagingUnstageEvent extends GraphContextEventData {
+	/** Whether a single file, multi-select batch, or unstage-all */
+	scope: GraphWipStagingScope;
+	/** Number of files being unstaged */
+	'files.count': number;
+}
+
+export type GraphWipStagingDiscardScope = 'file' | 'files' | 'staged' | 'unstaged';
+
+interface GraphWipStagingDiscardEvent extends GraphContextEventData {
+	/** Whether a single file, multi-select, discard-all-staged, or discard-all-unstaged */
+	scope: GraphWipStagingDiscardScope;
+	/** Number of files affected (available for file/files scope) */
+	'files.count': number | undefined;
+}
+
+interface GraphWipStagingStashEvent extends GraphContextEventData {
+	/** Whether a single file or multi-select batch */
+	scope: 'file' | 'files';
+	/** Number of files being stashed */
+	'files.count': number;
+}
+
+interface GraphWipStagingResolveConflictEvent extends GraphContextEventData {
+	/** Whether a single-file side pick or resolve-all-conflicts */
+	scope: 'file' | 'all';
+	/** Which side was chosen */
+	side: 'current' | 'incoming';
+}
+
+export type GraphWipStagingOperation = 'stage' | 'unstage' | 'discard' | 'stash' | 'resolveConflict';
+
+interface GraphWipStagingFailedEvent extends GraphContextEventData {
+	/** Which staging operation failed */
+	operation: GraphWipStagingOperation;
+	/** Scope of the failed operation */
+	scope: string;
 }
 
 export type GraphDetailsFileAction =

--- a/src/webviews/apps/plus/graph/components/detailsActions.ts
+++ b/src/webviews/apps/plus/graph/components/detailsActions.ts
@@ -35,6 +35,9 @@ import type {
 	GraphDetailsFileAction,
 	GraphVirtualFileFailureReason,
 	GraphVirtualFileMode,
+	GraphWipStagingDiscardScope,
+	GraphWipStagingOperation,
+	GraphWipStagingScope,
 	TelemetryEvents,
 } from '../../../../../constants.telemetry.js';
 import { getVirtualFsErrorReason } from '../../../../../virtual/virtualFsError.js';
@@ -2835,7 +2838,11 @@ export class DetailsActions {
 		if (!isConflictStatus(detail.status)) {
 			this.optimisticallyUpdateFileStaged(detail.path, true);
 		}
-		this._pendingStagingOp = this.runStagingOp(this.services.repository.stageFile(detail), 'stage file');
+		this.sendStagingTelemetry('stage', 'file', 1);
+		this._pendingStagingOp = this.runStagingOp(this.services.repository.stageFile(detail), 'stage file', {
+			operation: 'stage',
+			scope: 'file',
+		});
 	}
 
 	openConflictChanges(detail: FileChangeListItemDetail, side: 'current' | 'incoming'): void {
@@ -2845,9 +2852,11 @@ export class DetailsActions {
 	resolveAllConflicts(repoPath: string | undefined, resolution: 'current' | 'incoming'): void {
 		if (!repoPath) return;
 
+		this.sendTelemetryEvent('graph/wip/staging/resolveConflict', { scope: 'all', side: resolution });
 		this._pendingStagingOp = this.runStagingOp(
 			this.services.repository.resolveAllConflicts(repoPath, resolution),
 			'resolve all conflicts',
+			{ operation: 'resolveConflict', scope: 'all' },
 		);
 	}
 
@@ -2858,12 +2867,14 @@ export class DetailsActions {
 
 	/** Resolve a single conflicted file by taking one side, then stage it. */
 	stageConflictSide(repoPath: string, filePath: string, status: string, side: 'current' | 'incoming'): void {
+		this.sendTelemetryEvent('graph/wip/staging/resolveConflict', { scope: 'file', side: side });
 		this._pendingStagingOp = this.runStagingOp(
 			this.services.repository.stageConflictResolution(
 				{ repoPath: repoPath, path: filePath, status: status as GitFileConflictStatus },
 				side,
 			),
 			'stage conflict side',
+			{ operation: 'resolveConflict', scope: 'file' },
 		);
 	}
 
@@ -2874,72 +2885,135 @@ export class DetailsActions {
 
 	unstageFile(detail: FileChangeListItemDetail): void {
 		this.optimisticallyUpdateFileStaged(detail.path, false);
-		this._pendingStagingOp = this.runStagingOp(this.services.repository.unstageFile(detail), 'unstage file');
+		this.sendStagingTelemetry('unstage', 'file', 1);
+		this._pendingStagingOp = this.runStagingOp(this.services.repository.unstageFile(detail), 'unstage file', {
+			operation: 'unstage',
+			scope: 'file',
+		});
 	}
 
 	stageFiles(files: GitFileChangeShape[]): void {
 		for (const file of files) {
 			this.optimisticallyUpdateFileStaged(file.path, true);
 		}
-		this._pendingStagingOp = this.runStagingOp(this.services.repository.stageFiles(files), 'stage files');
+		this.sendStagingTelemetry('stage', 'files', files.length);
+		this._pendingStagingOp = this.runStagingOp(this.services.repository.stageFiles(files), 'stage files', {
+			operation: 'stage',
+			scope: 'files',
+		});
 	}
 
 	unstageFiles(files: GitFileChangeShape[]): void {
 		for (const file of files) {
 			this.optimisticallyUpdateFileStaged(file.path, false);
 		}
-		this._pendingStagingOp = this.runStagingOp(this.services.repository.unstageFiles(files), 'unstage files');
+		this.sendStagingTelemetry('unstage', 'files', files.length);
+		this._pendingStagingOp = this.runStagingOp(this.services.repository.unstageFiles(files), 'unstage files', {
+			operation: 'unstage',
+			scope: 'files',
+		});
 	}
 
 	stageAll(repoPath: string | undefined): void {
 		if (!repoPath) return;
 
+		const wip = this.state.wip.get();
+		const hasConflicts = wip?.changes?.hasConflicts ?? false;
 		// Same as stageFile — skip optimism when the repo has conflicts (host may prompt + cancel).
-		if (!this.state.wip.get()?.changes?.hasConflicts) {
+		if (!hasConflicts) {
 			this.optimisticallyUpdateAllFilesStaged(true);
 		}
-		this._pendingStagingOp = this.runStagingOp(this.services.repository.stageAll(repoPath), 'stage all');
+		this.sendStagingTelemetry('stage', 'all', wip?.changes?.files?.length ?? 0, hasConflicts);
+		this._pendingStagingOp = this.runStagingOp(this.services.repository.stageAll(repoPath), 'stage all', {
+			operation: 'stage',
+			scope: 'all',
+		});
 	}
 
 	unstageAll(repoPath: string | undefined): void {
 		if (!repoPath) return;
 
 		this.optimisticallyUpdateAllFilesStaged(false);
-		this._pendingStagingOp = this.runStagingOp(this.services.repository.unstageAll(repoPath), 'unstage all');
+		this.sendStagingTelemetry('unstage', 'all', this.state.wip.get()?.changes?.files?.length ?? 0);
+		this._pendingStagingOp = this.runStagingOp(this.services.repository.unstageAll(repoPath), 'unstage all', {
+			operation: 'unstage',
+			scope: 'all',
+		});
 	}
 
 	discardFile(detail: FileChangeListItemDetail): void {
-		this._pendingStagingOp = this.runStagingOp(this.services.repository.discardFile(detail), 'discard file');
+		this.sendDiscardTelemetry('file', 1);
+		this._pendingStagingOp = this.runStagingOp(this.services.repository.discardFile(detail), 'discard file', {
+			operation: 'discard',
+			scope: 'file',
+		});
 	}
 
 	discardFiles(files: GitFileChangeShape[]): void {
-		this._pendingStagingOp = this.runStagingOp(this.services.repository.discardFiles(files), 'discard files');
+		this.sendDiscardTelemetry('files', files.length);
+		this._pendingStagingOp = this.runStagingOp(this.services.repository.discardFiles(files), 'discard files', {
+			operation: 'discard',
+			scope: 'files',
+		});
 	}
 
 	stashFile(detail: FileChangeListItemDetail): void {
-		this._pendingStagingOp = this.runStagingOp(this.services.repository.stashFile(detail), 'stash file');
+		this.sendTelemetryEvent('graph/wip/staging/stash', { scope: 'file', 'files.count': 1 });
+		this._pendingStagingOp = this.runStagingOp(this.services.repository.stashFile(detail), 'stash file', {
+			operation: 'stash',
+			scope: 'file',
+		});
 	}
 
 	stashFiles(files: GitFileChangeShape[]): void {
-		this._pendingStagingOp = this.runStagingOp(this.services.repository.stashFiles(files), 'stash files');
+		this.sendTelemetryEvent('graph/wip/staging/stash', { scope: 'files', 'files.count': files.length });
+		this._pendingStagingOp = this.runStagingOp(this.services.repository.stashFiles(files), 'stash files', {
+			operation: 'stash',
+			scope: 'files',
+		});
 	}
 
 	discardUnstagedFiles(repoPath: string | undefined): void {
 		if (!repoPath) return;
 
+		this.sendDiscardTelemetry('unstaged', undefined);
 		this._pendingStagingOp = this.runStagingOp(
 			this.services.repository.discardUnstagedFiles(repoPath),
 			'discard unstaged files',
+			{ operation: 'discard', scope: 'unstaged' },
 		);
 	}
 
 	discardStagedFiles(repoPath: string | undefined): void {
 		if (!repoPath) return;
 
+		this.sendDiscardTelemetry('staged', undefined);
 		this._pendingStagingOp = this.runStagingOp(
 			this.services.repository.discardStagedFiles(repoPath),
 			'discard staged files',
+			{ operation: 'discard', scope: 'staged' },
 		);
+	}
+
+	private sendStagingTelemetry(
+		action: 'stage' | 'unstage',
+		scope: GraphWipStagingScope,
+		filesCount: number,
+		hasConflicts?: boolean,
+	): void {
+		if (action === 'stage') {
+			this.sendTelemetryEvent('graph/wip/staging/stage', {
+				scope: scope,
+				'files.count': filesCount,
+				hasConflicts: hasConflicts ?? this.state.wip.get()?.changes?.hasConflicts ?? false,
+			});
+		} else {
+			this.sendTelemetryEvent('graph/wip/staging/unstage', { scope: scope, 'files.count': filesCount });
+		}
+	}
+
+	private sendDiscardTelemetry(scope: GraphWipStagingDiscardScope, filesCount: number | undefined): void {
+		this.sendTelemetryEvent('graph/wip/staging/discard', { scope: scope, 'files.count': filesCount });
 	}
 
 	/**
@@ -2949,11 +3023,18 @@ export class DetailsActions {
 	 * push directly. The optimistic update (already fired by the caller) covers the brief
 	 * window between RPC dispatch and the push arriving.
 	 */
-	private async runStagingOp(op: Promise<void>, context: string): Promise<void> {
+	private async runStagingOp(
+		op: Promise<void>,
+		context: string,
+		telemetry?: { operation: GraphWipStagingOperation; scope: string },
+	): Promise<void> {
 		try {
 			await op;
 		} catch (ex) {
 			Logger.error(ex, `Staging op failed (${context})`);
+			if (telemetry != null) {
+				this.sendTelemetryEvent('graph/wip/staging/failed', telemetry);
+			}
 		}
 	}
 


### PR DESCRIPTION
## Summary

Part of #5356 (Staging checkbox under WIP Details).

- Adds 6 telemetry events covering all staging operations in the Graph Details WIP panel: `graph/wip/staging/stage`, `unstage`, `discard`, `stash`, `resolveConflict`, and a shared `failed` event
- Instruments all 14 staging methods in `detailsActions.ts` with privacy-safe payloads (counts, booleans, enum strings only — no file paths or content)
- Extends `runStagingOp` with optional telemetry metadata to centralize failure tracking

### New events

| Event | When |
|---|---|
| `graph/wip/staging/stage` | User stages file(s) — single, batch, or all |
| `graph/wip/staging/unstage` | User unstages file(s) — single, batch, or all |
| `graph/wip/staging/discard` | User discards changes — single file, batch, all staged, or all unstaged |
| `graph/wip/staging/stash` | User stashes specific file(s) |
| `graph/wip/staging/resolveConflict` | User resolves conflict(s) by taking a side |
| `graph/wip/staging/failed` | Any staging operation fails |

## Test plan

- [ ] Verify type-check passes (`npx tsc --noEmit` for both desktop and browser targets)
- [ ] Stage a single file in Graph WIP panel — confirm `graph/wip/staging/stage` event fires with `scope: 'file'`
- [ ] Stage all files — confirm event fires with `scope: 'all'` and `hasConflicts` reflects repo state
- [ ] Unstage via checkbox batch — confirm `graph/wip/staging/unstage` with `scope: 'files'`
- [ ] Discard a file — confirm `graph/wip/staging/discard` with `scope: 'file'`
- [ ] Discard all unstaged — confirm `scope: 'unstaged'`
- [ ] If conflicts available: resolve a conflict by taking a side — confirm `graph/wip/staging/resolveConflict`
- [ ] Verify telemetry docs regenerated correctly (`pnpm run generate:docs:telemetry`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)