### PR TITLE
Overview telemetry in graph

### DIFF
--- a/docs/telemetry-events.md
+++ b/docs/telemetry-events.md
@@ -2663,13 +2663,111 @@ background-upgraded the extension while the host kept running the old build
   'context.webview.type': string,
   // Where on the card the action was invoked
   'location': 'inline' | 'hover',
-  'name': 'pull' | 'push' | 'fetch' | 'publishBranch' | 'switch' | 'openWorktree' | 'compareWithHead' | 'compareWithWorking' | 'compareWithPr' | 'other'
+  'name': 'pull' | 'push' | 'fetch' | 'publishBranch' | 'switch' | 'openWorktree' | 'compareWithHead' | 'compareWithWorking' | 'compareWithPr' | 'openPrChanges' | 'openChanges' | 'other'
+}
+```
+
+### graph/overview/branchSelected
+
+> Sent when the user clicks a branch card to scope the graph to that branch
+
+```typescript
+{
+  'context.repository.closed': boolean,
+  'context.repository.folder.scheme': string,
+  'context.repository.id': string,
+  'context.repository.provider.id': string,
+  'context.repository.scheme': string,
+  'context.webview.host': 'view' | 'editor' | 'panel',
+  'context.webview.id': string,
+  'context.webview.instanceId': string,
+  'context.webview.type': string,
+  // Whether the branch has associated issues or autolinks
+  'hasIssues': boolean,
+  // Whether the branch has an associated pull request
+  'hasPr': boolean,
+  // Whether the branch has uncommitted working tree changes
+  'hasWip': boolean,
+  // Whether the branch is the currently opened (active) branch
+  'isActive': boolean,
+  // Whether the branch is checked out in a worktree
+  'isWorktree': boolean
+}
+```
+
+### graph/overview/hoverShown
+
+> Sent when the rich hover popover opens for the first time on a branch card
+
+```typescript
+{
+  'context.repository.closed': boolean,
+  'context.repository.folder.scheme': string,
+  'context.repository.id': string,
+  'context.repository.provider.id': string,
+  'context.repository.scheme': string,
+  'context.webview.host': 'view' | 'editor' | 'panel',
+  'context.webview.id': string,
+  'context.webview.instanceId': string,
+  'context.webview.type': string,
+  // Whether the branch has active agent sessions
+  'hasAgents': boolean,
+  // Whether the branch has associated issues or autolinks
+  'hasIssues': boolean,
+  // Whether the branch has an associated pull request
+  'hasPr': boolean,
+  // Whether the branch has uncommitted working tree changes
+  'hasWip': boolean,
+  // Whether the branch is the currently opened (active) branch
+  'isActive': boolean,
+  // Whether the branch is checked out in a worktree
+  'isWorktree': boolean
+}
+```
+
+### graph/overview/linkClicked
+
+> Sent when the user clicks a PR or issue link in the Graph Overview hover popover
+
+```typescript
+{
+  'context.repository.closed': boolean,
+  'context.repository.folder.scheme': string,
+  'context.repository.id': string,
+  'context.repository.provider.id': string,
+  'context.repository.scheme': string,
+  'context.webview.host': 'view' | 'editor' | 'panel',
+  'context.webview.id': string,
+  'context.webview.instanceId': string,
+  'context.webview.type': string,
+  // Type of external link clicked
+  'type': 'pullrequest' | 'issue' | 'autolink'
+}
+```
+
+### graph/overview/recentThresholdChanged
+
+> Sent when the user changes the Recent timeframe threshold in the Graph Overview
+
+```typescript
+{
+  'context.repository.closed': boolean,
+  'context.repository.folder.scheme': string,
+  'context.repository.id': string,
+  'context.repository.provider.id': string,
+  'context.repository.scheme': string,
+  'context.webview.host': 'view' | 'editor' | 'panel',
+  'context.webview.id': string,
+  'context.webview.instanceId': string,
+  'context.webview.type': string,
+  // New threshold value selected by the user
+  'threshold': 'OneDay' | 'OneWeek' | 'OneMonth'
 }
 ```
 
 ### graph/overview/shown
 
-> Sent when the Graph Overview panel becomes visible (mounted in the active sidebar slot)
+> Sent when the Graph Overview panel becomes visible
 
 ```typescript
 {
@@ -2685,7 +2783,9 @@ background-upgraded the extension while the host kept running the old build
   'context.webview.host': 'view' | 'editor' | 'panel',
   'context.webview.id': string,
   'context.webview.instanceId': string,
-  'context.webview.type': string
+  'context.webview.type': string,
+  // Active Recent timeframe threshold at the time of show
+  'recentThreshold': 'OneDay' | 'OneWeek' | 'OneMonth'
 }
 ```
 

--- a/src/constants.telemetry.ts
+++ b/src/constants.telemetry.ts
@@ -317,10 +317,18 @@ export interface TelemetryEvents extends WebviewShowAbortedEvents, WebviewShownE
 	/** Sent when opening a virtual-FS-backed file fails (e.g. the compose session is no longer registered) */
 	'graph/virtualFile/failed': GraphVirtualFileFailedEvent;
 
-	/** Sent when the Graph Overview panel becomes visible (mounted in the active sidebar slot) */
-	'graph/overview/shown': GraphOverviewShownEvent;
+	/** Sent when the Graph Overview panel becomes visible */
+	'graph/overview/shown': GraphSidebarOverviewShownEvent;
 	/** Sent when the user invokes an action item on a Graph Overview branch card */
-	'graph/overview/action': GraphOverviewActionEvent;
+	'graph/overview/action': GraphSidebarOverviewActionEvent;
+	/** Sent when the user changes the Recent timeframe threshold in the Graph Overview */
+	'graph/overview/recentThresholdChanged': GraphSidebarOverviewRecentThresholdChangedEvent;
+	/** Sent when the user clicks a branch card to scope the graph to that branch */
+	'graph/overview/branchSelected': GraphSidebarOverviewBranchSelectedEvent;
+	/** Sent when the rich hover popover opens for the first time on a branch card */
+	'graph/overview/hoverShown': GraphSidebarOverviewHoverShownEvent;
+	/** Sent when the user clicks a PR or issue link in the Graph Overview hover popover */
+	'graph/overview/linkClicked': GraphSidebarOverviewLinkClickedEvent;
 
 	/** Sent when the integrated graph details panel is expanded */
 	'graphDetails/shown': GraphDetailsShownEvent;
@@ -1620,14 +1628,16 @@ interface GraphVirtualFileFailedEvent extends GraphContextEventData {
 	'error.message'?: string;
 }
 
-interface GraphOverviewShownEvent extends GraphContextEventData {
+interface GraphSidebarOverviewShownEvent extends GraphContextEventData {
 	/** Number of branches in the "active" section at the time of show */
 	'branches.active.count': number;
 	/** Number of branches in the "recent" section at the time of show */
 	'branches.recent.count': number;
+	/** Active Recent timeframe threshold at the time of show */
+	recentThreshold: 'OneDay' | 'OneWeek' | 'OneMonth';
 }
 
-export type GraphOverviewActionName =
+export type GraphSidebarOverviewActionName =
 	| 'pull'
 	| 'push'
 	| 'fetch'
@@ -1637,14 +1647,54 @@ export type GraphOverviewActionName =
 	| 'compareWithHead'
 	| 'compareWithWorking'
 	| 'compareWithPr'
+	| 'openPrChanges'
+	| 'openChanges'
 	| 'other';
 
-interface GraphOverviewActionEvent extends GraphContextEventData {
-	name: GraphOverviewActionName;
+interface GraphSidebarOverviewActionEvent extends GraphContextEventData {
+	name: GraphSidebarOverviewActionName;
 	/** Where on the card the action was invoked */
 	location: 'inline' | 'hover';
 	/** Whether the user held Alt/Shift to swap to the alt action */
 	alt: boolean;
+}
+
+interface GraphSidebarOverviewRecentThresholdChangedEvent extends GraphContextEventData {
+	/** New threshold value selected by the user */
+	threshold: 'OneDay' | 'OneWeek' | 'OneMonth';
+}
+
+interface GraphSidebarOverviewBranchSelectedEvent extends GraphContextEventData {
+	/** Whether the branch is the currently opened (active) branch */
+	isActive: boolean;
+	/** Whether the branch is checked out in a worktree */
+	isWorktree: boolean;
+	/** Whether the branch has an associated pull request */
+	hasPr: boolean;
+	/** Whether the branch has associated issues or autolinks */
+	hasIssues: boolean;
+	/** Whether the branch has uncommitted working tree changes */
+	hasWip: boolean;
+}
+
+interface GraphSidebarOverviewHoverShownEvent extends GraphContextEventData {
+	/** Whether the branch is the currently opened (active) branch */
+	isActive: boolean;
+	/** Whether the branch is checked out in a worktree */
+	isWorktree: boolean;
+	/** Whether the branch has an associated pull request */
+	hasPr: boolean;
+	/** Whether the branch has associated issues or autolinks */
+	hasIssues: boolean;
+	/** Whether the branch has uncommitted working tree changes */
+	hasWip: boolean;
+	/** Whether the branch has active agent sessions */
+	hasAgents: boolean;
+}
+
+interface GraphSidebarOverviewLinkClickedEvent extends GraphContextEventData {
+	/** Type of external link clicked */
+	type: 'pullrequest' | 'issue' | 'autolink';
 }
 
 export type HomeTelemetryContext = WebviewTelemetryContext;

--- a/src/webviews/apps/plus/graph/overview/graph-overview-card.ts
+++ b/src/webviews/apps/plus/graph/overview/graph-overview-card.ts
@@ -9,7 +9,7 @@ import { formatDate, fromNow } from '@gitlens/utils/date.js';
 import { pluralize } from '@gitlens/utils/string.js';
 import type { AgentSessionState } from '../../../../../agents/models/agentSessionState.js';
 import type { GlWebviewCommandsOrCommandsWithSuffix } from '../../../../../constants.commands.js';
-import type { GraphOverviewActionName } from '../../../../../constants.telemetry.js';
+import type { GraphSidebarOverviewActionName } from '../../../../../constants.telemetry.js';
 import { isSubscriptionTrialOrPaidFromState } from '../../../../../plus/gk/utils/subscription.utils.js';
 import {
 	launchpadCategoryToGroupMap,
@@ -671,6 +671,19 @@ export class GlGraphOverviewCard extends LitElement {
 	private readonly onPopoverShow = () => {
 		if (!this._hoverShown) {
 			this._hoverShown = true;
+
+			emitTelemetrySentEvent<'graph/overview/hoverShown'>(this, {
+				name: 'graph/overview/hoverShown',
+				data: {
+					isActive: this.branch.opened,
+					isWorktree: this.isWorktree,
+					hasPr: this.enrichment?.pr != null,
+					hasIssues:
+						(this.enrichment?.issues?.length ?? 0) > 0 || (this.enrichment?.autolinks?.length ?? 0) > 0,
+					hasWip: this.hasWip,
+					hasAgents: (this.agentSessions?.length ?? 0) > 0,
+				},
+			});
 		}
 		// Kick off the lazy merge-target fetch on first popover open. Subsequent opens reuse
 		// `_mergeTargetPromise` (the chip short-circuits when the same promise reference is passed).
@@ -1140,7 +1153,9 @@ export class GlGraphOverviewCard extends LitElement {
 							<pr-icon ?draft=${pr!.draft} state=${pr!.state} pr-id=${pr!.id}></pr-icon>
 						</span>
 						<span class="hover__name">
-							<a href=${pr!.url} @click=${this.onLinkClick}>${pr!.title}</a>
+							<a href=${pr!.url} @click=${(e: Event) => this.onLinkClick(e, 'pullrequest')}
+								>${pr!.title}</a
+							>
 						</span>
 						<span class="hover__identifier">#${pr!.id}</span>
 					</div>
@@ -1160,8 +1175,10 @@ export class GlGraphOverviewCard extends LitElement {
 
 	private renderHoverItemRow(item: OverviewBranchIssue) {
 		const identifier = html`<span class="hover__identifier">${formatIssueIdentifier(item.id)}</span>`;
+		const linkType: 'pullrequest' | 'issue' | 'autolink' =
+			item.type === 'pullrequest' ? 'pullrequest' : item.type === 'issue' ? 'issue' : 'autolink';
 		const link = html`<span class="hover__name">
-			<a href=${item.url} @click=${this.onLinkClick}>${item.title}</a>
+			<a href=${item.url} @click=${(e: Event) => this.onLinkClick(e, linkType)}>${item.title}</a>
 		</span>`;
 
 		switch (item.type) {
@@ -1306,21 +1323,40 @@ export class GlGraphOverviewCard extends LitElement {
 		return false;
 	}
 
+	private isEventFromActionItem(e: Event): boolean {
+		const path = e.composedPath();
+		for (const node of path) {
+			if ((node as Element)?.tagName === 'ACTION-ITEM') return true;
+		}
+		return false;
+	}
+
 	private onCardClick(e: MouseEvent) {
-		if (this.isEventFromAgentPill(e)) return;
+		if (this.isEventFromAgentPill(e) || this.isEventFromActionItem(e)) return;
 
 		this.dispatchBranchSelected();
 	}
 
 	private onCardKeydown(e: KeyboardEvent) {
 		if (e.key !== 'Enter' && e.key !== ' ') return;
-		if (this.isEventFromAgentPill(e)) return;
+		if (this.isEventFromAgentPill(e) || this.isEventFromActionItem(e)) return;
 
 		e.preventDefault();
 		this.dispatchBranchSelected();
 	}
 
 	private dispatchBranchSelected() {
+		emitTelemetrySentEvent<'graph/overview/branchSelected'>(this, {
+			name: 'graph/overview/branchSelected',
+			data: {
+				isActive: this.branch.opened,
+				isWorktree: this.isWorktree,
+				hasPr: this.enrichment?.pr != null,
+				hasIssues: (this.enrichment?.issues?.length ?? 0) > 0 || (this.enrichment?.autolinks?.length ?? 0) > 0,
+				hasWip: this.hasWip,
+			},
+		});
+
 		this.dispatchEvent(
 			new CustomEvent('gl-graph-overview-branch-selected', {
 				detail: {
@@ -1338,8 +1374,15 @@ export class GlGraphOverviewCard extends LitElement {
 		);
 	}
 
-	private onLinkClick(e: Event) {
+	private onLinkClick(e: Event, type?: 'pullrequest' | 'issue' | 'autolink') {
 		e.stopPropagation();
+
+		if (type != null) {
+			emitTelemetrySentEvent<'graph/overview/linkClicked'>(this, {
+				name: 'graph/overview/linkClicked',
+				data: { type: type },
+			});
+		}
 	}
 
 	private onActionItemClick(e: MouseEvent) {
@@ -1375,7 +1418,7 @@ export class GlGraphOverviewCard extends LitElement {
 	}
 }
 
-function commandToOverviewActionName(href: string): GraphOverviewActionName {
+function commandToOverviewActionName(href: string): GraphSidebarOverviewActionName {
 	// command URIs look like `command:gitlens.x?{...}` or `command:gitlens.x:graph?{...}` for
 	// "commands with suffix". Capture the full id (up to `?` or end), then strip the trailing
 	// `:graph` suffix the overview-card webview emits via createCommandLink.
@@ -1401,6 +1444,10 @@ function commandToOverviewActionName(href: string): GraphOverviewActionName {
 			return 'compareWithWorking';
 		case 'gitlens.openPullRequestComparison':
 			return 'compareWithPr';
+		case 'gitlens.openPullRequestChanges':
+			return 'openPrChanges';
+		case 'gitlens.graph.openChangedFileDiffsWithMergeBase':
+			return 'openChanges';
 		default:
 			return 'other';
 	}

--- a/src/webviews/apps/plus/graph/overview/graph-overview.ts
+++ b/src/webviews/apps/plus/graph/overview/graph-overview.ts
@@ -303,6 +303,7 @@ export class GlGraphOverview extends SignalWatcher(LitElement) {
 				data: {
 					'branches.active.count': overview.active.length,
 					'branches.recent.count': overview.recent.length,
+					recentThreshold: this._state.overviewRecentThreshold ?? 'OneWeek',
 				},
 			});
 		}
@@ -570,6 +571,11 @@ export class GlGraphOverview extends SignalWatcher(LitElement) {
 
 	private onRecentThresholdSelected(threshold: OverviewRecentThreshold): void {
 		if ((this._state.overviewRecentThreshold ?? 'OneWeek') === threshold) return;
+
+		emitTelemetrySentEvent<'graph/overview/recentThresholdChanged'>(this, {
+			name: 'graph/overview/recentThresholdChanged',
+			data: { threshold: threshold },
+		});
 
 		// Let graph-app own the persisted signal + memento write (mirrors the timeline period
 		// flow); send the request here since this panel owns the overview fetch lifecycle.


### PR DESCRIPTION
Part of #5356 (Overview checkbox under Sidebar)

## Summary

- Extends existing `graph/overview/shown` with `recentThreshold` field and adds 4 new events covering interactions in the Graph Sidebar Overview panel
- Extends `GraphOverviewActionName` with `openPrChanges` and `openChanges` so those hover actions no longer fall through to `'other'`
- Adds `graph/overview/branchSelected` for click-to-scope tracking on branch cards
- Adds `graph/overview/hoverShown` for rich hover popover engagement (one-shot per card mount)
- Adds `graph/overview/linkClicked` for PR/issue external link clicks from the hover popover
- Adds `graph/overview/recentThresholdChanged` for Recent timeframe filter interaction
- Telemetry docs auto-regenerated via `pnpm run generate:docs:telemetry`

### New events

| Event | When |
|---|---|
| `graph/overview/recentThresholdChanged` | User changes the Recent timeframe filter (1 day / 1 week / 1 month) |
| `graph/overview/branchSelected` | User clicks or keyboard-activates a branch card to scope the graph |
| `graph/overview/hoverShown` | Rich hover popover opens for the first time on a branch card |
| `graph/overview/linkClicked` | User clicks a PR title or issue title link in the hover popover |

### Extended events

| Event | Change |
|---|---|
| `graph/overview/shown` | Added `recentThreshold` to payload |
| `graph/overview/action` | Added `openPrChanges` and `openChanges` to `GraphOverviewActionName` |

## Test plan

- [ ] Open the Graph, expand the sidebar, switch to the Overview tab — verify `graph/overview/shown` fires with `recentThreshold`
- [ ] Click a branch card — verify `graph/overview/branchSelected` fires with correct `isActive`, `isWorktree`, `hasPr`, `hasIssues`, `hasWip`
- [ ] Hover a branch card to open the rich popover — verify `graph/overview/hoverShown` fires once per card mount
- [ ] Click a PR title link in the hover popover — verify `graph/overview/linkClicked` fires with `type: 'pullrequest'`
- [ ] Click an issue link — verify `type: 'issue'`
- [ ] Change the Recent threshold from "1 week" to "1 day" — verify `graph/overview/recentThresholdChanged` fires with `threshold: 'OneDay'`
- [ ] Click "Open All Changes" in the hover — verify `graph/overview/action` fires with `name: 'openChanges'` (not `'other'`)
- [ ] Click "Open All Changes" on a PR branch — verify `name: 'openPrChanges'`
- [ ] Run `npx tsc --noEmit` — passes cleanly

🤖 Generated with [Claude Code](https://claude.com/claude-code)