### PR TITLE
Agents sidebar telemetry in graph

### DIFF
--- a/docs/telemetry-events.md
+++ b/docs/telemetry-events.md
@@ -2499,6 +2499,152 @@ background-upgraded the extension while the host kept running the old build
 }
 ```
 
+### graph/agents/filtered
+
+> Sent when the sidebar agents filter toggles between empty and non-empty (not on every keystroke)
+
+```typescript
+{
+  'context.repository.closed': boolean,
+  'context.repository.folder.scheme': string,
+  'context.repository.id': string,
+  'context.repository.provider.id': string,
+  'context.repository.scheme': string,
+  'context.webview.host': 'view' | 'editor' | 'panel',
+  'context.webview.id': string,
+  'context.webview.instanceId': string,
+  'context.webview.type': string,
+  'filter.length': number,
+  'hasFilter': boolean,
+  'sessions.count': number
+}
+```
+
+### graph/agents/headerAction
+
+> Sent when the user clicks a header action (Start Work, Start Review, Refresh) in the sidebar agents panel
+
+```typescript
+{
+  'action': 'startReview' | 'startWork' | 'refresh',
+  'context.repository.closed': boolean,
+  'context.repository.folder.scheme': string,
+  'context.repository.id': string,
+  'context.repository.provider.id': string,
+  'context.repository.scheme': string,
+  'context.webview.host': 'view' | 'editor' | 'panel',
+  'context.webview.id': string,
+  'context.webview.instanceId': string,
+  'context.webview.type': string
+}
+```
+
+### graph/agents/layoutToggled
+
+> Sent when the user toggles the tree/list layout in the sidebar agents panel
+
+```typescript
+{
+  'context.repository.closed': boolean,
+  'context.repository.folder.scheme': string,
+  'context.repository.id': string,
+  'context.repository.provider.id': string,
+  'context.repository.scheme': string,
+  'context.webview.host': 'view' | 'editor' | 'panel',
+  'context.webview.id': string,
+  'context.webview.instanceId': string,
+  'context.webview.type': string,
+  'layout': 'list' | 'tree',
+  'sessions.count': number
+}
+```
+
+### graph/agents/permissionResolved
+
+> Sent when the user resolves a permission (Allow/Deny/Always Allow) from the sidebar agents panel
+
+```typescript
+{
+  'alwaysAllow': boolean,
+  'context.repository.closed': boolean,
+  'context.repository.folder.scheme': string,
+  'context.repository.id': string,
+  'context.repository.provider.id': string,
+  'context.repository.scheme': string,
+  'context.webview.host': 'view' | 'editor' | 'panel',
+  'context.webview.id': string,
+  'context.webview.instanceId': string,
+  'context.webview.type': string,
+  'decision': 'allow' | 'deny',
+  'permission.kind': string
+}
+```
+
+### graph/agents/sessionAction
+
+> Sent when the user clicks Open Session or View Plan on a session, or Open Terminal on a worktree group, in the sidebar agents panel
+
+```typescript
+{
+  'action': 'openSession' | 'openPlanFile' | 'openTerminal',
+  'context.repository.closed': boolean,
+  'context.repository.folder.scheme': string,
+  'context.repository.id': string,
+  'context.repository.provider.id': string,
+  'context.repository.scheme': string,
+  'context.webview.host': 'view' | 'editor' | 'panel',
+  'context.webview.id': string,
+  'context.webview.instanceId': string,
+  'context.webview.type': string
+}
+```
+
+### graph/agents/sessionSelected
+
+> Sent when the user clicks an agent session leaf in the sidebar agents panel
+
+```typescript
+{
+  'context.repository.closed': boolean,
+  'context.repository.folder.scheme': string,
+  'context.repository.id': string,
+  'context.repository.provider.id': string,
+  'context.repository.scheme': string,
+  'context.webview.host': 'view' | 'editor' | 'panel',
+  'context.webview.id': string,
+  'context.webview.instanceId': string,
+  'context.webview.type': string,
+  'layout': 'list' | 'tree',
+  'session.category': 'working' | 'needs-input' | 'idle',
+  'session.hasPendingPermission': boolean,
+  'session.phase': string,
+  'session.sameRepo': boolean
+}
+```
+
+### graph/agents/shown
+
+> Sent when the Agents sidebar panel becomes visible
+
+```typescript
+{
+  'context.repository.closed': boolean,
+  'context.repository.folder.scheme': string,
+  'context.repository.id': string,
+  'context.repository.provider.id': string,
+  'context.repository.scheme': string,
+  'context.webview.host': 'view' | 'editor' | 'panel',
+  'context.webview.id': string,
+  'context.webview.instanceId': string,
+  'context.webview.type': string,
+  'layout': 'list' | 'tree',
+  'sessions.count': number,
+  'sessions.idle.count': number,
+  'sessions.needsInput.count': number,
+  'sessions.working.count': number
+}
+```
+
 ### graph/autoFetch
 
 > Sent when GitLens auto-fetch fires a `git fetch` for the visible Commit Graph
@@ -5071,7 +5217,7 @@ void
 {
   'instance': number,
   'items.error': string,
-  'action': 'settings' | 'connect' | 'feedback' | 'open-on-gkdev' | 'refresh',
+  'action': 'settings' | 'connect' | 'refresh' | 'feedback' | 'open-on-gkdev',
   'groups.blocked.collapsed': boolean,
   'groups.blocked.count': number,
   'groups.count': number,

--- a/package.json
+++ b/package.json
@@ -29423,7 +29423,7 @@
 		"zod": "4.4.3"
 	},
 	"lint-staged": {
-		"*.{ts,tsx,json,jsonc,md,scss,yaml}": "oxfmt"
+		"*.{ts,tsx,json,jsonc,md,scss,yaml}": "oxfmt --no-error-on-unmatched-pattern"
 	},
 	"packageManager": "pnpm@11.9.0",
 	"postcss-lit": {

--- a/src/constants.telemetry.ts
+++ b/src/constants.telemetry.ts
@@ -330,6 +330,21 @@ export interface TelemetryEvents extends WebviewShowAbortedEvents, WebviewShownE
 	/** Sent when the user clicks a PR or issue link in the Graph Overview hover popover */
 	'graph/overview/linkClicked': GraphSidebarOverviewLinkClickedEvent;
 
+	/** Sent when the Agents sidebar panel becomes visible */
+	'graph/agents/shown': GraphSidebarAgentsShownEvent;
+	/** Sent when the user clicks an agent session leaf in the sidebar agents panel */
+	'graph/agents/sessionSelected': GraphSidebarAgentsSessionSelectedEvent;
+	/** Sent when the user resolves a permission (Allow/Deny/Always Allow) from the sidebar agents panel */
+	'graph/agents/permissionResolved': GraphSidebarAgentsPermissionResolvedEvent;
+	/** Sent when the user clicks Open Session or View Plan on a session, or Open Terminal on a worktree group, in the sidebar agents panel */
+	'graph/agents/sessionAction': GraphSidebarAgentsSessionActionEvent;
+	/** Sent when the user clicks a header action (Start Work, Start Review, Refresh) in the sidebar agents panel */
+	'graph/agents/headerAction': GraphSidebarAgentsHeaderActionEvent;
+	/** Sent when the user toggles the tree/list layout in the sidebar agents panel */
+	'graph/agents/layoutToggled': GraphSidebarAgentsLayoutToggledEvent;
+	/** Sent when the sidebar agents filter toggles between empty and non-empty (not on every keystroke) */
+	'graph/agents/filtered': GraphSidebarAgentsFilteredEvent;
+
 	/** Sent when the integrated graph details panel is expanded */
 	'graphDetails/shown': GraphDetailsShownEvent;
 	/** Sent when the integrated graph details panel is collapsed */
@@ -1695,6 +1710,47 @@ interface GraphSidebarOverviewHoverShownEvent extends GraphContextEventData {
 interface GraphSidebarOverviewLinkClickedEvent extends GraphContextEventData {
 	/** Type of external link clicked */
 	type: 'pullrequest' | 'issue' | 'autolink';
+}
+
+interface GraphSidebarAgentsShownEvent extends GraphContextEventData {
+	layout: 'list' | 'tree';
+	'sessions.count': number;
+	'sessions.working.count': number;
+	'sessions.needsInput.count': number;
+	'sessions.idle.count': number;
+}
+
+interface GraphSidebarAgentsSessionSelectedEvent extends GraphContextEventData {
+	'session.phase': string;
+	'session.category': 'working' | 'needs-input' | 'idle';
+	'session.hasPendingPermission': boolean;
+	'session.sameRepo': boolean;
+	layout: 'list' | 'tree';
+}
+
+interface GraphSidebarAgentsPermissionResolvedEvent extends GraphContextEventData {
+	decision: 'allow' | 'deny';
+	alwaysAllow: boolean;
+	'permission.kind': string;
+}
+
+interface GraphSidebarAgentsSessionActionEvent extends GraphContextEventData {
+	action: 'openSession' | 'openPlanFile' | 'openTerminal';
+}
+
+interface GraphSidebarAgentsHeaderActionEvent extends GraphContextEventData {
+	action: 'startWork' | 'startReview' | 'refresh';
+}
+
+interface GraphSidebarAgentsLayoutToggledEvent extends GraphContextEventData {
+	layout: 'list' | 'tree';
+	'sessions.count': number;
+}
+
+interface GraphSidebarAgentsFilteredEvent extends GraphContextEventData {
+	hasFilter: boolean;
+	'filter.length': number;
+	'sessions.count': number;
 }
 
 export type HomeTelemetryContext = WebviewTelemetryContext;

--- a/src/webviews/apps/plus/graph/sidebar/sidebar-panel.ts
+++ b/src/webviews/apps/plus/graph/sidebar/sidebar-panel.ts
@@ -44,6 +44,7 @@ import type {
 	TreeModelFlat,
 } from '../../../shared/components/tree/base.js';
 import { ContextMenuProxyController } from '../../../shared/controllers/context-menu-proxy.js';
+import { emitTelemetrySentEvent } from '../../../shared/telemetry.js';
 import type { AppState } from '../context.js';
 import { graphStateContext } from '../context.js';
 import { sidebarActionsContext } from './sidebarContext.js';
@@ -417,6 +418,7 @@ export class GlGraphSidebarPanel extends SignalWatcher(LitElement) {
 	private readonly _contextMenuProxy = new ContextMenuProxyController(this);
 
 	private _pendingFocus = false;
+	private _agentsFilterActive = false;
 
 	focusFilter(): void {
 		if (this.activePanel == null || this.activePanel === 'overview') {
@@ -458,11 +460,22 @@ export class GlGraphSidebarPanel extends SignalWatcher(LitElement) {
 			// Keep the actions module in sync so invalidateAll can refetch
 			this._actions.activePanel = this.activePanel;
 
+			// `_actions.filterText` is a single string shared across panels and survives panel
+			// switches (its only write is `handleFilterChanged`), while `_agentsFilterActive` is
+			// only maintained while agents is active. Re-sync from the actual filter here, or the
+			// empty↔non-empty transition detection in `handleFilterChanged` compares against a
+			// stale value — emitting duplicate "activated" or missing "deactivated" events.
+			this._agentsFilterActive = this._actions.filterText.length > 0;
+
 			// Always fetch on panel switch — data may be stale even if non-null.
 			// The Resource's cancelPrevious handles dedup.
 			// Overview/Agents panels manage their own data via reactive state, skip sidebar fetch.
 			if (this.activePanel != null && this.activePanel !== 'overview' && this.activePanel !== 'agents') {
 				this._actions.fetchPanel(this.activePanel);
+			}
+
+			if (this.activePanel === 'agents') {
+				this.emitAgentsShownTelemetry();
 			}
 		}
 	}
@@ -1264,6 +1277,21 @@ export class GlGraphSidebarPanel extends SignalWatcher(LitElement) {
 
 	private handleFilterChanged = (e: CustomEvent<string>) => {
 		this._actions.filterText = e.detail;
+
+		if (this.activePanel === 'agents') {
+			const hasFilter = e.detail.length > 0;
+			if (hasFilter !== this._agentsFilterActive) {
+				this._agentsFilterActive = hasFilter;
+				emitTelemetrySentEvent<'graph/agents/filtered'>(this, {
+					name: 'graph/agents/filtered',
+					data: {
+						hasFilter: hasFilter,
+						'filter.length': e.detail.length,
+						'sessions.count': this._state.agentSessions?.length ?? 0,
+					},
+				});
+			}
+		}
 	};
 
 	private handleSearchBoxFilterChanged = (e: CustomEvent<boolean>) => {
@@ -1278,13 +1306,38 @@ export class GlGraphSidebarPanel extends SignalWatcher(LitElement) {
 	};
 
 	private handleAction(command: GlCommands, args?: unknown[]) {
+		if (this.activePanel === 'agents') {
+			const action =
+				command === 'gitlens.startWork'
+					? 'startWork'
+					: command === 'gitlens.startReview'
+						? 'startReview'
+						: undefined;
+			if (action != null) {
+				emitTelemetrySentEvent<'graph/agents/headerAction'>(this, {
+					name: 'graph/agents/headerAction',
+					data: { action: action },
+				});
+			}
+		}
+
 		this._actions?.executeAction(command, undefined, args);
 	}
 
 	private handleToggleLayout() {
 		if (this.activePanel == null) return;
 
-		this._actions?.toggleLayout(this.activePanel);
+		this._actions.toggleLayout(this.activePanel);
+
+		if (this.activePanel === 'agents') {
+			emitTelemetrySentEvent<'graph/agents/layoutToggled'>(this, {
+				name: 'graph/agents/layoutToggled',
+				data: {
+					layout: this._actions.agentsLayout.get(),
+					'sessions.count': this._state.agentSessions?.length ?? 0,
+				},
+			});
+		}
 	}
 
 	private handleRefresh() {
@@ -1295,6 +1348,13 @@ export class GlGraphSidebarPanel extends SignalWatcher(LitElement) {
 				| null;
 			overview?.refresh?.();
 			return;
+		}
+
+		if (this.activePanel === 'agents') {
+			emitTelemetrySentEvent<'graph/agents/headerAction'>(this, {
+				name: 'graph/agents/headerAction',
+				data: { action: 'refresh' },
+			});
 		}
 
 		this._actions?.refresh(this.activePanel);
@@ -1315,6 +1375,11 @@ export class GlGraphSidebarPanel extends SignalWatcher(LitElement) {
 		const useAlt = e.detail.altKey && action.altAction != null;
 		const command = (useAlt ? action.altAction! : action.action) as GlCommands;
 		const args = useAlt ? action.altArguments : action.arguments;
+
+		if (this.activePanel === 'agents') {
+			this.emitAgentsTreeItemActionTelemetry(command, args);
+		}
+
 		this._actions?.executeAction(command, node.contextData as string | undefined, args);
 	}
 
@@ -1326,6 +1391,17 @@ export class GlGraphSidebarPanel extends SignalWatcher(LitElement) {
 		}
 
 		const context = e.detail.context;
+		const sessionId = context?.[2];
+
+		// Selecting a session is a real user event regardless of whether the graph can navigate to
+		// it, so emit before the `sha` guard below. Cross-repo (`!sameFamily`) and worktree-less
+		// sessions resolve to a null `wipSha` (`resolveAgentAnchor`) — i.e. `sha == null` — which is
+		// exactly the `session.sameRepo: false` case this event exists to measure. Emitting after
+		// the guard would drop those clicks and skew the `sameRepo` dimension to `true`.
+		if (this.activePanel === 'agents' && sessionId != null) {
+			this.emitAgentsSessionSelectedTelemetry(sessionId);
+		}
+
 		const sha = context?.[0];
 		if (sha == null) return;
 
@@ -1343,7 +1419,6 @@ export class GlGraphSidebarPanel extends SignalWatcher(LitElement) {
 			);
 		}
 
-		const sessionId = context?.[2];
 		this.dispatchEvent(
 			new CustomEvent<GraphSidebarPanelSelectEventDetail>('gl-graph-sidebar-panel-select', {
 				detail: { sha: sha, sessionId: sessionId },
@@ -1363,6 +1438,97 @@ export class GlGraphSidebarPanel extends SignalWatcher(LitElement) {
 			paths.delete(e.detail.path);
 		}
 	};
+
+	private emitAgentsShownTelemetry(): void {
+		// Point-in-time snapshot: fired on the `activePanel → 'agents'` transition only. Sessions
+		// arrive asynchronously on `_state.agentSessions` (see `render`), so on first open the counts
+		// below may all read 0, and later arrivals don't re-fire this event. `agentSessions` is a
+		// signal initialized to `[]`, so "not yet loaded" and "loaded but empty" are indistinguishable
+		// here — treat the counts as "what was visible at open", not a settled total. Also no re-fire
+		// when the panel is re-revealed without an `activePanel` change: display-mode round trips
+		// (graph → kanban/visualizations → graph) hide/show the split but preserve the value, and
+		// rail re-clicks that set the same panel don't transition. Close/reopen does re-fire
+		// (`hideSidebar` clears `activePanel`).
+		const sessions = this._state.agentSessions ?? [];
+		let working = 0;
+		let needsInput = 0;
+		let idle = 0;
+		for (const s of sessions) {
+			const category = agentPhaseToCategory[s.phase];
+			if (category === 'working') {
+				working++;
+			} else if (category === 'needs-input') {
+				needsInput++;
+			} else {
+				idle++;
+			}
+		}
+
+		emitTelemetrySentEvent<'graph/agents/shown'>(this, {
+			name: 'graph/agents/shown',
+			data: {
+				layout: this._actions.agentsLayout.get(),
+				'sessions.count': sessions.length,
+				'sessions.working.count': working,
+				'sessions.needsInput.count': needsInput,
+				'sessions.idle.count': idle,
+			},
+		});
+	}
+
+	private emitAgentsSessionSelectedTelemetry(sessionId: string): void {
+		const session = this._state.agentSessions?.find(s => s.id === sessionId);
+		if (session == null) return;
+
+		const category = agentPhaseToCategory[session.phase];
+		const graphAnchor = this.resolveGraphAnchorContext();
+		const sameRepo = graphAnchor != null && session.commonPath === graphAnchor.family;
+
+		emitTelemetrySentEvent<'graph/agents/sessionSelected'>(this, {
+			name: 'graph/agents/sessionSelected',
+			data: {
+				'session.phase': session.phase,
+				'session.category': category,
+				'session.hasPendingPermission': session.pendingPermission != null,
+				'session.sameRepo': sameRepo,
+				layout: this._actions.agentsLayout.get(),
+			},
+		});
+	}
+
+	private emitAgentsTreeItemActionTelemetry(command: string, args: unknown[] | undefined): void {
+		if (command === 'gitlens.agents.resolvePermission') {
+			const arg = args?.[0] as { sessionId?: string; decision?: string; alwaysAllow?: boolean } | undefined;
+			const session =
+				arg?.sessionId != null ? this._state.agentSessions?.find(s => s.id === arg.sessionId) : undefined;
+
+			emitTelemetrySentEvent<'graph/agents/permissionResolved'>(this, {
+				name: 'graph/agents/permissionResolved',
+				data: {
+					decision: (arg?.decision as 'allow' | 'deny') ?? 'allow',
+					alwaysAllow: arg?.alwaysAllow ?? false,
+					'permission.kind': session?.pendingPermission?.kind ?? 'unknown',
+				},
+			});
+			return;
+		}
+
+		let action: 'openSession' | 'openPlanFile' | 'openTerminal' | undefined;
+		if (command === 'gitlens.agents.openSession') {
+			action = 'openSession';
+		} else if (command === 'gitlens.agents.openPlanFile') {
+			action = 'openPlanFile';
+		} else if (command === 'gitlens.openInIntegratedTerminal:graph') {
+			action = 'openTerminal';
+		}
+
+		if (action != null) {
+			emitTelemetrySentEvent<'graph/agents/sessionAction'>(this, {
+				name: 'graph/agents/sessionAction',
+				data: { action: action },
+			});
+		}
+	}
 }
 
 /**

--- a/src/webviews/apps/shared/telemetry.ts
+++ b/src/webviews/apps/shared/telemetry.ts
@@ -10,6 +10,11 @@ export function emitTelemetrySentEvent<T extends keyof TelemetryEvents>(
 	el.dispatchEvent(
 		new CustomEvent<TelemetrySendEventParams<T>>(telemetryEventName, {
 			bubbles: true,
+			// The only listener is on `window` (see `appBase.ts`), so the event must cross any
+			// shadow boundaries between the dispatching element and the document. Without this,
+			// events dispatched from inside a shadow root (e.g. `gl-graph-overview` inside
+			// `gl-graph-sidebar-panel`) are trapped at the boundary and silently dropped.
+			composed: true,
 			detail: params,
 		}),
 	);


### PR DESCRIPTION
## Summary

Part of #5356 (Agents checkbox under Sidebar).

- Adds 7 telemetry events covering all user interactions in the Graph Sidebar Agents panel
- Events use the `graph/agents/*` prefix following the flat `graph/{area}/...` convention
- All payloads are privacy-safe: counts, booleans, enum strings only — no session names, prompts, file paths, or branch names

### New events

| Event | When |
|---|---|
| `graph/agents/shown` | Agents panel becomes visible (includes session count breakdown by category; counts are a mount-time snapshot — see doc comment) |
| `graph/agents/sessionSelected` | User clicks an agent session leaf (tracks phase, category, same-repo). Emits before the graph-navigation `sha` guard so cross-repo and worktree-less sessions are counted — that's exactly what the `session.sameRepo` dimension exists to measure |
| `graph/agents/permissionResolved` | User clicks Allow / Deny / Always Allow (tracks decision, kind) |
| `graph/agents/sessionAction` | User clicks Open Session or View Plan on a session, or Open Terminal on a worktree group |
| `graph/agents/headerAction` | User clicks Start Work, Start PR Review, or Refresh |
| `graph/agents/layoutToggled` | User toggles between tree and list view |
| `graph/agents/filtered` | Filter toggles between empty and non-empty — not per keystroke (length only, never text content) |

### Also fixes: webview telemetry trapped at shadow DOM boundaries (pre-existing)

`emitTelemetrySentEvent` dispatched with `bubbles: true` but without `composed: true`, while the only listener lives on `window` (`appBase.ts`). Any event dispatched from inside a shadow root was silently dropped at the boundary. Concretely, **all `graph/overview/*` events have been dark since their introduction**: `gl-graph-overview` renders inside `gl-graph-sidebar-panel`'s shadow root, `gl-graph-overview-card` sits two boundaries deep.

Verified via live A/B (instrumented probes at each shadow root + at `window`, teardown/relaunch between runs):
- **Without the fix**: `graph/overview/shown` / `recentThresholdChanged` / `hoverShown` all dispatch but none reach `window`; a light-DOM control event (`graph/agents/shown`) does.
- **With `composed: true`**: all overview events reach `window` exactly once — no duplicates; light-DOM events unaffected.

📈 **Data heads-up**: `graph/overview/*` event volume will rise from ~zero once this ships — a dashboard discontinuity there is expected, not a regression.

### Out of scope

- Agent session state transitions (working/idle) — host-side, orthogonal
- Details panel agent-section interactions — covered separately
- Kanban agent card clicks — already tracked via `graphDetails/shown` with `trigger: 'request-agents'`
- Hooks install banner — already tracked cross-cuttingly via `source: 'graph-sidebar-agents'`

## Test plan

- [ ] Open Agents sidebar panel — verify `graph/agents/shown` fires with correct session counts and layout
- [ ] Click an agent session — verify `graph/agents/sessionSelected` fires with phase/category
- [ ] Click a **cross-repo** agent session (different repo than the graph) — verify `sessionSelected` still fires with `session.sameRepo: false`
- [ ] Click Allow on a needs-input session — verify `graph/agents/permissionResolved` with `decision: 'allow'`, `alwaysAllow: false`
- [ ] Alt-click Allow (Always Allow) — verify `alwaysAllow: true`
- [ ] Click Deny — verify `decision: 'deny'`
- [ ] Click Open Session — verify `graph/agents/sessionAction` with `action: 'openSession'`
- [ ] Click View Plan (on plan permission) — verify `action: 'openPlanFile'`
- [ ] Click "Start Work with Agent..." header — verify `graph/agents/headerAction` with `action: 'startWork'`
- [ ] Click "Start PR Review with Agent..." — verify `action: 'startReview'`
- [ ] Toggle tree/list layout — verify `graph/agents/layoutToggled` with new layout
- [ ] Type in filter box — verify `graph/agents/filtered` fires on empty↔non-empty transitions only; switch panels with a live filter and back — no duplicate/missed transition events
- [x] Overview telemetry reaches the host after the `composed: true` fix — verified via live A/B instrumentation (see "Also fixes" section)
- [ ] TypeScript compiles cleanly (`npx tsc --noEmit`)
- [ ] Telemetry docs regenerated (`pnpm run generate:docs:telemetry`)
