### PR TITLE
Adds telemetry for Worktrees sidebar panel

### DIFF
--- a/docs/telemetry-events.md
+++ b/docs/telemetry-events.md
@@ -3569,6 +3569,128 @@ background-upgraded the extension while the host kept running the old build
 }
 ```
 
+### graph/worktrees/filtered
+
+> Sent when the user types in the filter box in the sidebar worktrees panel
+
+```typescript
+{
+  'context.repository.closed': boolean,
+  'context.repository.folder.scheme': string,
+  'context.repository.id': string,
+  'context.repository.provider.id': string,
+  'context.repository.scheme': string,
+  'context.webview.host': 'view' | 'editor' | 'panel',
+  'context.webview.id': string,
+  'context.webview.instanceId': string,
+  'context.webview.type': string,
+  'filter.length': number,
+  'hasFilter': boolean,
+  'worktrees.count': number
+}
+```
+
+### graph/worktrees/headerAction
+
+> Sent when the user clicks a header action (Create Worktree, Refresh) in the sidebar worktrees panel
+
+```typescript
+{
+  'action': 'refresh' | 'createWorktree',
+  'context.repository.closed': boolean,
+  'context.repository.folder.scheme': string,
+  'context.repository.id': string,
+  'context.repository.provider.id': string,
+  'context.repository.scheme': string,
+  'context.webview.host': 'view' | 'editor' | 'panel',
+  'context.webview.id': string,
+  'context.webview.instanceId': string,
+  'context.webview.type': string
+}
+```
+
+### graph/worktrees/layoutToggled
+
+> Sent when the user toggles the tree/list layout in the sidebar worktrees panel
+
+```typescript
+{
+  'context.repository.closed': boolean,
+  'context.repository.folder.scheme': string,
+  'context.repository.id': string,
+  'context.repository.provider.id': string,
+  'context.repository.scheme': string,
+  'context.webview.host': 'view' | 'editor' | 'panel',
+  'context.webview.id': string,
+  'context.webview.instanceId': string,
+  'context.webview.type': string,
+  'layout': 'list' | 'tree',
+  'worktrees.count': number
+}
+```
+
+### graph/worktrees/shown
+
+> Sent when the Worktrees sidebar panel becomes visible
+
+```typescript
+{
+  'context.repository.closed': boolean,
+  'context.repository.folder.scheme': string,
+  'context.repository.id': string,
+  'context.repository.provider.id': string,
+  'context.repository.scheme': string,
+  'context.webview.host': 'view' | 'editor' | 'panel',
+  'context.webview.id': string,
+  'context.webview.instanceId': string,
+  'context.webview.type': string,
+  'layout': 'list' | 'tree',
+  'worktrees.count': number
+}
+```
+
+### graph/worktrees/worktreeAction
+
+> Sent when the user clicks an inline action (pull/push/fetch/open) on a worktree item
+
+```typescript
+{
+  'action': 'pull' | 'push' | 'fetch' | 'openWorktree' | 'openWorktreeInNewWindow',
+  'alt': boolean,
+  'context.repository.closed': boolean,
+  'context.repository.folder.scheme': string,
+  'context.repository.id': string,
+  'context.repository.provider.id': string,
+  'context.repository.scheme': string,
+  'context.webview.host': 'view' | 'editor' | 'panel',
+  'context.webview.id': string,
+  'context.webview.instanceId': string,
+  'context.webview.type': string
+}
+```
+
+### graph/worktrees/worktreeSelected
+
+> Sent when the user clicks a worktree leaf in the sidebar worktrees panel
+
+```typescript
+{
+  'context.repository.closed': boolean,
+  'context.repository.folder.scheme': string,
+  'context.repository.id': string,
+  'context.repository.provider.id': string,
+  'context.repository.scheme': string,
+  'context.webview.host': 'view' | 'editor' | 'panel',
+  'context.webview.id': string,
+  'context.webview.instanceId': string,
+  'context.webview.type': string,
+  'hasChanges': boolean,
+  'hasUpstream': boolean,
+  'isActive': boolean,
+  'isDefault': boolean
+}
+```
+
 ### graphDetails/closed
 
 > Sent when the integrated graph details panel is collapsed

--- a/src/constants.telemetry.ts
+++ b/src/constants.telemetry.ts
@@ -345,6 +345,19 @@ export interface TelemetryEvents extends WebviewShowAbortedEvents, WebviewShownE
 	/** Sent when the sidebar agents filter toggles between empty and non-empty (not on every keystroke) */
 	'graph/agents/filtered': GraphSidebarAgentsFilteredEvent;
 
+	/** Sent when the Worktrees sidebar panel becomes visible */
+	'graph/worktrees/shown': GraphSidebarWorktreesShownEvent;
+	/** Sent when the user clicks a worktree leaf in the sidebar worktrees panel */
+	'graph/worktrees/worktreeSelected': GraphSidebarWorktreesWorktreeSelectedEvent;
+	/** Sent when the user clicks an inline action (pull/push/fetch/open) on a worktree item */
+	'graph/worktrees/worktreeAction': GraphSidebarWorktreesWorktreeActionEvent;
+	/** Sent when the user clicks a header action (Create Worktree, Refresh) in the sidebar worktrees panel */
+	'graph/worktrees/headerAction': GraphSidebarWorktreesHeaderActionEvent;
+	/** Sent when the user toggles the tree/list layout in the sidebar worktrees panel */
+	'graph/worktrees/layoutToggled': GraphSidebarWorktreesLayoutToggledEvent;
+	/** Sent when the user types in the filter box in the sidebar worktrees panel */
+	'graph/worktrees/filtered': GraphSidebarWorktreesFilteredEvent;
+
 	/** Sent when the integrated graph details panel is expanded */
 	'graphDetails/shown': GraphDetailsShownEvent;
 	/** Sent when the integrated graph details panel is collapsed */
@@ -1751,6 +1764,38 @@ interface GraphSidebarAgentsFilteredEvent extends GraphContextEventData {
 	hasFilter: boolean;
 	'filter.length': number;
 	'sessions.count': number;
+}
+
+interface GraphSidebarWorktreesShownEvent extends GraphContextEventData {
+	layout: 'list' | 'tree';
+	'worktrees.count': number;
+}
+
+interface GraphSidebarWorktreesWorktreeSelectedEvent extends GraphContextEventData {
+	isActive: boolean;
+	isDefault: boolean;
+	hasChanges: boolean;
+	hasUpstream: boolean;
+}
+
+interface GraphSidebarWorktreesWorktreeActionEvent extends GraphContextEventData {
+	action: 'pull' | 'push' | 'fetch' | 'openWorktree' | 'openWorktreeInNewWindow';
+	alt: boolean;
+}
+
+interface GraphSidebarWorktreesHeaderActionEvent extends GraphContextEventData {
+	action: 'createWorktree' | 'refresh';
+}
+
+interface GraphSidebarWorktreesLayoutToggledEvent extends GraphContextEventData {
+	layout: 'list' | 'tree';
+	'worktrees.count': number;
+}
+
+interface GraphSidebarWorktreesFilteredEvent extends GraphContextEventData {
+	hasFilter: boolean;
+	'filter.length': number;
+	'worktrees.count': number;
 }
 
 export type HomeTelemetryContext = WebviewTelemetryContext;

--- a/src/webviews/apps/plus/graph/sidebar/sidebar-panel.ts
+++ b/src/webviews/apps/plus/graph/sidebar/sidebar-panel.ts
@@ -6,6 +6,7 @@ import { URI } from 'vscode-uri';
 import type { HierarchicalItem } from '@gitlens/utils/array.js';
 import { makeHierarchical } from '@gitlens/utils/array.js';
 import { fromNow } from '@gitlens/utils/date.js';
+import { debounce } from '@gitlens/utils/debounce.js';
 import { basename } from '@gitlens/utils/path.js';
 import type { AgentSessionState } from '../../../../../agents/models/agentSessionState.js';
 import type { GlCommands } from '../../../../../constants.commands.js';
@@ -186,6 +187,16 @@ function trackingDecorations(
 		},
 	];
 }
+
+const worktreeActionMap: Partial<
+	Record<GlCommands, 'pull' | 'push' | 'fetch' | 'openWorktree' | 'openWorktreeInNewWindow'>
+> = {
+	'gitlens.graph.pull': 'pull',
+	'gitlens.graph.push': 'push',
+	'gitlens.fetch:graph': 'fetch',
+	'gitlens.openWorktree:graph': 'openWorktree',
+	'gitlens.openWorktreeInNewWindow:graph': 'openWorktreeInNewWindow',
+};
 
 function formatWorktreeDescription(w: GraphSidebarWorktree): string | undefined {
 	if (w.upstream == null) return undefined;
@@ -420,6 +431,11 @@ export class GlGraphSidebarPanel extends SignalWatcher(LitElement) {
 	private _pendingFocus = false;
 	private _agentsFilterActive = false;
 
+	/** Whether `graph/worktrees/shown` has been fired for the current worktrees activation. Reset
+	 *  on disconnect and on `activePanel` change so switching away and back emits a fresh event
+	 *  while re-renders from data mutations (e.g. WIP pushes) do not. */
+	private _worktreesShownEmitted = false;
+
 	focusFilter(): void {
 		if (this.activePanel == null || this.activePanel === 'overview') {
 			this._pendingFocus = false;
@@ -447,6 +463,12 @@ export class GlGraphSidebarPanel extends SignalWatcher(LitElement) {
 		this.shadowRoot?.addEventListener('animationend', this._handlePanelAnimationEnd);
 	}
 
+	override disconnectedCallback(): void {
+		this.emitWorktreesFilteredTelemetryDebounced.cancel();
+		this._worktreesShownEmitted = false;
+		super.disconnectedCallback?.();
+	}
+
 	private readonly _handlePanelAnimationEnd = (e: Event): void => {
 		const name = (e as AnimationEvent).animationName;
 		if (name === 'panel-enter' || name === 'sub-panel-enter') {
@@ -457,6 +479,14 @@ export class GlGraphSidebarPanel extends SignalWatcher(LitElement) {
 
 	override willUpdate(changedProperties: Map<PropertyKey, unknown>): void {
 		if (changedProperties.has('activePanel') && this._actions != null) {
+			// Reset the shown guard so switching worktrees→other→worktrees emits a fresh impression
+			// while intra-activation re-renders (WIP pushes, refresh) do not.
+			this._worktreesShownEmitted = false;
+
+			// Cancel any pending filtered emit — filterText is shared across panels, so a trailing
+			// callback after a switch would report against the wrong (now-inactive) panel.
+			this.emitWorktreesFilteredTelemetryDebounced.cancel();
+
 			// Keep the actions module in sync so invalidateAll can refetch
 			this._actions.activePanel = this.activePanel;
 
@@ -484,6 +514,28 @@ export class GlGraphSidebarPanel extends SignalWatcher(LitElement) {
 		if (this._pendingFocus) {
 			this.focusFilter();
 		}
+
+		// Emit `shown` from the settled lifecycle (not render(), which Lit expects side-effect-free).
+		// The guard fires it once per worktrees activation — reset on disconnect and on `activePanel`
+		// change so a fresh impression is recorded then, but intra-activation re-renders (WIP pushes,
+		// refresh(), filter/expansion changes) do not re-emit.
+		this.emitWorktreesShownTelemetry();
+	}
+
+	private emitWorktreesShownTelemetry(): void {
+		if (this._worktreesShownEmitted || this.activePanel !== 'worktrees') return;
+
+		const data = this._actions?.state.panels.worktrees?.value.get();
+		if (data?.panel !== 'worktrees') return;
+
+		this._worktreesShownEmitted = true;
+		emitTelemetrySentEvent<'graph/worktrees/shown'>(this, {
+			name: 'graph/worktrees/shown',
+			data: {
+				layout: data.layout ?? 'list',
+				'worktrees.count': data.items.length,
+			},
+		});
 	}
 
 	override render(): unknown {
@@ -1292,6 +1344,10 @@ export class GlGraphSidebarPanel extends SignalWatcher(LitElement) {
 				});
 			}
 		}
+
+		if (this.activePanel === 'worktrees') {
+			this.emitWorktreesFilteredTelemetryDebounced();
+		}
 	};
 
 	private handleSearchBoxFilterChanged = (e: CustomEvent<boolean>) => {
@@ -1321,11 +1377,27 @@ export class GlGraphSidebarPanel extends SignalWatcher(LitElement) {
 			}
 		}
 
+		if (this.activePanel === 'worktrees') {
+			const action = command === 'gitlens.views.title.createWorktree' ? 'createWorktree' : undefined;
+			if (action != null) {
+				emitTelemetrySentEvent<'graph/worktrees/headerAction'>(this, {
+					name: 'graph/worktrees/headerAction',
+					data: { action: action },
+				});
+			}
+		}
+
 		this._actions?.executeAction(command, undefined, args);
 	}
 
 	private handleToggleLayout() {
 		if (this.activePanel == null) return;
+
+		// Compute the worktrees layout before toggling — the service update is async, so the
+		// resource value still reflects the old layout here; invert it to get the new one.
+		const worktreesData =
+			this.activePanel === 'worktrees' ? this._actions?.state.panels.worktrees?.value.get() : undefined;
+		const worktreesNewLayout = worktreesData?.layout === 'tree' ? 'list' : 'tree';
 
 		this._actions.toggleLayout(this.activePanel);
 
@@ -1335,6 +1407,16 @@ export class GlGraphSidebarPanel extends SignalWatcher(LitElement) {
 				data: {
 					layout: this._actions.agentsLayout.get(),
 					'sessions.count': this._state.agentSessions?.length ?? 0,
+				},
+			});
+		}
+
+		if (this.activePanel === 'worktrees') {
+			emitTelemetrySentEvent<'graph/worktrees/layoutToggled'>(this, {
+				name: 'graph/worktrees/layoutToggled',
+				data: {
+					layout: worktreesNewLayout,
+					'worktrees.count': worktreesData?.items.length ?? 0,
 				},
 			});
 		}
@@ -1353,6 +1435,13 @@ export class GlGraphSidebarPanel extends SignalWatcher(LitElement) {
 		if (this.activePanel === 'agents') {
 			emitTelemetrySentEvent<'graph/agents/headerAction'>(this, {
 				name: 'graph/agents/headerAction',
+				data: { action: 'refresh' },
+			});
+		}
+
+		if (this.activePanel === 'worktrees') {
+			emitTelemetrySentEvent<'graph/worktrees/headerAction'>(this, {
+				name: 'graph/worktrees/headerAction',
 				data: { action: 'refresh' },
 			});
 		}
@@ -1378,6 +1467,10 @@ export class GlGraphSidebarPanel extends SignalWatcher(LitElement) {
 
 		if (this.activePanel === 'agents') {
 			this.emitAgentsTreeItemActionTelemetry(command, args);
+		}
+
+		if (this.activePanel === 'worktrees') {
+			this.emitWorktreesTreeItemActionTelemetry(command, useAlt);
 		}
 
 		this._actions?.executeAction(command, node.contextData as string | undefined, args);
@@ -1417,6 +1510,10 @@ export class GlGraphSidebarPanel extends SignalWatcher(LitElement) {
 					composed: true,
 				}),
 			);
+		}
+
+		if (this.activePanel === 'worktrees') {
+			this.emitWorktreesSelectedTelemetry(sha);
 		}
 
 		this.dispatchEvent(
@@ -1476,6 +1573,41 @@ export class GlGraphSidebarPanel extends SignalWatcher(LitElement) {
 		});
 	}
 
+	private getWorktreesCount(): number {
+		const data = this._actions?.state.panels.worktrees?.value.get();
+		return data?.panel === 'worktrees' ? data.items.length : 0;
+	}
+
+	private readonly emitWorktreesFilteredTelemetryDebounced = debounce(() => {
+		const filterText = this._actions.filterText;
+		emitTelemetrySentEvent<'graph/worktrees/filtered'>(this, {
+			name: 'graph/worktrees/filtered',
+			data: {
+				hasFilter: filterText.length > 0,
+				'filter.length': filterText.length,
+				'worktrees.count': this.getWorktreesCount(),
+			},
+		});
+	}, 500);
+
+	private emitWorktreesSelectedTelemetry(wipSha: string): void {
+		const data = this._actions?.state.panels.worktrees?.value.get();
+		if (data?.panel !== 'worktrees') return;
+
+		const worktree = data.items.find(w => w.wipSha === wipSha);
+		if (worktree == null) return;
+
+		emitTelemetrySentEvent<'graph/worktrees/worktreeSelected'>(this, {
+			name: 'graph/worktrees/worktreeSelected',
+			data: {
+				isActive: worktree.opened,
+				isDefault: worktree.isDefault,
+				hasChanges: worktree.hasChanges === true,
+				hasUpstream: worktree.upstream != null,
+			},
+		});
+	}
+
 	private emitAgentsSessionSelectedTelemetry(sessionId: string): void {
 		const session = this._state.agentSessions?.find(s => s.id === sessionId);
 		if (session == null) return;
@@ -1528,6 +1660,16 @@ export class GlGraphSidebarPanel extends SignalWatcher(LitElement) {
 				data: { action: action },
 			});
 		}
+	}
+
+	private emitWorktreesTreeItemActionTelemetry(command: GlCommands, alt: boolean): void {
+		const action = worktreeActionMap[command];
+		if (action == null) return;
+
+		emitTelemetrySentEvent<'graph/worktrees/worktreeAction'>(this, {
+			name: 'graph/worktrees/worktreeAction',
+			data: { action: action, alt: alt },
+		});
 	}
 }
 


### PR DESCRIPTION
## Summary

- Adds 6 telemetry events for the Worktrees sidebar panel in the Commit Graph, as part of #5356
- Follows the same `graph/{area}/...` naming convention used by `graph/wip/...`, `graph/overview/...`, `graph/agents/...`
- All guards scoped to `this.activePanel === 'worktrees'`, matching the agents branch pattern

### New events

| Event | When |
|---|---|
| `graph/worktrees/shown` | Worktrees panel becomes visible |
| `graph/worktrees/worktreeSelected` | User clicks a worktree node |
| `graph/worktrees/worktreeAction` | User clicks an inline action (pull/push/fetch/open worktree) |
| `graph/worktrees/headerAction` | User clicks Create Worktree or Refresh |
| `graph/worktrees/layoutToggled` | User toggles list/tree layout |
| `graph/worktrees/filtered` | User types in the filter box |

### Files changed

- `src/constants.telemetry.ts` — event type definitions
- `src/webviews/apps/plus/graph/sidebar/sidebar-panel.ts` — instrumentation
- `docs/telemetry-events.md` — auto-generated via `pnpm run generate:docs:telemetry`

### Review follow-ups

- **`shown` emits from `updated()`, not `render()`** — matches the `graph/overview/shown` precedent and keeps `render()` side-effect-free (Lit expects it pure; dispatching the telemetry event mid-render ran the IPC listener synchronously during render).
- **Dropped `worktrees.withChanges.count` from `shown`** — working-tree status is computed async (fire-and-forget) and pushed *after* the panel first renders, so at impression time every item's `hasChanges` was still `undefined` and the count reported ~0 in essentially every session. Rather than ship a misleading metric — or defer the impression (bare worktrees never resolve `hasChanges`, so there's no clean "settled" gate) — the field is removed. A dirty-worktree signal, if wanted, should be emitted from a later settled state.
- **`filtered` debounce cancelled on panel switch** — `filterText` is shared across panels, so a trailing debounced emit after a switch would be misattributed to the now-inactive panel. Cancelled in `willUpdate` alongside the existing shown-guard reset.
- **`docs/telemetry-events.md` fully regenerated** — a Launchpad action-union reorder appears in the diff; it's deterministic generator output, not a hand edit.

### Merge note

Depends on overview and agents telemetry branches landing first. Rebase after both merge — textual conflict in `constants.telemetry.ts` is additive.

## Test plan

- [ ] Open Graph, click Worktrees icon — verify `graph/worktrees/shown` fires once with correct `layout` and `worktrees.count`
- [ ] Switch worktrees → other panel → worktrees — verify a fresh `shown` fires on return, but intra-activation re-renders (WIP pushes, refresh, filter) do not re-emit
- [ ] Click a worktree node — verify `graph/worktrees/worktreeSelected` fires with `isActive`, `isDefault`, `hasChanges`, `hasUpstream`
- [ ] Click pull/push/fetch/open inline action — verify `graph/worktrees/worktreeAction` fires with correct `action`
- [ ] Alt+click an action with alt variant — verify `alt: true`
- [ ] Click "Create Worktree..." header button — verify `graph/worktrees/headerAction` with `action: 'createWorktree'`
- [ ] Click Refresh — verify `graph/worktrees/headerAction` with `action: 'refresh'`
- [ ] Toggle list/tree layout — verify `graph/worktrees/layoutToggled` with new `layout`
- [ ] Type in filter box, then switch panels within 500ms — verify `graph/worktrees/filtered` does NOT fire for the switched-away panel
- [x] `pnpm run rebuild && pnpm run check` passes cleanly
- [x] Telemetry docs regenerated: `pnpm run generate:docs:telemetry`

🤖 Generated with [Claude Code](https://claude.com/claude-code)
