### PR TITLE
Remotes telemetry in graph sidebar

### DIFF
--- a/docs/telemetry-events.md
+++ b/docs/telemetry-events.md
@@ -3058,6 +3058,110 @@ background-upgraded the extension while the host kept running the old build
 }
 ```
 
+### graph/remotes/filtered
+
+> Sent when the user types in the filter box in the sidebar remotes panel (debounced, not on every keystroke)
+
+```typescript
+{
+  'context.repository.closed': boolean,
+  'context.repository.folder.scheme': string,
+  'context.repository.id': string,
+  'context.repository.provider.id': string,
+  'context.repository.scheme': string,
+  'context.webview.host': 'view' | 'editor' | 'panel',
+  'context.webview.id': string,
+  'context.webview.instanceId': string,
+  'context.webview.type': string,
+  'filter.length': number,
+  'hasFilter': boolean,
+  // Total remotes in the panel (the filter corpus), NOT the number of matches — matching happens inside the tree component and the match count isn't surfaced.
+  'remotes.count': number
+}
+```
+
+### graph/remotes/headerAction
+
+> Sent when the user clicks a header action (Add Remote, Refresh) in the sidebar remotes panel
+
+```typescript
+{
+  'action': 'refresh' | 'addRemote',
+  'context.repository.closed': boolean,
+  'context.repository.folder.scheme': string,
+  'context.repository.id': string,
+  'context.repository.provider.id': string,
+  'context.repository.scheme': string,
+  'context.webview.host': 'view' | 'editor' | 'panel',
+  'context.webview.id': string,
+  'context.webview.instanceId': string,
+  'context.webview.type': string
+}
+```
+
+### graph/remotes/layoutToggled
+
+> Sent when the user toggles the tree/list layout in the sidebar remotes panel
+
+```typescript
+{
+  'context.repository.closed': boolean,
+  'context.repository.folder.scheme': string,
+  'context.repository.id': string,
+  'context.repository.provider.id': string,
+  'context.repository.scheme': string,
+  'context.webview.host': 'view' | 'editor' | 'panel',
+  'context.webview.id': string,
+  'context.webview.instanceId': string,
+  'context.webview.type': string,
+  'layout': 'list' | 'tree',
+  'remotes.count': number
+}
+```
+
+### graph/remotes/remoteAction
+
+> Sent when the user clicks an inline action (fetch/open/copy/connect/disconnect) on a remote item
+
+```typescript
+{
+  'action': 'fetch' | 'openOnRemote' | 'copyUrl' | 'connectIntegration' | 'disconnectIntegration',
+  'alt': boolean,
+  'context.repository.closed': boolean,
+  'context.repository.folder.scheme': string,
+  'context.repository.id': string,
+  'context.repository.provider.id': string,
+  'context.repository.scheme': string,
+  'context.webview.host': 'view' | 'editor' | 'panel',
+  'context.webview.id': string,
+  'context.webview.instanceId': string,
+  'context.webview.type': string
+}
+```
+
+### graph/remotes/shown
+
+> Sent when the Remotes sidebar panel becomes visible
+
+```typescript
+{
+  'context.repository.closed': boolean,
+  'context.repository.folder.scheme': string,
+  'context.repository.id': string,
+  'context.repository.provider.id': string,
+  'context.repository.scheme': string,
+  'context.webview.host': 'view' | 'editor' | 'panel',
+  'context.webview.id': string,
+  'context.webview.instanceId': string,
+  'context.webview.type': string,
+  'hasMultipleRemotes': boolean,
+  'layout': 'list' | 'tree',
+  // Remotes whose integration is connected
+  'remotes.connected.count': number,
+  'remotes.count': number
+}
+```
+
 ### graph/repository/changed
 
 > Sent when the user changes the current repository on the Commit Graph
@@ -3695,7 +3799,7 @@ background-upgraded the extension while the host kept running the old build
 
 ### graph/worktrees/filtered
 
-> Sent when the user types in the filter box in the sidebar worktrees panel
+> Sent when the user types in the filter box in the sidebar worktrees panel (debounced, not on every keystroke)
 
 ```typescript
 {
@@ -4467,7 +4571,7 @@ background-upgraded the extension while the host kept running the old build
 ```typescript
 {
   // Which file open/diff operation was triggered
-  'action': 'comparePrevious' | 'multiDiff' | 'open' | 'openOnRemote' | 'compareWorking' | 'compareWip' | 'compareBetween' | 'defaultAction',
+  'action': 'openOnRemote' | 'comparePrevious' | 'multiDiff' | 'open' | 'compareWorking' | 'compareWip' | 'compareBetween' | 'defaultAction',
   'context.repository.closed': boolean,
   'context.repository.folder.scheme': string,
   'context.repository.id': string,

--- a/src/constants.telemetry.ts
+++ b/src/constants.telemetry.ts
@@ -355,7 +355,7 @@ export interface TelemetryEvents extends WebviewShowAbortedEvents, WebviewShownE
 	'graph/worktrees/headerAction': GraphSidebarWorktreesHeaderActionEvent;
 	/** Sent when the user toggles the tree/list layout in the sidebar worktrees panel */
 	'graph/worktrees/layoutToggled': GraphSidebarWorktreesLayoutToggledEvent;
-	/** Sent when the user types in the filter box in the sidebar worktrees panel */
+	/** Sent when the user types in the filter box in the sidebar worktrees panel (debounced, not on every keystroke) */
 	'graph/worktrees/filtered': GraphSidebarWorktreesFilteredEvent;
 
 	/** Sent when the Branches sidebar panel becomes visible */
@@ -370,6 +370,17 @@ export interface TelemetryEvents extends WebviewShowAbortedEvents, WebviewShownE
 	'graph/branches/layoutToggled': GraphSidebarBranchesLayoutToggledEvent;
 	/** Sent when the user types in the filter box in the sidebar branches panel */
 	'graph/branches/filtered': GraphSidebarBranchesFilteredEvent;
+
+	/** Sent when the Remotes sidebar panel becomes visible */
+	'graph/remotes/shown': GraphSidebarRemotesShownEvent;
+	/** Sent when the user clicks an inline action (fetch/open/copy/connect/disconnect) on a remote item */
+	'graph/remotes/remoteAction': GraphSidebarRemotesRemoteActionEvent;
+	/** Sent when the user clicks a header action (Add Remote, Refresh) in the sidebar remotes panel */
+	'graph/remotes/headerAction': GraphSidebarRemotesHeaderActionEvent;
+	/** Sent when the user toggles the tree/list layout in the sidebar remotes panel */
+	'graph/remotes/layoutToggled': GraphSidebarRemotesLayoutToggledEvent;
+	/** Sent when the user types in the filter box in the sidebar remotes panel (debounced, not on every keystroke) */
+	'graph/remotes/filtered': GraphSidebarRemotesFilteredEvent;
 
 	/** Sent when the integrated graph details panel is expanded */
 	'graphDetails/shown': GraphDetailsShownEvent;
@@ -1895,6 +1906,36 @@ interface GraphSidebarBranchesFilteredEvent extends GraphContextEventData {
 	/** Total branches in the panel (the filter corpus), NOT the number of matches — matching
 	 *  happens inside the tree component and the match count isn't surfaced. */
 	'branches.count': number;
+}
+
+interface GraphSidebarRemotesShownEvent extends GraphContextEventData {
+	layout: 'list' | 'tree';
+	'remotes.count': number;
+	/** Remotes whose integration is connected */
+	'remotes.connected.count': number;
+	hasMultipleRemotes: boolean;
+}
+
+interface GraphSidebarRemotesRemoteActionEvent extends GraphContextEventData {
+	action: 'fetch' | 'openOnRemote' | 'copyUrl' | 'connectIntegration' | 'disconnectIntegration';
+	alt: boolean;
+}
+
+interface GraphSidebarRemotesHeaderActionEvent extends GraphContextEventData {
+	action: 'addRemote' | 'refresh';
+}
+
+interface GraphSidebarRemotesLayoutToggledEvent extends GraphContextEventData {
+	layout: 'list' | 'tree';
+	'remotes.count': number;
+}
+
+interface GraphSidebarRemotesFilteredEvent extends GraphContextEventData {
+	hasFilter: boolean;
+	'filter.length': number;
+	/** Total remotes in the panel (the filter corpus), NOT the number of matches — matching
+	 *  happens inside the tree component and the match count isn't surfaced. */
+	'remotes.count': number;
 }
 
 export type HomeTelemetryContext = WebviewTelemetryContext;

--- a/src/webviews/apps/plus/graph/sidebar/sidebar-panel.ts
+++ b/src/webviews/apps/plus/graph/sidebar/sidebar-panel.ts
@@ -197,6 +197,16 @@ const worktreeActionMap: Partial<
 	'gitlens.openWorktreeInNewWindow:graph': 'openWorktreeInNewWindow',
 };
 
+const remoteActionMap: Partial<
+	Record<GlCommands, 'fetch' | 'openOnRemote' | 'copyUrl' | 'connectIntegration' | 'disconnectIntegration'>
+> = {
+	'gitlens.fetchRemote:graph': 'fetch',
+	'gitlens.openRepoOnRemote:graph': 'openOnRemote',
+	'gitlens.copyRemoteRepositoryUrl:graph': 'copyUrl',
+	'gitlens.connectRemoteProvider:graph': 'connectIntegration',
+	'gitlens.disconnectRemoteProvider:graph': 'disconnectIntegration',
+};
+
 function formatWorktreeDescription(w: GraphSidebarWorktree): string | undefined {
 	if (w.upstream == null) return undefined;
 	return `\u21C6 ${w.upstream}`;
@@ -435,6 +445,9 @@ export class GlGraphSidebarPanel extends SignalWatcher(LitElement) {
 	 *  while re-renders from data mutations (e.g. WIP pushes) do not. */
 	private _worktreesShownEmitted = false;
 
+	/** Same as `_worktreesShownEmitted`, for the remotes panel. */
+	private _remotesShownEmitted = false;
+
 	// Tracks that the branches panel was just shown and its `shown` telemetry is still owed —
 	// emitted once the switch-triggered fetch settles (see maybeEmitBranchesShownTelemetry).
 	private _branchesShownPending = false;
@@ -485,7 +498,9 @@ export class GlGraphSidebarPanel extends SignalWatcher(LitElement) {
 	override disconnectedCallback(): void {
 		this.emitWorktreesFilteredTelemetryDebounced.cancel();
 		this.emitBranchesFilteredTelemetryDebounced.cancel();
+		this.emitRemotesFilteredTelemetryDebounced.cancel();
 		this._worktreesShownEmitted = false;
+		this._remotesShownEmitted = false;
 		super.disconnectedCallback?.();
 	}
 
@@ -502,11 +517,13 @@ export class GlGraphSidebarPanel extends SignalWatcher(LitElement) {
 			// Reset the shown guard so switching worktrees→other→worktrees emits a fresh impression
 			// while intra-activation re-renders (WIP pushes, refresh) do not.
 			this._worktreesShownEmitted = false;
+			this._remotesShownEmitted = false;
 
 			// Cancel any pending filtered emits — filterText is shared across panels, so a trailing
 			// callback after a switch would report against the wrong (now-inactive) panel.
 			this.emitWorktreesFilteredTelemetryDebounced.cancel();
 			this.emitBranchesFilteredTelemetryDebounced.cancel();
+			this.emitRemotesFilteredTelemetryDebounced.cancel();
 
 			// Keep the actions module in sync so invalidateAll can refetch
 			this._actions.activePanel = this.activePanel;
@@ -547,6 +564,7 @@ export class GlGraphSidebarPanel extends SignalWatcher(LitElement) {
 		// change so a fresh impression is recorded then, but intra-activation re-renders (WIP pushes,
 		// refresh(), filter/expansion changes) do not re-emit.
 		this.emitWorktreesShownTelemetry();
+		this.emitRemotesShownTelemetry();
 
 		this.maybeEmitBranchesShownTelemetry();
 	}
@@ -1315,6 +1333,10 @@ export class GlGraphSidebarPanel extends SignalWatcher(LitElement) {
 		if (this.activePanel === 'branches') {
 			this.emitBranchesFilteredTelemetryDebounced();
 		}
+
+		if (this.activePanel === 'remotes') {
+			this.emitRemotesFilteredTelemetryDebounced();
+		}
 	};
 
 	private handleSearchBoxFilterChanged = (e: CustomEvent<boolean>) => {
@@ -1369,20 +1391,33 @@ export class GlGraphSidebarPanel extends SignalWatcher(LitElement) {
 			}
 		}
 
+		if (this.activePanel === 'remotes') {
+			const action = command === 'gitlens.views.addRemote' ? 'addRemote' : undefined;
+			if (action != null) {
+				emitTelemetrySentEvent<'graph/remotes/headerAction'>(this, {
+					name: 'graph/remotes/headerAction',
+					data: { action: action },
+				});
+			}
+		}
+
 		this._actions?.executeAction(command, undefined, args);
 	}
 
 	private handleToggleLayout() {
 		if (this.activePanel == null) return;
 
-		// Compute the worktrees/branches layout before toggling — the service update is async, so
-		// the resource value still reflects the old layout here; invert it to get the new one.
+		// Compute the worktrees/branches/remotes layout before toggling — the service update is async,
+		// so the resource value still reflects the old layout here; invert it to get the new one.
 		const worktreesData =
 			this.activePanel === 'worktrees' ? this._actions?.state.panels.worktrees?.value.get() : undefined;
 		const worktreesNewLayout = worktreesData?.layout === 'tree' ? 'list' : 'tree';
 
 		const branchesData =
 			this.activePanel === 'branches' ? this._actions?.state.panels.branches?.value.get() : undefined;
+
+		const remotesData =
+			this.activePanel === 'remotes' ? this._actions?.state.panels.remotes?.value.get() : undefined;
 
 		this._actions.toggleLayout(this.activePanel);
 
@@ -1414,6 +1449,17 @@ export class GlGraphSidebarPanel extends SignalWatcher(LitElement) {
 				data: {
 					layout: branchesData.layout === 'tree' ? 'list' : 'tree',
 					'branches.count': branchesData.items.length,
+				},
+			});
+		}
+
+		// Same reasoning for remotes — only report when the current layout is known.
+		if (this.activePanel === 'remotes' && remotesData?.layout != null) {
+			emitTelemetrySentEvent<'graph/remotes/layoutToggled'>(this, {
+				name: 'graph/remotes/layoutToggled',
+				data: {
+					layout: remotesData.layout === 'tree' ? 'list' : 'tree',
+					'remotes.count': remotesData.items.length,
 				},
 			});
 		}
@@ -1450,6 +1496,13 @@ export class GlGraphSidebarPanel extends SignalWatcher(LitElement) {
 			});
 		}
 
+		if (this.activePanel === 'remotes') {
+			emitTelemetrySentEvent<'graph/remotes/headerAction'>(this, {
+				name: 'graph/remotes/headerAction',
+				data: { action: 'refresh' },
+			});
+		}
+
 		this._actions?.refresh(this.activePanel);
 	}
 
@@ -1479,6 +1532,10 @@ export class GlGraphSidebarPanel extends SignalWatcher(LitElement) {
 
 		if (this.activePanel === 'branches') {
 			this.emitBranchesTreeItemActionTelemetry(command, useAlt);
+		}
+
+		if (this.activePanel === 'remotes') {
+			this.emitRemotesTreeItemActionTelemetry(command, useAlt);
 		}
 
 		this._actions?.executeAction(command, node.contextData as string | undefined, args);
@@ -1549,6 +1606,40 @@ export class GlGraphSidebarPanel extends SignalWatcher(LitElement) {
 			paths.delete(e.detail.path);
 		}
 	};
+
+	private getRemotesData(): GraphSidebarRemote[] | undefined {
+		const data = this._actions?.state.panels.remotes?.value.get();
+		if (data?.panel !== 'remotes') return undefined;
+		return data.items;
+	}
+
+	private getRemotesCount(): number {
+		return this.getRemotesData()?.length ?? 0;
+	}
+
+	private emitRemotesShownTelemetry(): void {
+		if (this._remotesShownEmitted || this.activePanel !== 'remotes') return;
+
+		// Wait for a successful fetch (mirrors emitWorktreesShownTelemetry): on reactivation the
+		// resource still holds the previous visit's value while the switch-triggered fetch is in
+		// flight — emitting off that would report stale counts.
+		const resource = this._actions?.state.panels.remotes;
+		if (resource?.status.get() !== 'success') return;
+
+		const data = resource.value.get();
+		if (data?.panel !== 'remotes') return;
+
+		this._remotesShownEmitted = true;
+		emitTelemetrySentEvent<'graph/remotes/shown'>(this, {
+			name: 'graph/remotes/shown',
+			data: {
+				layout: data.layout ?? 'list',
+				'remotes.count': data.items.length,
+				'remotes.connected.count': data.items.filter(r => r.connected === true).length,
+				hasMultipleRemotes: data.items.length > 1,
+			},
+		});
+	}
 
 	private emitAgentsShownTelemetry(): void {
 		// Point-in-time snapshot: fired on the `activePanel → 'agents'` transition only. Sessions
@@ -1642,6 +1733,20 @@ export class GlGraphSidebarPanel extends SignalWatcher(LitElement) {
 				hasFilter: filterText.length > 0,
 				'filter.length': filterText.length,
 				'worktrees.count': this.getWorktreesCount(),
+			},
+		});
+	}, 500);
+
+	private readonly emitRemotesFilteredTelemetryDebounced = debounce(() => {
+		if (this.activePanel !== 'remotes') return;
+
+		const filterText = this._actions.filterText;
+		emitTelemetrySentEvent<'graph/remotes/filtered'>(this, {
+			name: 'graph/remotes/filtered',
+			data: {
+				hasFilter: filterText.length > 0,
+				'filter.length': filterText.length,
+				'remotes.count': this.getRemotesCount(),
 			},
 		});
 	}, 500);
@@ -1753,6 +1858,16 @@ export class GlGraphSidebarPanel extends SignalWatcher(LitElement) {
 
 		emitTelemetrySentEvent<'graph/branches/branchAction'>(this, {
 			name: 'graph/branches/branchAction',
+			data: { action: action, alt: alt },
+		});
+	}
+
+	private emitRemotesTreeItemActionTelemetry(command: GlCommands, alt: boolean): void {
+		const action = remoteActionMap[command];
+		if (action == null) return;
+
+		emitTelemetrySentEvent<'graph/remotes/remoteAction'>(this, {
+			name: 'graph/remotes/remoteAction',
 			data: { action: action, alt: alt },
 		});
 	}


### PR DESCRIPTION
Part of #5356 (Sidebar → Remotes)

## Summary

- Instruments the Graph sidebar **Remotes** panel, which previously emitted no telemetry beyond the tab switch (`graph/action/sidebar` with `action: 'remotes'`).
- Follows the pattern established by the overview, agents, worktrees, and branches panels: flat `graph/remotes/*` event keys, `Sidebar` retained in the type-layer interface names, dot-notation for counts and camelCase for booleans/enums.
- All emission is client-side via `emitTelemetrySentEvent`, guarded by `if (this.activePanel === 'remotes')` in the shared `sidebar-panel.ts`.
- Telemetry docs auto-regenerated via `pnpm run generate:docs:telemetry`.

### New events

| Event | When | Notable payload |
|---|---|---|
| `graph/remotes/shown` | Remotes panel becomes visible | `layout`, `remotes.count`, `remotes.connected.count`, `hasMultipleRemotes` |
| `graph/remotes/remoteAction` | Inline action on a remote item | `action` (`fetch`/`openOnRemote`/`copyUrl`/`connectIntegration`/`disconnectIntegration`), `alt` |
| `graph/remotes/headerAction` | Header button | `action` (`addRemote`/`refresh`) |
| `graph/remotes/layoutToggled` | Tree/list toggle | `layout` (new), `remotes.count` |
| `graph/remotes/filtered` | Typing in the filter box | `hasFilter`, `filter.length`, `remotes.count` |

### Out of scope

- **Remote selection** — remote tree nodes carry `context: [undefined]` and aren't selectable; the only selectable leaves are branches (Branches-panel territory), so there's no `remoteSelected` event.
- **Context-menu-only commands** (prune, remove, set/unset default, open/copy branches URL) — these bypass the webview's `handleTreeItemAction` and go straight to VS Code; instrumenting them would require host-side hooks in `graphWebview.ts`. Deferred, consistent with how the agents/worktrees panels scoped it.

## Test plan

- [ ] Open the Remotes panel — `graph/remotes/shown` fires once with correct counts, `hasMultipleRemotes`, and `layout`.
- [ ] Click inline Fetch — `remoteAction` fires with `action: 'fetch'`, `alt: false`, exactly once (no double-count).
- [ ] Open on Remote, then Alt-click for Copy URL — `openOnRemote` (`alt: false`) then `copyUrl` (`alt: true`).
- [ ] Connect, then disconnect an integration — `connectIntegration` then `disconnectIntegration`.
- [ ] Add Remote from the header — `headerAction` with `action: 'addRemote'`; Refresh — `action: 'refresh'`.
- [ ] Toggle tree/list — `layoutToggled` with the new layout; type in the filter — `filtered` with correct fields.
- [ ] Payloads carry no remote names, URLs, or branch names.
- [ ] `npx tsc --noEmit` clean (host + webview); eslint + prettier clean; docs regenerate with no manual edits.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
