### PR TITLE
Adds telemetry for Graph Branches sidebar interactions

### DIFF
--- a/docs/telemetry-events.md
+++ b/docs/telemetry-events.md
@@ -2665,6 +2665,129 @@ background-upgraded the extension while the host kept running the old build
 }
 ```
 
+### graph/branches/branchAction
+
+> Sent when the user clicks an inline action (switch/fetch/pull/push/compare/open) on a branch item
+
+```typescript
+{
+  'action': 'switch' | 'fetch' | 'pull' | 'push' | 'compareWithHead' | 'compareWithWorking' | 'openWorktree' | 'openWorktreeInNewWindow',
+  'alt': boolean,
+  'context.repository.closed': boolean,
+  'context.repository.folder.scheme': string,
+  'context.repository.id': string,
+  'context.repository.provider.id': string,
+  'context.repository.scheme': string,
+  'context.webview.host': 'view' | 'editor' | 'panel',
+  'context.webview.id': string,
+  'context.webview.instanceId': string,
+  'context.webview.type': string
+}
+```
+
+### graph/branches/branchSelected
+
+> Sent when the user clicks a branch leaf in the sidebar branches panel
+
+```typescript
+{
+  'context.repository.closed': boolean,
+  'context.repository.folder.scheme': string,
+  'context.repository.id': string,
+  'context.repository.provider.id': string,
+  'context.repository.scheme': string,
+  'context.webview.host': 'view' | 'editor' | 'panel',
+  'context.webview.id': string,
+  'context.webview.instanceId': string,
+  'context.webview.type': string,
+  'hasUpstream': boolean,
+  'hasWorktree': boolean,
+  'isCurrent': boolean,
+  'isStarred': boolean
+}
+```
+
+### graph/branches/filtered
+
+> Sent when the user types in the filter box in the sidebar branches panel
+
+```typescript
+{
+  // Total branches in the panel (the filter corpus), NOT the number of matches — matching happens inside the tree component and the match count isn't surfaced.
+  'branches.count': number,
+  'context.repository.closed': boolean,
+  'context.repository.folder.scheme': string,
+  'context.repository.id': string,
+  'context.repository.provider.id': string,
+  'context.repository.scheme': string,
+  'context.webview.host': 'view' | 'editor' | 'panel',
+  'context.webview.id': string,
+  'context.webview.instanceId': string,
+  'context.webview.type': string,
+  'filter.length': number,
+  'hasFilter': boolean
+}
+```
+
+### graph/branches/headerAction
+
+> Sent when the user clicks a header action (Switch to Branch, Create Branch, Refresh) in the sidebar branches panel
+
+```typescript
+{
+  'action': 'refresh' | 'switchToBranch' | 'createBranch',
+  'context.repository.closed': boolean,
+  'context.repository.folder.scheme': string,
+  'context.repository.id': string,
+  'context.repository.provider.id': string,
+  'context.repository.scheme': string,
+  'context.webview.host': 'view' | 'editor' | 'panel',
+  'context.webview.id': string,
+  'context.webview.instanceId': string,
+  'context.webview.type': string
+}
+```
+
+### graph/branches/layoutToggled
+
+> Sent when the user toggles the tree/list layout in the sidebar branches panel
+
+```typescript
+{
+  'branches.count': number,
+  'context.repository.closed': boolean,
+  'context.repository.folder.scheme': string,
+  'context.repository.id': string,
+  'context.repository.provider.id': string,
+  'context.repository.scheme': string,
+  'context.webview.host': 'view' | 'editor' | 'panel',
+  'context.webview.id': string,
+  'context.webview.instanceId': string,
+  'context.webview.type': string,
+  'layout': 'list' | 'tree'
+}
+```
+
+### graph/branches/shown
+
+> Sent when the Branches sidebar panel becomes visible
+
+```typescript
+{
+  'branches.count': number,
+  'context.repository.closed': boolean,
+  'context.repository.folder.scheme': string,
+  'context.repository.id': string,
+  'context.repository.provider.id': string,
+  'context.repository.scheme': string,
+  'context.webview.host': 'view' | 'editor' | 'panel',
+  'context.webview.id': string,
+  'context.webview.instanceId': string,
+  'context.webview.type': string,
+  'layout': 'list' | 'tree'
+}
+```
+
 ### graph/branchesVisibility/changed
 
 > Sent when the user changes the "branches visibility" on the Commit Graph
@@ -2809,7 +2932,7 @@ background-upgraded the extension while the host kept running the old build
   'context.webview.type': string,
   // Where on the card the action was invoked
   'location': 'inline' | 'hover',
-  'name': 'pull' | 'push' | 'fetch' | 'publishBranch' | 'switch' | 'openWorktree' | 'compareWithHead' | 'compareWithWorking' | 'compareWithPr' | 'openPrChanges' | 'openChanges' | 'other'
+  'name': 'switch' | 'fetch' | 'pull' | 'push' | 'compareWithHead' | 'compareWithWorking' | 'openWorktree' | 'publishBranch' | 'compareWithPr' | 'openPrChanges' | 'openChanges' | 'other'
 }
 ```
 
@@ -3211,7 +3334,7 @@ background-upgraded the extension while the host kept running the old build
 ```typescript
 {
   // Which action was triggered
-  'action': 'createPullRequest' | 'startReview' | 'startWork' | 'pull' | 'push' | 'fetch' | 'publishBranch' | 'forcePush' | 'switchBranch' | 'createBranch' | 'createPullRequestWithAI' | 'rebaseOntoMergeTarget' | 'mergeMergeTarget' | 'shareAsCloudPatch' | 'copyPatch' | 'stashSave' | 'stashSaveStaged' | 'stashSaveFiles' | 'applyStash' | 'createWorktree',
+  'action': 'createPullRequest' | 'startReview' | 'startWork' | 'fetch' | 'pull' | 'push' | 'createBranch' | 'publishBranch' | 'forcePush' | 'switchBranch' | 'createPullRequestWithAI' | 'rebaseOntoMergeTarget' | 'mergeMergeTarget' | 'shareAsCloudPatch' | 'copyPatch' | 'stashSave' | 'stashSaveStaged' | 'stashSaveFiles' | 'applyStash' | 'createWorktree',
   'context.repository.closed': boolean,
   'context.repository.folder.scheme': string,
   'context.repository.id': string,
@@ -3655,7 +3778,7 @@ background-upgraded the extension while the host kept running the old build
 
 ```typescript
 {
-  'action': 'pull' | 'push' | 'fetch' | 'openWorktree' | 'openWorktreeInNewWindow',
+  'action': 'fetch' | 'pull' | 'push' | 'openWorktree' | 'openWorktreeInNewWindow',
   'alt': boolean,
   'context.repository.closed': boolean,
   'context.repository.folder.scheme': string,

--- a/scripts/generateTelemetryDocs.mjs
+++ b/scripts/generateTelemetryDocs.mjs
@@ -137,7 +137,13 @@ function expandType(file, type, indent = '', isRoot = true, prefix = '') {
 
 					const propDocs = prop.getDocumentationComment(typeChecker);
 					if (propDocs.length > 0) {
-						propString += `${indent}  // ${propDocs.map(doc => doc.text).join(' ')}\n`;
+						// Collapse newlines from multi-line doc comments — the text follows a single
+						// `//`, so embedded newlines would leave continuation lines unprefixed
+						const text = propDocs
+							.map(doc => doc.text)
+							.join(' ')
+							.replace(/\s*\n\s*/g, ' ');
+						propString += `${indent}  // ${text}\n`;
 					}
 
 					const jsDocTags = getJSDocTags(prop);
@@ -238,7 +244,13 @@ function expandType(file, type, indent = '', isRoot = true, prefix = '') {
 
 					const propDocs = prop.getDocumentationComment(typeChecker);
 					if (propDocs.length > 0) {
-						propString += `${indent}  // ${propDocs.map(doc => doc.text).join(' ')}\n`;
+						// Collapse newlines from multi-line doc comments — the text follows a single
+						// `//`, so embedded newlines would leave continuation lines unprefixed
+						const text = propDocs
+							.map(doc => doc.text)
+							.join(' ')
+							.replace(/\s*\n\s*/g, ' ');
+						propString += `${indent}  // ${text}\n`;
 					}
 
 					const jsDocTags = getJSDocTags(prop);

--- a/src/constants.telemetry.ts
+++ b/src/constants.telemetry.ts
@@ -358,6 +358,19 @@ export interface TelemetryEvents extends WebviewShowAbortedEvents, WebviewShownE
 	/** Sent when the user types in the filter box in the sidebar worktrees panel */
 	'graph/worktrees/filtered': GraphSidebarWorktreesFilteredEvent;
 
+	/** Sent when the Branches sidebar panel becomes visible */
+	'graph/branches/shown': GraphSidebarBranchesShownEvent;
+	/** Sent when the user clicks a branch leaf in the sidebar branches panel */
+	'graph/branches/branchSelected': GraphSidebarBranchesBranchSelectedEvent;
+	/** Sent when the user clicks an inline action (switch/fetch/pull/push/compare/open) on a branch item */
+	'graph/branches/branchAction': GraphSidebarBranchesBranchActionEvent;
+	/** Sent when the user clicks a header action (Switch to Branch, Create Branch, Refresh) in the sidebar branches panel */
+	'graph/branches/headerAction': GraphSidebarBranchesHeaderActionEvent;
+	/** Sent when the user toggles the tree/list layout in the sidebar branches panel */
+	'graph/branches/layoutToggled': GraphSidebarBranchesLayoutToggledEvent;
+	/** Sent when the user types in the filter box in the sidebar branches panel */
+	'graph/branches/filtered': GraphSidebarBranchesFilteredEvent;
+
 	/** Sent when the integrated graph details panel is expanded */
 	'graphDetails/shown': GraphDetailsShownEvent;
 	/** Sent when the integrated graph details panel is collapsed */
@@ -1832,6 +1845,54 @@ interface GraphSidebarWorktreesFilteredEvent extends GraphContextEventData {
 	hasFilter: boolean;
 	'filter.length': number;
 	'worktrees.count': number;
+}
+
+/** Fired when the branches panel becomes the active sidebar panel and its data has loaded.
+ *  Note: "shown" means mounted-active — in kanban/visualizations display modes the sidebar
+ *  split stays mounted but hidden, so a panel activation there still counts. The panel is
+ *  local-only (remote branches are filtered out host-side), so the count covers local branches. */
+interface GraphSidebarBranchesShownEvent extends GraphContextEventData {
+	layout: 'list' | 'tree';
+	'branches.count': number;
+}
+
+interface GraphSidebarBranchesBranchSelectedEvent extends GraphContextEventData {
+	isCurrent: boolean;
+	hasUpstream: boolean;
+	hasWorktree: boolean;
+	isStarred: boolean;
+}
+
+export type GraphSidebarBranchesActionName =
+	| 'switch'
+	| 'fetch'
+	| 'pull'
+	| 'push'
+	| 'compareWithHead'
+	| 'compareWithWorking'
+	| 'openWorktree'
+	| 'openWorktreeInNewWindow';
+
+interface GraphSidebarBranchesBranchActionEvent extends GraphContextEventData {
+	action: GraphSidebarBranchesActionName;
+	alt: boolean;
+}
+
+interface GraphSidebarBranchesHeaderActionEvent extends GraphContextEventData {
+	action: 'switchToBranch' | 'createBranch' | 'refresh';
+}
+
+interface GraphSidebarBranchesLayoutToggledEvent extends GraphContextEventData {
+	layout: 'list' | 'tree';
+	'branches.count': number;
+}
+
+interface GraphSidebarBranchesFilteredEvent extends GraphContextEventData {
+	hasFilter: boolean;
+	'filter.length': number;
+	/** Total branches in the panel (the filter corpus), NOT the number of matches — matching
+	 *  happens inside the tree component and the match count isn't surfaced. */
+	'branches.count': number;
 }
 
 export type HomeTelemetryContext = WebviewTelemetryContext;

--- a/src/webviews/apps/plus/graph/sidebar/__tests__/branchActions.utils.test.ts
+++ b/src/webviews/apps/plus/graph/sidebar/__tests__/branchActions.utils.test.ts
@@ -1,0 +1,65 @@
+import * as assert from 'assert';
+import type { GlCommands } from '../../../../../../constants.commands.js';
+import type { GraphSidebarBranch } from '../../../../../plus/graph/protocol.js';
+import { branchActionsToTelemetryNames, getBranchLeafActions } from '../branchActions.utils.js';
+
+function makeBranch(overrides: Partial<GraphSidebarBranch>): GraphSidebarBranch {
+	return {
+		name: 'feature/test',
+		sha: 'abc123',
+		current: false,
+		remote: false,
+		...overrides,
+	};
+}
+
+// The branch-state permutations that drive getBranchLeafActions' branching:
+// tracking state (behind / ahead / in-sync upstream / missing upstream / none) × role
+// (current / checked out in a worktree / other).
+const trackingStates: Partial<GraphSidebarBranch>[] = [
+	{ tracking: { ahead: 0, behind: 2 }, upstream: { name: 'origin/test', missing: false } },
+	{ tracking: { ahead: 2, behind: 0 }, upstream: { name: 'origin/test', missing: false } },
+	{ tracking: { ahead: 0, behind: 0 }, upstream: { name: 'origin/test', missing: false } },
+	{ upstream: { name: 'origin/test', missing: true } },
+	{},
+];
+const roles: Partial<GraphSidebarBranch>[] = [{ current: true }, { checkedOut: true }, {}];
+
+function collectProducedCommands(): Set<string> {
+	const produced = new Set<string>();
+	for (const tracking of trackingStates) {
+		for (const role of roles) {
+			for (const action of getBranchLeafActions(makeBranch({ ...tracking, ...role }))) {
+				produced.add(action.action);
+				if (action.altAction != null) {
+					produced.add(action.altAction);
+				}
+			}
+		}
+	}
+	return produced;
+}
+
+suite('branchActions.utils', () => {
+	test('every command a branch leaf can produce resolves to a telemetry action name', () => {
+		// If a new inline action is added without a mapping, graph/branches/branchAction drops
+		// it silently — this test turns that into a failure.
+		for (const command of collectProducedCommands()) {
+			assert.ok(
+				branchActionsToTelemetryNames[command as GlCommands] != null,
+				`Command '${command}' has no graph/branches/branchAction telemetry mapping — ` +
+					`add it to branchActionsToTelemetryNames`,
+			);
+		}
+	});
+
+	test('no orphaned telemetry mappings for commands no leaf produces', () => {
+		const produced = collectProducedCommands();
+		for (const command of Object.keys(branchActionsToTelemetryNames)) {
+			assert.ok(
+				produced.has(command),
+				`Telemetry mapping for '${command}' is orphaned — no branch leaf produces it`,
+			);
+		}
+	});
+});

--- a/src/webviews/apps/plus/graph/sidebar/branchActions.utils.ts
+++ b/src/webviews/apps/plus/graph/sidebar/branchActions.utils.ts
@@ -1,0 +1,89 @@
+import type { GlCommands } from '../../../../../constants.commands.js';
+import type { GraphSidebarBranchesActionName } from '../../../../../constants.telemetry.js';
+import type { GraphSidebarBranch } from '../../../../plus/graph/protocol.js';
+import type { TreeItemAction } from '../../../shared/components/tree/base.js';
+
+/**
+ * Builds the inline actions for a branch leaf in the branches sidebar panel.
+ *
+ * Every command (action/altAction) produced here must resolve in
+ * {@link branchActionsToTelemetryNames} — otherwise `graph/branches/branchAction` telemetry
+ * silently drops it. Guarded by `__tests__/branchActions.utils.test.ts`.
+ */
+export function getBranchLeafActions(b: GraphSidebarBranch): TreeItemAction[] {
+	const actions: TreeItemAction[] = [];
+
+	if (b.tracking?.behind) {
+		actions.push({
+			icon: 'repo-pull',
+			label: 'Pull',
+			action: 'gitlens.graph.pull',
+			altIcon: 'repo-fetch',
+			altLabel: 'Fetch',
+			altAction: 'gitlens.fetch:graph',
+		});
+	} else if (b.tracking?.ahead) {
+		actions.push({ icon: 'repo-push', label: 'Push', action: 'gitlens.graph.push' });
+	} else if (b.upstream && !b.upstream.missing) {
+		actions.push({
+			icon: 'repo-fetch',
+			label: 'Fetch',
+			action: 'gitlens.fetch:graph',
+			altIcon: 'repo-pull',
+			altLabel: 'Pull',
+			altAction: 'gitlens.graph.pull',
+		});
+	}
+
+	if (b.current) {
+		actions.unshift({
+			icon: 'gl-switch',
+			label: 'Switch to Another Branch...',
+			action: 'gitlens.switchToAnotherBranch:graph',
+		});
+		actions.push({
+			icon: 'gl-compare-ref-working',
+			label: 'Compare with Working Tree',
+			action: 'gitlens.graph.compareWithWorking',
+		});
+	} else if (b.checkedOut) {
+		actions.push({
+			icon: 'empty-window',
+			label: 'Open Worktree in New Window...',
+			action: 'gitlens.openWorktreeInNewWindow:graph',
+			altIcon: 'window',
+			altLabel: 'Open Worktree...',
+			altAction: 'gitlens.openWorktree:graph',
+		});
+	} else {
+		actions.unshift({
+			icon: 'gl-switch',
+			label: 'Switch to Branch...',
+			action: 'gitlens.switchToBranch:graph',
+		});
+		actions.push({
+			icon: 'compare-changes',
+			label: 'Compare with HEAD',
+			action: 'gitlens.graph.compareBranchWithHead',
+			altIcon: 'gl-compare-ref-working',
+			altLabel: 'Compare with Working Tree',
+			altAction: 'gitlens.graph.compareWithWorking',
+		});
+	}
+
+	return actions;
+}
+
+/** Maps the commands produced by {@link getBranchLeafActions} to `graph/branches/branchAction`
+ *  telemetry action names. Unknown commands are dropped silently, so keep this in sync. */
+export const branchActionsToTelemetryNames: Partial<Record<GlCommands, GraphSidebarBranchesActionName>> = {
+	'gitlens.switchToBranch:graph': 'switch',
+	'gitlens.switchToAnotherBranch:graph': 'switch',
+	'gitlens.fetch:graph': 'fetch',
+	'gitlens.graph.pull': 'pull',
+	'gitlens.graph.push': 'push',
+	'gitlens.graph.compareBranchWithHead': 'compareWithHead',
+	'gitlens.graph.compareWithWorking': 'compareWithWorking',
+	'gitlens.openWorktree:graph': 'openWorktree',
+	'gitlens.openWorktreeInNewWindow:graph': 'openWorktreeInNewWindow',
+};

--- a/src/webviews/apps/plus/graph/sidebar/sidebar-panel.ts
+++ b/src/webviews/apps/plus/graph/sidebar/sidebar-panel.ts
@@ -43,6 +43,7 @@ import { ContextMenuProxyController } from '../../../shared/controllers/context-
 import { emitTelemetrySentEvent } from '../../../shared/telemetry.js';
 import type { AppState } from '../context.js';
 import { graphStateContext } from '../context.js';
+import { branchActionsToTelemetryNames, getBranchLeafActions } from './branchActions.utils.js';
 import { sidebarActionsContext } from './sidebarContext.js';
 import type { SidebarActions } from './sidebarState.js';
 import '../overview/graph-overview.js';
@@ -145,7 +146,10 @@ export interface SidebarItemScope {
 	upstreamName?: string;
 }
 
-type SidebarItemContext = [sha: string | undefined, scope?: SidebarItemScope, sessionId?: string];
+/** `name` is the item's unique full name (branch leaves populate it) — shas can collide across
+ *  branches pointing at the same commit, so telemetry resolves the clicked branch by name
+ *  (the name itself is not emitted). */
+type SidebarItemContext = [sha: string | undefined, scope?: SidebarItemScope, sessionId?: string, name?: string];
 
 interface LeafProps {
 	label: string;
@@ -431,6 +435,26 @@ export class GlGraphSidebarPanel extends SignalWatcher(LitElement) {
 	 *  while re-renders from data mutations (e.g. WIP pushes) do not. */
 	private _worktreesShownEmitted = false;
 
+	// Tracks that the branches panel was just shown and its `shown` telemetry is still owed —
+	// emitted once the switch-triggered fetch settles (see maybeEmitBranchesShownTelemetry).
+	private _branchesShownPending = false;
+
+	// The raw `gl-tree-filter-changed` event fires on every keystroke (only the tree's filter
+	// apply is debounced), so debounce the telemetry to emit once per settled query.
+	private readonly emitBranchesFilteredTelemetryDebounced = debounce(() => {
+		if (this.activePanel !== 'branches') return;
+
+		const filterText = this._actions.filterText;
+		emitTelemetrySentEvent<'graph/branches/filtered'>(this, {
+			name: 'graph/branches/filtered',
+			data: {
+				hasFilter: filterText.length > 0,
+				'filter.length': filterText.length,
+				'branches.count': this.getBranchesCount(),
+			},
+		});
+	}, 250);
+
 	focusFilter(): void {
 		if (this.activePanel == null || this.activePanel === 'overview') {
 			this._pendingFocus = false;
@@ -460,6 +484,7 @@ export class GlGraphSidebarPanel extends SignalWatcher(LitElement) {
 
 	override disconnectedCallback(): void {
 		this.emitWorktreesFilteredTelemetryDebounced.cancel();
+		this.emitBranchesFilteredTelemetryDebounced.cancel();
 		this._worktreesShownEmitted = false;
 		super.disconnectedCallback?.();
 	}
@@ -478,9 +503,10 @@ export class GlGraphSidebarPanel extends SignalWatcher(LitElement) {
 			// while intra-activation re-renders (WIP pushes, refresh) do not.
 			this._worktreesShownEmitted = false;
 
-			// Cancel any pending filtered emit — filterText is shared across panels, so a trailing
+			// Cancel any pending filtered emits — filterText is shared across panels, so a trailing
 			// callback after a switch would report against the wrong (now-inactive) panel.
 			this.emitWorktreesFilteredTelemetryDebounced.cancel();
+			this.emitBranchesFilteredTelemetryDebounced.cancel();
 
 			// Keep the actions module in sync so invalidateAll can refetch
 			this._actions.activePanel = this.activePanel;
@@ -502,6 +528,12 @@ export class GlGraphSidebarPanel extends SignalWatcher(LitElement) {
 			if (this.activePanel === 'agents') {
 				this.emitAgentsShownTelemetry();
 			}
+
+			// Defer the `shown` event until the branches data actually resolves (see
+			// maybeEmitBranchesShownTelemetry). Emitting synchronously here would drop the
+			// first-ever view (data still undefined) and report stale counts on later views
+			// (the Resource retains the prior fetch's value until the new one lands).
+			this._branchesShownPending = this.activePanel === 'branches';
 		}
 	}
 
@@ -515,6 +547,8 @@ export class GlGraphSidebarPanel extends SignalWatcher(LitElement) {
 		// change so a fresh impression is recorded then, but intra-activation re-renders (WIP pushes,
 		// refresh(), filter/expansion changes) do not re-emit.
 		this.emitWorktreesShownTelemetry();
+
+		this.maybeEmitBranchesShownTelemetry();
 	}
 
 	private emitWorktreesShownTelemetry(): void {
@@ -767,65 +801,7 @@ export class GlGraphSidebarPanel extends SignalWatcher(LitElement) {
 	}
 
 	private toBranchLeaf(b: GraphSidebarBranch, isTree: boolean): LeafProps {
-		const actions: TreeItemAction[] = [];
-
-		if (b.tracking?.behind) {
-			actions.push({
-				icon: 'repo-pull',
-				label: 'Pull',
-				action: 'gitlens.graph.pull',
-				altIcon: 'repo-fetch',
-				altLabel: 'Fetch',
-				altAction: 'gitlens.fetch:graph',
-			});
-		} else if (b.tracking?.ahead) {
-			actions.push({ icon: 'repo-push', label: 'Push', action: 'gitlens.graph.push' });
-		} else if (b.upstream && !b.upstream.missing) {
-			actions.push({
-				icon: 'repo-fetch',
-				label: 'Fetch',
-				action: 'gitlens.fetch:graph',
-				altIcon: 'repo-pull',
-				altLabel: 'Pull',
-				altAction: 'gitlens.graph.pull',
-			});
-		}
-
-		if (b.current) {
-			actions.unshift({
-				icon: 'gl-switch',
-				label: 'Switch to Another Branch...',
-				action: 'gitlens.switchToAnotherBranch:graph',
-			});
-			actions.push({
-				icon: 'gl-compare-ref-working',
-				label: 'Compare with Working Tree',
-				action: 'gitlens.graph.compareWithWorking',
-			});
-		} else if (b.checkedOut) {
-			actions.push({
-				icon: 'empty-window',
-				label: 'Open Worktree in New Window...',
-				action: 'gitlens.openWorktreeInNewWindow:graph',
-				altIcon: 'window',
-				altLabel: 'Open Worktree...',
-				altAction: 'gitlens.openWorktree:graph',
-			});
-		} else {
-			actions.unshift({
-				icon: 'gl-switch',
-				label: 'Switch to Branch...',
-				action: 'gitlens.switchToBranch:graph',
-			});
-			actions.push({
-				icon: 'compare-changes',
-				label: 'Compare with HEAD',
-				action: 'gitlens.graph.compareBranchWithHead',
-				altIcon: 'gl-compare-ref-working',
-				altLabel: 'Compare with Working Tree',
-				altAction: 'gitlens.graph.compareWithWorking',
-			});
-		}
+		const actions = getBranchLeafActions(b);
 
 		return {
 			label: isTree ? (b.name.split('/').pop() ?? b.name) : b.name,
@@ -833,7 +809,7 @@ export class GlGraphSidebarPanel extends SignalWatcher(LitElement) {
 			tooltip: branchTooltip(b, this.dateFormat),
 			icon: { type: 'branch', status: b.status, worktree: b.worktree },
 			description: b.date != null ? fromNow(b.date) : undefined,
-			context: [b.sha] as SidebarItemContext,
+			context: [b.sha, undefined, undefined, b.name] as SidebarItemContext,
 			decorations: trackingDecorations(b.tracking, b.upstream?.missing),
 			actions: actions,
 			contextValue: b.context,
@@ -1327,6 +1303,10 @@ export class GlGraphSidebarPanel extends SignalWatcher(LitElement) {
 		if (this.activePanel === 'worktrees') {
 			this.emitWorktreesFilteredTelemetryDebounced();
 		}
+
+		if (this.activePanel === 'branches') {
+			this.emitBranchesFilteredTelemetryDebounced();
+		}
 	};
 
 	private handleSearchBoxFilterChanged = (e: CustomEvent<boolean>) => {
@@ -1366,17 +1346,35 @@ export class GlGraphSidebarPanel extends SignalWatcher(LitElement) {
 			}
 		}
 
+		if (this.activePanel === 'branches') {
+			const action =
+				command === 'gitlens.switchToAnotherBranch:views'
+					? 'switchToBranch'
+					: command === 'gitlens.views.title.createBranch'
+						? 'createBranch'
+						: undefined;
+			if (action != null) {
+				emitTelemetrySentEvent<'graph/branches/headerAction'>(this, {
+					name: 'graph/branches/headerAction',
+					data: { action: action },
+				});
+			}
+		}
+
 		this._actions?.executeAction(command, undefined, args);
 	}
 
 	private handleToggleLayout() {
 		if (this.activePanel == null) return;
 
-		// Compute the worktrees layout before toggling — the service update is async, so the
-		// resource value still reflects the old layout here; invert it to get the new one.
+		// Compute the worktrees/branches layout before toggling — the service update is async, so
+		// the resource value still reflects the old layout here; invert it to get the new one.
 		const worktreesData =
 			this.activePanel === 'worktrees' ? this._actions?.state.panels.worktrees?.value.get() : undefined;
 		const worktreesNewLayout = worktreesData?.layout === 'tree' ? 'list' : 'tree';
+
+		const branchesData =
+			this.activePanel === 'branches' ? this._actions?.state.panels.branches?.value.get() : undefined;
 
 		this._actions.toggleLayout(this.activePanel);
 
@@ -1396,6 +1394,18 @@ export class GlGraphSidebarPanel extends SignalWatcher(LitElement) {
 				data: {
 					layout: worktreesNewLayout,
 					'worktrees.count': worktreesData?.items.length ?? 0,
+				},
+			});
+		}
+
+		// Only report the branches toggle when the current layout is known — predicting off
+		// undefined data would misreport 'tree'.
+		if (this.activePanel === 'branches' && branchesData?.layout != null) {
+			emitTelemetrySentEvent<'graph/branches/layoutToggled'>(this, {
+				name: 'graph/branches/layoutToggled',
+				data: {
+					layout: branchesData.layout === 'tree' ? 'list' : 'tree',
+					'branches.count': branchesData.items.length,
 				},
 			});
 		}
@@ -1421,6 +1431,13 @@ export class GlGraphSidebarPanel extends SignalWatcher(LitElement) {
 		if (this.activePanel === 'worktrees') {
 			emitTelemetrySentEvent<'graph/worktrees/headerAction'>(this, {
 				name: 'graph/worktrees/headerAction',
+				data: { action: 'refresh' },
+			});
+		}
+
+		if (this.activePanel === 'branches') {
+			emitTelemetrySentEvent<'graph/branches/headerAction'>(this, {
+				name: 'graph/branches/headerAction',
 				data: { action: 'refresh' },
 			});
 		}
@@ -1452,6 +1469,10 @@ export class GlGraphSidebarPanel extends SignalWatcher(LitElement) {
 			this.emitWorktreesTreeItemActionTelemetry(command, useAlt);
 		}
 
+		if (this.activePanel === 'branches') {
+			this.emitBranchesTreeItemActionTelemetry(command, useAlt);
+		}
+
 		this._actions?.executeAction(command, node.contextData as string | undefined, args);
 	}
 
@@ -1472,6 +1493,12 @@ export class GlGraphSidebarPanel extends SignalWatcher(LitElement) {
 		// the guard would drop those clicks and skew the `sameRepo` dimension to `true`.
 		if (this.activePanel === 'agents' && sessionId != null) {
 			this.emitAgentsSessionSelectedTelemetry(sessionId);
+		}
+
+		// Same reasoning for branches: an unborn branch (no commits yet) has no tip sha, but
+		// clicking it is still a real selection — and the emit resolves by name, not sha.
+		if (this.activePanel === 'branches') {
+			this.emitBranchesSelectedTelemetry(context?.[3]);
 		}
 
 		const sha = context?.[0];
@@ -1552,6 +1579,48 @@ export class GlGraphSidebarPanel extends SignalWatcher(LitElement) {
 		});
 	}
 
+	private getBranchesData(): GraphSidebarBranch[] | undefined {
+		const data = this._actions?.state.panels.branches?.value.get();
+		if (data?.panel !== 'branches') return undefined;
+		return data.items;
+	}
+
+	private getBranchesCount(): number {
+		return this.getBranchesData()?.length ?? 0;
+	}
+
+	private maybeEmitBranchesShownTelemetry(): void {
+		if (!this._branchesShownPending || this.activePanel !== 'branches') return;
+
+		const resource = this._actions?.state.panels.branches;
+		if (resource == null) return;
+
+		// Wait for a successful fetch so counts reflect the freshly shown panel rather than a
+		// stale prior fetch's value. Gate on status, not `loading`: at webview boot the panel can
+		// be restored before the RPC service exists, so fetchPanel no-ops and the resource sits
+		// at 'idle' with loading=false — the flag must survive until initialize() refetches.
+		// 'error' also keeps the flag: if a retry/refresh succeeds while the panel is still
+		// active, the impression should still count. The flag is consumed on first success and
+		// reset on every panel switch, so it can't double-emit.
+		if (resource.status.get() !== 'success') return;
+
+		this._branchesShownPending = false;
+		this.emitBranchesShownTelemetry();
+	}
+
+	private emitBranchesShownTelemetry(): void {
+		const data = this._actions?.state.panels.branches?.value.get();
+		if (data?.panel !== 'branches') return;
+
+		emitTelemetrySentEvent<'graph/branches/shown'>(this, {
+			name: 'graph/branches/shown',
+			data: {
+				layout: data.layout ?? 'list',
+				'branches.count': data.items.length,
+			},
+		});
+	}
+
 	private getWorktreesCount(): number {
 		const data = this._actions?.state.panels.worktrees?.value.get();
 		return data?.panel === 'worktrees' ? data.items.length : 0;
@@ -1583,6 +1652,25 @@ export class GlGraphSidebarPanel extends SignalWatcher(LitElement) {
 				isDefault: worktree.isDefault,
 				hasChanges: worktree.hasChanges === true,
 				hasUpstream: worktree.upstream != null,
+			},
+		});
+	}
+
+	private emitBranchesSelectedTelemetry(name: string | undefined): void {
+		// Resolve by name, not sha — branch tips routinely coincide (e.g. right after
+		// `git checkout -b`), and names are unique.
+		const branch = name != null ? this.getBranchesData()?.find(b => b.name === name) : undefined;
+		if (branch == null) return;
+
+		emitTelemetrySentEvent<'graph/branches/branchSelected'>(this, {
+			name: 'graph/branches/branchSelected',
+			data: {
+				isCurrent: branch.current,
+				// A missing upstream (deleted remote branch) is functionally "no upstream" — the
+				// leaf offers no upstream affordances for it, so don't count it as one
+				hasUpstream: branch.upstream != null && !branch.upstream.missing,
+				hasWorktree: branch.worktree === true,
+				isStarred: branch.starred === true,
 			},
 		});
 	}
@@ -1647,6 +1735,16 @@ export class GlGraphSidebarPanel extends SignalWatcher(LitElement) {
 
 		emitTelemetrySentEvent<'graph/worktrees/worktreeAction'>(this, {
 			name: 'graph/worktrees/worktreeAction',
+			data: { action: action, alt: alt },
+		});
+	}
+
+	private emitBranchesTreeItemActionTelemetry(command: GlCommands, alt: boolean): void {
+		const action = branchActionsToTelemetryNames[command];
+		if (action == null) return;
+
+		emitTelemetrySentEvent<'graph/branches/branchAction'>(this, {
+			name: 'graph/branches/branchAction',
 			data: { action: action, alt: alt },
 		});
 	}

--- a/src/webviews/apps/plus/graph/sidebar/sidebarState.ts
+++ b/src/webviews/apps/plus/graph/sidebar/sidebarState.ts
@@ -202,8 +202,11 @@ export function createSidebarActions(): SidebarActions {
 			for (const [panel, r] of Object.entries(panels)) {
 				if (panel === actions.activePanel) continue;
 
-				r.cancel();
-				r.mutate(undefined);
+				// reset(), not mutate(undefined) — mutate marks the resource as resolved, so it
+				// reports status 'success' while holding no data. Consumers that gate on a settled
+				// status (e.g. the branches shown telemetry) would read that as "fetch landed,
+				// legitimately empty" instead of "nothing fetched yet".
+				r.reset();
 			}
 			actions.fetchCounts();
 
@@ -215,8 +218,10 @@ export function createSidebarActions(): SidebarActions {
 		},
 
 		refresh: function (panel: GraphSidebarPanel) {
-			panels[panel].cancel();
-			panels[panel].mutate(undefined);
+			// reset() (status → 'idle'), not mutate(undefined) (status → 'success') — see
+			// invalidateAll. The refetch arrives via the host round-trip: service.refresh →
+			// onSidebarRefresh → notifySidebarInvalidated → invalidateAll → fetchPanel.
+			panels[panel].reset();
 			service?.refresh(panel);
 		},
 


### PR DESCRIPTION
# Description

Adds privacy-safe telemetry for the **Graph Sidebar Branches** panel, the "Sidebar › Branches" item of #5356. Follows the conventions established by the Overview/Agents/Worktrees panels — flat `graph/branches/…` event keys, `GraphSidebarBranches…` interface names, dot-notation counts, camelCase booleans/enums, and an `if (this.activePanel === 'branches')` guard on every emit. Branches uses the same async resource-fetched data path as Worktrees, so the Worktrees PR was the primary reference.

Six events:

| Event | Fires from | Payload |
|---|---|---|
| `graph/branches/shown` | panel becomes visible (`willUpdate`) | `layout`, `branches.count`, `branches.local.count`, `branches.remote.count` |
| `graph/branches/branchSelected` | branch row selected | `isCurrent`, `isRemote`, `hasUpstream`, `hasWorktree`, `isStarred` |
| `graph/branches/branchAction` | inline row action | `action` (switch/fetch/pull/push/compareWithHead/compareWithWorking/openWorktree/openWorktreeInNewWindow), `alt` |
| `graph/branches/headerAction` | header buttons / refresh | `action` (switchToBranch/createBranch/refresh) |
| `graph/branches/layoutToggled` | list/tree toggle | `layout`, `branches.count` |
| `graph/branches/filtered` | filter box | `hasFilter`, `filter.length`, `branches.count` |

**Privacy:** no branch names, refs, repo paths, or user content — only counts, booleans, and enum discriminators. Repository/webview context is attached host-side via `GraphContextEventData`.

**Scope notes:**
- Expand/collapse is intentionally not instrumented, matching the Agents and Worktrees panels.
- Context-menu branch commands are already counted by the generic host-side `command` event; this PR covers the panel's inline/header interactions that lacked structured attribution.
- No end-user-visible behavior change — emits fire before the existing action and never alter control flow.

**Merge order:** Overview/Agents/Worktrees land first. After they merge, this branch rebases; the only conflict is in `src/constants.telemetry.ts` where every panel inserts near the same region — resolution is purely additive (keep all blocks, append branches), then re-run `pnpm run generate:docs:telemetry`.

Part of #5356.

# Checklist

- [x] My changes follow the coding style of this project
- [x] My changes build without any errors or warnings
- [x] My changes have been formatted and linted (`pnpm run check`, `tsc --noEmit`, Prettier — all clean)
- [x] My changes include any required corresponding changes to the documentation (`docs/telemetry-events.md` regenerated)
- [x] My changes have been rebased and squashed to a single commit
- [ ] CHANGELOG.md / README.md — not applicable (internal telemetry, not user-facing)
