### PR TITLE
Fixes #5426 - Hoists system prompts for Anthropic AI requests

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -43,6 +43,7 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/) and this p
 - Fixes the working changes (WIP) stats tooltip in the details header duplicating the visible stats pill instead of describing the change breakdown &mdash; the tooltip now reads e.g. _1 file added, 2 files changed in the working tree_
 - Fixes a stray gap in the _Commit Graph_ header next to the fetch and sync actions when the current branch is already published &mdash; the publish action no longer reserves empty space once the branch has an upstream
 - Fixes the design of the paused-operation banner (shown during a merge, rebase, cherry-pick, or revert in the _Commit Graph_/_Inspect_ details and _Home_) &mdash; the _Continue_ action now uses a start icon, and the action buttons' hover and active states blend into the banner instead of showing a clashing grey toolbar highlight ([#5394](https://github.com/gitkraken/vscode-gitlens/issues/5394))
+- Fixes Anthropic AI requests failing with a _400 Bad Request_ when the request includes system messages (e.g. generating commits with the commit composer) &mdash; system-role messages are now hoisted into the top-level `system` parameter of Anthropic's Messages API ([#5426](https://github.com/gitkraken/vscode-gitlens/issues/5426))
 
 ## [18.2.0] - 2026-06-15
 

--- a/packages/plus/ai/src/providers/anthropicProvider.ts
+++ b/packages/plus/ai/src/providers/anthropicProvider.ts
@@ -242,6 +242,28 @@ export class AnthropicProvider extends OpenAICompatibleProviderBase<typeof provi
 			const { max_completion_tokens: max, ...rest } = request;
 			request = max ? { max_tokens: max, ...rest } : rest;
 		}
+		// Anthropic's Messages API rejects `system`-role entries inside `messages` ("messages.0: use
+		// the top-level 'system' parameter for the initial system prompt"). Some callers — notably
+		// the compose-tools adapter, which goes through `sendRequest` and embeds the system prompt
+		// as a leading message — put the system prompt in `messages` rather than the top-level
+		// `system` field, which is valid for the OpenAI-compatible providers sharing the base.
+		// Hoist any such entries into `system`, after any existing top-level value.
+		if ('messages' in request && Array.isArray(request.messages)) {
+			const { system, messages } = request as {
+				system?: unknown;
+				messages: { role: string; content: string }[];
+			};
+			const systemMessages = messages.filter(m => m?.role === 'system');
+			if (systemMessages.length) {
+				request = {
+					...request,
+					system: [typeof system === 'string' ? system : undefined, ...systemMessages.map(m => m.content)]
+						.filter(s => s != null)
+						.join('\n\n'),
+					messages: messages.filter(m => m?.role !== 'system'),
+				};
+			}
+		}
 		return super.fetchCore(action, model, apiKey, request, signal);
 	}
 


### PR DESCRIPTION
# Description

The composer builds requests with the system prompt as a system-role entry in messages, but Anthropic's Messages API rejects that with a 400 and requires the top-level `system` parameter. The fix hoists any such messages into `system` in AnthropicProvider.fetchCore, appending after any existing top-level value.

# Checklist

- [o] I have followed the guidelines in the Contributing document
- [o] My changes follow the coding style of this project
- [o] My changes build without any errors or warnings
- [o] My changes have been formatted and linted
- [o] My changes include any required corresponding changes to the documentation (including CHANGELOG.md and README.md)
- [o] My changes have been rebased and squashed to the minimal number (typically 1) of relevant commits
- [o] My changes have a descriptive commit message with a short title, including a `Fixes $XXX -` or `Closes #XXX -` prefix to auto-close the issue that your PR addresses
