### PR TITLE
Adds E2E coverage for the Commit Graph Fetch popover

### DIFF
--- a/tests/e2e/specs/graphHeaderGitActions.test.ts
+++ b/tests/e2e/specs/graphHeaderGitActions.test.ts
@@ -62,6 +62,20 @@ async function openGraphOnBranch(vscode: VSCodeInstance, branch: string): Promis
 	return webview;
 }
 
+/**
+ * Open the Fetch button's popover (auto-fetch settings) and wait for its content (the settings
+ * gear) to be visible. Uses focus rather than hover: the anchor is a focusable `<a href>` and the
+ * popover's `hover focus` trigger shows immediately on focus — avoiding the hover path's 500ms
+ * `--show-delay` and the mouseout-hide race if a late reflow shifts the anchor out from under the
+ * (stationary) hover pointer.
+ */
+async function openFetchPopover(webview: FrameLocator): Promise<void> {
+	await fetchLink(webview).focus();
+	await expect(webview.locator('gl-button[aria-label="Open Git Auto-fetch Settings"]').first()).toBeVisible({
+		timeout: MaxTimeout,
+	});
+}
+
 const test = base.extend({
 	vscodeOptions: [
 		{
@@ -179,5 +193,28 @@ test.describe('Graph — Header git-action buttons', () => {
 		const forcePush = webview.locator('gl-button[aria-label="Force Push"]').first();
 		await expect(forcePush).toBeVisible({ timeout: MaxTimeout });
 		await expect(forcePush).toHaveAttribute('href', /command:gitlens\.graph\.pushWithForce/);
+	});
+
+	test('Fetch popover exposes the auto-fetch settings gear wired to Git settings', async ({ vscode }) => {
+		using _ = await vscode.gitlens.startSubscriptionSimulation({ state: 6, planId: 'pro' });
+
+		const webview = await openGraphOnBranch(vscode, 'main');
+		await openFetchPopover(webview);
+
+		const gear = webview.locator('gl-button[aria-label="Open Git Auto-fetch Settings"]').first();
+		await expect(gear).toHaveAttribute('href', /command:workbench\.action\.openSettings/);
+	});
+
+	test('Fetch popover surfaces the auto-fetch toggle', async ({ vscode }) => {
+		using _ = await vscode.gitlens.startSubscriptionSimulation({ state: 6, planId: 'pro' });
+
+		const webview = await openGraphOnBranch(vscode, 'main');
+		await openFetchPopover(webview);
+
+		// With auto-fetch off (the default), the popover offers the toggle rather than the
+		// "handled by VS Code" info row.
+		const toggle = webview.locator('gl-fetch-button gl-checkbox').first();
+		await expect(toggle).toBeVisible({ timeout: MaxTimeout });
+		await expect(toggle).toContainText('Auto-fetch');
 	});
 });

--- a/tests/e2e/specs/graphHeaderGitActions.test.ts
+++ b/tests/e2e/specs/graphHeaderGitActions.test.ts
@@ -80,6 +80,11 @@ const test = base.extend({
 	vscodeOptions: [
 		{
 			vscodeVersion: process.env.VSCODE_VERSION ?? 'stable',
+			// Pin `git.autofetch` off so the Fetch popover always renders the auto-fetch *toggle*
+			// branch, not the "handled by VS Code Git" info row. It's off by default, but pinning it
+			// makes the "Fetch popover surfaces the auto-fetch toggle" test immune to environment /
+			// VS Code-version drift in that default.
+			userSettings: { 'git.autofetch': false },
 			setup: async () => {
 				const repoDir = await createTmpDir();
 				git = new GitFixture(repoDir);
@@ -211,8 +216,8 @@ test.describe('Graph — Header git-action buttons', () => {
 		const webview = await openGraphOnBranch(vscode, 'main');
 		await openFetchPopover(webview);
 
-		// With auto-fetch off (the default), the popover offers the toggle rather than the
-		// "handled by VS Code" info row.
+		// With auto-fetch pinned off (see userSettings), the popover offers the toggle rather than
+		// the "handled by VS Code Git" info row.
 		const toggle = webview.locator('gl-fetch-button gl-checkbox').first();
 		await expect(toggle).toBeVisible({ timeout: MaxTimeout });
 		await expect(toggle).toContainText('Auto-fetch');


### PR DESCRIPTION
## Summary

Follow-up to #5432 — closes the last uncovered affordance in the Commit Graph header's `gl-git-actions-buttons` cluster: the **Fetch button's auto-fetch popover**.

Appends two tests to `tests/e2e/specs/graphHeaderGitActions.test.ts` (plus an `openFetchPopover` helper):

- **Auto-fetch settings gear** — the gear inside the Fetch popover is wired to `workbench.action.openSettings`
- **Auto-fetch toggle** — the popover surfaces the auto-fetch checkbox (shown when autofetch is off, the default)

Consistent with the rest of the file: asserts presence + command/settings wiring, under a Pro simulation, at `--workers=1`.

## Notes

- The popover is opened via **focus**, not hover: the Fetch anchor is a focusable `<a href>` and `gl-popover`'s `hover focus` trigger shows immediately on focus — avoiding the hover path's 500ms show-delay and a mouseout-hide race (a late reflow shifting the anchor out from under Playwright's stationary hover pointer would otherwise never re-trigger the open). This came out of independent review and also makes the tests faster.
- The popover's trigger, the gear's selector/href, and the off-mode checkbox branch were re-verified against a live graph webview before writing the tests.

7/7 green ×2 at `--workers=1`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
