### PR TITLE
Adds multiple simultaneous connections per provider integration (#5430)

### DIFF
--- a/packages/core/CHANGELOG.md
+++ b/packages/core/CHANGELOG.md
@@ -6,6 +6,11 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/) and this p
 
 ## [Unreleased]
 
+### Added
+
+- Adds multiple simultaneous connections (multi-account) per provider integration — `ConfiguredIntegrationDescriptor` now carries a stable per-connection `id` (backend `tokenId`) plus `primary`, `type`, and `accountName`; `IntegrationService` gains `setPrimaryConnection`, `deleteConnection`, and `refreshConnections`; cloud sync fans out over every backend connection (primary + secondaries) and resolves account names with a backend → cache → provider-API precedence. Existing single-connection sessions keep working with zero secret migration ([#5430](https://github.com/gitkraken/vscode-gitlens/issues/5430)) (plus/integrations)
+- Adds per-connection reads for multi-account integrations — issue/PR search and issue-tracker resource reads (`searchMyIssues`, `searchMyPullRequests`, `searchPullRequests`, `getIssuesForProject`, `getAccountForResource`, `getResourcesForUser`, `getProjectsForResources`) accept an optional `connectionId` that reads with that specific connection's token instead of the provider's primary (mirrors the `gk` CLI's `--connection`); omitting it preserves the existing primary behavior ([#5430](https://github.com/gitkraken/vscode-gitlens/issues/5430)) (plus/integrations)
+
 ## [0.4.0] - 2026-06-30
 
 ### Added

--- a/packages/plus/integrations/src/__tests__/cloudIntegrationService.test.ts
+++ b/packages/plus/integrations/src/__tests__/cloudIntegrationService.test.ts
@@ -92,6 +92,38 @@ suite('CloudIntegrationService — multi-account wire mapping (#5430)', () => {
 		assert.equal(connections?.find(c => c.id === 'secondary-tok')?.domain, 'ghe.example.com');
 	});
 
+	test('getConnections tolerates a non-array secondaries payload without throwing', async () => {
+		const { service } = createCloudService(() => ({
+			data: [
+				{
+					tokenId: 'primary-tok',
+					provider: 'github',
+					type: 'oauth',
+					domain: 'github.com',
+					// Malformed backend payload: secondaries should be an array. It must not abort the sync.
+					secondaries: {},
+				},
+			],
+		}));
+
+		const connections = await service.getConnections();
+
+		assert.deepEqual(
+			connections,
+			[
+				{
+					id: 'primary-tok',
+					type: 'oauth',
+					provider: 'github',
+					domain: 'github.com',
+					primary: true,
+					accountName: undefined,
+				},
+			],
+			'primary is still mapped and the malformed secondaries is ignored',
+		);
+	});
+
 	test('getConnectionSession targets /tokens/{tokenId} for a specific connection and maps tokenId to id', async () => {
 		const { service, calls } = createCloudService(() => ({
 			data: {

--- a/packages/plus/integrations/src/__tests__/cloudIntegrationService.test.ts
+++ b/packages/plus/integrations/src/__tests__/cloudIntegrationService.test.ts
@@ -1,0 +1,137 @@
+import * as assert from 'node:assert/strict';
+import { suite, test } from 'mocha';
+import { CloudIntegrationService } from '../authentication/cloudIntegrationService.js';
+import { GitCloudHostIntegrationId } from '../constants.js';
+import { createFakeRuntime } from './fakeRuntime.js';
+
+interface FetchCall {
+	path: string;
+	method: string | undefined;
+	body: string | undefined;
+}
+
+/** Wires a fake `fetchGkApi` that records calls and returns canned `{ data }` responses per path. */
+function createCloudService(responder: (path: string, init?: RequestInit) => unknown) {
+	const runtime = createFakeRuntime();
+	const calls: FetchCall[] = [];
+	runtime.account.fetchGkApi = (path: string, init?: RequestInit) => {
+		calls.push({ path: path, method: init?.method, body: init?.body as string | undefined });
+		const payload = responder(path, init);
+		return Promise.resolve(new Response(JSON.stringify(payload), { status: 200 }));
+	};
+	return { service: new CloudIntegrationService(runtime), calls: calls };
+}
+
+suite('CloudIntegrationService — multi-account wire mapping (#5430)', () => {
+	test('getConnections flattens primary + secondaries and maps tokenId/positional primary', async () => {
+		const { service } = createCloudService(() => ({
+			data: [
+				{
+					tokenId: 'primary-tok',
+					provider: 'github',
+					type: 'oauth',
+					domain: 'github.com',
+					accountName: 'octo-primary',
+					secondaries: [
+						{
+							tokenId: 'secondary-tok',
+							provider: 'github',
+							type: 'oauth',
+							domain: 'github.com',
+							accountName: 'octo-secondary',
+						},
+					],
+				},
+			],
+		}));
+
+		const connections = await service.getConnections();
+
+		assert.deepEqual(connections, [
+			{
+				id: 'primary-tok',
+				type: 'oauth',
+				provider: 'github',
+				domain: 'github.com',
+				primary: true,
+				accountName: 'octo-primary',
+			},
+			{
+				id: 'secondary-tok',
+				type: 'oauth',
+				provider: 'github',
+				domain: 'github.com',
+				primary: false,
+				accountName: 'octo-secondary',
+			},
+		]);
+	});
+
+	test('getConnectionSession targets /tokens/{tokenId} for a specific connection and maps tokenId to id', async () => {
+		const { service, calls } = createCloudService(() => ({
+			data: {
+				tokenId: 'secondary-tok',
+				isPrimary: false,
+				accessToken: 'secret',
+				expiresIn: 3600,
+				scopes: 'repo',
+				type: 'oauth',
+				domain: 'github.com',
+			},
+		}));
+
+		const session = await service.getConnectionSession(
+			GitCloudHostIntegrationId.GitHub,
+			undefined,
+			'secondary-tok',
+		);
+
+		assert.equal(calls[0].path, 'v1/provider-tokens/tokens/secondary-tok');
+		assert.equal(calls[0].method, 'GET');
+		assert.equal(session?.id, 'secondary-tok');
+		assert.equal(session?.accessToken, 'secret');
+	});
+
+	test('getConnectionSession refreshes a specific connection via /tokens/{tokenId}/refresh, not the provider endpoint', async () => {
+		// The provider-scoped /refresh only ever refreshes the PRIMARY, so a secondary must refresh by id.
+		const { service, calls } = createCloudService(() => ({
+			data: { tokenId: 'secondary-tok', accessToken: 'fresh', expiresIn: 3600, scopes: 'repo', type: 'oauth' },
+		}));
+
+		await service.getConnectionSession(GitCloudHostIntegrationId.GitHub, 'stale-access-token', 'secondary-tok');
+
+		assert.equal(calls[0].path, 'v1/provider-tokens/tokens/secondary-tok/refresh');
+		assert.equal(calls[0].method, 'POST');
+		assert.equal(calls[0].body, JSON.stringify({ access_token: 'stale-access-token' }));
+	});
+
+	test('getConnectionSession without a connectionId targets the provider (primary)', async () => {
+		const { service, calls } = createCloudService(() => ({
+			data: { tokenId: 'primary-tok', accessToken: 's', expiresIn: 3600, scopes: 'repo', type: 'oauth' },
+		}));
+
+		await service.getConnectionSession(GitCloudHostIntegrationId.GitHub);
+
+		assert.equal(calls[0].path, 'v1/provider-tokens/github');
+	});
+
+	test('setPrimaryConnection POSTs to /tokens/{tokenId}/primary', async () => {
+		const { service, calls } = createCloudService(() => ({ data: {} }));
+
+		const ok = await service.setPrimaryConnection(GitCloudHostIntegrationId.GitHub, 'secondary-tok');
+
+		assert.equal(ok, true);
+		assert.equal(calls[0].path, 'v1/provider-tokens/tokens/secondary-tok/primary');
+		assert.equal(calls[0].method, 'POST');
+	});
+
+	test('disconnectConnection DELETEs /tokens/{tokenId}', async () => {
+		const { service, calls } = createCloudService(() => ({ data: {} }));
+
+		const ok = await service.disconnectConnection(GitCloudHostIntegrationId.GitHub, 'secondary-tok');
+
+		assert.equal(ok, true);
+		assert.equal(calls[0].path, 'v1/provider-tokens/tokens/secondary-tok');
+		assert.equal(calls[0].method, 'DELETE');
+	});
+});

--- a/packages/plus/integrations/src/__tests__/cloudIntegrationService.test.ts
+++ b/packages/plus/integrations/src/__tests__/cloudIntegrationService.test.ts
@@ -67,6 +67,31 @@ suite('CloudIntegrationService — multi-account wire mapping (#5430)', () => {
 		]);
 	});
 
+	test('getConnections falls back to the primary domain when a secondary domain is empty', async () => {
+		const { service } = createCloudService(() => ({
+			data: [
+				{
+					tokenId: 'primary-tok',
+					provider: 'githubEnterprise',
+					type: 'oauth',
+					domain: 'ghe.example.com',
+					secondaries: [
+						{
+							tokenId: 'secondary-tok',
+							provider: 'githubEnterprise',
+							type: 'oauth',
+							domain: '',
+						},
+					],
+				},
+			],
+		}));
+
+		const connections = await service.getConnections();
+
+		assert.equal(connections?.find(c => c.id === 'secondary-tok')?.domain, 'ghe.example.com');
+	});
+
 	test('getConnectionSession targets /tokens/{tokenId} for a specific connection and maps tokenId to id', async () => {
 		const { service, calls } = createCloudService(() => ({
 			data: {

--- a/packages/plus/integrations/src/__tests__/configuredIntegrationService.test.ts
+++ b/packages/plus/integrations/src/__tests__/configuredIntegrationService.test.ts
@@ -186,6 +186,50 @@ suite('ConfiguredIntegrationService — multi-account (#5430)', () => {
 		assert.equal(configured.filter(c => c.primary).length, 1, 'still exactly one primary');
 	});
 
+	test('self-managed hosts keep independent primary connections per domain', async () => {
+		const runtime = createFakeRuntime();
+		const service = new ConfiguredIntegrationService(runtime);
+		const id = GitSelfManagedHostIntegrationId.CloudGitHubEnterprise;
+
+		await service.storeSession(id, cloudSession('ghe-a1', { domain: 'ghe-a.example.com' }));
+		await service.storeSession(id, cloudSession('ghe-b1', { domain: 'ghe-b.example.com' }));
+		await service.storeSession(id, cloudSession('ghe-b2', { domain: 'ghe-b.example.com' }));
+
+		let configured = service.getConfigured(id);
+		assert.equal(configured.filter(c => c.primary).length, 2, 'one primary per self-managed host');
+		assert.equal(
+			configured.find(c => c.domain === 'ghe-a.example.com' && c.primary)?.id,
+			'ghe-a1',
+			'first host has its own primary',
+		);
+		assert.equal(
+			configured.find(c => c.domain === 'ghe-b.example.com' && c.primary)?.id,
+			'ghe-b1',
+			'second host has its own primary',
+		);
+
+		await service.setPrimaryConnection(id, 'ghe-b2');
+
+		configured = service.getConfigured(id);
+		assert.equal(configured.find(c => c.domain === 'ghe-a.example.com' && c.primary)?.id, 'ghe-a1');
+		assert.equal(configured.find(c => c.domain === 'ghe-b.example.com' && c.primary)?.id, 'ghe-b2');
+
+		const firstHost = await service.getStoredSession(id, { domain: 'ghe-a.example.com', scopes: ['repo'] });
+		const secondHost = await service.getStoredSession(id, { domain: 'ghe-b.example.com', scopes: ['repo'] });
+		assert.equal(firstHost?.accessToken, 'token-ghe-a1');
+		assert.equal(secondHost?.accessToken, 'token-ghe-b2');
+
+		await service.deleteConnection(id, 'ghe-b2');
+
+		configured = service.getConfigured(id);
+		assert.equal(configured.find(c => c.domain === 'ghe-a.example.com' && c.primary)?.id, 'ghe-a1');
+		assert.equal(
+			configured.find(c => c.domain === 'ghe-b.example.com' && c.primary)?.id,
+			'ghe-b1',
+			'removing a host primary promotes a sibling from that host',
+		);
+	});
+
 	test('exposes type and accountName, preserving accountName across an empty re-store', async () => {
 		const runtime = createFakeRuntime();
 		const service = new ConfiguredIntegrationService(runtime);

--- a/packages/plus/integrations/src/__tests__/configuredIntegrationService.test.ts
+++ b/packages/plus/integrations/src/__tests__/configuredIntegrationService.test.ts
@@ -304,6 +304,37 @@ suite('ConfiguredIntegrationService — multi-account (#5430)', () => {
 		);
 	});
 
+	test('a cloud-scoped read resolves the cloud connection id when local and cloud ids differ', async () => {
+		const runtime = createFakeRuntime();
+		// Same domain, but the local (PAT) and cloud descriptors carry DIFFERENT ids. A cloud-scoped read
+		// must key off the cloud id, not silently resolve the local descriptor's id and miss the cloud secret.
+		// Cloud (non-self-managed) descriptors are stored without a domain, so both variants share the same
+		// candidate set. The local descriptor is ordered first and neither is primary, so an unscoped resolve
+		// picks the local id (candidates[0]); only cloud-scoping steers it to the cloud descriptor.
+		await runtime.storage.store('integrations:configured', {
+			github: [
+				{ id: 'local-x', cloud: false, integrationId: 'github', scopes: 'repo' },
+				{ id: 'cloud-y', cloud: true, integrationId: 'github', scopes: 'repo' },
+			],
+		});
+		await runtime.storage.storeSecret(
+			'integration.auth.cloud:github|cloud-y',
+			JSON.stringify({ id: 'cloud-y', accessToken: 'cloud-token', scopes: ['repo'], cloud: true, type: 'oauth' }),
+		);
+		await runtime.storage.storeSecret(
+			'integration.auth:github|local-x',
+			JSON.stringify({ id: 'local-x', accessToken: 'local-token', scopes: ['repo'], cloud: false, type: 'pat' }),
+		);
+
+		const service = new ConfiguredIntegrationService(runtime);
+		const session = await service.getStoredSession(GitCloudHostIntegrationId.GitHub, {
+			...githubDescriptor,
+			cloud: true,
+		});
+
+		assert.equal(session?.accessToken, 'cloud-token', 'cloud-scoped read resolves the cloud connection secret');
+	});
+
 	test('deleteAllStoredSessions removes every connection secret for a multi-account provider', async () => {
 		const runtime = createFakeRuntime();
 		const service = new ConfiguredIntegrationService(runtime);

--- a/packages/plus/integrations/src/__tests__/configuredIntegrationService.test.ts
+++ b/packages/plus/integrations/src/__tests__/configuredIntegrationService.test.ts
@@ -380,6 +380,31 @@ suite('ConfiguredIntegrationService — multi-account (#5430)', () => {
 		);
 	});
 
+	test('deleteAllStoredSessions falls back to the id (not an empty key) for a self-managed provider with no descriptors', async () => {
+		const runtime = createFakeRuntime();
+		// Orphaned cloud secret with no configured descriptor. The canonical domain for a self-managed cloud
+		// provider is '', so the fallback must key off the id, not produce `...|` (an empty connection id).
+		await runtime.storage.storeSecret(
+			'integration.auth.cloud:cloud-github-enterprise|cloud-github-enterprise',
+			JSON.stringify({
+				id: 'cloud-github-enterprise',
+				accessToken: 'orphan',
+				scopes: ['repo'],
+				cloud: true,
+				type: 'oauth',
+			}),
+		);
+
+		const service = new ConfiguredIntegrationService(runtime);
+		await service.deleteAllStoredSessions(GitSelfManagedHostIntegrationId.CloudGitHubEnterprise);
+
+		assert.equal(
+			await runtime.storage.getSecret('integration.auth.cloud:cloud-github-enterprise|cloud-github-enterprise'),
+			undefined,
+			'orphaned secret cleared via the id fallback',
+		);
+	});
+
 	test('deleteAllStoredSessions removes every connection secret for a multi-account provider', async () => {
 		const runtime = createFakeRuntime();
 		const service = new ConfiguredIntegrationService(runtime);

--- a/packages/plus/integrations/src/__tests__/configuredIntegrationService.test.ts
+++ b/packages/plus/integrations/src/__tests__/configuredIntegrationService.test.ts
@@ -335,6 +335,51 @@ suite('ConfiguredIntegrationService — multi-account (#5430)', () => {
 		assert.equal(session?.accessToken, 'cloud-token', 'cloud-scoped read resolves the cloud connection secret');
 	});
 
+	test('a cloud-scoped delete clears the cloud secret when a differing local id is primary', async () => {
+		const runtime = createFakeRuntime();
+		// Mixed local+cloud with different ids; the local descriptor is primary. A cloud-scoped delete must
+		// clear the cloud secret (resolving the cloud id), not resolve the primary local id and leave it.
+		await runtime.storage.store('integrations:configured', {
+			github: [
+				{ id: 'local-x', cloud: false, integrationId: 'github', scopes: 'repo', primary: true },
+				{ id: 'cloud-y', cloud: true, integrationId: 'github', scopes: 'repo', primary: false },
+			],
+		});
+		await runtime.storage.storeSecret(
+			'integration.auth.cloud:github|cloud-y',
+			JSON.stringify({ id: 'cloud-y', accessToken: 'cloud-token', scopes: ['repo'], cloud: true, type: 'oauth' }),
+		);
+		await runtime.storage.storeSecret(
+			'integration.auth:github|local-x',
+			JSON.stringify({ id: 'local-x', accessToken: 'local-token', scopes: ['repo'], cloud: false, type: 'pat' }),
+		);
+
+		const service = new ConfiguredIntegrationService(runtime);
+		await service.deleteStoredSessions(
+			GitCloudHostIntegrationId.GitHub,
+			{ ...githubDescriptor, cloud: true },
+			true,
+			{ preserveConfigured: true },
+		);
+
+		assert.equal(
+			await runtime.storage.getSecret('integration.auth.cloud:github|cloud-y'),
+			undefined,
+			'cloud secret cleared for the cloud connection id',
+		);
+		assert.ok(
+			(await runtime.storage.getSecret('integration.auth:github|local-x')) != null,
+			'local PAT secret left intact by the cloud-scoped delete',
+		);
+		// `preserveConfigured: true` is the contract `deleteSession` relies on for a forced re-sync: the
+		// secret is gone but `getConfigured()` must still report the connection so callers don't see a
+		// spurious disconnect while a replacement session is being fetched.
+		assert.ok(
+			service.getConfigured(GitCloudHostIntegrationId.GitHub).some(d => d.id === 'cloud-y'),
+			'configured descriptor for the deleted connection survives when preserveConfigured is set',
+		);
+	});
+
 	test('deleteAllStoredSessions removes every connection secret for a multi-account provider', async () => {
 		const runtime = createFakeRuntime();
 		const service = new ConfiguredIntegrationService(runtime);

--- a/packages/plus/integrations/src/__tests__/configuredIntegrationService.test.ts
+++ b/packages/plus/integrations/src/__tests__/configuredIntegrationService.test.ts
@@ -1,0 +1,283 @@
+import * as assert from 'node:assert/strict';
+import { suite, test } from 'mocha';
+import { ConfiguredIntegrationService } from '../authentication/configuredIntegrationService.js';
+import type { ProviderAuthenticationSession } from '../authentication/models.js';
+import { GitCloudHostIntegrationId, GitSelfManagedHostIntegrationId } from '../constants.js';
+import { createFakeRuntime } from './fakeRuntime.js';
+
+function cloudSession(id: string, overrides?: Partial<ProviderAuthenticationSession>): ProviderAuthenticationSession {
+	return {
+		id: id,
+		accessToken: `token-${id}`,
+		account: { id: `acct-${id}`, label: id },
+		scopes: ['repo'],
+		cloud: true,
+		type: 'oauth',
+		domain: 'github.com',
+		...overrides,
+	};
+}
+
+const githubDescriptor = { domain: 'github.com', scopes: ['repo'] };
+
+suite('ConfiguredIntegrationService — multi-account (#5430)', () => {
+	test('reads a legacy cloud session (no id, domain-keyed secret) with zero migration', async () => {
+		const runtime = createFakeRuntime();
+		// Pre-multi-account stored data: descriptor without `id`, cloud secret keyed by the canonical domain.
+		await runtime.storage.store('integrations:configured', {
+			github: [{ cloud: true, integrationId: 'github', scopes: 'repo' }],
+		});
+		await runtime.storage.storeSecret(
+			'integration.auth.cloud:github|github.com',
+			JSON.stringify({ id: 'github.com', accessToken: 'legacy', scopes: ['repo'], cloud: true, type: 'oauth' }),
+		);
+
+		const service = new ConfiguredIntegrationService(runtime);
+		const session = await service.getStoredSession(GitCloudHostIntegrationId.GitHub, githubDescriptor);
+
+		assert.ok(session != null, 'legacy session resolves');
+		assert.equal(session.accessToken, 'legacy');
+		// The original secret is untouched (no rewrite under a new key).
+		assert.ok(
+			(await runtime.storage.getSecret('integration.auth.cloud:github|github.com')) != null,
+			'legacy secret preserved',
+		);
+	});
+
+	test('hydration backfills the connection id from the canonical domain (never empty)', async () => {
+		const runtime = createFakeRuntime();
+		await runtime.storage.store('integrations:configured', {
+			github: [{ cloud: true, integrationId: 'github', scopes: 'repo' }],
+		});
+
+		const service = new ConfiguredIntegrationService(runtime);
+		const [descriptor] = service.getConfigured(GitCloudHostIntegrationId.GitHub);
+
+		assert.equal(descriptor.id, 'github.com');
+	});
+
+	test('reads a legacy self-managed session keyed by domain', async () => {
+		const runtime = createFakeRuntime();
+		await runtime.storage.store('integrations:configured', {
+			'cloud-github-enterprise': [
+				{ cloud: true, integrationId: 'cloud-github-enterprise', domain: 'gh.example.com', scopes: 'repo' },
+			],
+		});
+		await runtime.storage.storeSecret(
+			'integration.auth.cloud:cloud-github-enterprise|gh.example.com',
+			JSON.stringify({
+				id: 'gh.example.com',
+				accessToken: 'ent',
+				scopes: ['repo'],
+				cloud: true,
+				type: 'oauth',
+				domain: 'gh.example.com',
+			}),
+		);
+
+		const service = new ConfiguredIntegrationService(runtime);
+		const session = await service.getStoredSession(GitSelfManagedHostIntegrationId.CloudGitHubEnterprise, {
+			domain: 'gh.example.com',
+			scopes: ['repo'],
+		});
+
+		assert.ok(session != null, 'self-managed session resolves');
+		assert.equal(session.accessToken, 'ent');
+	});
+
+	test('two accounts on the same provider coexist; first is primary', async () => {
+		const runtime = createFakeRuntime();
+		const service = new ConfiguredIntegrationService(runtime);
+
+		await service.storeSession(GitCloudHostIntegrationId.GitHub, cloudSession('tok1'));
+		await service.storeSession(GitCloudHostIntegrationId.GitHub, cloudSession('tok2'));
+
+		const configured = service.getConfigured(GitCloudHostIntegrationId.GitHub);
+		assert.equal(configured.length, 2, 'both connections stored');
+		assert.deepEqual(configured.map(c => c.id).sort(), ['tok1', 'tok2'], 'both connection ids present');
+		assert.equal(configured.filter(c => c.primary).length, 1, 'exactly one primary');
+		assert.equal(configured.find(c => c.primary)?.id, 'tok1', 'first connection is primary');
+
+		// Both secrets exist under distinct keys.
+		assert.ok(await runtime.storage.getSecret('integration.auth.cloud:github|tok1'));
+		assert.ok(await runtime.storage.getSecret('integration.auth.cloud:github|tok2'));
+	});
+
+	test('a specific secondary connection is addressable via connectionId', async () => {
+		const runtime = createFakeRuntime();
+		const service = new ConfiguredIntegrationService(runtime);
+		await service.storeSession(GitCloudHostIntegrationId.GitHub, cloudSession('tok1'));
+		await service.storeSession(GitCloudHostIntegrationId.GitHub, cloudSession('tok2'));
+
+		const secondary = await service.getStoredSession(GitCloudHostIntegrationId.GitHub, {
+			...githubDescriptor,
+			connectionId: 'tok2',
+		});
+		assert.equal(secondary!.accessToken, 'token-tok2');
+
+		// No connectionId resolves to the primary.
+		const primary = await service.getStoredSession(GitCloudHostIntegrationId.GitHub, githubDescriptor);
+		assert.equal(primary!.accessToken, 'token-tok1');
+	});
+
+	test('deleting a secondary leaves the primary and its secret intact', async () => {
+		const runtime = createFakeRuntime();
+		const service = new ConfiguredIntegrationService(runtime);
+		await service.storeSession(GitCloudHostIntegrationId.GitHub, cloudSession('tok1'));
+		await service.storeSession(GitCloudHostIntegrationId.GitHub, cloudSession('tok2'));
+
+		await service.deleteConnection(GitCloudHostIntegrationId.GitHub, 'tok2');
+
+		const configured = service.getConfigured(GitCloudHostIntegrationId.GitHub);
+		assert.equal(configured.length, 1);
+		assert.equal(configured[0].id, 'tok1');
+		assert.equal(configured[0].primary, true);
+		assert.ok(await runtime.storage.getSecret('integration.auth.cloud:github|tok1'), 'primary secret intact');
+		assert.equal(
+			await runtime.storage.getSecret('integration.auth.cloud:github|tok2'),
+			undefined,
+			'secondary secret removed',
+		);
+	});
+
+	test('deleting the primary promotes a secondary', async () => {
+		const runtime = createFakeRuntime();
+		const service = new ConfiguredIntegrationService(runtime);
+		await service.storeSession(GitCloudHostIntegrationId.GitHub, cloudSession('tok1'));
+		await service.storeSession(GitCloudHostIntegrationId.GitHub, cloudSession('tok2'));
+
+		await service.deleteConnection(GitCloudHostIntegrationId.GitHub, 'tok1');
+
+		const configured = service.getConfigured(GitCloudHostIntegrationId.GitHub);
+		assert.equal(configured.length, 1);
+		assert.equal(configured[0].id, 'tok2');
+		assert.equal(configured[0].primary, true, 'secondary promoted to primary');
+		// The model descriptor (no connectionId) now resolves to the promoted connection.
+		const session = await service.getStoredSession(GitCloudHostIntegrationId.GitHub, githubDescriptor);
+		assert.equal(session!.accessToken, 'token-tok2');
+	});
+
+	test('setPrimaryConnection switches the default even when scopes/expiresAt are unchanged', async () => {
+		const runtime = createFakeRuntime();
+		const service = new ConfiguredIntegrationService(runtime);
+		await service.storeSession(GitCloudHostIntegrationId.GitHub, cloudSession('tok1'));
+		await service.storeSession(GitCloudHostIntegrationId.GitHub, cloudSession('tok2'));
+
+		await service.setPrimaryConnection(GitCloudHostIntegrationId.GitHub, 'tok2');
+
+		const configured = service.getConfigured(GitCloudHostIntegrationId.GitHub);
+		assert.equal(configured.find(c => c.primary)?.id, 'tok2');
+		assert.equal(configured.filter(c => c.primary).length, 1, 'only one primary after switch');
+		// Persisted across a fresh hydration.
+		const rehydrated = new ConfiguredIntegrationService(runtime);
+		assert.equal(rehydrated.getConfigured(GitCloudHostIntegrationId.GitHub).find(c => c.primary)?.id, 'tok2');
+	});
+
+	test('setPrimaryConnection ignores an unknown connection id', async () => {
+		const runtime = createFakeRuntime();
+		const service = new ConfiguredIntegrationService(runtime);
+		await service.storeSession(GitCloudHostIntegrationId.GitHub, cloudSession('tok1'));
+		await service.storeSession(GitCloudHostIntegrationId.GitHub, cloudSession('tok2'));
+
+		await service.setPrimaryConnection(GitCloudHostIntegrationId.GitHub, 'missing');
+
+		const configured = service.getConfigured(GitCloudHostIntegrationId.GitHub);
+		assert.equal(configured.find(c => c.primary)?.id, 'tok1', 'primary remains unchanged');
+		assert.equal(configured.filter(c => c.primary).length, 1, 'still exactly one primary');
+	});
+
+	test('exposes type and accountName, preserving accountName across an empty re-store', async () => {
+		const runtime = createFakeRuntime();
+		const service = new ConfiguredIntegrationService(runtime);
+		await service.storeSession(
+			GitCloudHostIntegrationId.GitHub,
+			cloudSession('tok1', { type: 'oauth', account: { id: 'u1', label: 'octocat' } }),
+		);
+
+		let [descriptor] = service.getConfigured(GitCloudHostIntegrationId.GitHub);
+		assert.equal(descriptor.type, 'oauth');
+		assert.equal(descriptor.accountName, 'octocat');
+
+		// The model re-stores the same connection with an empty account (getCloudSession sets it empty);
+		// the previously-resolved accountName must survive.
+		await service.storeSession(
+			GitCloudHostIntegrationId.GitHub,
+			cloudSession('tok1', { type: 'oauth', account: { id: '', label: '' } }),
+		);
+		[descriptor] = service.getConfigured(GitCloudHostIntegrationId.GitHub);
+		assert.equal(descriptor.accountName, 'octocat', 'accountName preserved across empty re-store');
+	});
+
+	test('deleteConnection scoped to cloud leaves a local PAT sharing the same id intact', async () => {
+		const runtime = createFakeRuntime();
+		const service = new ConfiguredIntegrationService(runtime);
+		// A local (PAT) and a cloud session can legitimately share a connection id (e.g. the domain).
+		await service.storeSession(GitCloudHostIntegrationId.GitHub, cloudSession('shared', { cloud: false }));
+		await service.storeSession(GitCloudHostIntegrationId.GitHub, cloudSession('shared', { cloud: true }));
+
+		await service.deleteConnection(GitCloudHostIntegrationId.GitHub, 'shared', true);
+
+		assert.ok(
+			(await runtime.storage.getSecret('integration.auth:github|shared')) != null,
+			'local PAT secret preserved',
+		);
+		assert.equal(
+			await runtime.storage.getSecret('integration.auth.cloud:github|shared'),
+			undefined,
+			'cloud secret removed',
+		);
+		const configured = service.getConfigured(GitCloudHostIntegrationId.GitHub);
+		assert.equal(configured.length, 1, 'only the cloud descriptor removed');
+		assert.equal(configured[0].cloud, false, 'the surviving descriptor is the local one');
+	});
+
+	test('rehydrates a local PAT descriptor when a cloud descriptor shares the same id', async () => {
+		const runtime = createFakeRuntime();
+		await runtime.storage.store('integrations:configured', {
+			github: [{ id: 'shared', cloud: true, integrationId: 'github', scopes: 'repo', primary: true }],
+		});
+		await runtime.storage.storeSecret(
+			'integration.auth:github|shared',
+			JSON.stringify({
+				id: 'shared',
+				accessToken: 'local',
+				scopes: ['repo'],
+				cloud: false,
+				type: 'pat',
+			}),
+		);
+
+		const service = new ConfiguredIntegrationService(runtime);
+		const session = await service.getStoredSession(GitCloudHostIntegrationId.GitHub, {
+			...githubDescriptor,
+			connectionId: 'shared',
+		});
+
+		assert.equal(session?.accessToken, 'local');
+		assert.ok(
+			service.getConfigured(GitCloudHostIntegrationId.GitHub).some(c => c.id === 'shared' && c.cloud === false),
+			'local descriptor restored alongside the cloud descriptor',
+		);
+	});
+
+	test('deleteAllStoredSessions removes every connection secret for a multi-account provider', async () => {
+		const runtime = createFakeRuntime();
+		const service = new ConfiguredIntegrationService(runtime);
+		await service.storeSession(GitCloudHostIntegrationId.GitHub, cloudSession('tok1'));
+		await service.storeSession(GitCloudHostIntegrationId.GitHub, cloudSession('tok2'));
+
+		await service.deleteAllStoredSessions(GitCloudHostIntegrationId.GitHub);
+
+		assert.equal(
+			await runtime.storage.getSecret('integration.auth.cloud:github|tok1'),
+			undefined,
+			'first secret removed',
+		);
+		assert.equal(
+			await runtime.storage.getSecret('integration.auth.cloud:github|tok2'),
+			undefined,
+			'second secret removed',
+		);
+		assert.equal(service.getConfigured(GitCloudHostIntegrationId.GitHub).length, 0, 'all descriptors removed');
+	});
+});

--- a/packages/plus/integrations/src/__tests__/manager.test.ts
+++ b/packages/plus/integrations/src/__tests__/manager.test.ts
@@ -95,11 +95,54 @@ suite('createIntegrationManager — vertical-slice smoke', () => {
 
 		const connected = await manager.connectSecondary(GitCloudHostIntegrationId.GitHub, { source: 'test' });
 
-		assert.equal(connected, true, 'reports true when the connection count grew');
+		assert.equal(connected, true, 'reports true when a new connection id was added');
 		assert.equal(
 			manager.getConfigured(GitCloudHostIntegrationId.GitHub).length,
 			2,
 			'both connections are now configured',
+		);
+		manager.dispose();
+	});
+
+	test('connectSecondary reports true when a new connection replaces the existing id', async () => {
+		const runtime = createFakeRuntime();
+		const configured = new ConfiguredIntegrationService(runtime);
+		await configured.storeSession(GitCloudHostIntegrationId.GitHub, cloudSession('tok1'));
+		runtime.account.getAccount = async () => ({ id: 'me' });
+		runtime.account.connect = async () => true;
+		runtime.account.fetchGkApi = (path: string) => {
+			const body =
+				path === 'v1/provider-tokens'
+					? {
+							data: [
+								{
+									tokenId: 'tok2',
+									provider: 'github',
+									type: 'oauth',
+									domain: '',
+								},
+							],
+						}
+					: {
+							data: {
+								tokenId: path.split('/').pop(),
+								accessToken: 'a',
+								expiresIn: 3600,
+								scopes: 'repo',
+								type: 'oauth',
+							},
+						};
+			return Promise.resolve(new Response(JSON.stringify(body), { status: 200 }));
+		};
+		const manager = createIntegrationManager(runtime);
+
+		const connected = await manager.connectSecondary(GitCloudHostIntegrationId.GitHub, { source: 'test' });
+
+		assert.equal(connected, true, 'reports true when a new connection id replaces the old one');
+		assert.deepEqual(
+			manager.getConfigured(GitCloudHostIntegrationId.GitHub).map(c => c.id),
+			['tok2'],
+			'only the replacement connection remains configured',
 		);
 		manager.dispose();
 	});

--- a/packages/plus/integrations/src/__tests__/manager.test.ts
+++ b/packages/plus/integrations/src/__tests__/manager.test.ts
@@ -1,9 +1,22 @@
 import * as assert from 'node:assert/strict';
 import { suite, test } from 'mocha';
 import { ConfiguredIntegrationService } from '../authentication/configuredIntegrationService.js';
+import type { ProviderAuthenticationSession } from '../authentication/models.js';
 import { GitCloudHostIntegrationId } from '../constants.js';
 import { createIntegrationManager } from '../index.js';
 import { createFakeRuntime } from './fakeRuntime.js';
+
+function cloudSession(id: string): ProviderAuthenticationSession {
+	return {
+		id: id,
+		accessToken: `token-${id}`,
+		account: { id: `acct-${id}`, label: id },
+		scopes: ['repo'],
+		cloud: true,
+		type: 'oauth',
+		domain: 'github.com',
+	};
+}
 
 suite('createIntegrationManager — vertical-slice smoke', () => {
 	test('constructs and disposes cleanly with a fake runtime', () => {
@@ -14,8 +27,80 @@ suite('createIntegrationManager — vertical-slice smoke', () => {
 		assert.ok(typeof manager.get === 'function', 'manager.get exists');
 		assert.ok(typeof manager.dispose === 'function', 'manager.dispose exists');
 		assert.ok(typeof manager.connectCloudIntegrations === 'function');
+		assert.ok(typeof manager.connectSecondary === 'function');
 
 		// Disposing should not throw
+		manager.dispose();
+	});
+
+	test('connectSecondary opens the connect flow even when the provider is already connected', async () => {
+		const runtime = createFakeRuntime();
+		await new ConfiguredIntegrationService(runtime).storeSession(
+			GitCloudHostIntegrationId.GitHub,
+			cloudSession('tok1'),
+		);
+		let connectOptions: Parameters<typeof runtime.account.connect>[0] | undefined;
+		runtime.account.connect = async options => {
+			connectOptions = options;
+			return false;
+		};
+		const manager = createIntegrationManager(runtime);
+
+		const connected = await manager.connectSecondary(GitCloudHostIntegrationId.GitHub, { source: 'test' });
+
+		// The host connect flow was opened (not short-circuited by the already-connected provider)…
+		assert.deepEqual(connectOptions, {
+			integrationIds: [GitCloudHostIntegrationId.GitHub],
+			source: { source: 'test' },
+		});
+		// …but no new connection was added, so it reports false.
+		assert.equal(connected, false, 'reports false when no new connection was added');
+		manager.dispose();
+	});
+
+	test('connectSecondary reports true when a new connection is actually added', async () => {
+		const runtime = createFakeRuntime();
+		const configured = new ConfiguredIntegrationService(runtime);
+		// GitHub already has a primary connection.
+		await configured.storeSession(GitCloudHostIntegrationId.GitHub, cloudSession('tok1'));
+		runtime.account.getAccount = async () => ({ id: 'me' });
+		// The host connect flow succeeds and the backend now reports a second connection.
+		runtime.account.connect = async () => true;
+		runtime.account.fetchGkApi = (path: string) => {
+			const body =
+				path === 'v1/provider-tokens'
+					? {
+							data: [
+								{
+									tokenId: 'tok1',
+									provider: 'github',
+									type: 'oauth',
+									domain: '',
+									secondaries: [{ tokenId: 'tok2', provider: 'github', type: 'oauth', domain: '' }],
+								},
+							],
+						}
+					: {
+							data: {
+								tokenId: path.split('/').pop(),
+								accessToken: 'a',
+								expiresIn: 3600,
+								scopes: 'repo',
+								type: 'oauth',
+							},
+						};
+			return Promise.resolve(new Response(JSON.stringify(body), { status: 200 }));
+		};
+		const manager = createIntegrationManager(runtime);
+
+		const connected = await manager.connectSecondary(GitCloudHostIntegrationId.GitHub, { source: 'test' });
+
+		assert.equal(connected, true, 'reports true when the connection count grew');
+		assert.equal(
+			manager.getConfigured(GitCloudHostIntegrationId.GitHub).length,
+			2,
+			'both connections are now configured',
+		);
 		manager.dispose();
 	});
 

--- a/packages/plus/integrations/src/__tests__/perConnectionReads.test.ts
+++ b/packages/plus/integrations/src/__tests__/perConnectionReads.test.ts
@@ -1,0 +1,202 @@
+import * as assert from 'node:assert/strict';
+import { suite, test } from 'mocha';
+import type { Account } from '@gitlens/git/models/author.js';
+import type { IssueShape } from '@gitlens/git/models/issue.js';
+import type { PullRequest } from '@gitlens/git/models/pullRequest.js';
+import type { ProviderAuthenticationSession } from '../authentication/models.js';
+import { GitCloudHostIntegrationId } from '../constants.js';
+import { createIntegrationManager } from '../index.js';
+import { createFakeRuntime } from './fakeRuntime.js';
+
+/**
+ * Verifies that reads (issues/PRs) can target a SPECIFIC connection (multi-account) via a `connectionId`,
+ * reading with that connection's token rather than the provider's primary — mirroring gkcli's
+ * `--connection <tokenId>` and the token backend's `GET /v1/provider-tokens/tokens/{tokenId}`.
+ */
+async function seedConnectionSecret(runtime: ReturnType<typeof createFakeRuntime>, tokenId: string, token: string) {
+	await runtime.storage.storeSecret(
+		`integration.auth.cloud:github|${tokenId}`,
+		JSON.stringify({
+			id: tokenId,
+			accessToken: token,
+			scopes: ['repo'],
+			cloud: true,
+			type: 'oauth',
+			domain: 'github.com',
+		}),
+	);
+}
+
+suite('per-connection reads (#5430)', () => {
+	test('searchMyIssues reads with the specified connection token, not the primary', async () => {
+		const runtime = createFakeRuntime();
+		await seedConnectionSecret(runtime, 'sec-tok', 'token-secondary');
+		const manager = createIntegrationManager(runtime);
+		const gh = await manager.get(GitCloudHostIntegrationId.GitHub);
+
+		let capturedToken: string | undefined;
+		(
+			gh as unknown as {
+				searchProviderMyIssues: (session: ProviderAuthenticationSession) => Promise<IssueShape[]>;
+			}
+		).searchProviderMyIssues = session => {
+			capturedToken = session.accessToken;
+			return Promise.resolve([]);
+		};
+
+		const result = await gh.searchMyIssues(undefined, undefined, 'sec-tok');
+
+		assert.deepEqual(result, [], 'returns the specified connection results');
+		assert.equal(capturedToken, 'token-secondary', 'read used the specified connection token');
+
+		manager.dispose();
+	});
+
+	test('searchMyPullRequests reads with the specified connection token', async () => {
+		const runtime = createFakeRuntime();
+		await seedConnectionSecret(runtime, 'sec-tok', 'token-secondary');
+		const manager = createIntegrationManager(runtime);
+		const gh = await manager.get(GitCloudHostIntegrationId.GitHub);
+
+		let capturedToken: string | undefined;
+		(
+			gh as unknown as {
+				searchProviderMyPullRequests: (session: ProviderAuthenticationSession) => Promise<PullRequest[]>;
+			}
+		).searchProviderMyPullRequests = session => {
+			capturedToken = session.accessToken;
+			return Promise.resolve([]);
+		};
+
+		await gh.searchMyPullRequests(undefined, undefined, undefined, 'sec-tok');
+
+		assert.equal(capturedToken, 'token-secondary', 'PR read used the specified connection token');
+
+		manager.dispose();
+	});
+
+	test('a network failure resolving the connection degrades to undefined instead of throwing', async () => {
+		const runtime = createFakeRuntime();
+		runtime.account.getAccount = async () => ({ id: 'me' });
+		// The stored secondary session is expired, so resolving it triggers a refresh…
+		await runtime.storage.storeSecret(
+			'integration.auth.cloud:github|exp-tok',
+			JSON.stringify({
+				id: 'exp-tok',
+				accessToken: 'stale',
+				scopes: ['repo'],
+				cloud: true,
+				type: 'oauth',
+				domain: 'github.com',
+				expiresAt: new Date(Date.now() - 60_000).toISOString(),
+			}),
+		);
+		// …and the refresh hits the backend, which fails.
+		runtime.account.fetchGkApi = () => Promise.reject(new Error('network down'));
+		const manager = createIntegrationManager(runtime);
+		const gh = await manager.get(GitCloudHostIntegrationId.GitHub);
+
+		let called = false;
+		(
+			gh as unknown as {
+				searchProviderMyIssues: (session: ProviderAuthenticationSession) => Promise<IssueShape[]>;
+			}
+		).searchProviderMyIssues = () => {
+			called = true;
+			return Promise.resolve([]);
+		};
+
+		const result = await gh.searchMyIssues(undefined, undefined, 'exp-tok');
+
+		assert.equal(result, undefined, 'a failed connection resolution yields no results (no throw)');
+		assert.equal(called, false, 'provider read not attempted when the session can’t be resolved');
+
+		manager.dispose();
+	});
+
+	test('a read for an unknown connection degrades to undefined without calling the provider', async () => {
+		const runtime = createFakeRuntime();
+		const manager = createIntegrationManager(runtime);
+		const gh = await manager.get(GitCloudHostIntegrationId.GitHub);
+
+		let called = false;
+		(
+			gh as unknown as {
+				searchProviderMyIssues: (session: ProviderAuthenticationSession) => Promise<IssueShape[]>;
+			}
+		).searchProviderMyIssues = () => {
+			called = true;
+			return Promise.resolve([]);
+		};
+
+		const result = await gh.searchMyIssues(undefined, undefined, 'does-not-exist');
+
+		assert.equal(result, undefined, 'unresolvable connection yields no results');
+		assert.equal(called, false, 'provider read not attempted without a session');
+
+		manager.dispose();
+	});
+
+	test('a locally disconnected provider blocks per-connection reads even when the secret remains', async () => {
+		const runtime = createFakeRuntime();
+		await seedConnectionSecret(runtime, 'sec-tok', 'token-secondary');
+		await runtime.storage.storeWorkspace('connected:github', false);
+		const manager = createIntegrationManager(runtime);
+		const gh = await manager.get(GitCloudHostIntegrationId.GitHub);
+
+		let called = false;
+		(
+			gh as unknown as {
+				searchProviderMyIssues: (session: ProviderAuthenticationSession) => Promise<IssueShape[]>;
+			}
+		).searchProviderMyIssues = () => {
+			called = true;
+			return Promise.resolve([]);
+		};
+
+		const result = await gh.searchMyIssues(undefined, undefined, 'sec-tok');
+
+		assert.equal(result, undefined, 'locally disconnected provider yields no results');
+		assert.equal(called, false, 'provider read not attempted while locally disconnected');
+
+		manager.dispose();
+	});
+
+	test('GitLab PR search resolves the username from the read session, not the primary account', async () => {
+		const runtime = createFakeRuntime();
+		// A secondary GitLab connection whose token differs from the (absent) primary.
+		await runtime.storage.storeSecret(
+			'integration.auth.cloud:gitlab|sec-tok',
+			JSON.stringify({
+				id: 'sec-tok',
+				accessToken: 'token-secondary',
+				scopes: ['api'],
+				cloud: true,
+				type: 'oauth',
+				domain: 'gitlab.com',
+			}),
+		);
+		const manager = createIntegrationManager(runtime);
+		const gl = await manager.get(GitCloudHostIntegrationId.GitLab);
+
+		// Capture the session the account lookup receives. GitLab used to call the primary-scoped
+		// getCurrentAccount(); the fix routes through getProviderCurrentAccount(session).
+		let accountLookupToken: string | undefined;
+		(
+			gl as unknown as {
+				getProviderCurrentAccount: (session: ProviderAuthenticationSession) => Promise<Account | undefined>;
+			}
+		).getProviderCurrentAccount = session => {
+			accountLookupToken = session.accessToken;
+			return Promise.resolve(undefined); // undefined username → method returns [] before hitting the API
+		};
+
+		// searchMyPullRequests wraps its result in an IntegrationResult ({ value, duration }).
+		const result = await gl.searchMyPullRequests(undefined, undefined, undefined, 'sec-tok');
+
+		assert.deepEqual(result?.value, [], 'no username resolves to empty results without an API call');
+		assert.equal(accountLookupToken, 'token-secondary', 'username resolved from the read session token');
+
+		manager.dispose();
+	});
+});

--- a/packages/plus/integrations/src/__tests__/perConnectionReads.test.ts
+++ b/packages/plus/integrations/src/__tests__/perConnectionReads.test.ts
@@ -31,6 +31,17 @@ suite('per-connection reads (#5430)', () => {
 	test('searchMyIssues reads with the specified connection token, not the primary', async () => {
 		const runtime = createFakeRuntime();
 		await seedConnectionSecret(runtime, 'sec-tok', 'token-secondary');
+		await runtime.storage.storeSecret(
+			'integration.auth:github|sec-tok',
+			JSON.stringify({
+				id: 'sec-tok',
+				accessToken: 'token-local-pat',
+				scopes: ['repo'],
+				cloud: false,
+				type: 'pat',
+				domain: 'github.com',
+			}),
+		);
 		const manager = createIntegrationManager(runtime);
 		const gh = await manager.get(GitCloudHostIntegrationId.GitHub);
 
@@ -47,7 +58,7 @@ suite('per-connection reads (#5430)', () => {
 		const result = await gh.searchMyIssues(undefined, undefined, 'sec-tok');
 
 		assert.deepEqual(result, [], 'returns the specified connection results');
-		assert.equal(capturedToken, 'token-secondary', 'read used the specified connection token');
+		assert.equal(capturedToken, 'token-secondary', 'read used the specified cloud connection token');
 
 		manager.dispose();
 	});

--- a/packages/plus/integrations/src/__tests__/reconcileConnections.test.ts
+++ b/packages/plus/integrations/src/__tests__/reconcileConnections.test.ts
@@ -400,6 +400,80 @@ suite('cloud sync — multi-account reconcile (#5430)', () => {
 		manager.dispose();
 	});
 
+	test('refreshConnections disconnects a cached self-managed host missing from the backend', async () => {
+		const { runtime, manager } = createManager({
+			connections: [
+				{
+					tokenId: 'ghe-a1',
+					provider: 'githubEnterprise',
+					type: 'oauth',
+					domain: 'ghe-a.example.com',
+					accountName: 'a-one',
+				},
+			],
+			token: (path: string) => {
+				const tokenId = path.endsWith('/githubEnterprise') ? 'ghe-a1' : path.split('/').pop();
+				return {
+					tokenId: tokenId,
+					accessToken: `tok-${tokenId}`,
+					expiresIn: 3600,
+					scopes: 'repo',
+					type: 'oauth',
+				};
+			},
+		});
+		await runtime.storage.store('integrations:configured', {
+			[GitSelfManagedHostIntegrationId.CloudGitHubEnterprise]: [
+				{
+					id: 'ghe-a1',
+					cloud: true,
+					integrationId: GitSelfManagedHostIntegrationId.CloudGitHubEnterprise,
+					domain: 'ghe-a.example.com',
+					scopes: 'repo',
+					primary: true,
+				},
+				{
+					id: 'ghe-b1',
+					cloud: true,
+					integrationId: GitSelfManagedHostIntegrationId.CloudGitHubEnterprise,
+					domain: 'ghe-b.example.com',
+					scopes: 'repo',
+					primary: true,
+				},
+			],
+		});
+		await runtime.storage.storeSecret(
+			'integration.auth.cloud:cloud-github-enterprise|ghe-b1',
+			JSON.stringify({
+				id: 'ghe-b1',
+				accessToken: 'b',
+				scopes: ['repo'],
+				cloud: true,
+				type: 'oauth',
+				domain: 'ghe-b.example.com',
+			}),
+		);
+
+		const gheB = await manager.get(GitSelfManagedHostIntegrationId.CloudGitHubEnterprise, 'ghe-b.example.com');
+		assert.ok(gheB != null, 'missing backend host integration constructs');
+		assert.equal(await gheB.isConnected(), true, 'missing backend host session is warm before sync');
+
+		await manager.refreshConnections();
+
+		assert.equal(await gheB.isConnected(), false, 'missing backend host cache is disconnected');
+		assert.ok(
+			!manager.getConfigured(GitSelfManagedHostIntegrationId.CloudGitHubEnterprise).some(c => c.id === 'ghe-b1'),
+			'missing backend host descriptor removed',
+		);
+		assert.equal(
+			await runtime.storage.getSecret('integration.auth.cloud:cloud-github-enterprise|ghe-b1'),
+			undefined,
+			'missing backend host secret removed',
+		);
+
+		manager.dispose();
+	});
+
 	test('a non-forced sync does not resurrect a provider disconnected locally', async () => {
 		const { runtime, manager, paths } = createManager({
 			connections: [{ tokenId: 'p1', provider: 'github', type: 'oauth', domain: '', accountName: 'octo' }],

--- a/packages/plus/integrations/src/__tests__/reconcileConnections.test.ts
+++ b/packages/plus/integrations/src/__tests__/reconcileConnections.test.ts
@@ -910,6 +910,83 @@ suite('cloud sync — multi-account reconcile (#5430)', () => {
 		manager.dispose();
 	});
 
+	test('force-syncing a multi-host self-managed provider scopes each host fetch to its own connection', async () => {
+		// Two GHE hosts. The provider-global endpoint (`v1/provider-tokens/githubEnterprise`) returns host B's
+		// primary; if a forced sync of host A fell back to it, host A would be hydrated with host B's token.
+		const { runtime, manager, paths } = createManager({
+			connections: [
+				{ tokenId: 'ghe-b1', provider: 'githubEnterprise', type: 'oauth', domain: 'ghe-b.example.com' },
+				{ tokenId: 'ghe-a1', provider: 'githubEnterprise', type: 'oauth', domain: 'ghe-a.example.com' },
+			],
+			token: (path: string) => {
+				// Provider-scoped endpoint yields the global primary (host B); token endpoints yield their id.
+				const tokenId = path.endsWith('/githubEnterprise') ? 'ghe-b1' : path.split('/').pop();
+				return {
+					tokenId: tokenId,
+					accessToken: `tok-${tokenId}`,
+					expiresIn: 3600,
+					scopes: 'repo',
+					type: 'oauth',
+					domain: tokenId === 'ghe-a1' ? 'ghe-a.example.com' : 'ghe-b.example.com',
+				};
+			},
+		});
+		await runtime.storage.store('integrations:configured', {
+			[GitSelfManagedHostIntegrationId.CloudGitHubEnterprise]: [
+				{
+					id: 'ghe-a1',
+					cloud: true,
+					integrationId: GitSelfManagedHostIntegrationId.CloudGitHubEnterprise,
+					domain: 'ghe-a.example.com',
+					scopes: 'repo',
+					primary: true,
+				},
+				{
+					id: 'ghe-b1',
+					cloud: true,
+					integrationId: GitSelfManagedHostIntegrationId.CloudGitHubEnterprise,
+					domain: 'ghe-b.example.com',
+					scopes: 'repo',
+					primary: true,
+				},
+			],
+		});
+		await runtime.storage.storeSecret(
+			'integration.auth.cloud:cloud-github-enterprise|ghe-a1',
+			JSON.stringify({
+				id: 'ghe-a1',
+				accessToken: 'old-ghe-a1',
+				scopes: ['repo'],
+				cloud: true,
+				type: 'oauth',
+				domain: 'ghe-a.example.com',
+			}),
+		);
+
+		const gheA = await manager.get(GitSelfManagedHostIntegrationId.CloudGitHubEnterprise, 'ghe-a.example.com');
+		assert.ok(gheA != null, 'host A integration constructs');
+		assert.equal(await gheA.isConnected(), true, 'host A session is warm');
+		paths.splice(0);
+
+		await manager.refreshConnections();
+
+		assert.ok(
+			paths.includes('v1/provider-tokens/tokens/ghe-a1'),
+			'host A session fetch is scoped to its own connection id',
+		);
+		assert.ok(
+			!paths.includes('v1/provider-tokens/githubEnterprise'),
+			'force sync must not fetch the provider-global primary for a configured multi-host provider',
+		);
+		assert.match(
+			(await runtime.storage.getSecret('integration.auth.cloud:cloud-github-enterprise|ghe-a1')) ?? '',
+			/tok-ghe-a1/,
+			'host A secret refreshed from its own connection token, not host B',
+		);
+
+		manager.dispose();
+	});
+
 	test('refreshing a cloud provider does not switch a cached self-managed provider with an overlapping id prefix', async () => {
 		const { manager } = createManager({
 			connections: [

--- a/packages/plus/integrations/src/__tests__/reconcileConnections.test.ts
+++ b/packages/plus/integrations/src/__tests__/reconcileConnections.test.ts
@@ -151,6 +151,88 @@ suite('cloud sync — multi-account reconcile (#5430)', () => {
 		manager.dispose();
 	});
 
+	test('intentionally skipped self-managed connections do not block stale pruning', async () => {
+		const { runtime, manager } = createManager({
+			connections: [
+				{
+					tokenId: 'ent-valid',
+					provider: 'githubEnterprise',
+					type: 'oauth',
+					domain: 'ghe.example.com',
+					accountName: 'ent-user',
+				},
+				{
+					tokenId: 'ent-invalid',
+					provider: 'githubEnterprise',
+					type: 'oauth',
+					domain: 'https://',
+					accountName: 'bad-host',
+				},
+			],
+			token: (path: string) => {
+				const tokenId = path.endsWith('/githubEnterprise') ? 'ent-valid' : path.split('/').pop();
+				return {
+					tokenId: tokenId,
+					accessToken: `tok-${tokenId}`,
+					expiresIn: 3600,
+					scopes: 'repo',
+					type: 'oauth',
+				};
+			},
+		});
+
+		await runtime.storage.store('integrations:configured', {
+			[GitSelfManagedHostIntegrationId.CloudGitHubEnterprise]: [
+				{
+					id: 'ent-valid',
+					cloud: true,
+					integrationId: GitSelfManagedHostIntegrationId.CloudGitHubEnterprise,
+					domain: 'ghe.example.com',
+					scopes: 'repo',
+					primary: true,
+				},
+				{
+					id: 'stale',
+					cloud: true,
+					integrationId: GitSelfManagedHostIntegrationId.CloudGitHubEnterprise,
+					domain: 'stale.example.com',
+					scopes: 'repo',
+					primary: true,
+				},
+			],
+		});
+		await runtime.storage.storeSecret(
+			'integration.auth.cloud:cloud-github-enterprise|stale',
+			JSON.stringify({
+				id: 'stale',
+				accessToken: 'stale-token',
+				scopes: ['repo'],
+				cloud: true,
+				type: 'oauth',
+				domain: 'stale.example.com',
+			}),
+		);
+
+		await manager.refreshConnections();
+
+		const configured = manager.getConfigured(GitSelfManagedHostIntegrationId.CloudGitHubEnterprise);
+		assert.ok(
+			configured.some(c => c.id === 'ent-valid'),
+			'valid backend connection remains configured',
+		);
+		assert.ok(
+			!configured.some(c => c.id === 'stale'),
+			'stale descriptor pruned even though another backend connection was intentionally skipped',
+		);
+		assert.equal(
+			await runtime.storage.getSecret('integration.auth.cloud:cloud-github-enterprise|stale'),
+			undefined,
+			'stale secret removed',
+		);
+
+		manager.dispose();
+	});
+
 	test('refreshConnections preserves non-expiring GitHub tokens as long-lived sessions', async () => {
 		const { manager } = createManager({
 			connections: [

--- a/packages/plus/integrations/src/__tests__/reconcileConnections.test.ts
+++ b/packages/plus/integrations/src/__tests__/reconcileConnections.test.ts
@@ -549,6 +549,9 @@ suite('cloud sync — multi-account reconcile (#5430)', () => {
 			'cached provider emits disconnected after deleting its last connection',
 		);
 
+		manager.dispose();
+	});
+
 	test('deleteConnection without an explicit cloud arg is cloud-scoped by default, preserving a shared-id local PAT', async () => {
 		const { runtime, manager } = createManager({
 			connections: [],
@@ -582,9 +585,6 @@ suite('cloud sync — multi-account reconcile (#5430)', () => {
 			undefined,
 			'cloud secret removed',
 		);
-
-		manager.dispose();
-	});
 
 		manager.dispose();
 	});
@@ -905,6 +905,55 @@ suite('cloud sync — multi-account reconcile (#5430)', () => {
 			(await runtime.storage.getSecret('integration.auth.cloud:github|p1')) ?? '',
 			/fresh-p1/,
 			'primary secret refreshed from the backend primary',
+		);
+
+		manager.dispose();
+	});
+
+	test('a non-forced check-in does not re-fetch tokens for already-stored, non-expired connections', async () => {
+		const { runtime, manager, paths } = createManager({
+			connections: [
+				{
+					tokenId: 'p1',
+					provider: 'github',
+					type: 'oauth',
+					domain: 'github.com',
+					secondaries: [{ tokenId: 's1', provider: 'github', type: 'oauth', domain: 'github.com' }],
+				},
+			],
+			token: githubToken,
+		});
+		// Both connections already stored with a future expiry, so a routine check-in has nothing to refresh.
+		const future = new Date(Date.now() + 3600_000).toISOString();
+		await runtime.storage.store('integrations:configured', {
+			github: [
+				{ id: 'p1', cloud: true, integrationId: 'github', scopes: 'repo', primary: true, expiresAt: future },
+				{ id: 's1', cloud: true, integrationId: 'github', scopes: 'repo', primary: false, expiresAt: future },
+			],
+		});
+		for (const tok of ['p1', 's1']) {
+			await runtime.storage.storeSecret(
+				`integration.auth.cloud:github|${tok}`,
+				JSON.stringify({ id: tok, accessToken: `tok-${tok}`, scopes: ['repo'], cloud: true, type: 'oauth' }),
+			);
+		}
+		paths.splice(0);
+
+		// Non-forced check-in (force=false).
+		runtime.fireSubscriptionCheckIn(false);
+		await flush();
+
+		assert.ok(
+			!paths.some(p => p.startsWith('v1/provider-tokens/tokens/')),
+			'no per-connection token fetch on a routine check-in when nothing expired',
+		);
+		assert.deepEqual(
+			manager
+				.getConfigured(GitCloudHostIntegrationId.GitHub)
+				.map(c => c.id)
+				.sort(),
+			['p1', 's1'],
+			'both connections remain configured (not pruned) despite the skipped fetch',
 		);
 
 		manager.dispose();

--- a/packages/plus/integrations/src/__tests__/reconcileConnections.test.ts
+++ b/packages/plus/integrations/src/__tests__/reconcileConnections.test.ts
@@ -429,10 +429,10 @@ suite('cloud sync — multi-account reconcile (#5430)', () => {
 	});
 
 	test('resolves account name for a self-managed provider using the parsed host (not the raw URL)', async () => {
-		const { manager } = createManager({
+		const { runtime, manager } = createManager({
 			// No `accountName` on the wire → forces the provider-API resolution tier.
 			connections: [
-				{ tokenId: 'ent1', provider: 'githubEnterprise', type: 'oauth', domain: 'https://ghe.example.com' },
+				{ tokenId: 'ent1', provider: 'githubEnterprise', type: 'oauth', domain: 'http://ghe.example.com' },
 			],
 			token: (path: string) => {
 				const tokenId = path.endsWith('/githubEnterprise') ? 'ent1' : path.split('/').pop();
@@ -447,7 +447,7 @@ suite('cloud sync — multi-account reconcile (#5430)', () => {
 		});
 
 		// Pre-create the self-managed integration under the PARSED host and stub its account lookup. Reconcile
-		// must resolve to THIS instance — proving it parsed 'https://ghe.example.com' → 'ghe.example.com'. A
+		// must resolve to THIS instance — proving it parsed 'http://ghe.example.com' → 'ghe.example.com'. A
 		// raw-URL key would miss this instance and fall through to a live provider call (undefined here).
 		const ghe = await manager.get(GitSelfManagedHostIntegrationId.CloudGitHubEnterprise, 'ghe.example.com');
 		assert.ok(ghe != null, 'self-managed integration constructs');
@@ -458,6 +458,11 @@ suite('cloud sync — multi-account reconcile (#5430)', () => {
 		const [connection] = manager.getConfigured(GitSelfManagedHostIntegrationId.CloudGitHubEnterprise);
 		assert.equal(connection?.accountName, 'ent-user', 'account name resolved via the host-keyed integration');
 		assert.equal(connection?.domain, 'ghe.example.com', 'self-managed descriptor keeps its host domain');
+		assert.match(
+			(await runtime.storage.getSecret('integration.auth.cloud:cloud-github-enterprise|ent1')) ?? '',
+			/"protocol":"http:"/,
+			'stored session preserves the backend URL protocol',
+		);
 
 		manager.dispose();
 	});

--- a/packages/plus/integrations/src/__tests__/reconcileConnections.test.ts
+++ b/packages/plus/integrations/src/__tests__/reconcileConnections.test.ts
@@ -656,14 +656,14 @@ suite('cloud sync — multi-account reconcile (#5430)', () => {
 		manager.dispose();
 	});
 
-	test('refreshConnections accepts a bare host domain for self-managed providers', async () => {
-		const { manager } = createManager({
+	test('refreshConnections accepts a bare host:port domain for self-managed providers', async () => {
+		const { runtime, manager } = createManager({
 			connections: [
 				{
 					tokenId: 'ent1',
 					provider: 'githubEnterprise',
 					type: 'oauth',
-					domain: 'ghe.example.com',
+					domain: 'ghe.example.com:8443',
 					accountName: 'ent-user',
 				},
 			],
@@ -683,9 +683,14 @@ suite('cloud sync — multi-account reconcile (#5430)', () => {
 
 		const [connection] = manager.getConfigured(GitSelfManagedHostIntegrationId.CloudGitHubEnterprise);
 		assert.equal(connection?.id, 'ent1');
-		assert.equal(connection?.domain, 'ghe.example.com');
+		assert.equal(connection?.domain, 'ghe.example.com:8443');
 		assert.equal(connection?.primary, true);
 		assert.equal(connection?.accountName, 'ent-user');
+		assert.doesNotMatch(
+			(await runtime.storage.getSecret('integration.auth.cloud:cloud-github-enterprise|ent1')) ?? '',
+			/"protocol"/,
+			'bare host:port does not persist a bogus protocol',
+		);
 
 		manager.dispose();
 	});

--- a/packages/plus/integrations/src/__tests__/reconcileConnections.test.ts
+++ b/packages/plus/integrations/src/__tests__/reconcileConnections.test.ts
@@ -1,0 +1,354 @@
+import * as assert from 'node:assert/strict';
+import { suite, test } from 'mocha';
+import type { Account } from '@gitlens/git/models/author.js';
+import { GitCloudHostIntegrationId, GitSelfManagedHostIntegrationId } from '../constants.js';
+import { createIntegrationManager } from '../index.js';
+import { createFakeRuntime } from './fakeRuntime.js';
+
+/**
+ * Drives the full cloud-sync path (`refreshConnections` → `syncCloudIntegrations` →
+ * `reconcileCloudConnections`) against a mocked `v1/provider-tokens` backend to verify multi-account
+ * end-to-end: list flattening, per-connection token fetch, account-name precedence, and the
+ * prune-on-transient-failure guard.
+ */
+
+interface TokenBackend {
+	/** GET /v1/provider-tokens list payload (primary + secondaries per provider). */
+	connections: unknown;
+	/** Per-path token responses; return null to simulate a failed/absent token. */
+	token: (path: string) => unknown;
+}
+
+function createManager(backend: TokenBackend) {
+	const runtime = createFakeRuntime();
+	const paths: string[] = [];
+	runtime.account.getAccount = async () => ({ id: 'me' });
+	runtime.account.fetchGkApi = (path: string) => {
+		paths.push(path);
+		let payload: unknown = { data: null };
+		let status = 200;
+		if (path === 'v1/provider-tokens') {
+			payload = { data: backend.connections };
+		} else if (path.startsWith('v1/provider-tokens/')) {
+			const data = backend.token(path);
+			if (data == null) {
+				status = 500;
+				payload = { error: 'boom' };
+			} else {
+				payload = { data: data };
+			}
+		}
+		return Promise.resolve(new Response(JSON.stringify(payload), { status: status }));
+	};
+	return { runtime: runtime, manager: createIntegrationManager(runtime), paths: paths };
+}
+
+/** Flush the (all-synchronous-resolving) mocked async chain triggered by a fire-and-forget sync. */
+async function flush(): Promise<void> {
+	for (let i = 0; i < 25; i++) {
+		await new Promise(resolve => setTimeout(resolve, 0));
+	}
+}
+
+const githubToken = (path: string) => {
+	const tokenId = path === 'v1/provider-tokens/github' ? 'p1' : path.split('/').pop();
+	return { tokenId: tokenId, accessToken: `tok-${tokenId}`, expiresIn: 3600, scopes: 'repo', type: 'oauth' };
+};
+
+suite('cloud sync — multi-account reconcile (#5430)', () => {
+	test('refreshConnections persists every account with wire account names and a single primary', async () => {
+		const { manager } = createManager({
+			connections: [
+				{
+					tokenId: 'p1',
+					provider: 'github',
+					type: 'oauth',
+					domain: 'github.com',
+					accountName: 'octo',
+					secondaries: [
+						{
+							tokenId: 's1',
+							provider: 'github',
+							type: 'oauth',
+							domain: 'github.com',
+							accountName: 'hubot',
+						},
+					],
+				},
+			],
+			token: githubToken,
+		});
+
+		await manager.refreshConnections();
+
+		const configured = manager.getConfigured(GitCloudHostIntegrationId.GitHub);
+		const byId = new Map(configured.map(c => [c.id, c]));
+		assert.deepEqual([...byId.keys()].sort(), ['p1', 's1'], 'both connections stored');
+		assert.equal(byId.get('p1')?.primary, true, 'p1 is primary');
+		assert.equal(byId.get('s1')?.primary ?? false, false, 's1 is not primary');
+		assert.equal(configured.filter(c => c.primary).length, 1, 'exactly one primary');
+		assert.equal(byId.get('p1')?.accountName, 'octo', 'primary account name from wire');
+		assert.equal(byId.get('s1')?.accountName, 'hubot', 'secondary account name from wire');
+		assert.equal(byId.get('p1')?.type, 'oauth');
+
+		manager.dispose();
+	});
+
+	test('a transient token-fetch failure defers pruning so a still-valid connection survives', async () => {
+		const { runtime, manager } = createManager({
+			connections: [
+				{
+					tokenId: 'p1',
+					provider: 'github',
+					type: 'oauth',
+					domain: 'github.com',
+					accountName: 'octo',
+					secondaries: [
+						{
+							tokenId: 's1',
+							provider: 'github',
+							type: 'oauth',
+							domain: 'github.com',
+							accountName: 'hubot',
+						},
+					],
+				},
+			],
+			// s1's token fetch fails this cycle; p1 (and the provider primary) succeed.
+			token: (path: string) => (path.endsWith('/s1') ? null : githubToken(path)),
+		});
+
+		// Seed a pre-existing cloud primary plus a secondary that is NOT in the backend list. The model only
+		// re-fetches the resolved primary on a forced sync, so the secondary ('stale') is untouched by the
+		// model — its survival isolates the reconcile prune guard: it must NOT be pruned while a sibling
+		// failed to sync (otherwise a transient blip would delete a still-valid connection).
+		await runtime.storage.store('integrations:configured', {
+			github: [
+				{ id: 'p1', cloud: true, integrationId: 'github', scopes: 'repo', primary: true },
+				{ id: 'stale', cloud: true, integrationId: 'github', scopes: 'repo', primary: false },
+			],
+		});
+		await runtime.storage.storeSecret(
+			'integration.auth.cloud:github|p1',
+			JSON.stringify({ id: 'p1', accessToken: 'tok-p1', scopes: ['repo'], cloud: true, type: 'oauth' }),
+		);
+		await runtime.storage.storeSecret(
+			'integration.auth.cloud:github|stale',
+			JSON.stringify({ id: 'stale', accessToken: 'keep', scopes: ['repo'], cloud: true, type: 'oauth' }),
+		);
+
+		await manager.refreshConnections();
+
+		assert.ok(
+			manager.getConfigured(GitCloudHostIntegrationId.GitHub).some(c => c.id === 'stale'),
+			'stale connection preserved because pruning was deferred after a partial sync',
+		);
+		assert.ok(
+			(await runtime.storage.getSecret('integration.auth.cloud:github|stale')) != null,
+			'stale secret preserved',
+		);
+
+		manager.dispose();
+	});
+
+	test('refreshConnections preserves non-expiring GitHub tokens as long-lived sessions', async () => {
+		const { manager } = createManager({
+			connections: [
+				{
+					tokenId: 'p1',
+					provider: 'github',
+					type: 'oauth',
+					domain: 'github.com',
+					accountName: 'octo',
+				},
+			],
+			token: path => {
+				const tokenId = path === 'v1/provider-tokens/github' ? 'p1' : path.split('/').pop();
+				return { tokenId: tokenId, accessToken: `tok-${tokenId}`, expiresIn: 0, scopes: 'repo', type: 'oauth' };
+			},
+		});
+
+		await manager.refreshConnections();
+
+		const [configured] = manager.getConfigured(GitCloudHostIntegrationId.GitHub);
+		assert.ok(configured.expiresAt != null, 'expiresAt is stored');
+		assert.ok(
+			new Date(configured.expiresAt).getTime() > Date.now() + 60_000,
+			'non-expiring GitHub token should not be stored as immediately expired',
+		);
+
+		manager.dispose();
+	});
+
+	test('fully disconnecting a provider clears every account secret and descriptor', async () => {
+		// Backend now reports the provider as fully disconnected (no connections).
+		const { runtime, manager } = createManager({ connections: [], token: githubToken });
+		await runtime.storage.store('integrations:configured', {
+			github: [
+				{ id: 'p1', cloud: true, integrationId: 'github', scopes: 'repo', primary: true },
+				{ id: 's1', cloud: true, integrationId: 'github', scopes: 'repo', primary: false },
+			],
+		});
+		await runtime.storage.storeSecret(
+			'integration.auth.cloud:github|p1',
+			JSON.stringify({ id: 'p1', accessToken: 'a', scopes: ['repo'], cloud: true, type: 'oauth' }),
+		);
+		await runtime.storage.storeSecret(
+			'integration.auth.cloud:github|s1',
+			JSON.stringify({ id: 's1', accessToken: 'b', scopes: ['repo'], cloud: true, type: 'oauth' }),
+		);
+
+		await manager.refreshConnections();
+
+		assert.equal(
+			manager.getConfigured(GitCloudHostIntegrationId.GitHub).length,
+			0,
+			'all descriptors removed on full disconnect',
+		);
+		assert.equal(await runtime.storage.getSecret('integration.auth.cloud:github|p1'), undefined, 'primary cleared');
+		assert.equal(
+			await runtime.storage.getSecret('integration.auth.cloud:github|s1'),
+			undefined,
+			'secondary cleared (not orphaned)',
+		);
+
+		manager.dispose();
+	});
+
+	test('deleteConnection without an explicit cloud arg is cloud-scoped by default, preserving a shared-id local PAT', async () => {
+		const { runtime, manager } = createManager({
+			connections: [],
+			token: () => ({}),
+		});
+		// A local (PAT) and a cloud session can legitimately share a connection id (e.g. the domain).
+		await runtime.storage.store('integrations:configured', {
+			github: [
+				{ id: 'shared', cloud: false, integrationId: 'github', scopes: 'repo' },
+				{ id: 'shared', cloud: true, integrationId: 'github', scopes: 'repo', primary: true },
+			],
+		});
+		await runtime.storage.storeSecret(
+			'integration.auth:github|shared',
+			JSON.stringify({ id: 'shared', accessToken: 'local-pat', scopes: ['repo'], cloud: false }),
+		);
+		await runtime.storage.storeSecret(
+			'integration.auth.cloud:github|shared',
+			JSON.stringify({ id: 'shared', accessToken: 'cloud-tok', scopes: ['repo'], cloud: true, type: 'oauth' }),
+		);
+
+		// Public manager API call with no third argument, as an external consumer would call it.
+		await manager.deleteConnection(GitCloudHostIntegrationId.GitHub, 'shared');
+
+		assert.ok(
+			(await runtime.storage.getSecret('integration.auth:github|shared')) != null,
+			'local PAT secret preserved by a default (unscoped) deleteConnection call',
+		);
+		assert.equal(
+			await runtime.storage.getSecret('integration.auth.cloud:github|shared'),
+			undefined,
+			'cloud secret removed',
+		);
+
+		manager.dispose();
+	});
+
+	test('a non-forced sync does not resurrect a provider disconnected locally', async () => {
+		const { runtime, manager, paths } = createManager({
+			connections: [{ tokenId: 'p1', provider: 'github', type: 'oauth', domain: '', accountName: 'octo' }],
+			token: githubToken,
+		});
+		// The user disconnected GitHub locally; the backend still lists the token.
+		await runtime.storage.storeWorkspace('connected:github', false);
+
+		// Non-forced sync (check-in with force:false → syncCloudIntegrations(false)). A forced sync would
+		// clear the local-disconnect flag and legitimately reconnect; a non-forced one must not.
+		runtime.fireSubscriptionCheckIn(false);
+		await flush();
+
+		assert.ok(paths.includes('v1/provider-tokens'), 'the sync actually ran');
+		assert.equal(
+			manager.getConfigured(GitCloudHostIntegrationId.GitHub).length,
+			0,
+			'locally-disconnected provider not resurrected by reconcile',
+		);
+		assert.equal(
+			await runtime.storage.getSecret('integration.auth.cloud:github|p1'),
+			undefined,
+			'no secret resurrected',
+		);
+
+		manager.dispose();
+	});
+
+	test('resolves account name for a self-managed provider using the parsed host (not the raw URL)', async () => {
+		const { manager } = createManager({
+			// No `accountName` on the wire → forces the provider-API resolution tier.
+			connections: [
+				{ tokenId: 'ent1', provider: 'githubEnterprise', type: 'oauth', domain: 'https://ghe.example.com' },
+			],
+			token: (path: string) => {
+				const tokenId = path.endsWith('/githubEnterprise') ? 'ent1' : path.split('/').pop();
+				return {
+					tokenId: tokenId,
+					accessToken: `tok-${tokenId}`,
+					expiresIn: 3600,
+					scopes: 'repo',
+					type: 'oauth',
+				};
+			},
+		});
+
+		// Pre-create the self-managed integration under the PARSED host and stub its account lookup. Reconcile
+		// must resolve to THIS instance — proving it parsed 'https://ghe.example.com' → 'ghe.example.com'. A
+		// raw-URL key would miss this instance and fall through to a live provider call (undefined here).
+		const ghe = await manager.get(GitSelfManagedHostIntegrationId.CloudGitHubEnterprise, 'ghe.example.com');
+		assert.ok(ghe != null, 'self-managed integration constructs');
+		ghe.getProviderAccountForSession = () => Promise.resolve({ username: 'ent-user' } as Account);
+
+		await manager.refreshConnections();
+
+		const [connection] = manager.getConfigured(GitSelfManagedHostIntegrationId.CloudGitHubEnterprise);
+		assert.equal(connection?.accountName, 'ent-user', 'account name resolved via the host-keyed integration');
+		assert.equal(connection?.domain, 'ghe.example.com', 'self-managed descriptor keeps its host domain');
+
+		manager.dispose();
+	});
+
+	test('refreshing a cloud provider does not switch a cached self-managed provider with an overlapping id prefix', async () => {
+		const { manager } = createManager({
+			connections: [
+				{
+					tokenId: 'bb1',
+					provider: 'bitbucket',
+					type: 'oauth',
+					domain: 'bitbucket.org',
+					accountName: 'bb-user',
+				},
+			],
+			token: (path: string) => {
+				const tokenId = path.endsWith('/bitbucket') ? 'bb1' : path.split('/').pop();
+				return {
+					tokenId: tokenId,
+					accessToken: `tok-${tokenId}`,
+					expiresIn: 3600,
+					scopes: 'repo',
+					type: 'oauth',
+				};
+			},
+		});
+
+		const bitbucketServer = await manager.get(GitSelfManagedHostIntegrationId.BitbucketServer, 'bbs.example.com');
+		assert.ok(bitbucketServer != null, 'self-managed Bitbucket integration constructs');
+
+		let switched = false;
+		bitbucketServer.switchConnection = () => {
+			switched = true;
+		};
+
+		await manager.refreshConnections();
+
+		assert.equal(switched, false, 'cloud Bitbucket refresh must not switch Bitbucket Data Center');
+
+		manager.dispose();
+	});
+});

--- a/packages/plus/integrations/src/__tests__/reconcileConnections.test.ts
+++ b/packages/plus/integrations/src/__tests__/reconcileConnections.test.ts
@@ -314,6 +314,40 @@ suite('cloud sync — multi-account reconcile (#5430)', () => {
 		manager.dispose();
 	});
 
+	test('refreshConnections accepts a bare host domain for self-managed providers', async () => {
+		const { manager } = createManager({
+			connections: [
+				{
+					tokenId: 'ent1',
+					provider: 'githubEnterprise',
+					type: 'oauth',
+					domain: 'ghe.example.com',
+					accountName: 'ent-user',
+				},
+			],
+			token: (path: string) => {
+				const tokenId = path.endsWith('/githubEnterprise') ? 'ent1' : path.split('/').pop();
+				return {
+					tokenId: tokenId,
+					accessToken: `tok-${tokenId}`,
+					expiresIn: 3600,
+					scopes: 'repo',
+					type: 'oauth',
+				};
+			},
+		});
+
+		await manager.refreshConnections();
+
+		const [connection] = manager.getConfigured(GitSelfManagedHostIntegrationId.CloudGitHubEnterprise);
+		assert.equal(connection?.id, 'ent1');
+		assert.equal(connection?.domain, 'ghe.example.com');
+		assert.equal(connection?.primary, true);
+		assert.equal(connection?.accountName, 'ent-user');
+
+		manager.dispose();
+	});
+
 	test('refreshing a cloud provider does not switch a cached self-managed provider with an overlapping id prefix', async () => {
 		const { manager } = createManager({
 			connections: [

--- a/packages/plus/integrations/src/__tests__/reconcileConnections.test.ts
+++ b/packages/plus/integrations/src/__tests__/reconcileConnections.test.ts
@@ -644,6 +644,73 @@ suite('cloud sync — multi-account reconcile (#5430)', () => {
 		manager.dispose();
 	});
 
+	test('refreshConnections fetches the backend primary when force-syncing a multi-account provider', async () => {
+		const { runtime, manager, paths } = createManager({
+			connections: [
+				{
+					tokenId: 'p1',
+					provider: 'github',
+					type: 'oauth',
+					domain: 'github.com',
+					accountName: 'octo',
+					secondaries: [
+						{
+							tokenId: 's1',
+							provider: 'github',
+							type: 'oauth',
+							domain: 'github.com',
+							accountName: 'hubot',
+						},
+					],
+				},
+			],
+			token: (path: string) => {
+				const tokenId = path === 'v1/provider-tokens/github' ? 'p1' : path.split('/').pop();
+				return {
+					tokenId: tokenId,
+					accessToken: `fresh-${tokenId}`,
+					expiresIn: 3600,
+					scopes: 'repo',
+					type: 'oauth',
+					domain: 'github.com',
+				};
+			},
+		});
+		await runtime.storage.store('integrations:configured', {
+			github: [
+				{ id: 'p1', cloud: true, integrationId: 'github', scopes: 'repo', primary: true },
+				{ id: 's1', cloud: true, integrationId: 'github', scopes: 'repo', primary: false },
+			],
+		});
+		await runtime.storage.storeSecret(
+			'integration.auth.cloud:github|p1',
+			JSON.stringify({ id: 'p1', accessToken: 'old-p1', scopes: ['repo'], cloud: true, type: 'oauth' }),
+		);
+		await runtime.storage.storeSecret(
+			'integration.auth.cloud:github|s1',
+			JSON.stringify({ id: 's1', accessToken: 'old-s1', scopes: ['repo'], cloud: true, type: 'oauth' }),
+		);
+
+		const github = await manager.get(GitCloudHostIntegrationId.GitHub);
+		assert.equal(await github.isConnected(), true, 'primary session is warm');
+		paths.splice(0);
+
+		await manager.refreshConnections();
+
+		assert.ok(
+			paths.includes('v1/provider-tokens/github'),
+			'force sync fetches the backend primary instead of falling back to a stored secondary',
+		);
+		assert.equal(manager.getConfigured(GitCloudHostIntegrationId.GitHub).find(c => c.primary)?.id, 'p1');
+		assert.match(
+			(await runtime.storage.getSecret('integration.auth.cloud:github|p1')) ?? '',
+			/fresh-p1/,
+			'primary secret refreshed from the backend primary',
+		);
+
+		manager.dispose();
+	});
+
 	test('refreshing a cloud provider does not switch a cached self-managed provider with an overlapping id prefix', async () => {
 		const { manager } = createManager({
 			connections: [

--- a/packages/plus/integrations/src/__tests__/reconcileConnections.test.ts
+++ b/packages/plus/integrations/src/__tests__/reconcileConnections.test.ts
@@ -348,6 +348,129 @@ suite('cloud sync — multi-account reconcile (#5430)', () => {
 		manager.dispose();
 	});
 
+	test('refreshConnections applies self-managed primaries and refreshes cached models per host', async () => {
+		const { runtime, manager } = createManager({
+			connections: [
+				{
+					tokenId: 'ghe-b2',
+					provider: 'githubEnterprise',
+					type: 'oauth',
+					domain: 'ghe-b.example.com',
+					accountName: 'b-two',
+					secondaries: [
+						{
+							tokenId: 'ghe-b1',
+							provider: 'githubEnterprise',
+							type: 'oauth',
+							domain: 'ghe-b.example.com',
+							accountName: 'b-one',
+						},
+					],
+				},
+				{
+					tokenId: 'ghe-a1',
+					provider: 'githubEnterprise',
+					type: 'oauth',
+					domain: 'ghe-a.example.com',
+					accountName: 'a-one',
+					secondaries: [
+						{
+							tokenId: 'ghe-a2',
+							provider: 'githubEnterprise',
+							type: 'oauth',
+							domain: 'ghe-a.example.com',
+							accountName: 'a-two',
+						},
+					],
+				},
+			],
+			token: (path: string) => {
+				const tokenId = path.endsWith('/githubEnterprise') ? 'ghe-a1' : path.split('/').pop();
+				return {
+					tokenId: tokenId,
+					accessToken: `tok-${tokenId}`,
+					expiresIn: 3600,
+					scopes: 'repo',
+					type: 'oauth',
+				};
+			},
+		});
+
+		await runtime.storage.store('integrations:configured', {
+			[GitSelfManagedHostIntegrationId.CloudGitHubEnterprise]: [
+				{
+					id: 'ghe-a1',
+					cloud: true,
+					integrationId: GitSelfManagedHostIntegrationId.CloudGitHubEnterprise,
+					domain: 'ghe-a.example.com',
+					scopes: 'repo',
+					primary: true,
+				},
+				{
+					id: 'ghe-a2',
+					cloud: true,
+					integrationId: GitSelfManagedHostIntegrationId.CloudGitHubEnterprise,
+					domain: 'ghe-a.example.com',
+					scopes: 'repo',
+					primary: false,
+				},
+				{
+					id: 'ghe-b1',
+					cloud: true,
+					integrationId: GitSelfManagedHostIntegrationId.CloudGitHubEnterprise,
+					domain: 'ghe-b.example.com',
+					scopes: 'repo',
+					primary: true,
+				},
+				{
+					id: 'ghe-b2',
+					cloud: true,
+					integrationId: GitSelfManagedHostIntegrationId.CloudGitHubEnterprise,
+					domain: 'ghe-b.example.com',
+					scopes: 'repo',
+					primary: false,
+				},
+			],
+		});
+
+		const gheA = await manager.get(GitSelfManagedHostIntegrationId.CloudGitHubEnterprise, 'ghe-a.example.com');
+		const gheB = await manager.get(GitSelfManagedHostIntegrationId.CloudGitHubEnterprise, 'ghe-b.example.com');
+		assert.ok(gheA != null, 'first self-managed integration constructs');
+		assert.ok(gheB != null, 'second self-managed integration constructs');
+
+		let switchedB = false;
+		gheB.switchConnection = () => {
+			switchedB = true;
+		};
+
+		await manager.refreshConnections();
+
+		const configured = manager.getConfigured(GitSelfManagedHostIntegrationId.CloudGitHubEnterprise);
+		assert.equal(
+			configured.find(c => c.domain === 'ghe-a.example.com' && c.primary)?.id,
+			'ghe-a1',
+			'host A primary is unchanged',
+		);
+		assert.equal(
+			configured.find(c => c.domain === 'ghe-b.example.com' && c.primary)?.id,
+			'ghe-b2',
+			'host B primary follows the backend primary',
+		);
+		assert.equal(
+			configured.filter(c => c.domain === 'ghe-a.example.com' && c.primary).length,
+			1,
+			'host A keeps exactly one primary',
+		);
+		assert.equal(
+			configured.filter(c => c.domain === 'ghe-b.example.com' && c.primary).length,
+			1,
+			'host B keeps exactly one primary',
+		);
+		assert.equal(switchedB, true, 'changed host refreshes its cached integration');
+
+		manager.dispose();
+	});
+
 	test('refreshing a cloud provider does not switch a cached self-managed provider with an overlapping id prefix', async () => {
 		const { manager } = createManager({
 			connections: [

--- a/packages/plus/integrations/src/__tests__/reconcileConnections.test.ts
+++ b/packages/plus/integrations/src/__tests__/reconcileConnections.test.ts
@@ -334,6 +334,72 @@ suite('cloud sync — multi-account reconcile (#5430)', () => {
 		manager.dispose();
 	});
 
+	test('fully disconnecting a self-managed provider clears every configured host', async () => {
+		const { runtime, manager } = createManager({ connections: [], token: githubToken });
+		await runtime.storage.store('integrations:configured', {
+			[GitSelfManagedHostIntegrationId.CloudGitHubEnterprise]: [
+				{
+					id: 'ghe-a1',
+					cloud: true,
+					integrationId: GitSelfManagedHostIntegrationId.CloudGitHubEnterprise,
+					domain: 'ghe-a.example.com',
+					scopes: 'repo',
+					primary: true,
+				},
+				{
+					id: 'ghe-b1',
+					cloud: true,
+					integrationId: GitSelfManagedHostIntegrationId.CloudGitHubEnterprise,
+					domain: 'ghe-b.example.com',
+					scopes: 'repo',
+					primary: true,
+				},
+			],
+		});
+		await runtime.storage.storeSecret(
+			'integration.auth.cloud:cloud-github-enterprise|ghe-a1',
+			JSON.stringify({
+				id: 'ghe-a1',
+				accessToken: 'a',
+				scopes: ['repo'],
+				cloud: true,
+				type: 'oauth',
+				domain: 'ghe-a.example.com',
+			}),
+		);
+		await runtime.storage.storeSecret(
+			'integration.auth.cloud:cloud-github-enterprise|ghe-b1',
+			JSON.stringify({
+				id: 'ghe-b1',
+				accessToken: 'b',
+				scopes: ['repo'],
+				cloud: true,
+				type: 'oauth',
+				domain: 'ghe-b.example.com',
+			}),
+		);
+
+		await manager.refreshConnections();
+
+		assert.equal(
+			manager.getConfigured(GitSelfManagedHostIntegrationId.CloudGitHubEnterprise).length,
+			0,
+			'all self-managed host descriptors removed on full disconnect',
+		);
+		assert.equal(
+			await runtime.storage.getSecret('integration.auth.cloud:cloud-github-enterprise|ghe-a1'),
+			undefined,
+			'first host secret cleared',
+		);
+		assert.equal(
+			await runtime.storage.getSecret('integration.auth.cloud:cloud-github-enterprise|ghe-b1'),
+			undefined,
+			'second host secret cleared',
+		);
+
+		manager.dispose();
+	});
+
 	test('a non-forced sync does not resurrect a provider disconnected locally', async () => {
 		const { runtime, manager, paths } = createManager({
 			connections: [{ tokenId: 'p1', provider: 'github', type: 'oauth', domain: '', accountName: 'octo' }],
@@ -430,7 +496,7 @@ suite('cloud sync — multi-account reconcile (#5430)', () => {
 		manager.dispose();
 	});
 
-	test('refreshConnections applies self-managed primaries and refreshes cached models per host', async () => {
+	test('check-in sync applies self-managed primaries and refreshes cached models per host', async () => {
 		const { runtime, manager } = createManager({
 			connections: [
 				{
@@ -514,18 +580,43 @@ suite('cloud sync — multi-account reconcile (#5430)', () => {
 				},
 			],
 		});
+		await runtime.storage.storeSecret(
+			'integration.auth.cloud:cloud-github-enterprise|ghe-a1',
+			JSON.stringify({
+				id: 'ghe-a1',
+				accessToken: 'tok-ghe-a1',
+				scopes: ['repo'],
+				cloud: true,
+				type: 'oauth',
+				domain: 'ghe-a.example.com',
+			}),
+		);
+		await runtime.storage.storeSecret(
+			'integration.auth.cloud:cloud-github-enterprise|ghe-b1',
+			JSON.stringify({
+				id: 'ghe-b1',
+				accessToken: 'tok-ghe-b1',
+				scopes: ['repo'],
+				cloud: true,
+				type: 'oauth',
+				domain: 'ghe-b.example.com',
+			}),
+		);
 
 		const gheA = await manager.get(GitSelfManagedHostIntegrationId.CloudGitHubEnterprise, 'ghe-a.example.com');
 		const gheB = await manager.get(GitSelfManagedHostIntegrationId.CloudGitHubEnterprise, 'ghe-b.example.com');
 		assert.ok(gheA != null, 'first self-managed integration constructs');
 		assert.ok(gheB != null, 'second self-managed integration constructs');
+		assert.equal(await gheA.isConnected(), true, 'first host session is warm');
+		assert.equal(await gheB.isConnected(), true, 'second host session is warm');
 
 		let switchedB = false;
 		gheB.switchConnection = () => {
 			switchedB = true;
 		};
 
-		await manager.refreshConnections();
+		runtime.fireSubscriptionCheckIn(false);
+		await flush();
 
 		const configured = manager.getConfigured(GitSelfManagedHostIntegrationId.CloudGitHubEnterprise);
 		assert.equal(

--- a/packages/plus/integrations/src/__tests__/reconcileConnections.test.ts
+++ b/packages/plus/integrations/src/__tests__/reconcileConnections.test.ts
@@ -94,6 +94,40 @@ suite('cloud sync — multi-account reconcile (#5430)', () => {
 		manager.dispose();
 	});
 
+	test('blank wire account names fall back to the cached account name', async () => {
+		const { runtime, manager } = createManager({
+			connections: [
+				{
+					tokenId: 'p1',
+					provider: 'github',
+					type: 'oauth',
+					domain: 'github.com',
+					accountName: '   ',
+				},
+			],
+			token: githubToken,
+		});
+		await runtime.storage.store('integrations:configured', {
+			github: [
+				{
+					id: 'p1',
+					cloud: true,
+					integrationId: 'github',
+					scopes: 'repo',
+					primary: true,
+					accountName: 'cached-octo',
+				},
+			],
+		});
+
+		await manager.refreshConnections();
+
+		const [connection] = manager.getConfigured(GitCloudHostIntegrationId.GitHub);
+		assert.equal(connection?.accountName, 'cached-octo', 'blank backend account name ignored');
+
+		manager.dispose();
+	});
+
 	test('a transient token-fetch failure defers pruning so a still-valid connection survives', async () => {
 		const { runtime, manager } = createManager({
 			connections: [
@@ -297,39 +331,49 @@ suite('cloud sync — multi-account reconcile (#5430)', () => {
 		manager.dispose();
 	});
 
-	test('deleteConnection without an explicit cloud arg is cloud-scoped by default, preserving a shared-id local PAT', async () => {
+	test('force-refreshing a cloud session preserves a local PAT sharing the same connection id', async () => {
 		const { runtime, manager } = createManager({
 			connections: [],
-			token: () => ({}),
+			token: () => ({
+				tokenId: 'shared',
+				accessToken: 'fresh-cloud-token',
+				expiresIn: 3600,
+				scopes: 'repo',
+				type: 'oauth',
+				domain: 'github.com',
+			}),
 		});
-		// A local (PAT) and a cloud session can legitimately share a connection id (e.g. the domain).
 		await runtime.storage.store('integrations:configured', {
 			github: [
-				{ id: 'shared', cloud: false, integrationId: 'github', scopes: 'repo' },
-				{ id: 'shared', cloud: true, integrationId: 'github', scopes: 'repo', primary: true },
+				{ id: 'shared', cloud: false, integrationId: 'github', scopes: 'repo', primary: true },
+				{ id: 'shared', cloud: true, integrationId: 'github', scopes: 'repo', primary: false },
 			],
 		});
 		await runtime.storage.storeSecret(
 			'integration.auth:github|shared',
-			JSON.stringify({ id: 'shared', accessToken: 'local-pat', scopes: ['repo'], cloud: false }),
+			JSON.stringify({ id: 'shared', accessToken: 'local-pat', scopes: ['repo'], cloud: false, type: 'pat' }),
 		);
 		await runtime.storage.storeSecret(
 			'integration.auth.cloud:github|shared',
-			JSON.stringify({ id: 'shared', accessToken: 'cloud-tok', scopes: ['repo'], cloud: true, type: 'oauth' }),
+			JSON.stringify({ id: 'shared', accessToken: 'old-cloud', scopes: ['repo'], cloud: true, type: 'oauth' }),
 		);
 
-		// Public manager API call with no third argument, as an external consumer would call it.
-		await manager.deleteConnection(GitCloudHostIntegrationId.GitHub, 'shared');
+		const github = await manager.get(GitCloudHostIntegrationId.GitHub);
+		assert.equal(await github.isConnected(), true, 'cached session is warm before refresh');
 
-		assert.ok(
-			(await runtime.storage.getSecret('integration.auth:github|shared')) != null,
-			'local PAT secret preserved by a default (unscoped) deleteConnection call',
+		await github.syncCloudConnection('connected', true);
+
+		assert.match(
+			(await runtime.storage.getSecret('integration.auth:github|shared')) ?? '',
+			/local-pat/,
+			'local PAT secret preserved',
 		);
-		assert.equal(
-			await runtime.storage.getSecret('integration.auth.cloud:github|shared'),
-			undefined,
-			'cloud secret removed',
+		assert.match(
+			(await runtime.storage.getSecret('integration.auth.cloud:github|shared')) ?? '',
+			/fresh-cloud-token/,
+			'cloud secret refreshed',
 		);
+		assert.equal((await github.getSession('integrations'))?.accessToken, 'fresh-cloud-token');
 
 		manager.dispose();
 	});
@@ -470,6 +514,77 @@ suite('cloud sync — multi-account reconcile (#5430)', () => {
 			undefined,
 			'missing backend host secret removed',
 		);
+
+		manager.dispose();
+	});
+
+	test('deleteConnection emits disconnected for a cached provider when the last connection is removed', async () => {
+		const { runtime, manager } = createManager({
+			connections: [],
+			token: () => ({}),
+		});
+		await runtime.storage.store('integrations:configured', {
+			github: [{ id: 'p1', cloud: true, integrationId: 'github', scopes: 'repo', primary: true }],
+		});
+		await runtime.storage.storeSecret(
+			'integration.auth.cloud:github|p1',
+			JSON.stringify({ id: 'p1', accessToken: 'tok-p1', scopes: ['repo'], cloud: true, type: 'oauth' }),
+		);
+
+		const github = await manager.get(GitCloudHostIntegrationId.GitHub);
+		assert.equal(await github.isConnected(), true, 'cached provider starts connected');
+		await flush();
+		runtime.emittedEvents.length = 0;
+
+		await manager.deleteConnection(GitCloudHostIntegrationId.GitHub, 'p1', true);
+		await flush();
+
+		assert.ok(
+			runtime.emittedEvents.some(
+				e =>
+					e.event === 'integration.connection.hosting.changed' &&
+					e.props?.key === 'github' &&
+					e.props?.connected === false,
+			),
+			'cached provider emits disconnected after deleting its last connection',
+		);
+
+	test('deleteConnection without an explicit cloud arg is cloud-scoped by default, preserving a shared-id local PAT', async () => {
+		const { runtime, manager } = createManager({
+			connections: [],
+			token: () => ({}),
+		});
+		// A local (PAT) and a cloud session can legitimately share a connection id (e.g. the domain).
+		await runtime.storage.store('integrations:configured', {
+			github: [
+				{ id: 'shared', cloud: false, integrationId: 'github', scopes: 'repo' },
+				{ id: 'shared', cloud: true, integrationId: 'github', scopes: 'repo', primary: true },
+			],
+		});
+		await runtime.storage.storeSecret(
+			'integration.auth:github|shared',
+			JSON.stringify({ id: 'shared', accessToken: 'local-pat', scopes: ['repo'], cloud: false }),
+		);
+		await runtime.storage.storeSecret(
+			'integration.auth.cloud:github|shared',
+			JSON.stringify({ id: 'shared', accessToken: 'cloud-tok', scopes: ['repo'], cloud: true, type: 'oauth' }),
+		);
+
+		// Public manager API call with no third argument, as an external consumer would call it.
+		await manager.deleteConnection(GitCloudHostIntegrationId.GitHub, 'shared');
+
+		assert.ok(
+			(await runtime.storage.getSecret('integration.auth:github|shared')) != null,
+			'local PAT secret preserved by a default (unscoped) deleteConnection call',
+		);
+		assert.equal(
+			await runtime.storage.getSecret('integration.auth.cloud:github|shared'),
+			undefined,
+			'cloud secret removed',
+		);
+
+		manager.dispose();
+	});
 
 		manager.dispose();
 	});

--- a/packages/plus/integrations/src/authentication/cloudIntegrationService.ts
+++ b/packages/plus/integrations/src/authentication/cloudIntegrationService.ts
@@ -69,7 +69,9 @@ export class CloudIntegrationService {
 		const data = ((await providersRsp.json()) as { data?: unknown })?.data as
 			| (GKProviderTokenData & { secondaries?: GKProviderTokenData[] })[]
 			| undefined;
-		if (data == null) return undefined;
+		// A non-array `data` (unexpected backend shape) would throw on iteration below and abort the
+		// whole cloud-sync path, so bail gracefully instead.
+		if (!Array.isArray(data)) return undefined;
 
 		// Flatten the primary + `secondaries[]` grouping into one connection per account. Primacy is
 		// positional on the wire (top-level entry = primary), so we set the `primary` flag here.

--- a/packages/plus/integrations/src/authentication/cloudIntegrationService.ts
+++ b/packages/plus/integrations/src/authentication/cloudIntegrationService.ts
@@ -85,7 +85,9 @@ export class CloudIntegrationService {
 				primary: true,
 				accountName: item.accountName,
 			});
-			for (const secondary of item.secondaries ?? []) {
+			// `secondaries` comes from the same unknown payload as `data`; guard against a non-array shape so
+			// an unexpected value doesn't throw here and abort the whole cloud-sync path.
+			for (const secondary of Array.isArray(item.secondaries) ? item.secondaries : []) {
 				connections.push({
 					id: secondary.tokenId,
 					type: secondary.type,

--- a/packages/plus/integrations/src/authentication/cloudIntegrationService.ts
+++ b/packages/plus/integrations/src/authentication/cloudIntegrationService.ts
@@ -1,8 +1,50 @@
 import { getScopedLogger } from '@gitlens/utils/logger.scoped.js';
 import type { IntegrationIds } from '../constants.js';
 import type { IntegrationServiceContext } from '../context.js';
-import type { CloudIntegrationAuthenticationSession, CloudIntegrationConnection } from './models.js';
+import type {
+	CloudIntegrationAuthenticationSession,
+	CloudIntegrationConnection,
+	CloudIntegrationType,
+} from './models.js';
 import { toCloudIntegrationType } from './models.js';
+
+/**
+ * Wire shape of a `v1/provider-tokens` connection descriptor. The list endpoint returns one such
+ * entry per provider as the primary, with additional accounts nested under `secondaries`. Field casing
+ * is the backend's (camelCase, `tokenId`).
+ */
+interface GKProviderTokenData {
+	tokenId: string;
+	provider: CloudIntegrationType;
+	type: CloudIntegrationAuthenticationSession['type'];
+	domain: string;
+	/** Human-readable account handle; the backend includes it on the connection when available. */
+	accountName?: string;
+}
+
+/** Wire shape of a single `v1/provider-tokens/...` token response (`data`). */
+interface GKProviderToken {
+	tokenId?: string;
+	isPrimary?: boolean;
+	accessToken: string;
+	appKey?: string;
+	expiresIn: number;
+	scopes: string;
+	type: CloudIntegrationAuthenticationSession['type'];
+	domain?: string;
+}
+
+function toSession(data: GKProviderToken): CloudIntegrationAuthenticationSession {
+	// Normalize the backend's `tokenId` onto our `id` so callers get a stable per-connection identity.
+	return {
+		type: data.type,
+		accessToken: data.accessToken,
+		domain: data.domain ?? '',
+		expiresIn: data.expiresIn,
+		scopes: data.scopes,
+		id: data.tokenId,
+	};
+}
 
 export class CloudIntegrationService {
 	constructor(private readonly ctx: IntegrationServiceContext) {}
@@ -24,12 +66,42 @@ export class CloudIntegrationService {
 			return undefined;
 		}
 
-		return ((await providersRsp.json()) as { data?: unknown })?.data as CloudIntegrationConnection[] | undefined;
+		const data = ((await providersRsp.json()) as { data?: unknown })?.data as
+			| (GKProviderTokenData & { secondaries?: GKProviderTokenData[] })[]
+			| undefined;
+		if (data == null) return undefined;
+
+		// Flatten the primary + `secondaries[]` grouping into one connection per account. Primacy is
+		// positional on the wire (top-level entry = primary), so we set the `primary` flag here.
+		const connections: CloudIntegrationConnection[] = [];
+		for (const item of data) {
+			connections.push({
+				id: item.tokenId,
+				type: item.type,
+				provider: item.provider,
+				domain: item.domain,
+				primary: true,
+				accountName: item.accountName,
+			});
+			for (const secondary of item.secondaries ?? []) {
+				connections.push({
+					id: secondary.tokenId,
+					type: secondary.type,
+					provider: secondary.provider ?? item.provider,
+					domain: secondary.domain ?? item.domain,
+					primary: false,
+					accountName: secondary.accountName,
+				});
+			}
+		}
+
+		return connections;
 	}
 
 	async getConnectionSession(
 		id: IntegrationIds,
 		refreshToken?: string,
+		connectionId?: string,
 	): Promise<CloudIntegrationAuthenticationSession | undefined> {
 		const scope = getScopedLogger();
 
@@ -49,10 +121,13 @@ export class CloudIntegrationService {
 				}
 			: { method: 'GET' };
 
-		const tokenRsp = await this.ctx.account.fetchGkApi(
-			`v1/provider-tokens/${cloudIntegrationType}${refresh ? '/refresh' : ''}`,
-			reqInitOptions,
-		);
+		// A specific connection (multi-account) is addressed by its token id under `/tokens/{tokenId}`,
+		// including refresh (`/tokens/{tokenId}/refresh`). The provider-scoped endpoints only ever operate
+		// on the provider's PRIMARY connection, so they must NOT be used to refresh a secondary.
+		const path = connectionId
+			? `v1/provider-tokens/tokens/${encodeURIComponent(connectionId)}${refresh ? '/refresh' : ''}`
+			: `v1/provider-tokens/${cloudIntegrationType}${refresh ? '/refresh' : ''}`;
+		const tokenRsp = await this.ctx.account.fetchGkApi(path, reqInitOptions);
 		if (!tokenRsp.ok) {
 			const error = ((await tokenRsp.json()) as { error?: unknown })?.error;
 			const errorMessage =
@@ -70,23 +145,23 @@ export class CloudIntegrationService {
 			});
 
 			if (refresh) {
-				// try once to just get the latest token if the refresh fails, and give up if that fails too
-				const newTokenRsp = await this.ctx.account.fetchGkApi(`v1/provider-tokens/${cloudIntegrationType}`, {
-					method: 'GET',
-				});
+				// try once to just get the latest token if the refresh fails, and give up if that fails too;
+				// stay scoped to the same connection (by token id) so we don't fall back to the primary.
+				const latestPath = connectionId
+					? `v1/provider-tokens/tokens/${encodeURIComponent(connectionId)}`
+					: `v1/provider-tokens/${cloudIntegrationType}`;
+				const newTokenRsp = await this.ctx.account.fetchGkApi(latestPath, { method: 'GET' });
 				if (newTokenRsp.ok) {
-					return ((await newTokenRsp.json()) as { data?: unknown })?.data as
-						| CloudIntegrationAuthenticationSession
-						| undefined;
+					const data = ((await newTokenRsp.json()) as { data?: GKProviderToken })?.data;
+					return data != null ? toSession(data) : undefined;
 				}
 			}
 
 			return undefined;
 		}
 
-		return ((await tokenRsp.json()) as { data?: unknown })?.data as
-			| CloudIntegrationAuthenticationSession
-			| undefined;
+		const data = ((await tokenRsp.json()) as { data?: GKProviderToken })?.data;
+		return data != null ? toSession(data) : undefined;
 	}
 
 	async disconnect(id: IntegrationIds): Promise<boolean> {
@@ -112,6 +187,59 @@ export class CloudIntegrationService {
 				id: id,
 				code: tokenRsp.status,
 			});
+			return false;
+		}
+
+		return true;
+	}
+
+	/**
+	 * Disconnects a single connection by its token id (multi-account). The backend promotes a secondary
+	 * to primary when the removed connection was the primary, so the provider stays connected if others
+	 * remain. Returns whether the delete succeeded.
+	 */
+	async disconnectConnection(id: IntegrationIds, connectionId: string): Promise<boolean> {
+		const scope = getScopedLogger();
+
+		const tokenRsp = await this.ctx.account.fetchGkApi(
+			`v1/provider-tokens/tokens/${encodeURIComponent(connectionId)}`,
+			{ method: 'DELETE' },
+		);
+		if (!tokenRsp.ok) {
+			const error = ((await tokenRsp.json()) as { error?: unknown })?.error;
+			const errorMessage =
+				typeof error === 'string' ? error : ((error as { message?: string })?.message ?? tokenRsp.statusText);
+			if (error != null) {
+				scope?.error(undefined, `Failed to disconnect connection '${connectionId}' for ${id}: ${errorMessage}`);
+			}
+			this.ctx.hooks?.connection?.onDisconnectFailed?.({ id: id, code: tokenRsp.status });
+			return false;
+		}
+
+		return true;
+	}
+
+	/**
+	 * Promotes a connection to primary by its token id (multi-account), clearing primacy on the provider's
+	 * other connections server-side. Returns whether the switch succeeded.
+	 */
+	async setPrimaryConnection(id: IntegrationIds, connectionId: string): Promise<boolean> {
+		const scope = getScopedLogger();
+
+		const tokenRsp = await this.ctx.account.fetchGkApi(
+			`v1/provider-tokens/tokens/${encodeURIComponent(connectionId)}/primary`,
+			{ method: 'POST' },
+		);
+		if (!tokenRsp.ok) {
+			const error = ((await tokenRsp.json()) as { error?: unknown })?.error;
+			const errorMessage =
+				typeof error === 'string' ? error : ((error as { message?: string })?.message ?? tokenRsp.statusText);
+			if (error != null) {
+				scope?.error(
+					undefined,
+					`Failed to set primary connection '${connectionId}' for ${id}: ${errorMessage}`,
+				);
+			}
 			return false;
 		}
 

--- a/packages/plus/integrations/src/authentication/cloudIntegrationService.ts
+++ b/packages/plus/integrations/src/authentication/cloudIntegrationService.ts
@@ -88,7 +88,7 @@ export class CloudIntegrationService {
 					id: secondary.tokenId,
 					type: secondary.type,
 					provider: secondary.provider ?? item.provider,
-					domain: secondary.domain ?? item.domain,
+					domain: secondary.domain || item.domain,
 					primary: false,
 					accountName: secondary.accountName,
 				});

--- a/packages/plus/integrations/src/authentication/configuredIntegrationService.ts
+++ b/packages/plus/integrations/src/authentication/configuredIntegrationService.ts
@@ -479,6 +479,19 @@ export class ConfiguredIntegrationService implements Disposable {
 	}
 
 	/**
+	 * Returns the id of the configured connection an unscoped descriptor resolves to (the primary for the
+	 * descriptor's domain, matching {@link resolveConnectionId}'s selection), or `undefined` when nothing is
+	 * configured for it. Unlike {@link resolveConnectionId} this never falls back to the domain, so callers
+	 * can safely use the result as a real per-connection token id (e.g. to scope a cloud token fetch to one
+	 * host of a multi-host self-managed provider instead of the provider-global primary).
+	 */
+	getConfiguredConnectionId(id: IntegrationIds, domain: string | undefined): string | undefined {
+		const scoped = isGitSelfManagedHostIntegrationId(id) ? domain : undefined;
+		const candidates = this.configured.get(id)?.filter(c => c.domain === scoped);
+		return (candidates?.find(c => c.primary) ?? candidates?.[0])?.id;
+	}
+
+	/**
 	 * Marks the given connection as the primary/default for the provider and clears the flag on its
 	 * siblings. Persists immediately instead of relying on a session re-store to carry the primary flag.
 	 */

--- a/packages/plus/integrations/src/authentication/configuredIntegrationService.ts
+++ b/packages/plus/integrations/src/authentication/configuredIntegrationService.ts
@@ -474,7 +474,7 @@ export class ConfiguredIntegrationService implements Disposable {
 		if (descriptor.connectionId) return descriptor.connectionId;
 
 		const domain = isGitSelfManagedHostIntegrationId(id) ? descriptor.domain : undefined;
-		const candidates = this.configured.get(id)?.filter(c => c.domain === domain);
+		const candidates = this.scopeConnectionCandidates(id, domain, descriptor.cloud);
 		return (candidates?.find(c => c.primary) ?? candidates?.[0])?.id ?? descriptor.domain;
 	}
 
@@ -485,10 +485,29 @@ export class ConfiguredIntegrationService implements Disposable {
 	 * can safely use the result as a real per-connection token id (e.g. to scope a cloud token fetch to one
 	 * host of a multi-host self-managed provider instead of the provider-global primary).
 	 */
-	getConfiguredConnectionId(id: IntegrationIds, domain: string | undefined): string | undefined {
+	getConfiguredConnectionId(id: IntegrationIds, domain: string | undefined, cloud?: boolean): string | undefined {
 		const scoped = isGitSelfManagedHostIntegrationId(id) ? domain : undefined;
-		const candidates = this.configured.get(id)?.filter(c => c.domain === scoped);
+		const candidates = this.scopeConnectionCandidates(id, scoped, cloud);
 		return (candidates?.find(c => c.primary) ?? candidates?.[0])?.id;
+	}
+
+	/**
+	 * Selects configured descriptors for a provider matching `domain`, further narrowed to the `cloud`
+	 * variant when specified. A connection id can have both a local (PAT) and cloud descriptor whose ids
+	 * differ (e.g. a legacy local descriptor keyed by domain alongside a real cloud token id); scoping by
+	 * `cloud` keeps a cloud-scoped read/delete from resolving the local id (and vice versa). Falls back to
+	 * the domain-only set when no variant matches, so legacy single-variant resolution is unchanged.
+	 */
+	private scopeConnectionCandidates(
+		id: IntegrationIds,
+		domain: string | undefined,
+		cloud: boolean | undefined,
+	): ConfiguredIntegrationDescriptor[] | undefined {
+		const candidates = this.configured.get(id)?.filter(c => c.domain === domain);
+		if (cloud == null || candidates == null) return candidates;
+
+		const scoped = candidates.filter(c => c.cloud === cloud);
+		return scoped.length ? scoped : candidates;
 	}
 
 	/**

--- a/packages/plus/integrations/src/authentication/configuredIntegrationService.ts
+++ b/packages/plus/integrations/src/authentication/configuredIntegrationService.ts
@@ -237,7 +237,7 @@ export class ConfiguredIntegrationService implements Disposable {
 		descriptor: IntegrationAuthenticationSessionDescriptor,
 	): Promise<ProviderAuthenticationSession | undefined> {
 		const sessionId = this.resolveConnectionId(id, descriptor);
-		let session = await this.readSecret(id, sessionId, false);
+		let session = descriptor.cloud === true ? undefined : await this.readSecret(id, sessionId, false);
 
 		let cloudIfMissing = false;
 		if (session != null) {
@@ -253,7 +253,7 @@ export class ConfiguredIntegrationService implements Disposable {
 		}
 
 		// If no local session we try to restore a session with the cloud key
-		if (session == null) {
+		if (session == null && descriptor.cloud !== false) {
 			cloudIfMissing = true;
 			session = await this.readSecret(id, sessionId, true);
 		}

--- a/packages/plus/integrations/src/authentication/configuredIntegrationService.ts
+++ b/packages/plus/integrations/src/authentication/configuredIntegrationService.ts
@@ -61,6 +61,10 @@ export class ConfiguredIntegrationService implements Disposable {
 
 				const descriptors = configured.map(d => ({
 					...d,
+					// Backfill a stable connection id for pre-multi-account stored data: the domain for
+					// self-managed hosts, or the provider's canonical domain for cloud (which is the legacy
+					// secret-key session id), so existing secrets keep resolving with zero migration.
+					id: d.id ?? d.domain ?? providersMetadata[id]?.domain ?? '',
 					expiresAt: d.expiresAt ? new Date(d.expiresAt) : undefined,
 				}));
 				this._configured.set(id, descriptors);
@@ -122,21 +126,43 @@ export class ConfiguredIntegrationService implements Disposable {
 
 	private async addOrUpdateConfigured(descriptor: ConfiguredIntegrationDescriptor): Promise<void> {
 		const descriptors = this.configured.get(descriptor.integrationId) ?? [];
-		const existing = descriptors.find(
-			d =>
-				d.domain === descriptor.domain &&
-				d.integrationId === descriptor.integrationId &&
-				d.cloud === descriptor.cloud,
-		);
+		// Key connections by their stable id (+ cloud, to preserve legacy local/cloud coexistence) so
+		// multiple accounts on the same provider+domain no longer overwrite each other.
+		const existing = descriptors.find(d => d.id === descriptor.id && d.cloud === descriptor.cloud);
+
+		// The first connection for a provider is primary by default; an explicit flag (or the existing
+		// value) always wins.
+		const primary = descriptor.primary ?? existing?.primary ?? !descriptors.some(d => d.primary);
+		// Preserve a previously-resolved type/accountName when the incoming write doesn't carry them (e.g.
+		// the model re-stores the primary session with an empty account, after reconcile enriched it).
+		const type = descriptor.type ?? existing?.type;
+		const accountName = descriptor.accountName ?? existing?.accountName;
+		const normalized: ConfiguredIntegrationDescriptor = {
+			...descriptor,
+			primary: primary,
+			type: type,
+			accountName: accountName,
+		};
 
 		let changed: boolean;
 		if (existing != null) {
-			if (existing.expiresAt === descriptor.expiresAt && existing.scopes === descriptor.scopes) {
+			if (
+				existing.domain === normalized.domain &&
+				existing.expiresAt === normalized.expiresAt &&
+				existing.scopes === normalized.scopes &&
+				(existing.primary ?? false) === (normalized.primary ?? false) &&
+				existing.type === normalized.type &&
+				existing.accountName === normalized.accountName
+			) {
 				return;
 			}
 
-			// Only fire the change event if the scopes changes (i.e. ignore any expiresAt changes)
-			changed = existing.scopes !== descriptor.scopes;
+			// Only fire the change event on domain/scopes/primary/accountName changes (ignore expiresAt/type churn)
+			changed =
+				existing.domain !== normalized.domain ||
+				existing.scopes !== normalized.scopes ||
+				(existing.primary ?? false) !== (normalized.primary ?? false) ||
+				existing.accountName !== normalized.accountName;
 
 			// remove the existing descriptor from the array
 			descriptors.splice(descriptors.indexOf(existing), 1);
@@ -144,7 +170,7 @@ export class ConfiguredIntegrationService implements Disposable {
 			changed = true;
 		}
 
-		descriptors.push(descriptor);
+		descriptors.push(normalized);
 		this.configured.set(descriptor.integrationId, descriptors);
 
 		if (changed) {
@@ -155,31 +181,39 @@ export class ConfiguredIntegrationService implements Disposable {
 
 	private async removeConfigured(
 		id: IntegrationIds,
-		options: { cloud: boolean | undefined; domain: string | undefined },
+		options: { connectionId: string; cloud: boolean | undefined },
 	): Promise<void> {
-		let changed = false;
-		const descriptors = [];
+		const existing = this.configured.get(id);
+		if (existing == null || existing.length === 0) return;
 
-		for (const d of this.configured.get(id) ?? []) {
+		let removedPrimary = false;
+		const descriptors: ConfiguredIntegrationDescriptor[] = [];
+		for (const d of existing) {
 			if (
-				d.domain === options.domain &&
+				d.id === options.connectionId &&
 				(options?.cloud == null ||
 					(options?.cloud === true && d.cloud === true) ||
 					(options?.cloud === false && d.cloud === false))
 			) {
-				changed = true;
+				if (d.primary) {
+					removedPrimary = true;
+				}
 				continue;
 			}
 
 			descriptors.push(d);
 		}
 
-		this.configured.set(id, descriptors);
+		if (descriptors.length === existing.length) return; // nothing matched
 
-		if (changed) {
-			this.fireChange(undefined, id);
+		// Promote a secondary to primary when the removed connection was the primary and others remain,
+		// so the provider stays in a well-defined connected state.
+		if (removedPrimary && descriptors.length && !descriptors.some(d => d.primary)) {
+			descriptors[0] = { ...descriptors[0], primary: true };
 		}
 
+		this.configured.set(id, descriptors);
+		this.fireChange(undefined, id);
 		await this.storeConfigured();
 	}
 
@@ -191,7 +225,7 @@ export class ConfiguredIntegrationService implements Disposable {
 		id: IntegrationIds,
 		descriptor: IntegrationAuthenticationSessionDescriptor,
 	): Promise<ProviderAuthenticationSession | undefined> {
-		const sessionId = this.getSessionId(descriptor);
+		const sessionId = this.resolveConnectionId(id, descriptor);
 		let session = await this.readSecret(id, sessionId, false);
 
 		let cloudIfMissing = false;
@@ -221,7 +255,7 @@ export class ConfiguredIntegrationService implements Disposable {
 		descriptor: IntegrationAuthenticationSessionDescriptor,
 		cloud?: boolean,
 	): Promise<void> {
-		await this.deleteSecrets(id, this.getSessionId(descriptor), cloud);
+		await this.deleteSecrets(id, this.resolveConnectionId(id, descriptor), cloud);
 	}
 
 	async deleteAllStoredSessions(id: IntegrationIds, cloud?: boolean): Promise<void> {
@@ -247,9 +281,9 @@ export class ConfiguredIntegrationService implements Disposable {
 			if (!(id in stored)) continue;
 
 			for (const descriptor of stored[id] ?? []) {
-				const sessionId = descriptor.domain ?? '';
-				await this.ctx.storage.deleteSecret(this.getLocalSecretKey(id as IntegrationIds, sessionId));
-				await this.ctx.storage.deleteSecret(this.getCloudSecretKey(id as IntegrationIds, sessionId));
+				const connectionId = descriptor.id ?? descriptor.domain ?? '';
+				await this.ctx.storage.deleteSecret(this.getLocalSecretKey(id as IntegrationIds, connectionId));
+				await this.ctx.storage.deleteSecret(this.getCloudSecretKey(id as IntegrationIds, connectionId));
 				if (descriptor.domain) {
 					await this.ctx.storage.deleteWorkspace(`connected:${id}:${descriptor.domain}`);
 				}
@@ -262,34 +296,32 @@ export class ConfiguredIntegrationService implements Disposable {
 		await this.ctx.storage.store('integrations:configured', remaining as StoredIntegrationConfigurations);
 	}
 
-	async deleteSecrets(id: IntegrationIds, sessionId: string, cloud?: boolean): Promise<void> {
+	async deleteSecrets(id: IntegrationIds, connectionId: string, cloud?: boolean): Promise<void> {
 		if (cloud == null || cloud === false) {
-			await this.ctx.storage.deleteSecret(this.getLocalSecretKey(id, sessionId));
+			await this.ctx.storage.deleteSecret(this.getLocalSecretKey(id, connectionId));
 		}
 
 		if (cloud == null || cloud === true) {
-			await this.ctx.storage.deleteSecret(this.getCloudSecretKey(id, sessionId));
+			await this.ctx.storage.deleteSecret(this.getCloudSecretKey(id, connectionId));
 		}
 
-		await this.removeConfigured(id, {
-			cloud: cloud,
-			domain: isGitSelfManagedHostIntegrationId(id) ? sessionId : undefined,
-		});
+		await this.removeConfigured(id, { connectionId: connectionId, cloud: cloud });
 	}
 
 	async deleteAllSecrets(id: IntegrationIds, cloud?: boolean): Promise<void> {
-		if (isGitSelfManagedHostIntegrationId(id)) {
-			// Hack because session IDs are tied to domain. Update this when session ids are different
-			const configuredDomains = this.configured.get(id)?.map(c => c.domain);
-			if (configuredDomains != null) {
-				for (const domain of configuredDomains) {
-					await this.deleteSecrets(id, domain!, cloud);
-				}
+		// Delete every connection's secret (multi-account): secrets are keyed per connection id, so a
+		// single canonical-domain delete would orphan secondary tokens.
+		const connectionIds = [...new Set(this.configured.get(id)?.map(c => c.id))];
+		if (connectionIds.length) {
+			for (const connectionId of connectionIds) {
+				await this.deleteSecrets(id, connectionId, cloud);
 			}
 
 			return;
 		}
 
+		// No configured connections (e.g. an orphaned secret with no descriptor): fall back to the
+		// provider's canonical domain, which is the legacy session id for cloud providers.
 		await this.deleteSecrets(id, providersMetadata[id].domain, cloud);
 	}
 
@@ -300,11 +332,14 @@ export class ConfiguredIntegrationService implements Disposable {
 		);
 
 		await this.addOrUpdateConfigured({
+			id: session.id,
 			integrationId: id,
 			domain: isGitSelfManagedHostIntegrationId(id) ? session.domain : undefined,
 			expiresAt: session.expiresAt,
 			scopes: session.scopes.join(','),
 			cloud: session.cloud ?? false,
+			type: session.type,
+			accountName: session.account?.label || undefined,
 		});
 	}
 
@@ -320,18 +355,27 @@ export class ConfiguredIntegrationService implements Disposable {
 				storedSession = JSON.parse(sessionJSON);
 				if (storedSession != null) {
 					const configured = this.configured.get(id);
-					const domain = isGitSelfManagedHostIntegrationId(id) ? storedSession.id : undefined;
+					const connectionId = storedSession.id ?? sessionId;
+					const sessionCloud = storedSession.cloud ?? cloud;
+					const domain = isGitSelfManagedHostIntegrationId(id)
+						? (storedSession.domain ?? storedSession.id)
+						: undefined;
 					if (
 						configured == null ||
 						configured.length === 0 ||
-						!configured.some(c => c.domain === domain && c.integrationId === id)
+						!configured.some(
+							c => c.id === connectionId && c.integrationId === id && c.cloud === sessionCloud,
+						)
 					) {
 						await this.addOrUpdateConfigured({
+							id: connectionId,
 							integrationId: id,
 							domain: domain,
 							expiresAt: storedSession.expiresAt,
 							scopes: storedSession.scopes.join(','),
-							cloud: storedSession.cloud ?? false,
+							cloud: sessionCloud,
+							type: storedSession.type,
+							accountName: storedSession.account?.label || undefined,
 						});
 					}
 				}
@@ -363,8 +407,54 @@ export class ConfiguredIntegrationService implements Disposable {
 		return `integration.auth.cloud:${id}|${sessionId}`;
 	}
 
-	getSessionId(descriptor: IntegrationAuthenticationSessionDescriptor): string {
-		return descriptor.domain;
+	/**
+	 * Resolves the connection id used as the secret-key session id for an auth descriptor.
+	 * - If the descriptor targets a specific connection (`connectionId`), that wins.
+	 * - Otherwise returns the primary connection's id for the provider (matching the descriptor's domain
+	 *   for self-managed hosts; any connection for cloud hosts, where the stored domain is undefined).
+	 * - Falls back to the descriptor domain when nothing is configured yet, preserving legacy
+	 *   (pre-multi-account) reads with zero secret migration.
+	 */
+	resolveConnectionId(id: IntegrationIds, descriptor: IntegrationAuthenticationSessionDescriptor): string {
+		if (descriptor.connectionId != null) return descriptor.connectionId;
+
+		const domain = isGitSelfManagedHostIntegrationId(id) ? descriptor.domain : undefined;
+		const candidates = this.configured.get(id)?.filter(c => c.domain === domain);
+		return (candidates?.find(c => c.primary) ?? candidates?.[0])?.id ?? descriptor.domain;
+	}
+
+	/**
+	 * Marks the given connection as the primary/default for the provider and clears the flag on its
+	 * siblings. Persists immediately instead of relying on a session re-store to carry the primary flag.
+	 */
+	async setPrimaryConnection(id: IntegrationIds, connectionId: string): Promise<void> {
+		const descriptors = this.configured.get(id);
+		if (descriptors == null || descriptors.length === 0) return;
+		if (!descriptors.some(d => d.id === connectionId)) return;
+
+		let changed = false;
+		const updated = descriptors.map(d => {
+			const primary = d.id === connectionId;
+			if ((d.primary ?? false) === primary) return d;
+
+			changed = true;
+			return { ...d, primary: primary };
+		});
+		if (!changed) return;
+
+		this.configured.set(id, updated);
+		this.fireChange(id);
+		await this.storeConfigured();
+	}
+
+	/**
+	 * Removes a single connection (its secret + configured descriptor). If it was the primary and other
+	 * connections remain, a secondary is promoted (see {@link removeConfigured}). Unlike
+	 * {@link deleteAllStoredSessions}, this only affects the targeted connection. Pass `cloud` to scope
+	 * the removal to the cloud/local variant when a local PAT and a cloud session share a connection id.
+	 */
+	async deleteConnection(id: IntegrationIds, connectionId: string, cloud?: boolean): Promise<void> {
+		await this.deleteSecrets(id, connectionId, cloud);
 	}
 
 	private _addedIds = new Set<IntegrationIds>();

--- a/packages/plus/integrations/src/authentication/configuredIntegrationService.ts
+++ b/packages/plus/integrations/src/authentication/configuredIntegrationService.ts
@@ -356,8 +356,10 @@ export class ConfiguredIntegrationService implements Disposable {
 		if (domain != null) return;
 
 		// No configured connections (e.g. an orphaned secret with no descriptor): fall back to the
-		// provider's canonical domain, which is the legacy session id for cloud providers.
-		await this.deleteSecrets(id, providersMetadata[id].domain, cloud);
+		// provider's canonical domain, which is the legacy session id for cloud providers. Mirror the
+		// hydration backfill's `|| id` guard so a self-managed provider (empty canonical domain) doesn't
+		// target an ambiguous empty connection id.
+		await this.deleteSecrets(id, providersMetadata[id]?.domain || id, cloud);
 	}
 
 	async writeSecret(id: IntegrationIds, session: ProviderAuthenticationSession | StoredSession): Promise<void> {

--- a/packages/plus/integrations/src/authentication/configuredIntegrationService.ts
+++ b/packages/plus/integrations/src/authentication/configuredIntegrationService.ts
@@ -157,11 +157,12 @@ export class ConfiguredIntegrationService implements Disposable {
 				return;
 			}
 
-			// Only fire the change event on domain/scopes/primary/accountName changes (ignore expiresAt/type churn)
+			// Only fire the change event on domain/scopes/primary/type/accountName changes (ignore expiresAt churn)
 			changed =
 				existing.domain !== normalized.domain ||
 				existing.scopes !== normalized.scopes ||
 				(existing.primary ?? false) !== (normalized.primary ?? false) ||
+				existing.type !== normalized.type ||
 				existing.accountName !== normalized.accountName;
 
 			// remove the existing descriptor from the array

--- a/packages/plus/integrations/src/authentication/configuredIntegrationService.ts
+++ b/packages/plus/integrations/src/authentication/configuredIntegrationService.ts
@@ -63,8 +63,11 @@ export class ConfiguredIntegrationService implements Disposable {
 					...d,
 					// Backfill a stable connection id for pre-multi-account stored data: the domain for
 					// self-managed hosts, or the provider's canonical domain for cloud (which is the legacy
-					// secret-key session id), so existing secrets keep resolving with zero migration.
-					id: d.id ?? d.domain ?? providersMetadata[id]?.domain ?? '',
+					// secret-key session id), so existing secrets keep resolving with zero migration. Fall back
+					// to the integration id (never empty) when no domain is known — self-managed providers carry
+					// `domain: ''` in metadata, and an empty id would collide across connections and produce
+					// ambiguous secret keys (`...|`).
+					id: d.id || d.domain || providersMetadata[id]?.domain || id,
 					expiresAt: d.expiresAt ? new Date(d.expiresAt) : undefined,
 				}));
 				this._configured.set(id, descriptors);

--- a/packages/plus/integrations/src/authentication/configuredIntegrationService.ts
+++ b/packages/plus/integrations/src/authentication/configuredIntegrationService.ts
@@ -262,8 +262,8 @@ export class ConfiguredIntegrationService implements Disposable {
 		await this.deleteSecrets(id, this.resolveConnectionId(id, descriptor), cloud);
 	}
 
-	async deleteAllStoredSessions(id: IntegrationIds, cloud?: boolean): Promise<void> {
-		await this.deleteAllSecrets(id, cloud);
+	async deleteAllStoredSessions(id: IntegrationIds, cloud?: boolean, domain?: string): Promise<void> {
+		await this.deleteAllSecrets(id, cloud, domain);
 	}
 
 	/**
@@ -317,10 +317,14 @@ export class ConfiguredIntegrationService implements Disposable {
 		await this.removeConfigured(id, { connectionId: connectionId, cloud: cloud });
 	}
 
-	async deleteAllSecrets(id: IntegrationIds, cloud?: boolean): Promise<void> {
+	async deleteAllSecrets(id: IntegrationIds, cloud?: boolean, domain?: string): Promise<void> {
 		// Delete every connection's secret (multi-account): secrets are keyed per connection id, so a
-		// single canonical-domain delete would orphan secondary tokens.
-		const connectionIds = [...new Set(this.configured.get(id)?.map(c => c.id))];
+		// single canonical-domain delete would orphan secondary tokens. When a domain is given (self-managed
+		// disconnect of one host), scope to that host so other hosts under the same provider id survive.
+		const descriptors = this.configured.get(id);
+		const connectionIds = [
+			...new Set((domain != null ? descriptors?.filter(c => c.domain === domain) : descriptors)?.map(c => c.id)),
+		];
 		if (connectionIds.length) {
 			for (const connectionId of connectionIds) {
 				await this.deleteSecrets(id, connectionId, cloud);
@@ -328,6 +332,11 @@ export class ConfiguredIntegrationService implements Disposable {
 
 			return;
 		}
+
+		// A domain-scoped clear that matched nothing means this host has no stored connections, so it must be
+		// a no-op. The canonical-domain fallback below would target a bogus key (self-managed canonical domain
+		// is empty), so skip it.
+		if (domain != null) return;
 
 		// No configured connections (e.g. an orphaned secret with no descriptor): fall back to the
 		// provider's canonical domain, which is the legacy session id for cloud providers.

--- a/packages/plus/integrations/src/authentication/configuredIntegrationService.ts
+++ b/packages/plus/integrations/src/authentication/configuredIntegrationService.ts
@@ -133,9 +133,11 @@ export class ConfiguredIntegrationService implements Disposable {
 		// multiple accounts on the same provider+domain no longer overwrite each other.
 		const existing = descriptors.find(d => d.id === descriptor.id && d.cloud === descriptor.cloud);
 
-		// The first connection for a provider is primary by default; an explicit flag (or the existing
-		// value) always wins.
-		const primary = descriptor.primary ?? existing?.primary ?? !descriptors.some(d => d.primary);
+		// The first connection for a provider/domain is primary by default; an explicit flag (or the
+		// existing value) always wins. Self-managed providers can span multiple hosts under the same
+		// integration id, so each host needs its own primary.
+		const primaryScope = this.getPrimaryScope(descriptor.integrationId, descriptors, descriptor.domain);
+		const primary = descriptor.primary ?? existing?.primary ?? !primaryScope.some(d => d.primary);
 		// Preserve a previously-resolved type/accountName when the incoming write doesn't carry them (e.g.
 		// the model re-stores the primary session with an empty account, after reconcile enriched it).
 		const type = descriptor.type ?? existing?.type;
@@ -190,7 +192,7 @@ export class ConfiguredIntegrationService implements Disposable {
 		const existing = this.configured.get(id);
 		if (existing == null || existing.length === 0) return;
 
-		let removedPrimary = false;
+		const removedPrimaryDomains = new Set<string | undefined>();
 		const descriptors: ConfiguredIntegrationDescriptor[] = [];
 		for (const d of existing) {
 			if (
@@ -200,7 +202,7 @@ export class ConfiguredIntegrationService implements Disposable {
 					(options?.cloud === false && d.cloud === false))
 			) {
 				if (d.primary) {
-					removedPrimary = true;
+					removedPrimaryDomains.add(d.domain);
 				}
 				continue;
 			}
@@ -210,10 +212,15 @@ export class ConfiguredIntegrationService implements Disposable {
 
 		if (descriptors.length === existing.length) return; // nothing matched
 
-		// Promote a secondary to primary when the removed connection was the primary and others remain,
-		// so the provider stays in a well-defined connected state.
-		if (removedPrimary && descriptors.length && !descriptors.some(d => d.primary)) {
-			descriptors[0] = { ...descriptors[0], primary: true };
+		// Promote a secondary to primary when the removed connection was the primary and others remain
+		// in the same primary scope, so the provider/host stays in a well-defined connected state.
+		for (const domain of removedPrimaryDomains) {
+			if (descriptors.some(d => this.isInPrimaryScope(id, d, domain) && d.primary)) continue;
+
+			const index = descriptors.findIndex(d => this.isInPrimaryScope(id, d, domain));
+			if (index !== -1) {
+				descriptors[index] = { ...descriptors[index], primary: true };
+			}
 		}
 
 		this.configured.set(id, descriptors);
@@ -425,6 +432,24 @@ export class ConfiguredIntegrationService implements Disposable {
 		return `integration.auth.cloud:${id}|${sessionId}`;
 	}
 
+	private getPrimaryScope(
+		id: IntegrationIds,
+		descriptors: ConfiguredIntegrationDescriptor[],
+		domain: string | undefined,
+	): ConfiguredIntegrationDescriptor[] {
+		return isGitSelfManagedHostIntegrationId(id)
+			? descriptors.filter(d => this.isInPrimaryScope(id, d, domain))
+			: descriptors;
+	}
+
+	private isInPrimaryScope(
+		id: IntegrationIds,
+		descriptor: ConfiguredIntegrationDescriptor,
+		domain: string | undefined,
+	): boolean {
+		return !isGitSelfManagedHostIntegrationId(id) || descriptor.domain === domain;
+	}
+
 	/**
 	 * Resolves the connection id used as the secret-key session id for an auth descriptor.
 	 * - If the descriptor targets a specific connection (`connectionId`), that wins.
@@ -452,14 +477,22 @@ export class ConfiguredIntegrationService implements Disposable {
 		if (descriptors == null || descriptors.length === 0) return;
 		if (!descriptors.some(d => d.id === connectionId)) return;
 
+		const target =
+			descriptors.find(d => d.id === connectionId && d.cloud) ?? descriptors.find(d => d.id === connectionId);
+		if (target == null) return;
+
+		const domain = isGitSelfManagedHostIntegrationId(id) ? target.domain : undefined;
 		// A connection id can have both a local (PAT) and cloud descriptor. Mark the primary on a single
-		// canonical variant (prefer cloud, since multi-account primaries are cloud-driven) so the
-		// "exactly one primary" invariant holds; readers key off the connection id, which is identical
-		// across variants, and getStoredSession keeps its own local-then-cloud precedence.
-		const primaryIsCloud = descriptors.some(d => d.id === connectionId && d.cloud);
+		// canonical variant (prefer cloud, since multi-account primaries are cloud-driven) within the
+		// provider/host scope, so other self-managed hosts keep their own default connection.
+		const primaryIsCloud = descriptors.some(
+			d => d.id === connectionId && d.cloud && this.isInPrimaryScope(id, d, domain),
+		);
 
 		let changed = false;
 		const updated = descriptors.map(d => {
+			if (!this.isInPrimaryScope(id, d, domain)) return d;
+
 			const primary = d.id === connectionId && (d.cloud ?? false) === primaryIsCloud;
 			if ((d.primary ?? false) === primary) return d;
 

--- a/packages/plus/integrations/src/authentication/configuredIntegrationService.ts
+++ b/packages/plus/integrations/src/authentication/configuredIntegrationService.ts
@@ -434,7 +434,9 @@ export class ConfiguredIntegrationService implements Disposable {
 	 *   (pre-multi-account) reads with zero secret migration.
 	 */
 	resolveConnectionId(id: IntegrationIds, descriptor: IntegrationAuthenticationSessionDescriptor): string {
-		if (descriptor.connectionId != null) return descriptor.connectionId;
+		// An empty connectionId is not a real target — treat it as "no target" so it resolves the primary
+		// rather than keying a secret under an empty id.
+		if (descriptor.connectionId) return descriptor.connectionId;
 
 		const domain = isGitSelfManagedHostIntegrationId(id) ? descriptor.domain : undefined;
 		const candidates = this.configured.get(id)?.filter(c => c.domain === domain);

--- a/packages/plus/integrations/src/authentication/configuredIntegrationService.ts
+++ b/packages/plus/integrations/src/authentication/configuredIntegrationService.ts
@@ -285,7 +285,12 @@ export class ConfiguredIntegrationService implements Disposable {
 			if (!(id in stored)) continue;
 
 			for (const descriptor of stored[id] ?? []) {
-				const connectionId = descriptor.id ?? descriptor.domain ?? '';
+				// Mirror the hydration backfill so the secret keys we delete match what was written: fall back
+				// through domain, the provider's canonical domain, then the integration id (never empty). A
+				// legacy cloud descriptor stored neither id nor domain, so an empty connection id here would
+				// miss the canonical-domain secret (e.g. `integration.auth.cloud:github|github.com`) and orphan it.
+				const connectionId =
+					descriptor.id || descriptor.domain || providersMetadata[id as IntegrationIds]?.domain || id;
 				await this.ctx.storage.deleteSecret(this.getLocalSecretKey(id as IntegrationIds, connectionId));
 				await this.ctx.storage.deleteSecret(this.getCloudSecretKey(id as IntegrationIds, connectionId));
 				if (descriptor.domain) {

--- a/packages/plus/integrations/src/authentication/configuredIntegrationService.ts
+++ b/packages/plus/integrations/src/authentication/configuredIntegrationService.ts
@@ -265,8 +265,9 @@ export class ConfiguredIntegrationService implements Disposable {
 		id: IntegrationIds,
 		descriptor: IntegrationAuthenticationSessionDescriptor,
 		cloud?: boolean,
+		options?: { preserveConfigured?: boolean },
 	): Promise<void> {
-		await this.deleteSecrets(id, this.resolveConnectionId(id, descriptor), cloud);
+		await this.deleteSecrets(id, this.resolveConnectionId(id, descriptor), cloud, options);
 	}
 
 	async deleteAllStoredSessions(id: IntegrationIds, cloud?: boolean, domain?: string): Promise<void> {
@@ -312,7 +313,12 @@ export class ConfiguredIntegrationService implements Disposable {
 		await this.ctx.storage.store('integrations:configured', remaining as StoredIntegrationConfigurations);
 	}
 
-	async deleteSecrets(id: IntegrationIds, connectionId: string, cloud?: boolean): Promise<void> {
+	async deleteSecrets(
+		id: IntegrationIds,
+		connectionId: string,
+		cloud?: boolean,
+		options?: { preserveConfigured?: boolean },
+	): Promise<void> {
 		if (cloud == null || cloud === false) {
 			await this.ctx.storage.deleteSecret(this.getLocalSecretKey(id, connectionId));
 		}
@@ -320,6 +326,8 @@ export class ConfiguredIntegrationService implements Disposable {
 		if (cloud == null || cloud === true) {
 			await this.ctx.storage.deleteSecret(this.getCloudSecretKey(id, connectionId));
 		}
+
+		if (options?.preserveConfigured) return;
 
 		await this.removeConfigured(id, { connectionId: connectionId, cloud: cloud });
 	}
@@ -330,7 +338,9 @@ export class ConfiguredIntegrationService implements Disposable {
 		// disconnect of one host), scope to that host so other hosts under the same provider id survive.
 		const descriptors = this.configured.get(id);
 		const connectionIds = [
-			...new Set((domain != null ? descriptors?.filter(c => c.domain === domain) : descriptors)?.map(c => c.id)),
+			...new Set(
+				(domain != null ? descriptors?.filter(c => c.domain === domain) : descriptors)?.map(c => c.id) ?? [],
+			),
 		];
 		if (connectionIds.length) {
 			for (const connectionId of connectionIds) {

--- a/packages/plus/integrations/src/authentication/configuredIntegrationService.ts
+++ b/packages/plus/integrations/src/authentication/configuredIntegrationService.ts
@@ -441,9 +441,15 @@ export class ConfiguredIntegrationService implements Disposable {
 		if (descriptors == null || descriptors.length === 0) return;
 		if (!descriptors.some(d => d.id === connectionId)) return;
 
+		// A connection id can have both a local (PAT) and cloud descriptor. Mark the primary on a single
+		// canonical variant (prefer cloud, since multi-account primaries are cloud-driven) so the
+		// "exactly one primary" invariant holds; readers key off the connection id, which is identical
+		// across variants, and getStoredSession keeps its own local-then-cloud precedence.
+		const primaryIsCloud = descriptors.some(d => d.id === connectionId && d.cloud);
+
 		let changed = false;
 		const updated = descriptors.map(d => {
-			const primary = d.id === connectionId;
+			const primary = d.id === connectionId && (d.cloud ?? false) === primaryIsCloud;
 			if ((d.primary ?? false) === primary) return d;
 
 			changed = true;

--- a/packages/plus/integrations/src/authentication/integrationAuthenticationProvider.ts
+++ b/packages/plus/integrations/src/authentication/integrationAuthenticationProvider.ts
@@ -36,6 +36,13 @@ export interface IntegrationAuthenticationSessionDescriptor {
 }
 
 export interface IntegrationAuthenticationProvider extends Disposable {
+	/**
+	 * Clears the stored secret for one connection only (never the whole provider). Unlike
+	 * {@link deleteAllSessions}, this deliberately leaves the descriptor in `integrations:configured` — its
+	 * only caller today is a forced re-sync, which needs `getConfigured()` to keep reporting the connection
+	 * while a fresh session is fetched to replace the deleted secret. Implementers should not treat this as
+	 * a full disconnect.
+	 */
 	deleteSession(descriptor: IntegrationAuthenticationSessionDescriptor): Promise<void>;
 	deleteAllSessions(descriptor?: IntegrationAuthenticationSessionDescriptor): Promise<void>;
 	getSession(
@@ -75,9 +82,15 @@ abstract class IntegrationAuthenticationProviderBase<
 			domain: domain,
 		});
 
-		await this.configuredIntegrationService.deleteStoredSessions(this.authProviderId, descriptor, true, {
-			preserveConfigured: true,
-		});
+		// Scope the descriptor to cloud so resolveConnectionId targets the cloud variant's id: this is a
+		// cloud-only delete, and a mixed local+cloud connection whose local descriptor is primary would
+		// otherwise resolve the local id and leave the cloud secret intact.
+		await this.configuredIntegrationService.deleteStoredSessions(
+			this.authProviderId,
+			{ ...descriptor, cloud: true },
+			true,
+			{ preserveConfigured: true },
+		);
 
 		if (configured?.length) {
 			this.fireChange();
@@ -110,7 +123,13 @@ abstract class IntegrationAuthenticationProviderBase<
 		let session;
 		let previousToken;
 		if (options?.forceNewSession) {
-			await this.configuredIntegrationService.deleteStoredSessions(this.authProviderId, descriptor, true);
+			// Cloud-only delete (see deleteSession): scope to cloud so the cloud variant's id is cleared even
+			// when a mixed local+cloud connection's local descriptor is primary.
+			await this.configuredIntegrationService.deleteStoredSessions(
+				this.authProviderId,
+				{ ...descriptor, cloud: true },
+				true,
+			);
 		} else {
 			session = await this.configuredIntegrationService.getStoredSession(
 				this.authProviderId,

--- a/packages/plus/integrations/src/authentication/integrationAuthenticationProvider.ts
+++ b/packages/plus/integrations/src/authentication/integrationAuthenticationProvider.ts
@@ -35,7 +35,7 @@ export interface IntegrationAuthenticationSessionDescriptor {
 
 export interface IntegrationAuthenticationProvider extends Disposable {
 	deleteSession(descriptor: IntegrationAuthenticationSessionDescriptor): Promise<void>;
-	deleteAllSessions(): Promise<void>;
+	deleteAllSessions(descriptor?: IntegrationAuthenticationSessionDescriptor): Promise<void>;
 	getSession(
 		descriptor: IntegrationAuthenticationSessionDescriptor,
 		options?:
@@ -81,12 +81,16 @@ abstract class IntegrationAuthenticationProviderBase<
 	}
 
 	@trace()
-	async deleteAllSessions(): Promise<void> {
+	async deleteAllSessions(descriptor?: IntegrationAuthenticationSessionDescriptor): Promise<void> {
+		// Self-managed providers group every host under one provider id, so scope the clear to this
+		// descriptor's host when given; for cloud providers the domain stays undefined here, clearing every account.
+		const domain = isGitSelfManagedHostIntegrationId(this.authProviderId) ? descriptor?.domain : undefined;
 		const configured = this.configuredIntegrationService.getConfigured(this.authProviderId, {
 			cloud: true,
+			domain: domain,
 		});
 
-		await this.configuredIntegrationService.deleteAllStoredSessions(this.authProviderId, undefined);
+		await this.configuredIntegrationService.deleteAllStoredSessions(this.authProviderId, undefined, domain);
 
 		if (configured?.length) {
 			this.fireChange();

--- a/packages/plus/integrations/src/authentication/integrationAuthenticationProvider.ts
+++ b/packages/plus/integrations/src/authentication/integrationAuthenticationProvider.ts
@@ -259,7 +259,11 @@ export class CloudIntegrationAuthenticationProvider<
 		const connectionId =
 			descriptor.connectionId ??
 			(isGitSelfManagedHostIntegrationId(this.authProviderId)
-				? this.configuredIntegrationService.getConfiguredConnectionId(this.authProviderId, descriptor.domain)
+				? this.configuredIntegrationService.getConfiguredConnectionId(
+						this.authProviderId,
+						descriptor.domain,
+						true,
+					)
 				: undefined);
 		let session = await cloudIntegrations.getConnectionSession(this.authProviderId, undefined, connectionId);
 

--- a/packages/plus/integrations/src/authentication/integrationAuthenticationProvider.ts
+++ b/packages/plus/integrations/src/authentication/integrationAuthenticationProvider.ts
@@ -24,6 +24,8 @@ export interface IntegrationAuthenticationProviderDescriptor {
 export interface IntegrationAuthenticationSessionDescriptor {
 	domain: string;
 	scopes: string[];
+	/** When set, reads/deletes only the matching storage variant. */
+	cloud?: boolean;
 	/**
 	 * Targets a specific connection when a provider has multiple accounts connected. When omitted,
 	 * operations resolve to the provider's primary connection (see
@@ -73,7 +75,7 @@ abstract class IntegrationAuthenticationProviderBase<
 			domain: domain,
 		});
 
-		await this.configuredIntegrationService.deleteStoredSessions(this.authProviderId, descriptor, undefined, {
+		await this.configuredIntegrationService.deleteStoredSessions(this.authProviderId, descriptor, true, {
 			preserveConfigured: true,
 		});
 
@@ -108,9 +110,12 @@ abstract class IntegrationAuthenticationProviderBase<
 		let session;
 		let previousToken;
 		if (options?.forceNewSession) {
-			await this.configuredIntegrationService.deleteStoredSessions(this.authProviderId, descriptor, undefined);
+			await this.configuredIntegrationService.deleteStoredSessions(this.authProviderId, descriptor, true);
 		} else {
-			session = await this.configuredIntegrationService.getStoredSession(this.authProviderId, descriptor);
+			session = await this.configuredIntegrationService.getStoredSession(
+				this.authProviderId,
+				options?.sync ? { ...descriptor, cloud: true } : descriptor,
+			);
 			previousToken = session?.accessToken;
 		}
 

--- a/packages/plus/integrations/src/authentication/integrationAuthenticationProvider.ts
+++ b/packages/plus/integrations/src/authentication/integrationAuthenticationProvider.ts
@@ -68,12 +68,14 @@ abstract class IntegrationAuthenticationProviderBase<
 
 	@trace()
 	async deleteSession(descriptor: IntegrationAuthenticationSessionDescriptor): Promise<void> {
+		const domain = isGitSelfManagedHostIntegrationId(this.authProviderId) ? descriptor?.domain : undefined;
 		const configured = this.configuredIntegrationService.getConfigured(this.authProviderId, {
-			cloud: true,
-			domain: isGitSelfManagedHostIntegrationId(this.authProviderId) ? descriptor?.domain : undefined,
+			domain: domain,
 		});
 
-		await this.configuredIntegrationService.deleteStoredSessions(this.authProviderId, descriptor, undefined);
+		await this.configuredIntegrationService.deleteStoredSessions(this.authProviderId, descriptor, undefined, {
+			preserveConfigured: true,
+		});
 
 		if (configured?.length) {
 			this.fireChange();
@@ -86,7 +88,6 @@ abstract class IntegrationAuthenticationProviderBase<
 		// descriptor's host when given; for cloud providers the domain stays undefined here, clearing every account.
 		const domain = isGitSelfManagedHostIntegrationId(this.authProviderId) ? descriptor?.domain : undefined;
 		const configured = this.configuredIntegrationService.getConfigured(this.authProviderId, {
-			cloud: true,
 			domain: domain,
 		});
 

--- a/packages/plus/integrations/src/authentication/integrationAuthenticationProvider.ts
+++ b/packages/plus/integrations/src/authentication/integrationAuthenticationProvider.ts
@@ -24,6 +24,12 @@ export interface IntegrationAuthenticationProviderDescriptor {
 export interface IntegrationAuthenticationSessionDescriptor {
 	domain: string;
 	scopes: string[];
+	/**
+	 * Targets a specific connection when a provider has multiple accounts connected. When omitted,
+	 * operations resolve to the provider's primary connection (see
+	 * {@link ConfiguredIntegrationService.resolveConnectionId}).
+	 */
+	connectionId?: string;
 	[key: string]: unknown;
 }
 
@@ -235,7 +241,11 @@ export class CloudIntegrationAuthenticationProvider<
 		if (!loggedIn) return undefined;
 
 		const cloudIntegrations = this.authenticationService.cloudIntegrations;
-		let session = await cloudIntegrations.getConnectionSession(this.authProviderId);
+		let session = await cloudIntegrations.getConnectionSession(
+			this.authProviderId,
+			undefined,
+			descriptor.connectionId,
+		);
 
 		// Make an exception for GitHub and Cloud Self-Hosted integrations because they always return 0
 		if (
@@ -248,7 +258,11 @@ export class CloudIntegrationAuthenticationProvider<
 		}
 
 		if (session != null && session.expiresIn < 60) {
-			session = await cloudIntegrations.getConnectionSession(this.authProviderId, session.accessToken);
+			session = await cloudIntegrations.getConnectionSession(
+				this.authProviderId,
+				session.accessToken,
+				descriptor.connectionId,
+			);
 		}
 
 		if (!session) return undefined;
@@ -263,7 +277,9 @@ export class CloudIntegrationAuthenticationProvider<
 
 		// TODO: Once we care about domains, we should try to match the domain here against ours, and if it fails, return undefined
 		return {
-			id: this.configuredIntegrationService.getSessionId(descriptor),
+			// Prefer the backend's per-connection token id (multi-account); fall back to the resolved
+			// primary/legacy connection id so existing single-connection storage keys are preserved.
+			id: session.id ?? this.configuredIntegrationService.resolveConnectionId(this.authProviderId, descriptor),
 			accessToken: session.accessToken,
 			scopes: descriptor.scopes,
 			account: {

--- a/packages/plus/integrations/src/authentication/integrationAuthenticationProvider.ts
+++ b/packages/plus/integrations/src/authentication/integrationAuthenticationProvider.ts
@@ -278,11 +278,14 @@ export class CloudIntegrationAuthenticationProvider<
 		if (!session) return undefined;
 
 		let sessionProtocol;
-		try {
-			sessionProtocol = new URL(session.domain).protocol;
-		} catch {
-			// If the domain is invalid, we can't use it to create a session
-			sessionProtocol = undefined;
+		// Only derive a protocol from a domain carrying an explicit scheme; a bare `host:port` (e.g. a
+		// self-managed `ghe.example.com:8443`) parses the host as the protocol, corrupting the value.
+		if (/^[a-z][a-z\d+\-.]*:\/\//i.test(session.domain)) {
+			try {
+				sessionProtocol = new URL(session.domain).protocol;
+			} catch {
+				sessionProtocol = undefined;
+			}
 		}
 
 		// TODO: Once we care about domains, we should try to match the domain here against ours, and if it fails, return undefined

--- a/packages/plus/integrations/src/authentication/integrationAuthenticationProvider.ts
+++ b/packages/plus/integrations/src/authentication/integrationAuthenticationProvider.ts
@@ -251,11 +251,17 @@ export class CloudIntegrationAuthenticationProvider<
 		if (!loggedIn) return undefined;
 
 		const cloudIntegrations = this.authenticationService.cloudIntegrations;
-		let session = await cloudIntegrations.getConnectionSession(
-			this.authProviderId,
-			undefined,
-			descriptor.connectionId,
-		);
+		// An unscoped descriptor (no explicit connectionId) would fetch the provider-global primary via
+		// `v1/provider-tokens/<provider>`. For a self-managed provider spanning multiple hosts that primary
+		// can belong to a different host, so a forced sync of host A would hydrate host B's token here (before
+		// reconcile corrects storage). Scope to this host's own configured connection when we have one; fall
+		// through to the provider-scoped path only when nothing is configured yet (legacy/first sync).
+		const connectionId =
+			descriptor.connectionId ??
+			(isGitSelfManagedHostIntegrationId(this.authProviderId)
+				? this.configuredIntegrationService.getConfiguredConnectionId(this.authProviderId, descriptor.domain)
+				: undefined);
+		let session = await cloudIntegrations.getConnectionSession(this.authProviderId, undefined, connectionId);
 
 		// Make an exception for GitHub and Cloud Self-Hosted integrations because they always return 0
 		if (
@@ -271,7 +277,7 @@ export class CloudIntegrationAuthenticationProvider<
 			session = await cloudIntegrations.getConnectionSession(
 				this.authProviderId,
 				session.accessToken,
-				descriptor.connectionId,
+				connectionId,
 			);
 		}
 

--- a/packages/plus/integrations/src/authentication/models.ts
+++ b/packages/plus/integrations/src/authentication/models.ts
@@ -80,6 +80,26 @@ export type TokenOptInfo<T extends IntegrationIds = IntegrationIds> =
 	| { providerId: T; accessToken?: undefined };
 
 export interface ConfiguredIntegrationDescriptor {
+	/**
+	 * Stable per-connection identifier, distinct from the domain, so multiple accounts can be
+	 * connected to the same provider+domain simultaneously. For legacy/migrated single connections
+	 * this is the domain (self-managed) or the provider's canonical domain (cloud), which keeps the
+	 * existing secret key (`integration.auth[.cloud]:{id}|{domain}`) valid with zero migration.
+	 */
+	readonly id: string;
+	/**
+	 * Whether this is the connection used by default for the provider. Optional: when no descriptor
+	 * for a provider+domain carries an explicit flag, the first one is treated as primary. Only
+	 * {@link ConfiguredIntegrationService.setPrimaryConnection} sets the flag (and clears it on siblings).
+	 */
+	readonly primary?: boolean;
+	/** The connection's auth type (`oauth`/`pat`), when known. */
+	readonly type?: CloudIntegrationAuthType;
+	/**
+	 * Human-readable account handle for this connection (e.g. the GitHub login). Resolved from the
+	 * provider API (the token backend doesn't expose it); absent until resolved or if the lookup fails.
+	 */
+	readonly accountName?: string;
 	readonly cloud: boolean;
 	readonly integrationId: IntegrationIds;
 	readonly scopes: string;
@@ -93,6 +113,8 @@ export interface CloudIntegrationAuthenticationSession {
 	domain: string;
 	expiresIn: number;
 	scopes: string;
+	/** Backend per-connection token identifier, when the provider-tokens backend supports multi-account. */
+	id?: string;
 }
 
 export interface CloudIntegrationAuthorization {
@@ -103,6 +125,12 @@ export interface CloudIntegrationConnection {
 	type: CloudIntegrationAuthType;
 	provider: CloudIntegrationType;
 	domain: string;
+	/** Backend per-connection token identifier, when the provider-tokens backend supports multi-account. */
+	id?: string;
+	/** Whether the backend marks this connection as the primary/default for the provider. */
+	primary?: boolean;
+	/** Human-readable account handle, when the backend provides it on the connection (may be absent). */
+	accountName?: string;
 }
 
 export type CloudIntegrationType =

--- a/packages/plus/integrations/src/constants.ts
+++ b/packages/plus/integrations/src/constants.ts
@@ -1,3 +1,5 @@
+import type { CloudIntegrationAuthType } from './authentication/models.js';
+
 export enum GitCloudHostIntegrationId {
 	GitHub = 'github',
 	GitLab = 'gitlab',
@@ -82,6 +84,14 @@ export interface IntegrationDescriptor {
 
 /** Stored shape of a configured-integration descriptor in workspace state. */
 export interface StoredConfiguredIntegrationDescriptor {
+	/** Stable per-connection identifier. Backfilled from the domain for pre-multi-account stored data. */
+	id?: string;
+	/** Whether this is the primary/default connection for the provider. */
+	primary?: boolean;
+	/** The connection's auth type (`oauth`/`pat`), when known. */
+	type?: CloudIntegrationAuthType;
+	/** Human-readable account handle for this connection (e.g. the GitHub login), when resolved. */
+	accountName?: string;
 	cloud: boolean;
 	integrationId: IntegrationIds;
 	domain?: string;

--- a/packages/plus/integrations/src/index.ts
+++ b/packages/plus/integrations/src/index.ts
@@ -99,8 +99,14 @@ export type {
 export type {
 	AuthenticationSessionLike,
 	CloudIntegrationAuthType,
+	CloudIntegrationConnection,
+	CloudIntegrationType,
+	ConfiguredIntegrationDescriptor,
 	ProviderAuthenticationSession,
 } from './authentication/models.js';
+// Provider-id mapping helpers for consumers bridging their own provider ids to `IntegrationIds`
+// (e.g. mapping multi-account connections from `getConfigured` back to a provider) and vice versa.
+export { toCloudIntegrationType, toIntegrationId } from './authentication/models.js';
 
 // Convenience: wrap a static access token (env var, CLI flag, secret manager)
 // as an `IntegrationAuthenticationProvider`. For OAuth/refresh flows, implement

--- a/packages/plus/integrations/src/integrationService.ts
+++ b/packages/plus/integrations/src/integrationService.ts
@@ -203,14 +203,14 @@ export class IntegrationService implements Disposable {
 	/**
 	 * Starts the cloud connect flow without skipping an already-connected provider, allowing the host/GK Dev
 	 * flow to add another account for that provider instead of treating the existing primary as sufficient.
-	 * Returns whether a new connection was actually added (measured by the connection count growing), since
-	 * {@link connectCloudIntegrations}' boolean reasons at the provider level and can't detect a newly added
-	 * secondary for an already-connected provider.
+	 * Returns whether a new connection was actually added (measured by a new cloud connection id appearing),
+	 * since {@link connectCloudIntegrations}' boolean reasons at the provider level and can't detect a newly
+	 * added secondary for an already-connected provider.
 	 */
 	async connectSecondary(id: SupportedCloudIntegrationIds, source?: Source): Promise<boolean> {
-		const before = this.getConfigured(id).length;
+		const before = new Set(this.getConfigured(id, { cloud: true }).map(c => c.id));
 		await this.connectCloudIntegrations({ integrationIds: [id], skipIfConnected: false }, source);
-		return this.getConfigured(id).length > before;
+		return this.getConfigured(id, { cloud: true }).some(c => !before.has(c.id));
 	}
 
 	get(id: GitCloudHostIntegrationId): Promise<GitHostIntegration>;

--- a/packages/plus/integrations/src/integrationService.ts
+++ b/packages/plus/integrations/src/integrationService.ts
@@ -877,7 +877,7 @@ export class IntegrationService implements Disposable {
 	): AsyncIterable<Integration> {
 		for (const id of getSupportedCloudIntegrationIds()) {
 			if (isCloudGitSelfManagedHostIntegrationId(id)) {
-				const domains = new Set(domainsById.get(id));
+				const domains = new Set(domainsById.get(id) ?? []);
 				for (const domain of this.configuredIntegrationService
 					.getConfigured(id, { cloud: true })
 					.map(c => c.domain)
@@ -1133,10 +1133,12 @@ export class IntegrationService implements Disposable {
 		// backend id rollout); defer pruning to a later clean cycle. Deliberately skipped connections (local
 		// disconnects or invalid self-managed hosts) don't block pruning of unrelated stale descriptors.
 		// Scope deletes to cloud so a local PAT sharing the id survives.
+		const prunedDomains = new Set<string | undefined>();
 		if ([...syncEligibleIds].every(connectionId => syncedIds.has(connectionId))) {
 			const liveIds = new Set(identified.map(c => c.id));
 			for (const descriptor of this.configuredIntegrationService.getConfigured(id, { cloud: true })) {
 				if (!liveIds.has(descriptor.id)) {
+					prunedDomains.add(isGitSelfManagedHostIntegrationId(id) ? descriptor.domain : undefined);
 					await this.configuredIntegrationService.deleteConnection(id, descriptor.id, true);
 				}
 			}
@@ -1155,8 +1157,11 @@ export class IntegrationService implements Disposable {
 		for (const domain of primaryAfter.keys()) {
 			domains.add(domain);
 		}
+		for (const domain of prunedDomains) {
+			domains.add(domain);
+		}
 		for (const domain of domains) {
-			if (primaryBefore.get(domain) === primaryAfter.get(domain)) continue;
+			if (primaryBefore.get(domain) === primaryAfter.get(domain) && !prunedDomains.has(domain)) continue;
 
 			this.getCachedForDomain(id, domain)?.switchConnection();
 		}
@@ -1235,10 +1240,12 @@ function hostFromDomain(domain: string | undefined): string | undefined {
 	const value = domain?.trim();
 	if (!value) return undefined;
 
-	try {
-		return new URL(value).host || undefined;
-	} catch {
-		if (/^[a-z][a-z\d+\-.]*:\/\//i.test(value)) return undefined;
+	if (/^[a-z][a-z\d+\-.]*:\/\//i.test(value)) {
+		try {
+			return new URL(value).host || undefined;
+		} catch {
+			return undefined;
+		}
 	}
 
 	try {
@@ -1251,6 +1258,7 @@ function hostFromDomain(domain: string | undefined): string | undefined {
 function protocolFromDomain(domain: string | undefined): string | undefined {
 	const value = domain?.trim();
 	if (!value) return undefined;
+	if (!/^[a-z][a-z\d+\-.]*:\/\//i.test(value)) return undefined;
 
 	try {
 		return new URL(value).protocol || undefined;

--- a/packages/plus/integrations/src/integrationService.ts
+++ b/packages/plus/integrations/src/integrationService.ts
@@ -17,7 +17,11 @@ import type {
 	ConfiguredIntegrationService,
 } from './authentication/configuredIntegrationService.js';
 import type { IntegrationAuthenticationService } from './authentication/integrationAuthenticationService.js';
-import type { ConfiguredIntegrationDescriptor } from './authentication/models.js';
+import type {
+	CloudIntegrationConnection,
+	ConfiguredIntegrationDescriptor,
+	ProviderAuthenticationSession,
+} from './authentication/models.js';
 import {
 	getSupportedCloudIntegrationIds,
 	isSupportedCloudIntegrationId,
@@ -46,6 +50,7 @@ import type { IssuesIntegration } from './models/issuesIntegration.js';
 import type { ApiClients } from './providers/apiClients.js';
 import { createApiClients } from './providers/apiClients.js';
 import type { GitHubApi } from './providers/github/github.js';
+import { providersMetadata } from './providers/models.js';
 import type { ProvidersApi } from './providers/providersApi.js';
 import type { Source } from './telemetry.js';
 import {
@@ -65,6 +70,8 @@ export interface ConnectionStateChangeEvent {
 export interface IntegrationConnectionChangeEvent extends ConnectionStateChangeEvent {
 	integration: IntegrationBase;
 }
+
+const maxSmallIntegerV8 = 2 ** 30 - 1; // Max number that can be stored in V8's smis (small integers)
 
 export class IntegrationService implements Disposable {
 	get onDidChange(): Event<ConfiguredIntegrationsChangeEvent> {
@@ -224,7 +231,7 @@ export class IntegrationService implements Disposable {
 
 						const configured = this.getConfigured(GitSelfManagedHostIntegrationId.CloudGitHubEnterprise);
 						if (configured.length) {
-							const { domain: configuredDomain } = configured[0];
+							const { domain: configuredDomain } = configured.find(c => c.primary) ?? configured[0];
 							if (configuredDomain == null) throw new Error(`Domain is required for '${id}' integration`);
 
 							integration = new (
@@ -275,7 +282,7 @@ export class IntegrationService implements Disposable {
 
 						const configured = this.getConfigured(GitSelfManagedHostIntegrationId.CloudGitLabSelfHosted);
 						if (configured.length) {
-							const { domain: configuredDomain } = configured[0];
+							const { domain: configuredDomain } = configured.find(c => c.primary) ?? configured[0];
 							if (configuredDomain == null) throw new Error(`Domain is required for '${id}' integration`);
 
 							integration = new (
@@ -326,7 +333,7 @@ export class IntegrationService implements Disposable {
 
 						const configured = this.getConfigured(GitSelfManagedHostIntegrationId.BitbucketServer);
 						if (configured.length) {
-							const { domain: configuredDomain } = configured[0];
+							const { domain: configuredDomain } = configured.find(c => c.primary) ?? configured[0];
 							if (configuredDomain == null) throw new Error(`Domain is required for '${id}' integration`);
 
 							integration = new (
@@ -377,7 +384,7 @@ export class IntegrationService implements Disposable {
 
 						const configured = this.getConfigured(GitSelfManagedHostIntegrationId.AzureDevOpsServer);
 						if (configured.length) {
-							const { domain: configuredDomain } = configured[0];
+							const { domain: configuredDomain } = configured.find(c => c.primary) ?? configured[0];
 							if (configuredDomain == null) throw new Error(`Domain is required for '${id}' integration`);
 
 							integration = new (
@@ -870,7 +877,10 @@ export class IntegrationService implements Disposable {
 	}
 
 	private findCachedById<T extends IntegrationIds>(id: T): IntegrationById<T> | undefined {
-		const key = this.getCacheKey(id, '');
+		const cached = this._integrations.get(id as IntegrationKey);
+		if (cached != null) return cached as IntegrationById<T>;
+
+		const key = `${id}:`;
 		for (const [k, integration] of this._integrations) {
 			if (k.startsWith(key)) {
 				return integration as IntegrationById<T>;
@@ -885,27 +895,40 @@ export class IntegrationService implements Disposable {
 		const scope = getScopedLogger();
 		const connectedIntegrations = new Set<IntegrationIds>();
 		const domainsById = new Map<IntegrationIds, string>();
+		const connectionsById = new Map<IntegrationIds, CloudIntegrationConnection[]>();
 
 		const loggedIn = (await this.ctx.account.getAccount()) != null;
 		if (loggedIn) {
 			const connections = await this.authenticationService.cloudIntegrations.getConnections();
 			if (connections == null) return;
 
-			connections.map(p => {
+			for (const p of connections) {
 				const integrationId = toIntegrationId[p.provider];
 				// GKDev includes some integrations like "google" that we don't support
-				if (integrationId == null) return;
+				if (integrationId == null) continue;
 
-				connectedIntegrations.add(toIntegrationId[p.provider]);
+				connectedIntegrations.add(integrationId);
+
+				const list = connectionsById.get(integrationId);
+				if (list != null) {
+					list.push(p);
+				} else {
+					connectionsById.set(integrationId, [p]);
+				}
+
 				if (p.domain?.length > 0) {
 					try {
 						const host = new URL(p.domain).host;
-						domainsById.set(integrationId, host);
+						// The default integration instance tracks the primary connection's domain; fall back to
+						// the first connection when the backend doesn't flag a primary.
+						if (p.primary || !domainsById.has(integrationId)) {
+							domainsById.set(integrationId, host);
+						}
 					} catch {
 						scope?.warn(`Invalid domain for ${integrationId} integration: ${p.domain}. Ignoring.`);
 					}
 				}
-			});
+			}
 		}
 
 		for await (const integration of this.getSupportedCloudIntegrations(domainsById)) {
@@ -915,10 +938,207 @@ export class IntegrationService implements Disposable {
 			);
 		}
 
+		// Persist every account when the backend advertises per-connection identity (multi-account). This
+		// is a strict no-op for backends that return a single, id-less connection per provider.
+		for (const [integrationId, connections] of connectionsById) {
+			await this.reconcileCloudConnections(integrationId, connections);
+		}
+
 		this.ctx.hooks?.connection?.onConnectedChanged?.({
 			integrationIds: [...connectedIntegrations.values()],
 		});
 
 		return connectedIntegrations;
 	}
+
+	/**
+	 * Whether the user has locally disconnected this provider/host. Mirrors the integration model's
+	 * `connected:${key}` workspace flag (key = id for cloud, `${id}:${domain}` for self-managed), which is
+	 * set to `false` on a local disconnect and cleared on (re)connect.
+	 */
+	private isLocallyDisconnected(id: IntegrationIds, host: string | undefined): boolean {
+		const key = isGitSelfManagedHostIntegrationId(id) ? `connected:${id}:${host ?? ''}` : `connected:${id}`;
+		return this.ctx.storage.getWorkspace<boolean>(key) === false;
+	}
+
+	/**
+	 * Reconciles the locally stored connections for a provider with what the backend reports, so that
+	 * multiple accounts on the same provider coexist. Only engages when the backend provides
+	 * per-connection ids; otherwise the single-connection flow above already handled the primary.
+	 */
+	private async reconcileCloudConnections(
+		id: IntegrationIds,
+		connections: CloudIntegrationConnection[],
+	): Promise<void> {
+		const scope = getScopedLogger();
+
+		const identified = connections.filter((c): c is CloudIntegrationConnection & { id: string } => c.id != null);
+		if (identified.length === 0) return;
+
+		const cloudIntegrations = this.authenticationService.cloudIntegrations;
+
+		// Fetch + store each connection's session so getConfigured() reflects every account.
+		const syncedIds = new Set<string>();
+		for (const connection of identified) {
+			// The wire `domain` is a full URL; self-managed integrations are keyed/constructed by host.
+			const host = hostFromDomain(connection.domain);
+
+			// Don't resurrect a connection the user disconnected locally: a host "disconnect" only clears
+			// local state (the backend still lists the token), so without this the next non-forced sync would
+			// re-store the secret/config. A forced reconnect clears this flag (in the sync loop above) before
+			// reconcile runs, so it proceeds normally.
+			if (this.isLocallyDisconnected(id, host)) continue;
+
+			try {
+				const session = await cloudIntegrations.getConnectionSession(id, undefined, connection.id);
+				if (session == null) continue;
+
+				let providerSession = toProviderSession(id, connection, session, host);
+
+				// Resolve a human-readable account handle with the same precedence as the gk CLI:
+				// (1) the value the backend put on the connection, (2) a previously-resolved name cached in
+				// our configured store (keyed by connection id), (3) a live provider-API lookup. This keeps
+				// provider round-trips to the first sight of a connection; degrade to undefined on failure.
+				const existing = this.configuredIntegrationService
+					.getConfigured(id, { cloud: true })
+					.find(c => c.id === connection.id);
+				const accountName =
+					connection.accountName ??
+					existing?.accountName ??
+					(await this.resolveAccountName(id, host, providerSession));
+				if (accountName != null) {
+					providerSession = {
+						...providerSession,
+						account: { ...providerSession.account, label: accountName },
+					};
+				}
+
+				await this.configuredIntegrationService.storeSession(id, providerSession);
+				syncedIds.add(connection.id);
+			} catch (ex) {
+				scope?.warn(`Failed to sync connection '${connection.id}' for ${id}: ${ex.message}`);
+			}
+		}
+
+		// Prune stored cloud connections that no longer exist on the backend — but only when every backend
+		// connection synced this cycle. Otherwise a transient token fetch failure would delete a still-valid
+		// connection with no replacement (e.g. a legacy single connection during the backend id rollout);
+		// defer pruning to a later clean cycle. Scope deletes to cloud so a local PAT sharing the id survives.
+		if (syncedIds.size === identified.length) {
+			const liveIds = new Set(identified.map(c => c.id));
+			for (const descriptor of this.configuredIntegrationService.getConfigured(id, { cloud: true })) {
+				if (!liveIds.has(descriptor.id)) {
+					await this.configuredIntegrationService.deleteConnection(id, descriptor.id, true);
+				}
+			}
+		}
+
+		// Apply the backend's primary selection and refresh any warm model so it picks up the new primary.
+		const primary = identified.find(c => c.primary);
+		if (primary != null) {
+			await this.configuredIntegrationService.setPrimaryConnection(id, primary.id);
+		}
+		this.findCachedById(id)?.switchConnection();
+	}
+
+	/**
+	 * Switches the default connection for a provider to `connectionId` (its backend token id). Performs
+	 * the server-side primary switch first, then mirrors it locally and refreshes any warm model. Throws
+	 * if the backend switch fails so the caller can surface it (local state stays untouched).
+	 */
+	async setPrimaryConnection(id: IntegrationIds, connectionId: string): Promise<void> {
+		if (!(await this.authenticationService.cloudIntegrations.setPrimaryConnection(id, connectionId))) {
+			throw new Error(`Failed to set primary connection '${connectionId}' for '${id}'`);
+		}
+
+		await this.configuredIntegrationService.setPrimaryConnection(id, connectionId);
+		this.findCachedById(id)?.switchConnection();
+	}
+
+	/**
+	 * Removes a single connection for a provider by its backend token id. The backend removes the
+	 * connection (auto-promoting a secondary to primary when the removed one was primary); we then mirror
+	 * that locally and refresh any warm model. Unlike {@link IntegrationBase.disconnect}, this targets one
+	 * account. This always talks to the cloud backend, so the local mirror defaults to cloud-scoped too —
+	 * pass `cloud: false` only if a caller genuinely needs to also drop a local PAT sharing the same id.
+	 * Throws if the backend delete fails so the caller can surface it (local state stays untouched).
+	 */
+	async deleteConnection(id: IntegrationIds, connectionId: string, cloud: boolean = true): Promise<void> {
+		if (!(await this.authenticationService.cloudIntegrations.disconnectConnection(id, connectionId))) {
+			throw new Error(`Failed to delete connection '${connectionId}' for '${id}'`);
+		}
+
+		await this.configuredIntegrationService.deleteConnection(id, connectionId, cloud);
+		this.findCachedById(id)?.switchConnection();
+	}
+
+	/**
+	 * Resolves a human-readable account handle (e.g. the GitHub login) for a connection by asking the
+	 * provider API with that connection's token. The token backend doesn't expose it. Routes through the
+	 * integration model so the correct provider API base URL (incl. self-managed domains) and auth type
+	 * are used. Best-effort: returns undefined on any failure so callers degrade gracefully.
+	 */
+	private async resolveAccountName(
+		id: IntegrationIds,
+		host: string | undefined,
+		session: ProviderAuthenticationSession,
+	): Promise<string | undefined> {
+		const scope = getScopedLogger();
+		try {
+			// Route through the integration so the correct provider API base URL (incl. the self-managed
+			// host) and auth type are used. Cloud providers ignore the host.
+			const integration = await this.get(id, host);
+			const account = await integration?.getProviderAccountForSession(session);
+			return account?.username ?? account?.name ?? undefined;
+		} catch (ex) {
+			scope?.warn(`Failed to resolve account name for '${id}': ${ex.message}`);
+			return undefined;
+		}
+	}
+
+	/**
+	 * Forces a refresh of connected cloud integrations from the backend (equivalent to a "--sync" list),
+	 * reconciling local state (multi-account connections, primary flags, account names) so a subsequent
+	 * {@link getConfigured} reflects the latest server-side connections. Intended for consumers that need
+	 * an up-to-date connection list on demand.
+	 */
+	async refreshConnections(): Promise<void> {
+		await this.syncCloudIntegrations(true);
+	}
+}
+
+/** Extracts the host from a backend connection domain (a full URL); undefined when unparseable/empty. */
+function hostFromDomain(domain: string | undefined): string | undefined {
+	if (!domain) return undefined;
+
+	try {
+		return new URL(domain).host;
+	} catch {
+		return undefined;
+	}
+}
+
+function toProviderSession(
+	id: IntegrationIds,
+	connection: CloudIntegrationConnection & { id: string },
+	session: { accessToken: string; expiresIn: number; scopes: string; type: CloudIntegrationConnection['type'] },
+	host: string | undefined,
+): ProviderAuthenticationSession {
+	const expiresIn =
+		session.expiresIn === 0 &&
+		(id === GitCloudHostIntegrationId.GitHub || isCloudGitSelfManagedHostIntegrationId(id))
+			? maxSmallIntegerV8
+			: session.expiresIn;
+
+	return {
+		id: connection.id,
+		accessToken: session.accessToken,
+		account: { id: '', label: '' },
+		scopes: session.scopes ? session.scopes.split(',') : [],
+		cloud: true,
+		type: session.type,
+		expiresAt: new Date(expiresIn * 1000 + Date.now()),
+		// Self-managed connections are keyed by their host; cloud providers use the canonical domain.
+		domain: isGitSelfManagedHostIntegrationId(id) ? (host ?? '') : (providersMetadata[id]?.domain ?? ''),
+	};
 }

--- a/packages/plus/integrations/src/integrationService.ts
+++ b/packages/plus/integrations/src/integrationService.ts
@@ -1067,6 +1067,12 @@ export class IntegrationService implements Disposable {
 		const syncedIds = new Set<string>();
 		const syncEligibleIds = new Set<string>();
 		const syncedPrimaryIdsByDomain = new Map<string | undefined, string>();
+		// Snapshot existing cloud descriptors by id once, so the per-connection account-name lookup below is
+		// O(1) instead of re-filtering the whole configured list each iteration (O(n²) with multi-account).
+		// Each backend connection id is processed once, so reading the pre-loop snapshot is sufficient.
+		const existingById = new Map(
+			this.configuredIntegrationService.getConfigured(id, { cloud: true }).map(c => [c.id, c]),
+		);
 		for (const connection of identified) {
 			// The wire `domain` is usually a full URL, though cloud providers can return a bare host.
 			// Self-managed integrations are keyed/constructed by host.
@@ -1098,9 +1104,7 @@ export class IntegrationService implements Disposable {
 				// (1) the value the backend put on the connection, (2) a previously-resolved name cached in
 				// our configured store (keyed by connection id), (3) a live provider-API lookup. This keeps
 				// provider round-trips to the first sight of a connection; degrade to undefined on failure.
-				const existing = this.configuredIntegrationService
-					.getConfigured(id, { cloud: true })
-					.find(c => c.id === connection.id);
+				const existing = existingById.get(connection.id);
 				const accountName =
 					normalizeAccountName(connection.accountName) ??
 					normalizeAccountName(existing?.accountName) ??

--- a/packages/plus/integrations/src/integrationService.ts
+++ b/packages/plus/integrations/src/integrationService.ts
@@ -988,6 +988,13 @@ export class IntegrationService implements Disposable {
 		const identified = connections.filter((c): c is CloudIntegrationConnection & { id: string } => c.id != null);
 		if (identified.length === 0) return;
 
+		// Capture the effective primary before any mutation (sync store, prune-driven promotion, or the
+		// backend primary selection below) so we can tell whether it actually changed. The prune step can
+		// promote a secondary to primary via removeConfigured, so sampling this after pruning would miss it.
+		const primaryBefore = this.configuredIntegrationService
+			.getConfigured(id, { cloud: true })
+			.find(c => c.primary)?.id;
+
 		const cloudIntegrations = this.authenticationService.cloudIntegrations;
 
 		// Fetch + store each connection's session so getConfigured() reflects every account.
@@ -1057,12 +1064,20 @@ export class IntegrationService implements Disposable {
 			}
 		}
 
-		// Apply the backend's primary selection and refresh any warm model so it picks up the new primary.
+		// Apply the backend's primary selection, then refresh any warm model only when the effective primary
+		// actually changed (vs the pre-reconcile value captured above). switchConnection() drops the in-memory
+		// session and fires change events, so calling it on every check-in (when the primary is unchanged)
+		// causes needless churn for multi-account providers.
 		const primary = identified.find(c => c.primary);
 		if (primary != null) {
 			await this.configuredIntegrationService.setPrimaryConnection(id, primary.id);
 		}
-		this.findCachedById(id)?.switchConnection();
+		const primaryAfter = this.configuredIntegrationService
+			.getConfigured(id, { cloud: true })
+			.find(c => c.primary)?.id;
+		if (primaryBefore !== primaryAfter) {
+			this.findCachedById(id)?.switchConnection();
+		}
 	}
 
 	/**

--- a/packages/plus/integrations/src/integrationService.ts
+++ b/packages/plus/integrations/src/integrationService.ts
@@ -200,6 +200,19 @@ export class IntegrationService implements Disposable {
 		return true;
 	}
 
+	/**
+	 * Starts the cloud connect flow without skipping an already-connected provider, allowing the host/GK Dev
+	 * flow to add another account for that provider instead of treating the existing primary as sufficient.
+	 * Returns whether a new connection was actually added (measured by the connection count growing), since
+	 * {@link connectCloudIntegrations}' boolean reasons at the provider level and can't detect a newly added
+	 * secondary for an already-connected provider.
+	 */
+	async connectSecondary(id: SupportedCloudIntegrationIds, source?: Source): Promise<boolean> {
+		const before = this.getConfigured(id).length;
+		await this.connectCloudIntegrations({ integrationIds: [id], skipIfConnected: false }, source);
+		return this.getConfigured(id).length > before;
+	}
+
 	get(id: GitCloudHostIntegrationId): Promise<GitHostIntegration>;
 	get(id: IssuesCloudHostIntegrationId): Promise<IssuesIntegration>;
 	get(

--- a/packages/plus/integrations/src/integrationService.ts
+++ b/packages/plus/integrations/src/integrationService.ts
@@ -877,14 +877,12 @@ export class IntegrationService implements Disposable {
 	): AsyncIterable<Integration> {
 		for (const id of getSupportedCloudIntegrationIds()) {
 			if (isCloudGitSelfManagedHostIntegrationId(id)) {
-				let domains = domainsById.get(id);
-				if (domains == null || domains.size === 0) {
-					domains = new Set(
-						this.configuredIntegrationService
-							.getConfigured(id, { cloud: true })
-							.map(c => c.domain)
-							.filter((domain): domain is string => domain != null && domain.length > 0),
-					);
+				const domains = new Set(domainsById.get(id));
+				for (const domain of this.configuredIntegrationService
+					.getConfigured(id, { cloud: true })
+					.map(c => c.domain)
+					.filter((domain): domain is string => domain != null && domain.length > 0)) {
+					domains.add(domain);
 				}
 
 				if (domains.size !== 0) {
@@ -912,6 +910,18 @@ export class IntegrationService implements Disposable {
 				yield integration;
 			}
 		}
+	}
+
+	private getCloudConnectionState(
+		integration: Integration,
+		connectedIntegrations: Set<IntegrationIds>,
+		domainsById: Map<IntegrationIds, Set<string>>,
+	): 'connected' | 'disconnected' {
+		if (isCloudGitSelfManagedHostIntegrationId(integration.id)) {
+			return domainsById.get(integration.id)?.has(integration.domain) ? 'connected' : 'disconnected';
+		}
+
+		return connectedIntegrations.has(integration.id) ? 'connected' : 'disconnected';
 	}
 
 	private findCachedById<T extends IntegrationIds>(id: T): IntegrationById<T> | undefined {
@@ -1004,7 +1014,7 @@ export class IntegrationService implements Disposable {
 
 		for await (const integration of this.getSupportedCloudIntegrations(domainsById)) {
 			await integration.syncCloudConnection(
-				connectedIntegrations.has(integration.id) ? 'connected' : 'disconnected',
+				this.getCloudConnectionState(integration, connectedIntegrations, domainsById),
 				forceConnect,
 			);
 		}

--- a/packages/plus/integrations/src/integrationService.ts
+++ b/packages/plus/integrations/src/integrationService.ts
@@ -1029,6 +1029,7 @@ export class IntegrationService implements Disposable {
 
 		// Fetch + store each connection's session so getConfigured() reflects every account.
 		const syncedIds = new Set<string>();
+		const syncEligibleIds = new Set<string>();
 		const syncedPrimaryIdsByDomain = new Map<string | undefined, string>();
 		for (const connection of identified) {
 			// The wire `domain` is usually a full URL, though cloud providers can return a bare host.
@@ -1050,6 +1051,7 @@ export class IntegrationService implements Disposable {
 			// reconcile runs, so it proceeds normally.
 			if (this.isLocallyDisconnected(id, host)) continue;
 
+			syncEligibleIds.add(connection.id);
 			try {
 				const session = await cloudIntegrations.getConnectionSession(id, undefined, connection.id);
 				if (session == null) continue;
@@ -1090,10 +1092,12 @@ export class IntegrationService implements Disposable {
 		}
 
 		// Prune stored cloud connections that no longer exist on the backend — but only when every backend
-		// connection synced this cycle. Otherwise a transient token fetch failure would delete a still-valid
-		// connection with no replacement (e.g. a legacy single connection during the backend id rollout);
-		// defer pruning to a later clean cycle. Scope deletes to cloud so a local PAT sharing the id survives.
-		if (syncedIds.size === identified.length) {
+		// connection that should sync did sync this cycle. Otherwise a transient token fetch failure would
+		// delete a still-valid connection with no replacement (e.g. a legacy single connection during the
+		// backend id rollout); defer pruning to a later clean cycle. Deliberately skipped connections (local
+		// disconnects or invalid self-managed hosts) don't block pruning of unrelated stale descriptors.
+		// Scope deletes to cloud so a local PAT sharing the id survives.
+		if ([...syncEligibleIds].every(connectionId => syncedIds.has(connectionId))) {
 			const liveIds = new Set(identified.map(c => c.id));
 			for (const descriptor of this.configuredIntegrationService.getConfigured(id, { cloud: true })) {
 				if (!liveIds.has(descriptor.id)) {

--- a/packages/plus/integrations/src/integrationService.ts
+++ b/packages/plus/integrations/src/integrationService.ts
@@ -996,6 +996,15 @@ export class IntegrationService implements Disposable {
 			// The wire `domain` is a full URL; self-managed integrations are keyed/constructed by host.
 			const host = hostFromDomain(connection.domain);
 
+			// Self-managed connections are keyed by host, so an unparseable/empty domain would store the
+			// session and descriptor under an empty host — producing ambiguous keys (`connected:<id>:`) that
+			// break later resolution and local-disconnect checks. Skip such a connection rather than corrupt
+			// state; cloud providers key off their canonical domain and are unaffected.
+			if (isGitSelfManagedHostIntegrationId(id) && !host) {
+				scope?.warn(`Skipping connection '${connection.id}' for ${id}: unresolved host from domain`);
+				continue;
+			}
+
 			// Don't resurrect a connection the user disconnected locally: a host "disconnect" only clears
 			// local state (the backend still lists the token), so without this the next non-forced sync would
 			// re-store the secret/config. A forced reconnect clears this flag (in the sync loop above) before
@@ -1029,7 +1038,9 @@ export class IntegrationService implements Disposable {
 				await this.configuredIntegrationService.storeSession(id, providerSession);
 				syncedIds.add(connection.id);
 			} catch (ex) {
-				scope?.warn(`Failed to sync connection '${connection.id}' for ${id}: ${ex.message}`);
+				scope?.warn(
+					`Failed to sync connection '${connection.id}' for ${id}: ${ex instanceof Error ? ex.message : String(ex)}`,
+				);
 			}
 		}
 
@@ -1104,7 +1115,7 @@ export class IntegrationService implements Disposable {
 			const account = await integration?.getProviderAccountForSession(session);
 			return account?.username ?? account?.name ?? undefined;
 		} catch (ex) {
-			scope?.warn(`Failed to resolve account name for '${id}': ${ex.message}`);
+			scope?.warn(`Failed to resolve account name for '${id}': ${ex instanceof Error ? ex.message : String(ex)}`);
 			return undefined;
 		}
 	}

--- a/packages/plus/integrations/src/integrationService.ts
+++ b/packages/plus/integrations/src/integrationService.ts
@@ -204,8 +204,8 @@ export class IntegrationService implements Disposable {
 	 * Starts the cloud connect flow without skipping an already-connected provider, allowing the host/GK Dev
 	 * flow to add another account for that provider instead of treating the existing primary as sufficient.
 	 * Returns whether a new connection was actually added (measured by a new cloud connection id appearing),
-	 * since {@link connectCloudIntegrations}' boolean reasons at the provider level and can't detect a newly
-	 * added secondary for an already-connected provider.
+	 * since {@link connectCloudIntegrations} only reports provider-level success and can't detect a newly added
+	 * secondary for an already-connected provider.
 	 */
 	async connectSecondary(id: SupportedCloudIntegrationIds, source?: Source): Promise<boolean> {
 		const before = new Set(this.getConfigured(id, { cloud: true }).map(c => c.id));

--- a/packages/plus/integrations/src/integrationService.ts
+++ b/packages/plus/integrations/src/integrationService.ts
@@ -902,6 +902,38 @@ export class IntegrationService implements Disposable {
 		return undefined;
 	}
 
+	private getCachedForDomain<T extends IntegrationIds>(id: T, domain?: string): IntegrationById<T> | undefined {
+		return isGitSelfManagedHostIntegrationId(id) ? this.getCached(id, domain) : this.findCachedById(id);
+	}
+
+	private getConfiguredConnectionDomain(id: IntegrationIds, connectionId: string): string | undefined {
+		if (!isGitSelfManagedHostIntegrationId(id)) return undefined;
+		return this.configuredIntegrationService.getConfigured(id).find(c => c.id === connectionId)?.domain;
+	}
+
+	private getCloudPrimaryConnectionIdsByDomain(id: IntegrationIds): Map<string | undefined, string> {
+		const primaryByDomain = new Map<string | undefined, string>();
+		const fallbackByDomain = new Map<string | undefined, string>();
+
+		for (const descriptor of this.configuredIntegrationService.getConfigured(id, { cloud: true })) {
+			const domain = isGitSelfManagedHostIntegrationId(id) ? descriptor.domain : undefined;
+			if (!fallbackByDomain.has(domain)) {
+				fallbackByDomain.set(domain, descriptor.id);
+			}
+			if (descriptor.primary && !primaryByDomain.has(domain)) {
+				primaryByDomain.set(domain, descriptor.id);
+			}
+		}
+
+		for (const [domain, connectionId] of fallbackByDomain) {
+			if (!primaryByDomain.has(domain)) {
+				primaryByDomain.set(domain, connectionId);
+			}
+		}
+
+		return primaryByDomain;
+	}
+
 	@gate()
 	@trace()
 	private async syncCloudIntegrations(forceConnect: boolean) {
@@ -991,14 +1023,13 @@ export class IntegrationService implements Disposable {
 		// Capture the effective primary before any mutation (sync store, prune-driven promotion, or the
 		// backend primary selection below) so we can tell whether it actually changed. The prune step can
 		// promote a secondary to primary via removeConfigured, so sampling this after pruning would miss it.
-		const primaryBefore = this.configuredIntegrationService
-			.getConfigured(id, { cloud: true })
-			.find(c => c.primary)?.id;
+		const primaryBefore = this.getCloudPrimaryConnectionIdsByDomain(id);
 
 		const cloudIntegrations = this.authenticationService.cloudIntegrations;
 
 		// Fetch + store each connection's session so getConfigured() reflects every account.
 		const syncedIds = new Set<string>();
+		const syncedPrimaryIdsByDomain = new Map<string | undefined, string>();
 		for (const connection of identified) {
 			// The wire `domain` is usually a full URL, though cloud providers can return a bare host.
 			// Self-managed integrations are keyed/constructed by host.
@@ -1045,6 +1076,12 @@ export class IntegrationService implements Disposable {
 
 				await this.configuredIntegrationService.storeSession(id, providerSession);
 				syncedIds.add(connection.id);
+				if (connection.primary) {
+					const domain = isGitSelfManagedHostIntegrationId(id) ? host : undefined;
+					if (!syncedPrimaryIdsByDomain.has(domain)) {
+						syncedPrimaryIdsByDomain.set(domain, connection.id);
+					}
+				}
 			} catch (ex) {
 				scope?.warn(
 					`Failed to sync connection '${connection.id}' for ${id}: ${ex instanceof Error ? ex.message : String(ex)}`,
@@ -1068,16 +1105,20 @@ export class IntegrationService implements Disposable {
 		// Apply the backend's primary selection, then refresh any warm model only when the effective primary
 		// actually changed (vs the pre-reconcile value captured above). switchConnection() drops the in-memory
 		// session and fires change events, so calling it on every check-in (when the primary is unchanged)
-		// causes needless churn for multi-account providers.
-		const primary = identified.find(c => c.primary);
-		if (primary != null) {
-			await this.configuredIntegrationService.setPrimaryConnection(id, primary.id);
+		// causes needless churn for multi-account providers. Self-managed providers can have one primary per
+		// host, so apply and refresh by host scope rather than by provider id alone.
+		for (const connectionId of syncedPrimaryIdsByDomain.values()) {
+			await this.configuredIntegrationService.setPrimaryConnection(id, connectionId);
 		}
-		const primaryAfter = this.configuredIntegrationService
-			.getConfigured(id, { cloud: true })
-			.find(c => c.primary)?.id;
-		if (primaryBefore !== primaryAfter) {
-			this.findCachedById(id)?.switchConnection();
+		const primaryAfter = this.getCloudPrimaryConnectionIdsByDomain(id);
+		const domains = new Set<string | undefined>(primaryBefore.keys());
+		for (const domain of primaryAfter.keys()) {
+			domains.add(domain);
+		}
+		for (const domain of domains) {
+			if (primaryBefore.get(domain) === primaryAfter.get(domain)) continue;
+
+			this.getCachedForDomain(id, domain)?.switchConnection();
 		}
 	}
 
@@ -1087,12 +1128,13 @@ export class IntegrationService implements Disposable {
 	 * if the backend switch fails so the caller can surface it (local state stays untouched).
 	 */
 	async setPrimaryConnection(id: IntegrationIds, connectionId: string): Promise<void> {
+		const domain = this.getConfiguredConnectionDomain(id, connectionId);
 		if (!(await this.authenticationService.cloudIntegrations.setPrimaryConnection(id, connectionId))) {
 			throw new Error(`Failed to set primary connection '${connectionId}' for '${id}'`);
 		}
 
 		await this.configuredIntegrationService.setPrimaryConnection(id, connectionId);
-		this.findCachedById(id)?.switchConnection();
+		this.getCachedForDomain(id, domain)?.switchConnection();
 	}
 
 	/**
@@ -1104,12 +1146,13 @@ export class IntegrationService implements Disposable {
 	 * Throws if the backend delete fails so the caller can surface it (local state stays untouched).
 	 */
 	async deleteConnection(id: IntegrationIds, connectionId: string, cloud: boolean = true): Promise<void> {
+		const domain = this.getConfiguredConnectionDomain(id, connectionId);
 		if (!(await this.authenticationService.cloudIntegrations.disconnectConnection(id, connectionId))) {
 			throw new Error(`Failed to delete connection '${connectionId}' for '${id}'`);
 		}
 
 		await this.configuredIntegrationService.deleteConnection(id, connectionId, cloud);
-		this.findCachedById(id)?.switchConnection();
+		this.getCachedForDomain(id, domain)?.switchConnection();
 	}
 
 	/**

--- a/packages/plus/integrations/src/integrationService.ts
+++ b/packages/plus/integrations/src/integrationService.ts
@@ -1238,6 +1238,17 @@ function hostFromDomain(domain: string | undefined): string | undefined {
 	}
 }
 
+function protocolFromDomain(domain: string | undefined): string | undefined {
+	const value = domain?.trim();
+	if (!value) return undefined;
+
+	try {
+		return new URL(value).protocol || undefined;
+	} catch {
+		return undefined;
+	}
+}
+
 function toProviderSession(
 	id: IntegrationIds,
 	connection: CloudIntegrationConnection & { id: string },
@@ -1249,6 +1260,7 @@ function toProviderSession(
 		(id === GitCloudHostIntegrationId.GitHub || isCloudGitSelfManagedHostIntegrationId(id))
 			? maxSmallIntegerV8
 			: session.expiresIn;
+	const protocol = protocolFromDomain(connection.domain);
 
 	return {
 		id: connection.id,
@@ -1260,5 +1272,6 @@ function toProviderSession(
 		expiresAt: new Date(expiresIn * 1000 + Date.now()),
 		// Self-managed connections are keyed by their host; cloud providers use the canonical domain.
 		domain: isGitSelfManagedHostIntegrationId(id) ? (host ?? '') : (providersMetadata[id]?.domain ?? ''),
+		...(protocol != null ? { protocol: protocol } : {}),
 	};
 }

--- a/packages/plus/integrations/src/integrationService.ts
+++ b/packages/plus/integrations/src/integrationService.ts
@@ -930,14 +930,14 @@ export class IntegrationService implements Disposable {
 				}
 
 				if (p.domain?.length > 0) {
-					try {
-						const host = new URL(p.domain).host;
+					const host = hostFromDomain(p.domain);
+					if (host != null) {
 						// The default integration instance tracks the primary connection's domain; fall back to
 						// the first connection when the backend doesn't flag a primary.
 						if (p.primary || !domainsById.has(integrationId)) {
 							domainsById.set(integrationId, host);
 						}
-					} catch {
+					} else {
 						scope?.warn(`Invalid domain for ${integrationId} integration: ${p.domain}. Ignoring.`);
 					}
 				}
@@ -1000,7 +1000,8 @@ export class IntegrationService implements Disposable {
 		// Fetch + store each connection's session so getConfigured() reflects every account.
 		const syncedIds = new Set<string>();
 		for (const connection of identified) {
-			// The wire `domain` is a full URL; self-managed integrations are keyed/constructed by host.
+			// The wire `domain` is usually a full URL, though cloud providers can return a bare host.
+			// Self-managed integrations are keyed/constructed by host.
 			const host = hostFromDomain(connection.domain);
 
 			// Self-managed connections are keyed by host, so an unparseable/empty domain would store the
@@ -1146,12 +1147,19 @@ export class IntegrationService implements Disposable {
 	}
 }
 
-/** Extracts the host from a backend connection domain (a full URL); undefined when unparseable/empty. */
+/** Extracts the host from a backend connection domain (URL or bare host); undefined when unparseable/empty. */
 function hostFromDomain(domain: string | undefined): string | undefined {
-	if (!domain) return undefined;
+	const value = domain?.trim();
+	if (!value) return undefined;
 
 	try {
-		return new URL(domain).host;
+		return new URL(value).host || undefined;
+	} catch {
+		if (/^[a-z][a-z\d+\-.]*:\/\//i.test(value)) return undefined;
+	}
+
+	try {
+		return new URL(`https://${value}`).host || undefined;
 	} catch {
 		return undefined;
 	}

--- a/packages/plus/integrations/src/integrationService.ts
+++ b/packages/plus/integrations/src/integrationService.ts
@@ -1022,7 +1022,7 @@ export class IntegrationService implements Disposable {
 		// Persist every account when the backend advertises per-connection identity (multi-account). This
 		// is a strict no-op for backends that return a single, id-less connection per provider.
 		for (const [integrationId, connections] of connectionsById) {
-			await this.reconcileCloudConnections(integrationId, connections);
+			await this.reconcileCloudConnections(integrationId, connections, forceConnect);
 		}
 
 		this.ctx.hooks?.connection?.onConnectedChanged?.({
@@ -1050,6 +1050,7 @@ export class IntegrationService implements Disposable {
 	private async reconcileCloudConnections(
 		id: IntegrationIds,
 		connections: CloudIntegrationConnection[],
+		forceConnect: boolean,
 	): Promise<void> {
 		const scope = getScopedLogger();
 
@@ -1094,6 +1095,24 @@ export class IntegrationService implements Disposable {
 			if (this.isLocallyDisconnected(id, host)) continue;
 
 			syncEligibleIds.add(connection.id);
+
+			// On a routine (non-forced) check-in, skip the token fetch + secret write for a connection we
+			// already have stored and that hasn't expired: nothing to refresh, so avoid the extra GK API
+			// traffic and secret churn. Still treat it as synced (so it doesn't trip the prune guard) and
+			// record its primary below. Forced syncs, new connections, and expired tokens fall through and
+			// fetch as before.
+			const cached = existingById.get(connection.id);
+			if (!forceConnect && cached != null && !isDescriptorExpired(cached)) {
+				syncedIds.add(connection.id);
+				if (connection.primary) {
+					const domain = isGitSelfManagedHostIntegrationId(id) ? host : undefined;
+					if (!syncedPrimaryIdsByDomain.has(domain)) {
+						syncedPrimaryIdsByDomain.set(domain, connection.id);
+					}
+				}
+				continue;
+			}
+
 			try {
 				const session = await cloudIntegrations.getConnectionSession(id, undefined, connection.id);
 				if (session == null) continue;
@@ -1274,6 +1293,16 @@ function protocolFromDomain(domain: string | undefined): string | undefined {
 function normalizeAccountName(accountName: string | undefined): string | undefined {
 	const value = accountName?.trim();
 	return value ? value : undefined;
+}
+
+/**
+ * Whether a stored connection descriptor's token has expired. A missing `expiresAt` is treated as
+ * not-expired (non-expiring/legacy tokens, e.g. GitHub and self-managed cloud, carry no meaningful
+ * expiry), matching the session-expiry checks elsewhere.
+ */
+function isDescriptorExpired(descriptor: ConfiguredIntegrationDescriptor): boolean {
+	if (descriptor.expiresAt == null) return false;
+	return new Date(descriptor.expiresAt).getTime() < Date.now();
 }
 
 function toProviderSession(

--- a/packages/plus/integrations/src/integrationService.ts
+++ b/packages/plus/integrations/src/integrationService.ts
@@ -1102,8 +1102,8 @@ export class IntegrationService implements Disposable {
 					.getConfigured(id, { cloud: true })
 					.find(c => c.id === connection.id);
 				const accountName =
-					connection.accountName ??
-					existing?.accountName ??
+					normalizeAccountName(connection.accountName) ??
+					normalizeAccountName(existing?.accountName) ??
 					(await this.resolveAccountName(id, host, providerSession));
 				if (accountName != null) {
 					providerSession = {
@@ -1257,6 +1257,11 @@ function protocolFromDomain(domain: string | undefined): string | undefined {
 	} catch {
 		return undefined;
 	}
+}
+
+function normalizeAccountName(accountName: string | undefined): string | undefined {
+	const value = accountName?.trim();
+	return value ? value : undefined;
 }
 
 function toProviderSession(

--- a/packages/plus/integrations/src/integrationService.ts
+++ b/packages/plus/integrations/src/integrationService.ts
@@ -872,19 +872,44 @@ export class IntegrationService implements Disposable {
 		return isGitSelfManagedHostIntegrationId(id) ? (`${id}:${domain}` as const) : id;
 	}
 
-	private async *getSupportedCloudIntegrations(domainsById: Map<IntegrationIds, string>): AsyncIterable<Integration> {
+	private async *getSupportedCloudIntegrations(
+		domainsById: Map<IntegrationIds, Set<string>>,
+	): AsyncIterable<Integration> {
 		for (const id of getSupportedCloudIntegrationIds()) {
-			if (isCloudGitSelfManagedHostIntegrationId(id) && !domainsById.has(id)) {
-				// Try getting whatever we have now because we will need to disconnect
+			if (isCloudGitSelfManagedHostIntegrationId(id)) {
+				let domains = domainsById.get(id);
+				if (domains == null || domains.size === 0) {
+					domains = new Set(
+						this.configuredIntegrationService
+							.getConfigured(id, { cloud: true })
+							.map(c => c.domain)
+							.filter((domain): domain is string => domain != null && domain.length > 0),
+					);
+				}
+
+				if (domains.size !== 0) {
+					for (const domain of domains) {
+						const integration = await this.get(id, domain);
+						if (integration != null) {
+							yield integration;
+						}
+					}
+
+					continue;
+				}
+
+				// Try getting whatever we have now because we will need to disconnect.
 				const integration = await this.get(id, undefined);
 				if (integration != null) {
 					yield integration;
 				}
-			} else {
-				const integration = await this.get(id, domainsById.get(id));
-				if (integration != null) {
-					yield integration;
-				}
+
+				continue;
+			}
+
+			const integration = await this.get(id);
+			if (integration != null) {
+				yield integration;
 			}
 		}
 	}
@@ -939,7 +964,7 @@ export class IntegrationService implements Disposable {
 	private async syncCloudIntegrations(forceConnect: boolean) {
 		const scope = getScopedLogger();
 		const connectedIntegrations = new Set<IntegrationIds>();
-		const domainsById = new Map<IntegrationIds, string>();
+		const domainsById = new Map<IntegrationIds, Set<string>>();
 		const connectionsById = new Map<IntegrationIds, CloudIntegrationConnection[]>();
 
 		const loggedIn = (await this.ctx.account.getAccount()) != null;
@@ -964,11 +989,12 @@ export class IntegrationService implements Disposable {
 				if (p.domain?.length > 0) {
 					const host = hostFromDomain(p.domain);
 					if (host != null) {
-						// The default integration instance tracks the primary connection's domain; fall back to
-						// the first connection when the backend doesn't flag a primary.
-						if (p.primary || !domainsById.has(integrationId)) {
-							domainsById.set(integrationId, host);
+						let domains = domainsById.get(integrationId);
+						if (domains == null) {
+							domains = new Set<string>();
+							domainsById.set(integrationId, domains);
 						}
+						domains.add(host);
 					} else {
 						scope?.warn(`Invalid domain for ${integrationId} integration: ${p.domain}. Ignoring.`);
 					}

--- a/packages/plus/integrations/src/models/gitHostIntegration.ts
+++ b/packages/plus/integrations/src/models/gitHostIntegration.ts
@@ -699,28 +699,30 @@ export abstract class GitHostIntegration<
 		repo?: T,
 		cancellation?: AbortSignal,
 		silent?: boolean,
+		connectionId?: string,
 	): Promise<IntegrationResult<PullRequest[] | undefined>>;
 	async searchMyPullRequests(
 		repos?: T[],
 		cancellation?: AbortSignal,
 		silent?: boolean,
+		connectionId?: string,
 	): Promise<IntegrationResult<PullRequest[] | undefined>>;
 	@trace()
 	async searchMyPullRequests(
 		repos?: T | T[],
 		cancellation?: AbortSignal,
 		silent?: boolean,
+		connectionId?: string,
 	): Promise<IntegrationResult<PullRequest[] | undefined>> {
 		const scope = getScopedLogger();
-		const connected = this.maybeConnected ?? (await this.isConnected());
-		if (!connected) return undefined;
-
-		await this.refreshSessionIfExpired(scope);
+		// `connectionId` targets a specific account (multi-account); omitted reads the primary.
+		const session = await this.resolveReadSession(connectionId, scope);
+		if (session == null) return undefined;
 
 		const start = performance.now();
 		try {
 			const pullRequests = await this.searchProviderMyPullRequests(
-				this._session!,
+				session,
 				repos != null ? (Array.isArray(repos) ? repos : [repos]) : undefined,
 				cancellation,
 				silent,
@@ -750,27 +752,29 @@ export abstract class GitHostIntegration<
 		searchQuery: string,
 		repo?: T,
 		cancellation?: AbortSignal,
+		connectionId?: string,
 	): Promise<PullRequest[] | undefined>;
 	async searchPullRequests(
 		searchQuery: string,
 		repos?: T[],
 		cancellation?: AbortSignal,
+		connectionId?: string,
 	): Promise<PullRequest[] | undefined>;
 	@trace()
 	async searchPullRequests(
 		searchQuery: string,
 		repos?: T | T[],
 		cancellation?: AbortSignal,
+		connectionId?: string,
 	): Promise<PullRequest[] | undefined> {
 		const scope = getScopedLogger();
-		const connected = this.maybeConnected ?? (await this.isConnected());
-		if (!connected) return undefined;
-
-		await this.refreshSessionIfExpired(scope);
+		// `connectionId` targets a specific account (multi-account); omitted reads the primary.
+		const session = await this.resolveReadSession(connectionId, scope);
+		if (session == null) return undefined;
 
 		try {
 			const prs = await this.searchProviderPullRequests?.(
-				this._session!,
+				session,
 				searchQuery,
 				repos != null ? (Array.isArray(repos) ? repos : [repos]) : undefined,
 				cancellation,

--- a/packages/plus/integrations/src/models/integration.ts
+++ b/packages/plus/integrations/src/models/integration.ts
@@ -184,8 +184,11 @@ export abstract class IntegrationBase<
 		}
 
 		if (signOut) {
+			// Disconnecting a provider signs out of ALL its connected accounts (multi-account), not just the
+			// primary — otherwise secondary connections' secrets/config would be orphaned. Removing a single
+			// account is done via IntegrationService.deleteConnection instead.
 			const authProvider = await this.authenticationService.get(this.authProvider.id);
-			void authProvider.deleteSession(this.authProviderDescriptor);
+			void authProvider.deleteAllSessions();
 		}
 
 		this.resetRequestExceptionCount('all');
@@ -251,6 +254,19 @@ export abstract class IntegrationBase<
 	async reset(): Promise<void> {
 		await this.disconnect({ silent: true });
 		await this.ctx.storage.deleteWorkspace(this.connectedKey);
+	}
+
+	/**
+	 * Drops the in-memory session so the next access re-resolves it from storage. Used when the primary
+	 * connection changed underneath a warm integration (e.g. after `setPrimaryConnection`/
+	 * `deleteConnection`). Unlike {@link reset}/{@link disconnect}, it deletes nothing from storage.
+	 */
+	switchConnection(): void {
+		if (this._session === undefined) return;
+
+		this._session = undefined;
+		this._onDidChange.fire();
+		this.refresh();
 	}
 
 	private skippedNonCloudReported = false;
@@ -626,6 +642,15 @@ export abstract class IntegrationBase<
 		session: ProviderAuthenticationSession,
 		options?: { avatarSize?: number },
 	): Promise<Account | undefined>;
+
+	/**
+	 * Resolves the account for a specific session/token — including connections other than the current
+	 * primary (multi-account) — using this integration's provider API base URL and auth type. Returns
+	 * undefined when the provider doesn't support account lookup. Uncached (callers cache per connection).
+	 */
+	getProviderAccountForSession(session: ProviderAuthenticationSession): Promise<Account | undefined> {
+		return this.getProviderCurrentAccount?.(session) ?? Promise.resolve(undefined);
+	}
 
 	@trace()
 	async getPullRequest(resource: T, id: string): Promise<PullRequest | undefined> {

--- a/packages/plus/integrations/src/models/integration.ts
+++ b/packages/plus/integrations/src/models/integration.ts
@@ -312,9 +312,19 @@ export abstract class IntegrationBase<
 	switchConnection(): void {
 		if (this._session === undefined) return;
 
+		const wasConnected = this._session != null;
 		this._session = undefined;
 		this._onDidChange.fire();
-		this.refresh();
+		void this.refreshAfterSwitch(wasConnected);
+	}
+
+	private async refreshAfterSwitch(wasConnected: boolean): Promise<void> {
+		const session = await this.ensureSession({ createIfNeeded: false });
+		if (session != null || !wasConnected) return;
+
+		this._onDidChange.fire();
+		this.didChangeConnection?.fire({ integration: this, key: this.key, reason: 'disconnected' });
+		await this.providerOnDisconnect?.();
 	}
 
 	private skippedNonCloudReported = false;

--- a/packages/plus/integrations/src/models/integration.ts
+++ b/packages/plus/integrations/src/models/integration.ts
@@ -181,7 +181,7 @@ export abstract class IntegrationBase<
 			try {
 				const authProvider = await this.authenticationService.get(this.authProvider.id);
 				const session = await authProvider.getSession(
-					{ ...this.authProviderDescriptor, connectionId: connectionId },
+					{ ...this.authProviderDescriptor, connectionId: connectionId, cloud: true },
 					{ source: source },
 				);
 				return session ?? undefined;

--- a/packages/plus/integrations/src/models/integration.ts
+++ b/packages/plus/integrations/src/models/integration.ts
@@ -229,9 +229,12 @@ export abstract class IntegrationBase<
 		if (signOut) {
 			// Disconnecting a provider signs out of ALL its connected accounts (multi-account), not just the
 			// primary — otherwise secondary connections' secrets/config would be orphaned. Removing a single
-			// account is done via IntegrationService.deleteConnection instead.
+			// account is done via IntegrationService.deleteConnection instead. Pass this instance's descriptor
+			// so self-managed disconnects stay scoped to this host: those group every host under one provider
+			// id, so an unscoped clear would sign the user out of unrelated hosts. deleteAllSessions derives an
+			// undefined domain for cloud providers, so they still clear every account as intended.
 			const authProvider = await this.authenticationService.get(this.authProvider.id);
-			void authProvider.deleteAllSessions();
+			void authProvider.deleteAllSessions(this.authProviderDescriptor);
 		}
 
 		this.resetRequestExceptionCount('all');

--- a/packages/plus/integrations/src/models/integration.ts
+++ b/packages/plus/integrations/src/models/integration.ts
@@ -173,7 +173,9 @@ export abstract class IntegrationBase<
 			return undefined;
 		}
 
-		if (connectionId != null) {
+		// A truthy connectionId targets a specific account; an empty string is not a real target, so it falls
+		// through to the primary path below.
+		if (connectionId) {
 			// Degrade to "no results" on failure, matching the primary path (whose ensureSession/
 			// refreshSessionIfExpired swallow errors) so read methods keep their never-throws contract.
 			try {

--- a/packages/plus/integrations/src/models/integration.ts
+++ b/packages/plus/integrations/src/models/integration.ts
@@ -153,6 +153,49 @@ export abstract class IntegrationBase<
 		return this._session ?? undefined;
 	}
 
+	/**
+	 * Resolves the session to read as, for a per-connection (multi-account) read. When `connectionId` is
+	 * omitted this is the integration's primary session, resolved exactly like the existing read flow
+	 * (ensure-connected + refresh-if-expired). When set, it resolves THAT connection's session directly
+	 * from the auth provider — refreshing it if expired — WITHOUT disturbing the cached primary
+	 * `_session`. Returns undefined when the requested session can't be resolved (e.g. the connection is
+	 * gone or the provider isn't connected), so callers degrade to "no results".
+	 */
+	protected async resolveReadSession(
+		connectionId: string | undefined,
+		scope: ScopedLogger | undefined,
+		source?: Sources,
+	): Promise<ProviderAuthenticationSession | undefined> {
+		if (
+			this.ctx.config.isIntegrationsEnabled?.() === false ||
+			this.ctx.storage.getWorkspace(this.connectedKey) === false
+		) {
+			return undefined;
+		}
+
+		if (connectionId != null) {
+			// Degrade to "no results" on failure, matching the primary path (whose ensureSession/
+			// refreshSessionIfExpired swallow errors) so read methods keep their never-throws contract.
+			try {
+				const authProvider = await this.authenticationService.get(this.authProvider.id);
+				const session = await authProvider.getSession(
+					{ ...this.authProviderDescriptor, connectionId: connectionId },
+					{ source: source },
+				);
+				return session ?? undefined;
+			} catch (ex) {
+				scope?.error(ex);
+				return undefined;
+			}
+		}
+
+		const connected = this.maybeConnected ?? (await this.isConnected());
+		if (!connected) return undefined;
+
+		await this.refreshSessionIfExpired(scope);
+		return this._session ?? undefined;
+	}
+
 	@debug()
 	async connect(source: Sources): Promise<boolean> {
 		try {
@@ -470,25 +513,30 @@ export abstract class IntegrationBase<
 		return this.authenticationService.ignoreSSLErrors(this);
 	}
 
-	async searchMyIssues(resource?: ResourceDescriptor, cancellation?: AbortSignal): Promise<IssueShape[] | undefined>;
+	async searchMyIssues(
+		resource?: ResourceDescriptor,
+		cancellation?: AbortSignal,
+		connectionId?: string,
+	): Promise<IssueShape[] | undefined>;
 	async searchMyIssues(
 		resources?: ResourceDescriptor[],
 		cancellation?: AbortSignal,
+		connectionId?: string,
 	): Promise<IssueShape[] | undefined>;
 	@trace()
 	async searchMyIssues(
 		resources?: ResourceDescriptor | ResourceDescriptor[],
 		cancellation?: AbortSignal,
+		connectionId?: string,
 	): Promise<IssueShape[] | undefined> {
 		const scope = getScopedLogger();
-		const connected = this.maybeConnected ?? (await this.isConnected());
-		if (!connected) return undefined;
-
-		await this.refreshSessionIfExpired(scope);
+		// `connectionId` targets a specific account (multi-account); omitted reads the primary.
+		const session = await this.resolveReadSession(connectionId, scope);
+		if (session == null) return undefined;
 
 		try {
 			const issues = await this.searchProviderMyIssues(
-				this._session!,
+				session,
 				resources != null ? (Array.isArray(resources) ? resources : [resources]) : undefined,
 				cancellation,
 			);

--- a/packages/plus/integrations/src/models/issuesIntegration.ts
+++ b/packages/plus/integrations/src/models/issuesIntegration.ts
@@ -22,15 +22,14 @@ export abstract class IssuesIntegration<
 
 	@gate()
 	@trace()
-	async getAccountForResource(resource: T): Promise<Account | undefined> {
+	async getAccountForResource(resource: T, connectionId?: string): Promise<Account | undefined> {
 		const scope = getScopedLogger();
-		const connected = this.maybeConnected ?? (await this.isConnected());
-		if (!connected) return undefined;
-
-		await this.refreshSessionIfExpired(scope);
+		// `connectionId` targets a specific account (multi-account); omitted reads the primary.
+		const session = await this.resolveReadSession(connectionId, scope);
+		if (session == null) return undefined;
 
 		try {
-			const account = await this.getProviderAccountForResource(this._session!, resource);
+			const account = await this.getProviderAccountForResource(session, resource);
 			this.resetRequestExceptionCount('getAccountForResource');
 			return account;
 		} catch (ex) {
@@ -46,15 +45,14 @@ export abstract class IssuesIntegration<
 
 	@gate()
 	@trace()
-	async getResourcesForUser(): Promise<T[] | undefined> {
+	async getResourcesForUser(connectionId?: string): Promise<T[] | undefined> {
 		const scope = getScopedLogger();
-		const connected = this.maybeConnected ?? (await this.isConnected());
-		if (!connected) return undefined;
-
-		await this.refreshSessionIfExpired(scope);
+		// `connectionId` targets a specific account (multi-account); omitted reads the primary.
+		const session = await this.resolveReadSession(connectionId, scope);
+		if (session == null) return undefined;
 
 		try {
-			const resources = await this.getProviderResourcesForUser(this._session!);
+			const resources = await this.getProviderResourcesForUser(session);
 			this.resetRequestExceptionCount('getResourcesForUser');
 			return resources;
 		} catch (ex) {
@@ -66,15 +64,14 @@ export abstract class IssuesIntegration<
 	protected abstract getProviderResourcesForUser(session: ProviderAuthenticationSession): Promise<T[] | undefined>;
 
 	@trace()
-	async getProjectsForResources(resources: T[]): Promise<T[] | undefined> {
+	async getProjectsForResources(resources: T[], connectionId?: string): Promise<T[] | undefined> {
 		const scope = getScopedLogger();
-		const connected = this.maybeConnected ?? (await this.isConnected());
-		if (!connected) return undefined;
-
-		await this.refreshSessionIfExpired(scope);
+		// `connectionId` targets a specific account (multi-account); omitted reads the primary.
+		const session = await this.resolveReadSession(connectionId, scope);
+		if (session == null) return undefined;
 
 		try {
-			const projects = await this.getProviderProjectsForResources(this._session!, resources);
+			const projects = await this.getProviderProjectsForResources(session, resources);
 			this.resetRequestExceptionCount('getProjectsForResources');
 			return projects;
 		} catch (ex) {
@@ -83,11 +80,11 @@ export abstract class IssuesIntegration<
 		}
 	}
 
-	async getProjectsForUser(): Promise<T[] | undefined> {
-		const resources = await this.getResourcesForUser();
+	async getProjectsForUser(connectionId?: string): Promise<T[] | undefined> {
+		const resources = await this.getResourcesForUser(connectionId);
 		if (resources == null) return undefined;
 
-		return this.getProjectsForResources(resources);
+		return this.getProjectsForResources(resources, connectionId);
 	}
 
 	protected abstract getProviderProjectsForResources(
@@ -99,15 +96,15 @@ export abstract class IssuesIntegration<
 	async getIssuesForProject(
 		project: T,
 		options?: { user?: string; filters?: IssueFilter[] },
+		connectionId?: string,
 	): Promise<IssueShape[] | undefined> {
 		const scope = getScopedLogger();
-		const connected = this.maybeConnected ?? (await this.isConnected());
-		if (!connected) return undefined;
-
-		await this.refreshSessionIfExpired(scope);
+		// `connectionId` targets a specific account (multi-account); omitted reads the primary.
+		const session = await this.resolveReadSession(connectionId, scope);
+		if (session == null) return undefined;
 
 		try {
-			const issues = await this.getProviderIssuesForProject(this._session!, project, options);
+			const issues = await this.getProviderIssuesForProject(session, project, options);
 			this.resetRequestExceptionCount('getIssuesForProject');
 			return issues;
 		} catch (ex) {

--- a/packages/plus/integrations/src/providers/gitlab.ts
+++ b/packages/plus/integrations/src/providers/gitlab.ts
@@ -283,7 +283,9 @@ abstract class GitLabIntegrationBase<ID extends GitLabIntegrationIds> extends Gi
 		repos?: GitLabRepositoryDescriptor[],
 	): Promise<PullRequest[] | undefined> {
 		const api = await this.getProvidersApi();
-		const username = (await this.getCurrentAccount())?.username;
+		// Resolve the username from THIS session's token (multi-account: `session` may be a non-primary
+		// connection); `getCurrentAccount()` would use the primary `_session` and filter by the wrong user.
+		const username = (await this.getProviderCurrentAccount(session))?.username;
 		if (!username) {
 			return Promise.resolve([]);
 		}

--- a/src/constants.storage.ts
+++ b/src/constants.storage.ts
@@ -1,7 +1,10 @@
 import type { AIProviderAndModel, AIProviders } from '@gitlens/ai/constants.js';
 import type { GitRevisionRangeNotation } from '@gitlens/git/models/revision.js';
-import type { CloudIntegrationAuthType } from '@gitlens/integrations/authentication/models.js';
-import type { IntegrationIds } from '@gitlens/integrations/constants.js';
+import type {
+	IntegrationIds,
+	StoredConfiguredIntegrationDescriptor,
+	StoredIntegrationConfigurations,
+} from '@gitlens/integrations/constants.js';
 import type { IntegrationConnectedKey } from '@gitlens/integrations/models/integration.js';
 import type { GraphBranchesVisibility, ViewShowBranchComparison } from './config.js';
 import type { SubscriptionState } from './constants.subscription.js';
@@ -160,26 +163,10 @@ export interface StoredGkCLIInstallInfo {
 	version?: string;
 }
 
-export type StoredIntegrationConfigurations = Record<
-	IntegrationIds,
-	StoredConfiguredIntegrationDescriptor[] | undefined
->;
-
-export interface StoredConfiguredIntegrationDescriptor {
-	/** Stable per-connection identifier. Backfilled from the domain for pre-multi-account stored data. */
-	id?: string;
-	/** Whether this is the primary/default connection for the provider. */
-	primary?: boolean;
-	/** The connection's auth type (`oauth`/`pat`), when known. */
-	type?: CloudIntegrationAuthType;
-	/** Human-readable account handle for this connection (e.g. the GitHub login), when resolved. */
-	accountName?: string;
-	cloud: boolean;
-	integrationId: IntegrationIds;
-	domain?: string;
-	expiresAt?: string;
-	scopes: string;
-}
+// Re-export the canonical stored-configuration types (imported above) rather than redefining them here,
+// so the multi-account descriptor shape (id/primary/type/accountName) can't drift between the extension's
+// storage typing and the integrations package that owns it.
+export type { StoredConfiguredIntegrationDescriptor, StoredIntegrationConfigurations };
 
 export interface StoredProductConfig {
 	promos: StoredPromo[];

--- a/src/constants.storage.ts
+++ b/src/constants.storage.ts
@@ -1,5 +1,6 @@
 import type { AIProviderAndModel, AIProviders } from '@gitlens/ai/constants.js';
 import type { GitRevisionRangeNotation } from '@gitlens/git/models/revision.js';
+import type { CloudIntegrationAuthType } from '@gitlens/integrations/authentication/models.js';
 import type { IntegrationIds } from '@gitlens/integrations/constants.js';
 import type { IntegrationConnectedKey } from '@gitlens/integrations/models/integration.js';
 import type { GraphBranchesVisibility, ViewShowBranchComparison } from './config.js';
@@ -165,6 +166,14 @@ export type StoredIntegrationConfigurations = Record<
 >;
 
 export interface StoredConfiguredIntegrationDescriptor {
+	/** Stable per-connection identifier. Backfilled from the domain for pre-multi-account stored data. */
+	id?: string;
+	/** Whether this is the primary/default connection for the provider. */
+	primary?: boolean;
+	/** The connection's auth type (`oauth`/`pat`), when known. */
+	type?: CloudIntegrationAuthType;
+	/** Human-readable account handle for this connection (e.g. the GitHub login), when resolved. */
+	accountName?: string;
 	cloud: boolean;
 	integrationId: IntegrationIds;
 	domain?: string;

--- a/src/webviews/home/homeWebview.ts
+++ b/src/webviews/home/homeWebview.ts
@@ -992,11 +992,18 @@ export class HomeWebviewProvider implements WebviewProvider<State, State, HomeWe
 
 	private getIntegrationStates(force = false) {
 		if (force || this._integrationStates == null) {
+			// A provider can have multiple connections (multi-account); surface one state per provider.
+			const seenIntegrationIds = new Set<string>();
 			const integrations: IntegrationState[] = [
 				...filterMap(this.container.integrations.getConfigured(), i => {
 					if (!isSupportedCloudIntegrationId(i.integrationId)) {
 						return undefined;
 					}
+					if (seenIntegrationIds.has(i.integrationId)) {
+						return undefined;
+					}
+
+					seenIntegrationIds.add(i.integrationId);
 
 					const supportedCloudDescriptor = supportedCloudIntegrationDescriptors.find(
 						item => item.id === i.integrationId,

--- a/src/webviews/rpc/services/integrations.ts
+++ b/src/webviews/rpc/services/integrations.ts
@@ -22,10 +22,14 @@ export function getIntegrationStates(container: Container): IntegrationStateInfo
 	const configured = container.integrations.getConfigured();
 	const integrations: IntegrationStateInfo[] = [];
 
+	// A provider can have multiple connections (multi-account); surface one connected state per provider.
+	const seenIntegrationIds = new Set<string>();
+
 	for (const i of configured) {
 		if (!isSupportedCloudIntegrationId(i.integrationId)) continue;
-		// A provider can have multiple connections (multi-account); surface one connected state per provider.
-		if (integrations.some(s => s.id === i.integrationId)) continue;
+		if (seenIntegrationIds.has(i.integrationId)) continue;
+
+		seenIntegrationIds.add(i.integrationId);
 
 		const meta = providersMetadata[i.integrationId];
 		const descriptor = supportedCloudIntegrationDescriptors.find(d => d.id === i.integrationId);

--- a/src/webviews/rpc/services/integrations.ts
+++ b/src/webviews/rpc/services/integrations.ts
@@ -24,6 +24,8 @@ export function getIntegrationStates(container: Container): IntegrationStateInfo
 
 	for (const i of configured) {
 		if (!isSupportedCloudIntegrationId(i.integrationId)) continue;
+		// A provider can have multiple connections (multi-account); surface one connected state per provider.
+		if (integrations.some(s => s.id === i.integrationId)) continue;
 
 		const meta = providersMetadata[i.integrationId];
 		const descriptor = supportedCloudIntegrationDescriptors.find(d => d.id === i.integrationId);


### PR DESCRIPTION
Adds multi-account support for cloud provider integrations, allowing users to connect and manage multiple simultaneous accounts per provider.

Closes #5430 

## Changes

- Introduces a stable `connectionId` per configured integration and stores all active cloud connections for a provider instead of a single session.
- Adds `IntegrationService.setPrimaryConnection(providerId, connectionId)` to change the default account.
- Adds `IntegrationService.connectSecondary(providerId)` to start the host connect flow even when an account is already connected, enabling additional accounts.
- Adds `IntegrationService.deleteConnection(providerId, connectionId)` to remove a single connection without disconnecting the provider.
- Adds per-connection reads: `searchMyIssues(..., connectionId)` and `searchMyPullRequests(..., connectionId)` use the requested account instead of the primary.
- Improves `connectSecondary` to detect a newly added connection by comparing connection ids rather than raw counts, and to detect replacement of the existing id.
- Fires change events on `type` mutations in `ConfiguredIntegrationService`.
- Updates GitLab to resolve the PR/issue username from the requested connection's session.
- Adds tests for multi-account wiring, reconciliation, per-connection reads, and the secondary connection flow.

## Related

- Closes #5430

## Testing

- `pnpm --filter @gitlens/integrations test`: 79 passing
