### PR TITLE
Fixes #5405 - binary file handling in the Commit Composer

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -44,6 +44,7 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/) and this p
 - Fixes the working changes (WIP) stats tooltip in the details header duplicating the visible stats pill instead of describing the change breakdown &mdash; the tooltip now reads e.g. _1 file added, 2 files changed in the working tree_
 - Fixes a stray gap in the _Commit Graph_ header next to the fetch and sync actions when the current branch is already published &mdash; the publish action no longer reserves empty space once the branch has an upstream
 - Fixes the design of the paused-operation banner (shown during a merge, rebase, cherry-pick, or revert in the _Commit Graph_/_Inspect_ details and _Home_) &mdash; the _Continue_ action now uses a start icon, and the action buttons' hover and active states blend into the banner instead of showing a clashing grey toolbar highlight ([#5394](https://github.com/gitkraken/vscode-gitlens/issues/5394))
+- Fixes the _Commit Composer_ failing to commit changes that include binary files &mdash; binary changes are now carried as full binary patches and committed byte-identically ([#5405](https://github.com/gitkraken/vscode-gitlens/issues/5405))
 
 ## [18.2.0] - 2026-06-15
 

--- a/packages/git-cli/src/providers/diff.ts
+++ b/packages/git-cli/src/providers/diff.ts
@@ -120,6 +120,7 @@ export class DiffGitSubProvider implements GitDiffSubProvider {
 		to: string,
 		from?: string,
 		options?: {
+			binary?: boolean;
 			context?: number;
 			index?: DisposableTemporaryGitIndex;
 			notation?: GitRevisionRangeNotation;
@@ -129,6 +130,10 @@ export class DiffGitSubProvider implements GitDiffSubProvider {
 	): Promise<GitDiff | undefined> {
 		const scope = getScopedLogger();
 		const args = [`-U${options?.context ?? 3}`];
+
+		if (options?.binary) {
+			args.push('--binary');
+		}
 
 		if (to != null && isRevisionRange(to)) {
 			const parts = getRevisionRangeParts(to);

--- a/packages/git/src/providers/diff.ts
+++ b/packages/git/src/providers/diff.ts
@@ -40,6 +40,8 @@ export interface GitDiffSubProvider {
 		to: string,
 		from?: string,
 		options?: {
+			/** Emit a full `GIT binary patch` (with full index line) for binary files instead of the `Binary files ... differ` marker. Required when the diff will be replayed through `git apply`. */
+			binary?: boolean;
 			context?: number;
 			index?: DisposableTemporaryGitIndex;
 			notation?: GitRevisionRangeNotation;

--- a/src/webviews/plus/composer/composerWebview.ts
+++ b/src/webviews/plus/composer/composerWebview.ts
@@ -92,6 +92,7 @@ import {
 	getAuthorAndCoAuthorsForCombinedDiffHunk,
 	getBranchCommits,
 	getComposerDiffs,
+	redactBinaryHunkContent,
 	validateResultingDiff,
 	validateSafetyState,
 } from './utils/composer.utils.js';
@@ -383,7 +384,7 @@ export class ComposerWebviewProvider implements WebviewProvider<State, State, Co
 
 		return {
 			...this.initialState,
-			hunks: hunks,
+			hunks: redactBinaryHunkContent(hunks),
 			baseCommit: baseCommit ?? null,
 			commits: commits,
 			aiEnabled: aiEnabled,
@@ -878,7 +879,7 @@ export class ComposerWebviewProvider implements WebviewProvider<State, State, Co
 
 			// Notify the state provider with fresh data to completely reload the state
 			await this.host.notify(DidReloadComposerNotification, {
-				hunks: composerData.hunks,
+				hunks: redactBinaryHunkContent(composerData.hunks),
 				commits: composerData.commits,
 				baseCommit: composerData.baseCommit,
 				loadingError: composerData.loadingError,
@@ -1338,11 +1339,12 @@ export class ComposerWebviewProvider implements WebviewProvider<State, State, Co
 					}
 				}
 			} else {
+				const aiHunks = redactBinaryHunkContent(hunks);
 				result = await this.container.ai.actions.generateCommits(
-					hunks,
+					aiHunks,
 					existingCommits,
 					this._recompose?.enabled ? (this._recompose.messages ?? []) : [],
-					hunks.map(m => ({ index: m.index, hunkHeader: m.hunkHeader })),
+					aiHunks.map(m => ({ index: m.index, hunkHeader: m.hunkHeader })),
 					{ source: 'composer', correlationId: this.host.instanceId },
 					{
 						cancellation: this._generateCommitsCancellation.token,
@@ -1418,7 +1420,7 @@ export class ComposerWebviewProvider implements WebviewProvider<State, State, Co
 				const shouldSendHunks = useLibraryRoute || this._recompose?.enabled === true;
 				await this.host.notify(DidGenerateCommitsNotification, {
 					commits: newCommits,
-					hunks: shouldSendHunks ? this._hunks : undefined,
+					hunks: shouldSendHunks ? redactBinaryHunkContent(this._hunks) : undefined,
 					replacedCommitIds: params.commitsToReplace?.commits.map(c => c.id),
 				});
 			} else if (result === 'cancelled') {
@@ -1501,9 +1503,8 @@ export class ComposerWebviewProvider implements WebviewProvider<State, State, Co
 			// Notify webview that commit message generation is starting
 			await this.host.notify(DidStartGeneratingCommitMessageNotification, { commitId: params.commitId });
 
-			// Create combined diff for the commit
 			const { patch } = createCombinedDiffForCommit(
-				this._hunks.filter(h => params.commitHunkIndices.includes(h.index)),
+				redactBinaryHunkContent(this._hunks.filter(h => params.commitHunkIndices.includes(h.index))),
 			);
 			if (!patch) {
 				this._context.operations.generateCommitMessage.errorCount++;
@@ -1806,8 +1807,13 @@ export class ComposerWebviewProvider implements WebviewProvider<State, State, Co
 			}
 
 			const baseRef = params.baseCommit?.sha ?? ((await repo.git.commits.getCommit('HEAD')) ? 'HEAD' : rootSha);
+			// `binary: true` must match the flag used when the safety-state hashes were captured
+			// (see getComposerDiffs / calculateCombinedDiffBetweenCommits); otherwise binary files
+			// hash differently here (abbreviated "Binary files … differ" vs. the full `GIT binary
+			// patch`) and validateResultingDiff false-fails with "Output diff does not match input".
 			const resultingDiff = (
 				await repo.git.diff.getDiff?.(shas.at(-1)!, baseRef, {
+					binary: true,
 					notation: params.baseCommit?.sha ? '...' : undefined,
 				})
 			)?.contents;

--- a/src/webviews/plus/composer/utils/composer.utils.ts
+++ b/src/webviews/plus/composer/utils/composer.utils.ts
@@ -10,6 +10,9 @@ import type { ComposerCommit, ComposerHunk, ComposerSafetyState } from '../proto
 
 const hunkOldRangeRegex = /@@ -(\d+),(\d+)/;
 const hunkNewRangeRegex = /@@ -\d+,\d+ \+(\d+),(\d+)/;
+// The `GIT binary patch` marker emitted by `git diff --binary` for binary files. Surrounding
+// newlines anchor it to its own line so it can't match inside a path or hunk body.
+const binaryPatchMarker = '\nGIT binary patch\n';
 
 export function getHunksForCommit(commit: ComposerCommit, hunks: ComposerHunk[]): ComposerHunk[] {
 	return hunks.filter(hunk => commit.hunkIndices.includes(hunk.index));
@@ -121,6 +124,16 @@ export function createCombinedDiffForCommit(hunks: ComposerHunk[]): {
 	// Build the complete patch string
 	let commitPatch = '';
 	for (const [header, hunkContents] of filePatches.entries()) {
+		// Binary files have no textual hunks: the `diffHeader` is the complete, verbatim per-file
+		// diff — including the `GIT binary patch` body, whose terminating blank line `git apply`
+		// requires. Emit it untouched. Trimming it (and appending synthesized hunk-header/content
+		// lines, as the text path below does) strips that terminator and corrupts the patch, which
+		// `git apply` rejects with "corrupt binary patch … no-content-change".
+		if (header.includes(binaryPatchMarker)) {
+			commitPatch += header.endsWith('\n') ? header : `${header}\n`;
+			continue;
+		}
+
 		commitPatch += `${header.trim()}\n`;
 		// Only add hunk contents if they exist (renames might have empty content)
 		const nonEmptyContents = hunkContents.filter(content => content.trim() !== '');
@@ -130,6 +143,32 @@ export function createCombinedDiffForCommit(hunks: ComposerHunk[]): {
 	}
 
 	return { patch: commitPatch, filePatches: filePatches };
+}
+
+/**
+ * Returns a copy of `hunks` safe to send to an AI model or the composer webview: each binary
+ * file's `GIT binary patch` body — base85-encoded bytes that a text model can't use and that can
+ * run to many MB (e.g. a committed build artifact), enough to overflow an AI request or freeze the
+ * webview renderer — is replaced with a compact `Binary file` placeholder.
+ *
+ * Only the body is dropped; the `diff --git`/mode/`index` header lines (and the filename) are kept
+ * so consumers still see that the file changed and whether it was added or modified. `index` is
+ * preserved on every hunk, so hunk assignments still map back to the original, un-redacted hunks
+ * that the apply path ({@link createCombinedDiffForCommit}) must always use.
+ */
+export function redactBinaryHunkContent(hunks: ComposerHunk[]): ComposerHunk[] {
+	return hunks.map(hunk => {
+		const markerIndex = hunk.diffHeader.indexOf(binaryPatchMarker);
+		if (markerIndex === -1) return hunk;
+
+		return {
+			...hunk,
+			// Keep only the textual header (diff --git / mode / index lines); drop the binary body.
+			diffHeader: hunk.diffHeader.slice(0, markerIndex),
+			hunkHeader: 'binary',
+			content: 'Binary file',
+		};
+	});
 }
 
 // Given a group of hunks assigned to a single commit, each with their own author and co-authors, determine a single author and co-authors list for the commit
@@ -459,9 +498,9 @@ export async function getComposerDiffs(
 
 			// Get all three diffs using the temp index
 			const [stagedDiffResult, unstagedDiffResult, unifiedDiffResult] = await Promise.allSettled([
-				repo.git.diff.getDiff?.(uncommittedStaged, undefined, { index: disposableIndex }),
-				repo.git.diff.getDiff?.(uncommitted, undefined, { index: disposableIndex }),
-				repo.git.diff.getDiff?.(uncommitted, 'HEAD', { notation: '...', index: disposableIndex }),
+				repo.git.diff.getDiff?.(uncommittedStaged, undefined, { binary: true, index: disposableIndex }),
+				repo.git.diff.getDiff?.(uncommitted, undefined, { binary: true, index: disposableIndex }),
+				repo.git.diff.getDiff?.(uncommitted, 'HEAD', { binary: true, notation: '...', index: disposableIndex }),
 			]);
 
 			return {
@@ -475,11 +514,11 @@ export async function getComposerDiffs(
 
 	const [stagedDiffResult, unstagedDiffResult, unifiedDiffResult] = await Promise.allSettled([
 		// Get staged diff (index vs HEAD)
-		repo.git.diff.getDiff?.(uncommittedStaged),
+		repo.git.diff.getDiff?.(uncommittedStaged, undefined, { binary: true }),
 		// Get unstaged diff (working tree vs index)
-		repo.git.diff.getDiff?.(uncommitted),
+		repo.git.diff.getDiff?.(uncommitted, undefined, { binary: true }),
 		// Get unified diff (working tree vs HEAD)
-		repo.git.diff.getDiff?.(uncommitted, 'HEAD', { notation: '...' }),
+		repo.git.diff.getDiff?.(uncommitted, 'HEAD', { binary: true, notation: '...' }),
 	]);
 
 	return {
@@ -769,8 +808,7 @@ export async function calculateCombinedDiffBetweenCommits(
 			return undefined;
 		}
 
-		// Get the combined diff from base to head
-		const diff = await diffService.getDiff(headCommitSha, baseCommitSha);
+		const diff = await diffService.getDiff(headCommitSha, baseCommitSha, { binary: true });
 		if (!diff?.contents) {
 			return undefined;
 		}


### PR DESCRIPTION
# Description

Fixes #5405.

The composer (legacy/non-compose-tools path) collects its diffs without --binary, so binary changes are carried only as Binary files ... differ placeholders, which git apply rejects when the composed commits are replayed.

- Adds a binary option to the git diff providers (--binary → full GIT binary patch blocks) and uses it for the composer's diffs
- Emits binary hunks verbatim when building patches
- Redacts the base85 bodies before hunks reach the webview or AI prompts (they can run to many MB); apply always uses the un-redacted hunks

Verified with the repro from #5405 (I used Recompose Commits from here...).

Maybe this is actually a new feature since legacy compose never supported binary...? IDK, it looked like a bug when originally I filed it :)

# Checklist

- [o] I have followed the guidelines in the Contributing document
- [o] My changes follow the coding style of this project
- [o] My changes build without any errors or warnings
- [o] My changes have been formatted and linted
- [o] My changes include any required corresponding changes to the documentation (including CHANGELOG.md and README.md)
- [o] My changes have been rebased and squashed to the minimal number (typically 1) of relevant commits
- [o] My changes have a descriptive commit message with a short title, including a `Fixes $XXX -` or `Closes #XXX -` prefix to auto-close the issue that your PR addresses
