### PR TITLE
Introduces Kepler in Welcome view walkthrough

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,7 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/) and this p
 - Adds manual take-side fallbacks and conflict-type labels to the AI **Resolve** mode in the _Commit Graph_ WIP details panel &mdash; conflicts the AI can't auto-merge (binary, symlink, submodule, file-mode, add/add, and rename/rename or rename/delete conflicts) are now labeled by type and offer inline _Take Current_, _Take Incoming_, and _Delete_ actions instead of dead-ending as "needs review"; resolving a rename/rename conflict also removes the other side's renamed file. Also decodes UTF-16/BOM-encoded files so their conflicts can be resolved rather than skipped ([#5393](https://github.com/gitkraken/vscode-gitlens/issues/5393))
 - Adds a commit signing indicator to the _Commit Graph_'s working changes (WIP) commit box &mdash; a key icon appears when commits will be signed (via the repo's `commit.gpgsign` Git config or VS Code's `git.enableCommitSigning` setting), with the signing format (GPG, SSH, X.509, or OpenPGP) shown on hover
 - Adds a _Start Review with an Agent_ action to _Launchpad_ pull request items &mdash; after selecting a pull request in the _Launchpad_, you can start an AI agent review that checks out the PR in a worktree and routes straight to the agent picker (or your default agent); available when AI features are enabled ([#5395](https://github.com/gitkraken/vscode-gitlens/issues/5395))
+- Adds a _Take your agent workflows further_ step to the _Welcome_ view walkthrough &mdash; introduces Kepler, GitKraken's Agentic Development Environment (ADE), with a _Get Kepler_ call-to-action ([#5378](https://github.com/gitkraken/vscode-gitlens/issues/5378))
 
 ### Changed
 
@@ -31,6 +32,7 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/) and this p
 
 ### Removed
 
+- Removes the _Streamline Workflow with the Home View_ step from the _Welcome_ view walkthrough ([#5378](https://github.com/gitkraken/vscode-gitlens/issues/5378))
 - Removes the Overview (working changes) mode from the _Inspect_ view, making it commit/stash-only &mdash; reviewing working changes is now consolidated in the _Commit Graph_. Launchpad _Switch to Branch_ and _Open Details_ actions, and PR switch deep links, now open the _Commit Graph_ at the working changes (WIP) row instead of the _Inspect_ view; the Launchpad code-suggestion entry points are retired (code suggestions remain available in the _Commit Graph_) ([#5399](https://github.com/gitkraken/vscode-gitlens/issues/5399))
 
 ### Fixed

--- a/docs/telemetry-events.md
+++ b/docs/telemetry-events.md
@@ -6967,7 +6967,7 @@ or
 
 ```typescript
 {
-  'context.key': 'homeView' | 'gettingStarted' | 'visualizeCodeHistory' | 'gitBlame' | 'prReviews' | 'mcpFeatures' | 'aiFeatures' | 'graphAgentMonitoring' | 'graphParallelWork' | 'graphAiReview' | 'graphCompose' | 'graphCompare' | 'graphNextSteps'
+  'context.key': 'gettingStarted' | 'visualizeCodeHistory' | 'gitBlame' | 'prReviews' | 'kepler' | 'mcpFeatures' | 'aiFeatures' | 'graphAgentMonitoring' | 'graphParallelWork' | 'graphAiReview' | 'graphCompose' | 'graphCompare' | 'graphNextSteps'
 }
 ```
 
@@ -6988,7 +6988,7 @@ or
 ```typescript
 {
   'command': string,
-  'name': 'open/help-center/community-vs-pro' | 'open/composer' | 'open/graph' | 'open/launchpad' | 'open/help-center' | 'plus/login' | 'plus/sign-up' | 'plus/upgrade' | 'plus/reactivate' | 'shown' | 'dismiss' | 'open/home-view',
+  'name': 'open/help-center/community-vs-pro' | 'open/composer' | 'open/graph' | 'open/launchpad' | 'open/help-center' | 'plus/login' | 'plus/sign-up' | 'plus/upgrade' | 'plus/reactivate' | 'shown' | 'dismiss' | 'open/home-view' | 'open/kepler',
   'type': 'command'
 }
 ```
@@ -6997,7 +6997,7 @@ or
 
 ```typescript
 {
-  'name': 'open/help-center/community-vs-pro' | 'open/composer' | 'open/graph' | 'open/launchpad' | 'open/help-center' | 'plus/login' | 'plus/sign-up' | 'plus/upgrade' | 'plus/reactivate' | 'shown' | 'dismiss' | 'open/home-view',
+  'name': 'open/help-center/community-vs-pro' | 'open/composer' | 'open/graph' | 'open/launchpad' | 'open/help-center' | 'plus/login' | 'plus/sign-up' | 'plus/upgrade' | 'plus/reactivate' | 'shown' | 'dismiss' | 'open/home-view' | 'open/kepler',
   'type': 'url',
   'url': string
 }

--- a/src/commands/welcome.ts
+++ b/src/commands/welcome.ts
@@ -48,6 +48,23 @@ export class WelcomeOpenHelpCenterCommand extends GlCommandBase {
 }
 
 @command()
+export class WelcomeOpenKeplerCommand extends GlCommandBase {
+	constructor(private readonly container: Container) {
+		super('gitlens.welcome.openKepler');
+	}
+
+	execute(): void {
+		const url = urls.kepler;
+		this.container.telemetry.sendEvent('welcome/action', {
+			type: 'url',
+			name: 'open/kepler',
+			url: url,
+		});
+		void openUrl(url);
+	}
+}
+
+@command()
 export class WelcomePlusSignUpCommand extends GlCommandBase {
 	constructor(private readonly container: Container) {
 		super('gitlens.welcome.plus.signUp');

--- a/src/constants.commands.ts
+++ b/src/constants.commands.ts
@@ -135,6 +135,7 @@ type InternalWalkthroughCommands =
 type InternalWelcomeCommands =
 	| 'gitlens.welcome.openCommunityVsPro'
 	| 'gitlens.welcome.openHelpCenter'
+	| 'gitlens.welcome.openKepler'
 	| 'gitlens.welcome.plus.login'
 	| 'gitlens.welcome.plus.reactivate'
 	| 'gitlens.welcome.plus.signUp'

--- a/src/constants.telemetry.ts
+++ b/src/constants.telemetry.ts
@@ -2531,6 +2531,7 @@ type WelcomeActionNames =
 	| 'open/home-view'
 	| 'open/help-center'
 	| 'open/help-center/community-vs-pro'
+	| 'open/kepler'
 	| 'open/launchpad'
 	| 'plus/login'
 	| 'plus/reactivate'

--- a/src/constants.ts
+++ b/src/constants.ts
@@ -132,6 +132,8 @@ export const urls = Object.freeze({
 	security: `https://help.gitkraken.com/gitlens/security?${utm}`,
 	workspaces: `https://gitkraken.com/solutions/workspaces?${utm}`,
 
+	kepler: `https://www.gitkraken.com/kepler?${utm}`,
+
 	cli: `https://gitkraken.com/cli?${utm}`,
 	browserExtension: `https://gitkraken.com/browser-extension?${utm}`,
 	desktop: `https://gitkraken.com/git-client?${utm}`,

--- a/src/constants.walkthroughs.ts
+++ b/src/constants.walkthroughs.ts
@@ -1,19 +1,19 @@
 export type WalkthroughContextKeys =
 	| 'gettingStarted'
-	| 'homeView'
 	| 'visualizeCodeHistory'
 	| 'gitBlame'
 	| 'prReviews'
+	| 'kepler'
 	| 'mcpFeatures'
 	| 'aiFeatures';
 
 export const walkthroughProgressSteps: Record<WalkthroughContextKeys, string> = {
 	gettingStarted: 'Getting Started',
-	homeView: 'Home View',
 	visualizeCodeHistory: 'Visualize Code History',
 	aiFeatures: 'AI Features',
 	gitBlame: 'Inline Blame',
 	prReviews: 'Launchpad',
+	kepler: 'Kepler',
 	mcpFeatures: 'MCP Features',
 };
 

--- a/src/onboarding/walkthroughStateProvider.ts
+++ b/src/onboarding/walkthroughStateProvider.ts
@@ -99,6 +99,12 @@ const walkthroughRequiredMapping: Readonly<Map<WalkthroughContextKeys, Walkthrou
 		},
 	],
 	[
+		'kepler',
+		{
+			usage: ['command:gitlens.welcome.openKepler:executed'],
+		},
+	],
+	[
 		'mcpFeatures',
 		{
 			usage: [
@@ -108,12 +114,6 @@ const walkthroughRequiredMapping: Readonly<Map<WalkthroughContextKeys, Walkthrou
 				'action:gitlens.ai.openInAgent:happened',
 				'action:gitlens.mcp.bundledMcpDefinitionProvided:happened',
 			],
-		},
-	],
-	[
-		'homeView',
-		{
-			usage: ['homeView:shown', 'command:gitlens.showHomeView:executed'],
 		},
 	],
 ]);

--- a/src/webviews/apps/welcome/components/welcome-page.ts
+++ b/src/webviews/apps/welcome/components/welcome-page.ts
@@ -197,21 +197,6 @@ const walkthroughSteps: WalkthroughStep[] = [
 	},
 
 	{
-		id: 'home-view',
-		walkthroughKey: 'homeView',
-		title: 'Streamline Workflow with the Home View',
-		body: html`
-			<p>
-				Streamline your workflow — effortlessly track, manage, and collaborate on your branches and pull
-				requests, all in one intuitive hub.
-			</p>
-			<div class="card-part--centered">
-				<gl-button href="command:gitlens.welcome.showHomeView">Open Home View</gl-button>
-			</div>
-		`,
-	},
-
-	{
 		id: 'ai-features',
 		walkthroughKey: 'aiFeatures',
 		title: 'Commit smarter, not harder',
@@ -277,6 +262,26 @@ const walkthroughSteps: WalkthroughStep[] = [
 			<p>Stay in flow, ship faster, and never lose track of what matters.</p>
 			<div class="card-part--centered">
 				<gl-button href="command:gitlens.welcome.showLaunchpad">Open Launchpad</gl-button>
+			</div>
+		`,
+	},
+
+	{
+		id: 'kepler',
+		walkthroughKey: 'kepler',
+		title: 'Take your agent workflows further',
+		body: html`
+			<p>
+				GitLens helps you understand and review agent-generated work inside your IDE. Kepler, GitKraken's
+				Agentic Development Environment (ADE), gives you a dedicated workspace to coordinate AI agents, organize
+				Tasks, and manage complex development workflows from one place.
+			</p>
+			<p>
+				Start from an issue or pull request, and Kepler creates the environment, launches the agent, and keeps
+				related work organized in a single Task across repositories.
+			</p>
+			<div class="card-part--centered">
+				<gl-button href="command:gitlens.welcome.openKepler">Get Kepler</gl-button>
 			</div>
 		`,
 	},


### PR DESCRIPTION
# Description

Closes #5378

Replaces the "Streamline Workflow with the Home View" step in the Welcome view walkthrough with a new Kepler step ("Take your agent workflows further"), placed above the GitKraken MCP step.

- Removes the `home-view` step from the Welcome webview and its walkthrough progress tracking (`homeView` context key + progress mapping)
- Adds a Kepler step with a "Get Kepler" CTA that opens https://www.gitkraken.com/kepler (with the standard in-app UTM parameters)
- Adds the `gitlens.welcome.openKepler` command; the step completes when the user clicks the CTA (driven by command-execution usage tracking)
- Adds corresponding telemetry and CHANGELOG entries

# Checklist

- [x] I have followed the guidelines in the Contributing document
- [x] My changes follow the coding style of this project
- [x] My changes build without any errors or warnings
- [x] My changes have been formatted and linted
- [x] My changes include any required corresponding changes to the documentation (including CHANGELOG.md and README.md)
- [x] My changes have been rebased and squashed to the minimal number (typically 1) of relevant commits
- [ ] My changes have a descriptive commit message with a short title, including a `Fixes $XXX -` or `Closes #XXX -` prefix to auto-close the issue that your PR addresses
