### PR TITLE
Extracts account bar and shows it in the Graph view

### DIFF
--- a/src/webviews/apps/plus/graph/graph-app.ts
+++ b/src/webviews/apps/plus/graph/graph-app.ts
@@ -1,7 +1,7 @@
 import type { GraphRow, SelectCommitsOptions } from '@gitkraken/gitkraken-components';
 import { refZone } from '@gitkraken/gitkraken-components';
 import { SignalWatcher } from '@lit-labs/signals';
-import { consume, provide } from '@lit/context';
+import { consume, ContextProvider, provide } from '@lit/context';
 import { html, LitElement, nothing } from 'lit';
 import { customElement, query, state } from 'lit/decorators.js';
 import { classMap } from 'lit/directives/class-map.js';
@@ -49,6 +49,7 @@ import {
 	UpdateGraphConfigurationCommand,
 	UpdateGraphDisplayModeCommand,
 } from '../../../plus/graph/protocol.js';
+import { noop } from '../../shared/actions/rpc.js';
 import {
 	formatAgentElapsed,
 	indexAgentSessionsByRepoAndWorktree,
@@ -56,12 +57,16 @@ import {
 } from '../../shared/agentUtils.js';
 import type { CustomEventType } from '../../shared/components/element.js';
 import type { GlDragShiftOverlay } from '../../shared/components/overlays/drag-shift-overlay.js';
+import { aiContext, createAIState } from '../../shared/contexts/ai.js';
+import { createIntegrationsState, integrationsContext } from '../../shared/contexts/integrations.js';
 import { ipcContext } from '../../shared/contexts/ipc.js';
+import { createDefaultSubscriptionContextState, subscriptionContext } from '../../shared/contexts/subscription.js';
 import type { TelemetryContext } from '../../shared/contexts/telemetry.js';
 import { telemetryContext } from '../../shared/contexts/telemetry.js';
 import type { NavigationState } from '../../shared/controllers/navigationStack.js';
 import { NavigationStack } from '../../shared/controllers/navigationStack.js';
 import { subscribeAll } from '../../shared/events/subscriptions.js';
+import '../shared/components/account-bar.js';
 import { emitTelemetrySentEvent } from '../../shared/telemetry.js';
 import type { GlGraphDetailsPanel } from './components/gl-graph-details-panel.js';
 import type { GlGraphKeyboardShortcuts } from './components/gl-graph-keyboard-shortcuts.js';
@@ -352,6 +357,31 @@ export class GraphApp extends SignalWatcher(LitElement) {
 		500,
 	);
 
+	// Account/integrations bar state (issue #5411). The `<gl-account-bar>` chips consume these
+	// shared contexts; provide them here (the common ancestor) and populate from the host once
+	// `services` resolves. `promosContext` is provided globally by the app host. NOTE: this
+	// mirrors the Home view's wiring — a follow-up should extract it into a reusable helper.
+	private readonly _integrationsState = createIntegrationsState();
+	private readonly _aiState = createAIState();
+	private readonly _subscriptionCtx = new ContextProvider(this, {
+		context: subscriptionContext,
+		initialValue: createDefaultSubscriptionContextState(),
+	});
+	// `_integrationsCtx`/`_aiCtx` are intentionally kept as fields: `ContextProvider` self-registers
+	// on construction, so they're never read again (Home provides these as bare `new ContextProvider`
+	// statements instead — same effect). `_subscriptionCtx` above is a field because it's read later.
+	private readonly _integrationsCtx = new ContextProvider(this, {
+		context: integrationsContext,
+		initialValue: this._integrationsState,
+	});
+	private readonly _aiCtx = new ContextProvider(this, {
+		context: aiContext,
+		initialValue: this._aiState,
+	});
+	/** One-shot guard mirroring `_launchpadInitialized` for the account-bar context wiring. */
+	private _accountContextsInitialized = false;
+	private _accountUnsubscribe: (() => void) | undefined;
+
 	@consume({ context: ipcContext })
 	private readonly _ipc!: typeof ipcContext.__context__;
 
@@ -497,6 +527,9 @@ export class GraphApp extends SignalWatcher(LitElement) {
 		this._launchpadUnsubscribe?.();
 		this._launchpadUnsubscribe = undefined;
 		this._launchpadRefreshDebounced.cancel();
+
+		this._accountUnsubscribe?.();
+		this._accountUnsubscribe = undefined;
 	}
 
 	/** Starts the shared Launchpad pipeline once `services` resolves: subscribes to host-side
@@ -514,6 +547,85 @@ export class GraphApp extends SignalWatcher(LitElement) {
 		}
 		// Defer the initial fetch off the cold graph-load path.
 		setTimeout(() => void this.refreshLaunchpadSummary(), 0);
+	}
+
+	/** Populates the account-bar contexts once `services` resolves (issue #5411). Swaps the
+	 *  subscription context to the host-side RemoteSignals, seeds the initial integrations/AI
+	 *  state, and subscribes to change events. Mirrors the Home view (see `home.ts` / `actions.ts`
+	 *  / `events.ts`). A failed subscription must not break the graph. */
+	private async initAccountContexts(services: NonNullable<typeof this.services>): Promise<void> {
+		// Wiring the account bar must never break the graph, so guard the whole pipeline: a rejected
+		// service promise or a failed subscription just leaves the bar without live state.
+		try {
+			const [subscription, integrations, ai] = await Promise.all([
+				services.subscription,
+				services.integrations,
+				services.ai,
+			]);
+
+			// Swap the subscription context to use the host-side RemoteSignals directly (no copy),
+			// exactly as Home does. Supertalk proxy properties are thenable at runtime.
+			/* eslint-disable @typescript-eslint/await-thenable -- Supertalk proxy properties are thenable at runtime */
+			const [subscriptionSignal, orgSettingsSignal, avatarSignal, hasAccountSignal, orgCountSignal] =
+				await Promise.all([
+					subscription.subscriptionState,
+					subscription.orgSettingsState,
+					subscription.avatarState,
+					subscription.hasAccountState,
+					subscription.organizationsCountState,
+				]);
+			/* eslint-enable @typescript-eslint/await-thenable */
+			this._subscriptionCtx.setValue(
+				{
+					subscription: subscriptionSignal,
+					orgSettings: orgSettingsSignal,
+					avatar: avatarSignal,
+					hasAccount: hasAccountSignal,
+					organizationsCount: orgCountSignal,
+				},
+				true,
+			);
+
+			// Seed initial integrations + AI state (the change subscriptions below only fire on change).
+			// `.catch(noop)` also swallows any error thrown inside the success callback (not just a
+			// rejected promise), which the 2nd-arg handler wouldn't.
+			void integrations
+				.getIntegrationStates()
+				.then(s => {
+					this._integrationsState.integrations.set(s);
+					this._integrationsState.hasAnyIntegrationConnected.set(s.some(i => i.connected));
+				})
+				.catch(noop);
+			void ai
+				.getModel()
+				.then(m => this._aiState.model.set(m))
+				.catch(noop);
+			void ai
+				.getState()
+				.then(s => this._aiState.state.set(s))
+				.catch(noop);
+
+			// Subscribe to host-side change events so the bar stays live.
+			const unsubscribe = await subscribeAll([
+				async () =>
+					integrations.onIntegrationsChanged(data => {
+						this._integrationsState.hasAnyIntegrationConnected.set(data.hasAnyConnected);
+						this._integrationsState.integrations.set(data.integrations);
+					}),
+				async () => ai.onModelChanged(model => this._aiState.model.set(model)),
+				async () => ai.onStateChanged(state => this._aiState.state.set(state)),
+			]);
+			// Guard against late completion: if the element disconnected while awaiting, `disconnectedCallback`
+			// already ran with `_accountUnsubscribe` still undefined, so tear down here to avoid leaking host
+			// subscriptions on a disposed graph.
+			if (!this.isConnected) {
+				unsubscribe?.();
+				return;
+			}
+			this._accountUnsubscribe = unsubscribe;
+		} catch {
+			// The account bar is non-critical — swallow so wiring failures never break the graph.
+		}
 	}
 
 	/** Fetches the Launchpad summary into the shared store. Connection-gated: probes integration
@@ -1277,6 +1389,13 @@ export class GraphApp extends SignalWatcher(LitElement) {
 			void this.initLaunchpad(this.services);
 		}
 
+		// Start the account-bar context wiring once `services` first resolves (same one-shot
+		// pattern as the Launchpad pipeline above — `services` is a `@consume`d context value).
+		if (!this._accountContextsInitialized && this.services != null) {
+			this._accountContextsInitialized = true;
+			void this.initAccountContexts(this.services);
+		}
+
 		// Invalidate any captured scope-restore mode on repo switch: a captured `_modeBeforeScope`
 		// always belongs to the repo that was active when `openTimelineScope` ran. If the user
 		// switches repos before scope-applied fires, restoring that mode on the new repo would
@@ -1434,6 +1553,7 @@ export class GraphApp extends SignalWatcher(LitElement) {
 		const { single, multi } = this.activeSelection;
 		return html`
 			<div class="graph">
+				<gl-account-bar class="graph__account-bar"></gl-account-bar>
 				<gl-graph-header
 					class="graph__header"
 					.selectCommits=${this.selectCommits}

--- a/src/webviews/apps/plus/graph/graph.scss
+++ b/src/webviews/apps/plus/graph/graph.scss
@@ -1576,6 +1576,17 @@ web-graph {
 	padding: 0.1rem;
 	overflow: hidden;
 
+	// Account + integrations bar (issue #5411): sits above the graph header, always visible so
+	// account/integrations state is available when the Graph is the main GitLens panel.
+	&__account-bar {
+		position: relative;
+		z-index: var(--gl-z-sticky);
+		flex: none;
+		min-width: 0;
+		padding: var(--gl-space-4) var(--gl-space-6);
+		border-bottom: var(--gl-border-width) solid var(--vscode-sideBarSectionHeader-border, transparent);
+	}
+
 	&__header {
 		position: relative;
 		z-index: var(--gl-z-sticky);

--- a/src/webviews/apps/plus/shared/components/account-bar.ts
+++ b/src/webviews/apps/plus/shared/components/account-bar.ts
@@ -1,0 +1,61 @@
+import { css, html, LitElement } from 'lit';
+import { customElement, query } from 'lit/decorators.js';
+import { elementBase, linkBase } from '../../../shared/components/styles/lit/base.css.js';
+import type { GlAccountChip } from './account-chip.js';
+import './account-chip.js';
+import './integrations-chip.js';
+
+/**
+ * The account + integrations bar: the user's account chip (avatar + subscription tier)
+ * on the left and the integrations status chip on the right.
+ *
+ * Extracted from `<gl-home-header>` so it can be reused across webviews (e.g. the Graph
+ * view). Consumes the shared `subscriptionContext`, `integrationsContext`, and `aiContext`
+ * — the host must provide those for the chips to render live state.
+ */
+@customElement('gl-account-bar')
+export class GlAccountBar extends LitElement {
+	static override styles = [
+		elementBase,
+		linkBase,
+		css`
+			:host {
+				display: block;
+			}
+
+			.container {
+				display: flex;
+				gap: var(--gl-space-6);
+				align-items: center;
+				justify-content: space-between;
+				color: var(--vscode-sideBar-foreground, var(--vscode-foreground));
+			}
+
+			.container:focus,
+			.container:focus-within {
+				outline: none;
+			}
+
+			.group {
+				display: flex;
+				gap: var(--gl-space-4);
+				align-items: center;
+			}
+		`,
+	];
+
+	@query('gl-account-chip')
+	private accountChip!: GlAccountChip;
+
+	override render(): unknown {
+		return html`<div class="container" tabindex="-1">
+			<span class="group"><gl-account-chip></gl-account-chip></span>
+			<gl-integrations-chip></gl-integrations-chip>
+		</div>`;
+	}
+
+	show(): void {
+		// `show()` may be called before the first render completes, so guard the queried chip.
+		this.accountChip?.show();
+	}
+}

--- a/src/webviews/apps/plus/shared/components/home-header.ts
+++ b/src/webviews/apps/plus/shared/components/home-header.ts
@@ -2,9 +2,8 @@ import { css, html, LitElement } from 'lit';
 import { customElement, query } from 'lit/decorators.js';
 import type { GlPromoBanner } from '../../../home/components/promo-banner.js';
 import { elementBase, linkBase } from '../../../shared/components/styles/lit/base.css.js';
-import type { GlAccountChip } from './account-chip.js';
-import './account-chip.js';
-import './integrations-chip.js';
+import type { GlAccountBar } from './account-bar.js';
+import './account-bar.js';
 import '../../../home/components/onboarding.js';
 import '../../../home/components/promo-banner.js';
 import '../../../shared/components/button.js';
@@ -23,28 +22,6 @@ export class GlHomeHeader extends LitElement {
 				display: block;
 			}
 
-			.container {
-				display: flex;
-				gap: var(--gl-space-6);
-				align-items: center;
-				justify-content: space-between;
-				color: var(--vscode-sideBar-foreground, var(--vscode-foreground));
-			}
-
-			.container:focus,
-			.container:focus-within {
-				outline: none;
-			}
-
-			/* .actions {
-		flex: none;
-		display: flex;
-		gap: var(--gl-space-2);
-		flex-direction: row;
-		align-items: center;
-		justify-content: center;
-	} */
-
 			gl-promo-banner {
 				margin: 0 var(--gl-space-2) var(--gl-space-6);
 			}
@@ -52,32 +29,24 @@ export class GlHomeHeader extends LitElement {
 			gl-promo-banner:has(gl-promo:not([has-promo])) {
 				display: none;
 			}
-
-			.group {
-				display: flex;
-				gap: var(--gl-space-4);
-				align-items: center;
-			}
 		`,
 	];
 
-	@query('gl-account-chip')
-	private accountChip!: GlAccountChip;
+	@query('gl-account-bar')
+	private accountBar!: GlAccountBar;
 
 	@query('gl-promo-banner')
 	private promoBanner!: GlPromoBanner;
 
 	override render(): unknown {
 		return html`<gl-promo-banner></gl-promo-banner>
-			<div class="container" tabindex="-1">
-				<span class="group"><gl-account-chip></gl-account-chip></span>
-				<gl-integrations-chip></gl-integrations-chip>
-			</div>
+			<gl-account-bar></gl-account-bar>
 			<gl-onboarding></gl-onboarding>`;
 	}
 
 	show(): void {
-		this.accountChip.show();
+		// `show()` may be called before the first render resolves the queried bar.
+		this.accountBar?.show();
 	}
 
 	refreshPromo(): void {


### PR DESCRIPTION
# Description

Extracts the account + integrations bar out of `<gl-home-header>` into a reusable `<gl-account-bar>` component and wires it into the Graph view, so account/integrations state is visible when the Graph is the main GitLens panel.

- Adds `<gl-account-bar>` wrapping the account and integrations chips
- Updates `<gl-home-header>` to consume the new component
- Provides `subscription`/`integrations`/`ai` contexts in the Graph app and populates them from the host once services resolve (mirrors the Home view wiring)
- Styles the account bar above the graph header

Closes #5411

> [!NOTE]
> The context wiring in `graph-app.ts` mirrors the Home view — a follow-up should extract it into a reusable helper.

# Checklist

- [x] My changes follow the coding style of this project
- [x] My changes build without any errors or warnings
- [x] My changes have been formatted and linted
- [x] My changes have been rebased on the latest `main`
- [ ] My changes include any required corresponding changes to the documentation (including CHANGELOG.md and README.md)
