### PR TITLE
Stashes and Tags telemetry in graph sidebar

### DIFF
--- a/docs/telemetry-events.md
+++ b/docs/telemetry-events.md
@@ -3387,6 +3387,229 @@ background-upgraded the extension while the host kept running the old build
 }
 ```
 
+### graph/stashes/filtered
+
+> Sent when the user types in the filter box in the sidebar stashes panel
+
+```typescript
+{
+  'context.repository.closed': boolean,
+  'context.repository.folder.scheme': string,
+  'context.repository.id': string,
+  'context.repository.provider.id': string,
+  'context.repository.scheme': string,
+  'context.webview.host': 'view' | 'editor' | 'panel',
+  'context.webview.id': string,
+  'context.webview.instanceId': string,
+  'context.webview.type': string,
+  'filter.length': number,
+  'hasFilter': boolean,
+  'stashes.count': number
+}
+```
+
+### graph/stashes/headerAction
+
+> Sent when the user clicks a header action (Stash All, Apply/Pop Stash, Refresh) in the sidebar stashes panel
+
+```typescript
+{
+  'action': 'refresh' | 'stashAll' | 'applyStash',
+  'context.repository.closed': boolean,
+  'context.repository.folder.scheme': string,
+  'context.repository.id': string,
+  'context.repository.provider.id': string,
+  'context.repository.scheme': string,
+  'context.webview.host': 'view' | 'editor' | 'panel',
+  'context.webview.id': string,
+  'context.webview.instanceId': string,
+  'context.webview.type': string
+}
+```
+
+### graph/stashes/shown
+
+> Sent when the Stashes sidebar panel becomes visible
+
+```typescript
+{
+  'context.repository.closed': boolean,
+  'context.repository.folder.scheme': string,
+  'context.repository.id': string,
+  'context.repository.provider.id': string,
+  'context.repository.scheme': string,
+  'context.webview.host': 'view' | 'editor' | 'panel',
+  'context.webview.id': string,
+  'context.webview.instanceId': string,
+  'context.webview.type': string,
+  'stashes.count': number
+}
+```
+
+### graph/stashes/stashAction
+
+> Sent when the user clicks an inline action (apply/pop, delete) on a stash item
+
+```typescript
+{
+  'action': 'apply' | 'delete',
+  // Reserved for parity with other panels' item actions — no stash inline action defines an alt variant yet, so always false today
+  'alt': boolean,
+  'context.repository.closed': boolean,
+  'context.repository.folder.scheme': string,
+  'context.repository.id': string,
+  'context.repository.provider.id': string,
+  'context.repository.scheme': string,
+  'context.webview.host': 'view' | 'editor' | 'panel',
+  'context.webview.id': string,
+  'context.webview.instanceId': string,
+  'context.webview.type': string
+}
+```
+
+### graph/stashes/stashSelected
+
+> Sent when the user clicks a stash leaf in the sidebar stashes panel
+
+```typescript
+{
+  'context.repository.closed': boolean,
+  'context.repository.folder.scheme': string,
+  'context.repository.id': string,
+  'context.repository.provider.id': string,
+  'context.repository.scheme': string,
+  'context.webview.host': 'view' | 'editor' | 'panel',
+  'context.webview.id': string,
+  'context.webview.instanceId': string,
+  'context.webview.type': string,
+  // Whether the stash carries the branch ref it was created on
+  'hasStashOnRef': boolean
+}
+```
+
+### graph/tags/filtered
+
+> Sent when the user types in the filter box in the sidebar tags panel
+
+```typescript
+{
+  'context.repository.closed': boolean,
+  'context.repository.folder.scheme': string,
+  'context.repository.id': string,
+  'context.repository.provider.id': string,
+  'context.repository.scheme': string,
+  'context.webview.host': 'view' | 'editor' | 'panel',
+  'context.webview.id': string,
+  'context.webview.instanceId': string,
+  'context.webview.type': string,
+  'filter.length': number,
+  'hasFilter': boolean,
+  'tags.count': number
+}
+```
+
+### graph/tags/headerAction
+
+> Sent when the user clicks a header action (Create Tag, Refresh) in the sidebar tags panel
+
+```typescript
+{
+  'action': 'refresh' | 'createTag',
+  'context.repository.closed': boolean,
+  'context.repository.folder.scheme': string,
+  'context.repository.id': string,
+  'context.repository.provider.id': string,
+  'context.repository.scheme': string,
+  'context.webview.host': 'view' | 'editor' | 'panel',
+  'context.webview.id': string,
+  'context.webview.instanceId': string,
+  'context.webview.type': string
+}
+```
+
+### graph/tags/layoutToggled
+
+> Sent when the user toggles the tree/list layout in the sidebar tags panel
+
+```typescript
+{
+  'context.repository.closed': boolean,
+  'context.repository.folder.scheme': string,
+  'context.repository.id': string,
+  'context.repository.provider.id': string,
+  'context.repository.scheme': string,
+  'context.webview.host': 'view' | 'editor' | 'panel',
+  'context.webview.id': string,
+  'context.webview.instanceId': string,
+  'context.webview.type': string,
+  'layout': 'list' | 'tree',
+  'tags.count': number
+}
+```
+
+### graph/tags/shown
+
+> Sent when the Tags sidebar panel becomes visible
+
+```typescript
+{
+  'context.repository.closed': boolean,
+  'context.repository.folder.scheme': string,
+  'context.repository.id': string,
+  'context.repository.provider.id': string,
+  'context.repository.scheme': string,
+  'context.webview.host': 'view' | 'editor' | 'panel',
+  'context.webview.id': string,
+  'context.webview.instanceId': string,
+  'context.webview.type': string,
+  'layout': 'list' | 'tree',
+  // Number of annotated tags (tag objects with their own metadata) vs lightweight refs
+  'tags.annotated.count': number,
+  'tags.count': number
+}
+```
+
+### graph/tags/tagAction
+
+> Sent when the user clicks an inline action (switch to tag) on a tag item
+
+```typescript
+{
+  'action': 'switchTo',
+  // Reserved for parity with other panels' item actions — no tag inline action defines an alt variant yet, so always false today
+  'alt': boolean,
+  'context.repository.closed': boolean,
+  'context.repository.folder.scheme': string,
+  'context.repository.id': string,
+  'context.repository.provider.id': string,
+  'context.repository.scheme': string,
+  'context.webview.host': 'view' | 'editor' | 'panel',
+  'context.webview.id': string,
+  'context.webview.instanceId': string,
+  'context.webview.type': string
+}
+```
+
+### graph/tags/tagSelected
+
+> Sent when the user clicks a tag leaf in the sidebar tags panel
+
+```typescript
+{
+  // Whether the selected tag is annotated (a tag object) vs a lightweight ref
+  'annotated': boolean,
+  'context.repository.closed': boolean,
+  'context.repository.folder.scheme': string,
+  'context.repository.id': string,
+  'context.repository.provider.id': string,
+  'context.repository.scheme': string,
+  'context.webview.host': 'view' | 'editor' | 'panel',
+  'context.webview.id': string,
+  'context.webview.instanceId': string,
+  'context.webview.type': string
+}
+```
+
 ### graph/virtualFile/failed
 
 > Sent when opening a virtual-FS-backed file fails (e.g. the compose session is no longer registered)
@@ -3439,7 +3662,7 @@ background-upgraded the extension while the host kept running the old build
 ```typescript
 {
   // Which action was triggered
-  'action': 'createPullRequest' | 'startReview' | 'startWork' | 'fetch' | 'pull' | 'push' | 'createBranch' | 'publishBranch' | 'forcePush' | 'switchBranch' | 'createPullRequestWithAI' | 'rebaseOntoMergeTarget' | 'mergeMergeTarget' | 'shareAsCloudPatch' | 'copyPatch' | 'stashSave' | 'stashSaveStaged' | 'stashSaveFiles' | 'applyStash' | 'createWorktree',
+  'action': 'createPullRequest' | 'startReview' | 'startWork' | 'fetch' | 'pull' | 'push' | 'createBranch' | 'publishBranch' | 'applyStash' | 'forcePush' | 'switchBranch' | 'createPullRequestWithAI' | 'rebaseOntoMergeTarget' | 'mergeMergeTarget' | 'shareAsCloudPatch' | 'copyPatch' | 'stashSave' | 'stashSaveStaged' | 'stashSaveFiles' | 'createWorktree',
   'context.repository.closed': boolean,
   'context.repository.folder.scheme': string,
   'context.repository.id': string,

--- a/packages/git-cli/src/providers/__tests__/integration/tags.test.ts
+++ b/packages/git-cli/src/providers/__tests__/integration/tags.test.ts
@@ -43,6 +43,16 @@ suite('TagsSubProvider', () => {
 		assert.strictEqual(tag.sha, getHeadSha(repo.path));
 	});
 
+	test('getTags reports annotated vs lightweight tags', async () => {
+		const result = await repo.provider.tags.getTags(repo.path);
+		const byName = new Map(result.values.map(t => [t.name, t]));
+
+		// v1.0.0 and v2.0.0 were created with a message (annotated); v1.1.0 without (lightweight).
+		assert.strictEqual(byName.get('v1.0.0')?.annotated, true, 'v1.0.0 should be annotated');
+		assert.strictEqual(byName.get('v2.0.0')?.annotated, true, 'v2.0.0 should be annotated');
+		assert.strictEqual(byName.get('v1.1.0')?.annotated, false, 'v1.1.0 should be lightweight');
+	});
+
 	test('getTags supports filtering', async () => {
 		const result = await repo.provider.tags.getTags(repo.path, {
 			filter: t => t.name.startsWith('v1.'),

--- a/packages/git-cli/src/providers/tags.ts
+++ b/packages/git-cli/src/providers/tags.ts
@@ -66,6 +66,7 @@ export class TagsGitSubProvider implements GitTagsSubProvider {
 
 						// Annotated tags: peeledObjectname is the commit SHA; objectname is the tag-object SHA.
 						// Lightweight tags: peeledObjectname is empty; objectname is already the commit SHA.
+						const annotated = Boolean(record.peeledObjectname);
 						const sha = record.peeledObjectname || record.objectname;
 
 						tags.push(
@@ -76,6 +77,7 @@ export class TagsGitSubProvider implements GitTagsSubProvider {
 								record.subject,
 								record.creatorDate ? new Date(record.creatorDate) : undefined,
 								record.authorDate ? new Date(record.authorDate) : undefined,
+								annotated,
 							),
 						);
 					}

--- a/packages/git/src/models/tag.ts
+++ b/packages/git/src/models/tag.ts
@@ -28,8 +28,9 @@ export class GitTag implements GitTagReference {
 		public readonly commitDate: Date | undefined,
 		/** Whether this is an annotated tag (a tag object with its own metadata) vs a lightweight
 		 *  tag (a plain ref to a commit). Note `message` is the commit subject for lightweight tags,
-		 *  so it can't be used to infer this. */
-		public readonly annotated: boolean = false,
+		 *  so it can't be used to infer this. Required so any new tag source must decide explicitly
+		 *  rather than silently defaulting (which would skew tag-annotation telemetry). */
+		public readonly annotated: boolean,
 	) {
 		({ name: this._name } = parseRefName(refName));
 

--- a/packages/git/src/models/tag.ts
+++ b/packages/git/src/models/tag.ts
@@ -26,6 +26,10 @@ export class GitTag implements GitTagReference {
 		public readonly message: string,
 		public readonly date: Date | undefined,
 		public readonly commitDate: Date | undefined,
+		/** Whether this is an annotated tag (a tag object with its own metadata) vs a lightweight
+		 *  tag (a plain ref to a commit). Note `message` is the commit subject for lightweight tags,
+		 *  so it can't be used to infer this. */
+		public readonly annotated: boolean = false,
 	) {
 		({ name: this._name } = parseRefName(refName));
 
@@ -46,7 +50,7 @@ export class GitTag implements GitTagReference {
 	withRepoPath(repoPath: string): GitTag {
 		if (repoPath === this.repoPath) return this;
 
-		return new GitTag(repoPath, this.refName, this.sha, this.message, this.date, this.commitDate);
+		return new GitTag(repoPath, this.refName, this.sha, this.message, this.date, this.commitDate, this.annotated);
 	}
 
 	static is(tag: unknown): tag is GitTag {

--- a/packages/plus/git-github/src/providers/github/tags.ts
+++ b/packages/plus/git-github/src/providers/github/tags.ts
@@ -80,6 +80,8 @@ export class TagsGitSubProvider implements GitTagsSubProvider {
 									tag.target.message ?? tag.target.target?.message ?? '',
 									authoredDate != null ? new Date(authoredDate) : undefined,
 									committedDate != null ? new Date(committedDate) : undefined,
+									// Annotated tags carry a tagger (and a nested target commit); lightweight tags don't.
+									tag.target.tagger != null || tag.target.target != null,
 								),
 							);
 						}

--- a/src/constants.telemetry.ts
+++ b/src/constants.telemetry.ts
@@ -382,6 +382,30 @@ export interface TelemetryEvents extends WebviewShowAbortedEvents, WebviewShownE
 	/** Sent when the user types in the filter box in the sidebar remotes panel (debounced, not on every keystroke) */
 	'graph/remotes/filtered': GraphSidebarRemotesFilteredEvent;
 
+	/** Sent when the Stashes sidebar panel becomes visible */
+	'graph/stashes/shown': GraphSidebarStashesShownEvent;
+	/** Sent when the user clicks a stash leaf in the sidebar stashes panel */
+	'graph/stashes/stashSelected': GraphSidebarStashesStashSelectedEvent;
+	/** Sent when the user clicks an inline action (apply/pop, delete) on a stash item */
+	'graph/stashes/stashAction': GraphSidebarStashesStashActionEvent;
+	/** Sent when the user clicks a header action (Stash All, Apply/Pop Stash, Refresh) in the sidebar stashes panel */
+	'graph/stashes/headerAction': GraphSidebarStashesHeaderActionEvent;
+	/** Sent when the user types in the filter box in the sidebar stashes panel */
+	'graph/stashes/filtered': GraphSidebarStashesFilteredEvent;
+
+	/** Sent when the Tags sidebar panel becomes visible */
+	'graph/tags/shown': GraphSidebarTagsShownEvent;
+	/** Sent when the user clicks a tag leaf in the sidebar tags panel */
+	'graph/tags/tagSelected': GraphSidebarTagsTagSelectedEvent;
+	/** Sent when the user clicks an inline action (switch to tag) on a tag item */
+	'graph/tags/tagAction': GraphSidebarTagsTagActionEvent;
+	/** Sent when the user clicks a header action (Create Tag, Refresh) in the sidebar tags panel */
+	'graph/tags/headerAction': GraphSidebarTagsHeaderActionEvent;
+	/** Sent when the user toggles the tree/list layout in the sidebar tags panel */
+	'graph/tags/layoutToggled': GraphSidebarTagsLayoutToggledEvent;
+	/** Sent when the user types in the filter box in the sidebar tags panel */
+	'graph/tags/filtered': GraphSidebarTagsFilteredEvent;
+
 	/** Sent when the integrated graph details panel is expanded */
 	'graphDetails/shown': GraphDetailsShownEvent;
 	/** Sent when the integrated graph details panel is collapsed */
@@ -1936,6 +1960,64 @@ interface GraphSidebarRemotesFilteredEvent extends GraphContextEventData {
 	/** Total remotes in the panel (the filter corpus), NOT the number of matches — matching
 	 *  happens inside the tree component and the match count isn't surfaced. */
 	'remotes.count': number;
+}
+
+interface GraphSidebarStashesShownEvent extends GraphContextEventData {
+	'stashes.count': number;
+}
+
+interface GraphSidebarStashesStashSelectedEvent extends GraphContextEventData {
+	/** Whether the stash carries the branch ref it was created on */
+	hasStashOnRef: boolean;
+}
+
+interface GraphSidebarStashesStashActionEvent extends GraphContextEventData {
+	action: 'apply' | 'delete';
+	/** Reserved for parity with other panels' item actions — no stash inline action defines an alt variant yet, so always false today */
+	alt: boolean;
+}
+
+interface GraphSidebarStashesHeaderActionEvent extends GraphContextEventData {
+	action: 'stashAll' | 'applyStash' | 'refresh';
+}
+
+interface GraphSidebarStashesFilteredEvent extends GraphContextEventData {
+	hasFilter: boolean;
+	'filter.length': number;
+	'stashes.count': number;
+}
+
+interface GraphSidebarTagsShownEvent extends GraphContextEventData {
+	layout: 'list' | 'tree';
+	'tags.count': number;
+	/** Number of annotated tags (tag objects with their own metadata) vs lightweight refs */
+	'tags.annotated.count': number;
+}
+
+interface GraphSidebarTagsTagSelectedEvent extends GraphContextEventData {
+	/** Whether the selected tag is annotated (a tag object) vs a lightweight ref */
+	annotated: boolean;
+}
+
+interface GraphSidebarTagsTagActionEvent extends GraphContextEventData {
+	action: 'switchTo';
+	/** Reserved for parity with other panels' item actions — no tag inline action defines an alt variant yet, so always false today */
+	alt: boolean;
+}
+
+interface GraphSidebarTagsHeaderActionEvent extends GraphContextEventData {
+	action: 'createTag' | 'refresh';
+}
+
+interface GraphSidebarTagsLayoutToggledEvent extends GraphContextEventData {
+	layout: 'list' | 'tree';
+	'tags.count': number;
+}
+
+interface GraphSidebarTagsFilteredEvent extends GraphContextEventData {
+	hasFilter: boolean;
+	'filter.length': number;
+	'tags.count': number;
 }
 
 export type HomeTelemetryContext = WebviewTelemetryContext;

--- a/src/git/__tests__/cache.test.ts
+++ b/src/git/__tests__/cache.test.ts
@@ -307,7 +307,7 @@ suite('Cache Test Suite', () => {
 			const factory = (commonPath: string): PagedResult<GitTag> => {
 				factoryCallCount++;
 				return {
-					values: [new GitTag(commonPath, 'refs/tags/v1.0', 'abc', 'Release', undefined, undefined)],
+					values: [new GitTag(commonPath, 'refs/tags/v1.0', 'abc', 'Release', undefined, undefined, false)],
 				};
 			};
 
@@ -339,7 +339,7 @@ suite('Cache Test Suite', () => {
 			const factory = (commonPath: string): PagedResult<GitTag> => {
 				factoryCallCount++;
 				return {
-					values: [new GitTag(commonPath, 'refs/tags/v1.0', 'abc', 'Release', undefined, undefined)],
+					values: [new GitTag(commonPath, 'refs/tags/v1.0', 'abc', 'Release', undefined, undefined, false)],
 				};
 			};
 
@@ -369,7 +369,9 @@ suite('Cache Test Suite', () => {
 			const factory = (commonPath: string): PagedResult<GitTag> => {
 				factoryCallCount++;
 				return {
-					values: [new GitTag(commonPath, 'refs/tags/v1.0', 'abc123', 'Release', undefined, undefined)],
+					values: [
+						new GitTag(commonPath, 'refs/tags/v1.0', 'abc123', 'Release', undefined, undefined, false),
+					],
 				};
 			};
 
@@ -399,7 +401,9 @@ suite('Cache Test Suite', () => {
 			const factory = (commonPath: string): PagedResult<GitTag> => {
 				factoryCallCount++;
 				return {
-					values: [new GitTag(commonPath, 'refs/tags/v1.0', 'abc123', 'Release', undefined, undefined)],
+					values: [
+						new GitTag(commonPath, 'refs/tags/v1.0', 'abc123', 'Release', undefined, undefined, false),
+					],
 				};
 			};
 
@@ -433,7 +437,9 @@ suite('Cache Test Suite', () => {
 				factoryCallCount++;
 				factorySignal = signal;
 				return d.promise.then(r => ({
-					values: r.values.map(t => new GitTag(commonPath, t.name, t.sha, t.message, t.date, t.commitDate)),
+					values: r.values.map(
+						t => new GitTag(commonPath, t.name, t.sha, t.message, t.date, t.commitDate, t.annotated),
+					),
 				}));
 			};
 
@@ -452,7 +458,9 @@ suite('Cache Test Suite', () => {
 			await assert.rejects(p1, (e: unknown) => isCancellationError(e));
 
 			d.resolve({
-				values: [new GitTag('/code/project', 'refs/tags/v1.0', 'abc123', 'Release', undefined, undefined)],
+				values: [
+					new GitTag('/code/project', 'refs/tags/v1.0', 'abc123', 'Release', undefined, undefined, false),
+				],
 			});
 			const result = await p2;
 			assert.strictEqual(result.values.length, 1);
@@ -472,7 +480,9 @@ suite('Cache Test Suite', () => {
 			const factory = (commonPath: string): PagedResult<GitTag> => {
 				factoryCallCount++;
 				return {
-					values: [new GitTag(commonPath, 'refs/tags/v1.0', 'abc123', 'Release', undefined, undefined)],
+					values: [
+						new GitTag(commonPath, 'refs/tags/v1.0', 'abc123', 'Release', undefined, undefined, false),
+					],
 				};
 			};
 
@@ -498,7 +508,9 @@ suite('Cache Test Suite', () => {
 			const factory = (commonPath: string): Promise<PagedResult<GitTag>> => {
 				factoryCallCount++;
 				return d.promise.then(r => ({
-					values: r.values.map(t => new GitTag(commonPath, t.name, t.sha, t.message, t.date, t.commitDate)),
+					values: r.values.map(
+						t => new GitTag(commonPath, t.name, t.sha, t.message, t.date, t.commitDate, t.annotated),
+					),
 				}));
 			};
 
@@ -517,7 +529,7 @@ suite('Cache Test Suite', () => {
 
 			// Existing waiter still resolves with the in-flight value
 			d.resolve({
-				values: [new GitTag('/code/project', 'refs/tags/v1.0', 'abc', 'Release', undefined, undefined)],
+				values: [new GitTag('/code/project', 'refs/tags/v1.0', 'abc', 'Release', undefined, undefined, false)],
 			});
 			await p1;
 			await p2;
@@ -528,12 +540,14 @@ suite('Cache Test Suite', () => {
 			const p3 = cache.getTags('/code/project', (commonPath: string) => {
 				factoryCallCount++;
 				return d2.promise.then(r => ({
-					values: r.values.map(t => new GitTag(commonPath, t.name, t.sha, t.message, t.date, t.commitDate)),
+					values: r.values.map(
+						t => new GitTag(commonPath, t.name, t.sha, t.message, t.date, t.commitDate, t.annotated),
+					),
 				}));
 			});
 			assert.strictEqual(factoryCallCount, 2);
 			d2.resolve({
-				values: [new GitTag('/code/project', 'refs/tags/v1.0', 'abc', 'Release', undefined, undefined)],
+				values: [new GitTag('/code/project', 'refs/tags/v1.0', 'abc', 'Release', undefined, undefined, false)],
 			});
 			await p3;
 		});
@@ -556,7 +570,9 @@ suite('Cache Test Suite', () => {
 			const factory = (commonPath: string): PagedResult<GitTag> => {
 				factoryCallCount++;
 				return {
-					values: [new GitTag(commonPath, 'refs/tags/v1.0', 'abc123', 'Release', undefined, undefined)],
+					values: [
+						new GitTag(commonPath, 'refs/tags/v1.0', 'abc123', 'Release', undefined, undefined, false),
+					],
 				};
 			};
 
@@ -651,7 +667,7 @@ suite('Cache Test Suite', () => {
 			const factory2 = (commonPath: string): PagedResult<GitTag> => {
 				factoryCallCount++;
 				return {
-					values: [new GitTag(commonPath, 'refs/tags/v1.0', 'abc', 'Release', undefined, undefined)],
+					values: [new GitTag(commonPath, 'refs/tags/v1.0', 'abc', 'Release', undefined, undefined, false)],
 				};
 			};
 
@@ -686,7 +702,7 @@ suite('Cache Test Suite', () => {
 			const seedFactory = (commonPath: string): PagedResult<GitTag> => {
 				factoryCallCount++;
 				return {
-					values: [new GitTag(commonPath, 'refs/tags/v0.1', 'aaa', 'Seed', undefined, undefined)],
+					values: [new GitTag(commonPath, 'refs/tags/v0.1', 'aaa', 'Seed', undefined, undefined, false)],
 				};
 			};
 			await cache.getTags('/code/project-feature-a', seedFactory);
@@ -718,7 +734,7 @@ suite('Cache Test Suite', () => {
 			const freshFactory = (commonPath: string): PagedResult<GitTag> => {
 				factoryCallCount++;
 				return {
-					values: [new GitTag(commonPath, 'refs/tags/v2.0', 'ccc', 'Fresh', undefined, undefined)],
+					values: [new GitTag(commonPath, 'refs/tags/v2.0', 'ccc', 'Fresh', undefined, undefined, false)],
 				};
 			};
 			const resultB = await cache.getTags('/code/project-feature-b', freshFactory);

--- a/src/webviews/apps/plus/graph/sidebar/__tests__/sidebarTelemetry.utils.test.ts
+++ b/src/webviews/apps/plus/graph/sidebar/__tests__/sidebarTelemetry.utils.test.ts
@@ -1,0 +1,54 @@
+import * as assert from 'assert';
+import { getSidebarTagNameFromPath, resolveSelectedTag } from '../sidebarTelemetry.utils.js';
+
+suite('getSidebarTagNameFromPath', () => {
+	test('list mode: parses name after the second colon', () => {
+		assert.strictEqual(getSidebarTagNameFromPath('flat:abc123:v1.0'), 'v1.0');
+	});
+
+	test('list mode: preserves colons within the tag name', () => {
+		assert.strictEqual(getSidebarTagNameFromPath('flat:abc123:release:1.0'), 'release:1.0');
+	});
+
+	test('tree mode: strips the leading slash from a simple name', () => {
+		assert.strictEqual(getSidebarTagNameFromPath('/v2.0'), 'v2.0');
+	});
+
+	test('tree mode: strips only the leading slash from a nested name', () => {
+		assert.strictEqual(getSidebarTagNameFromPath('/release/1.0'), 'release/1.0');
+	});
+
+	test('returns undefined for an undefined path', () => {
+		assert.strictEqual(getSidebarTagNameFromPath(undefined), undefined);
+	});
+});
+
+suite('resolveSelectedTag', () => {
+	const annotated = { name: 'release/1.0', sha: 'shared', annotated: true };
+	const lightweight = { name: 'v1.0', sha: 'shared', annotated: false };
+	const other = { name: 'v2.0', sha: 'other', annotated: false };
+	const items = [annotated, lightweight, other];
+
+	test('resolves the nested tag by tree-mode path (leading slash)', () => {
+		assert.strictEqual(resolveSelectedTag(items, 'shared', '/release/1.0'), annotated);
+	});
+
+	test('resolves by list-mode path', () => {
+		assert.strictEqual(resolveSelectedTag(items, 'shared', 'flat:shared:v1.0'), lightweight);
+	});
+
+	test('two tags sharing a commit resolve distinctly by path, not sha', () => {
+		// Both `annotated` and `lightweight` are on sha `shared`; the path must decide which one.
+		assert.strictEqual(resolveSelectedTag(items, 'shared', '/release/1.0'), annotated);
+		assert.strictEqual(resolveSelectedTag(items, 'shared', '/v1.0'), lightweight);
+	});
+
+	test('falls back to the first sha match when the path does not resolve to a name', () => {
+		assert.strictEqual(resolveSelectedTag(items, 'shared', undefined), annotated);
+		assert.strictEqual(resolveSelectedTag(items, 'other', '/nonexistent'), other);
+	});
+
+	test('returns undefined when neither path nor sha matches', () => {
+		assert.strictEqual(resolveSelectedTag(items, 'missing', '/nonexistent'), undefined);
+	});
+});

--- a/src/webviews/apps/plus/graph/sidebar/sidebar-panel.ts
+++ b/src/webviews/apps/plus/graph/sidebar/sidebar-panel.ts
@@ -46,6 +46,7 @@ import { graphStateContext } from '../context.js';
 import { branchActionsToTelemetryNames, getBranchLeafActions } from './branchActions.utils.js';
 import { sidebarActionsContext } from './sidebarContext.js';
 import type { SidebarActions } from './sidebarState.js';
+import { resolveSelectedTag } from './sidebarTelemetry.utils.js';
 import '../overview/graph-overview.js';
 import '../../../shared/components/commit/commit-stats.js';
 import '../../../shared/components/commit/wip-stats.js';
@@ -2066,13 +2067,9 @@ export class GlGraphSidebarPanel extends SignalWatcher(LitElement) {
 		const data = this._actions?.state.panels.tags?.value.get();
 		if (data?.panel !== 'tags') return;
 
-		// Multiple tags can point at the same commit (`sha` is the peeled commit sha), so a sha
-		// match can resolve to the wrong tag and mis-report `annotated`. Prefer the clicked node's
-		// path, which uniquely identifies the tag — `flat:<sha>:<name>` in list mode; in tree mode
-		// `makeHierarchical`'s `relativePath`, which is the tag name with a leading slash (the
-		// join fold seeds from '') — and fall back to the first sha match.
-		const name = path?.startsWith('flat:') ? path.substring(path.indexOf(':', 5) + 1) : path?.replace(/^\//, '');
-		const tag = data.items.find(t => t.name === name) ?? data.items.find(t => t.sha === sha);
+		// Resolve by the clicked node's path (unique per tag) rather than sha, since tags can share
+		// a commit — see resolveSelectedTag for the path formats and sha fallback.
+		const tag = resolveSelectedTag(data.items, sha, path);
 		if (tag == null) return;
 
 		emitTelemetrySentEvent<'graph/tags/tagSelected'>(this, {

--- a/src/webviews/apps/plus/graph/sidebar/sidebar-panel.ts
+++ b/src/webviews/apps/plus/graph/sidebar/sidebar-panel.ts
@@ -207,6 +207,15 @@ const remoteActionMap: Partial<
 	'gitlens.disconnectRemoteProvider:graph': 'disconnectIntegration',
 };
 
+const stashActionMap: Partial<Record<GlCommands, 'apply' | 'delete'>> = {
+	'gitlens.stashApply:graph': 'apply',
+	'gitlens.stashDelete:graph': 'delete',
+};
+
+const tagActionMap: Partial<Record<GlCommands, 'switchTo'>> = {
+	'gitlens.graph.switchToTag': 'switchTo',
+};
+
 function formatWorktreeDescription(w: GraphSidebarWorktree): string | undefined {
 	if (w.upstream == null) return undefined;
 	return `\u21C6 ${w.upstream}`;
@@ -444,6 +453,10 @@ export class GlGraphSidebarPanel extends SignalWatcher(LitElement) {
 	 *  on disconnect and on `activePanel` change so switching away and back emits a fresh event
 	 *  while re-renders from data mutations (e.g. WIP pushes) do not. */
 	private _worktreesShownEmitted = false;
+	/** Same guard as `_worktreesShownEmitted`, for `graph/stashes/shown`. */
+	private _stashesShownEmitted = false;
+	/** Same guard as `_worktreesShownEmitted`, for `graph/tags/shown`. */
+	private _tagsShownEmitted = false;
 
 	/** Same as `_worktreesShownEmitted`, for the remotes panel. */
 	private _remotesShownEmitted = false;
@@ -499,8 +512,12 @@ export class GlGraphSidebarPanel extends SignalWatcher(LitElement) {
 		this.emitWorktreesFilteredTelemetryDebounced.cancel();
 		this.emitBranchesFilteredTelemetryDebounced.cancel();
 		this.emitRemotesFilteredTelemetryDebounced.cancel();
+		this.emitStashesFilteredTelemetryDebounced.cancel();
+		this.emitTagsFilteredTelemetryDebounced.cancel();
 		this._worktreesShownEmitted = false;
 		this._remotesShownEmitted = false;
+		this._stashesShownEmitted = false;
+		this._tagsShownEmitted = false;
 		super.disconnectedCallback?.();
 	}
 
@@ -514,16 +531,20 @@ export class GlGraphSidebarPanel extends SignalWatcher(LitElement) {
 
 	override willUpdate(changedProperties: Map<PropertyKey, unknown>): void {
 		if (changedProperties.has('activePanel') && this._actions != null) {
-			// Reset the shown guard so switching worktrees→other→worktrees emits a fresh impression
+			// Reset the shown guards so switching away and back emits a fresh impression
 			// while intra-activation re-renders (WIP pushes, refresh) do not.
 			this._worktreesShownEmitted = false;
 			this._remotesShownEmitted = false;
+			this._stashesShownEmitted = false;
+			this._tagsShownEmitted = false;
 
 			// Cancel any pending filtered emits — filterText is shared across panels, so a trailing
 			// callback after a switch would report against the wrong (now-inactive) panel.
 			this.emitWorktreesFilteredTelemetryDebounced.cancel();
 			this.emitBranchesFilteredTelemetryDebounced.cancel();
 			this.emitRemotesFilteredTelemetryDebounced.cancel();
+			this.emitStashesFilteredTelemetryDebounced.cancel();
+			this.emitTagsFilteredTelemetryDebounced.cancel();
 
 			// Keep the actions module in sync so invalidateAll can refetch
 			this._actions.activePanel = this.activePanel;
@@ -560,13 +581,14 @@ export class GlGraphSidebarPanel extends SignalWatcher(LitElement) {
 		}
 
 		// Emit `shown` from the settled lifecycle (not render(), which Lit expects side-effect-free).
-		// The guard fires it once per worktrees activation — reset on disconnect and on `activePanel`
+		// The guards fire it once per panel activation — reset on disconnect and on `activePanel`
 		// change so a fresh impression is recorded then, but intra-activation re-renders (WIP pushes,
 		// refresh(), filter/expansion changes) do not re-emit.
 		this.emitWorktreesShownTelemetry();
 		this.emitRemotesShownTelemetry();
-
 		this.maybeEmitBranchesShownTelemetry();
+		this.emitStashesShownTelemetry();
+		this.emitTagsShownTelemetry();
 	}
 
 	private emitWorktreesShownTelemetry(): void {
@@ -589,6 +611,50 @@ export class GlGraphSidebarPanel extends SignalWatcher(LitElement) {
 			data: {
 				layout: data.layout ?? 'list',
 				'worktrees.count': data.items.length,
+			},
+		});
+	}
+
+	private emitStashesShownTelemetry(): void {
+		if (this._stashesShownEmitted || this.activePanel !== 'stashes') return;
+
+		const resource = this._actions?.state.panels.stashes;
+		// Wait for a successful fetch (mirrors emitWorktreesShownTelemetry): on reactivation the
+		// resource still holds the previous visit's value while the switch-triggered fetch is in
+		// flight — emitting off that would report stale counts.
+		if (resource?.status.get() !== 'success') return;
+
+		const data = resource.value.get();
+		if (data?.panel !== 'stashes') return;
+
+		this._stashesShownEmitted = true;
+		emitTelemetrySentEvent<'graph/stashes/shown'>(this, {
+			name: 'graph/stashes/shown',
+			data: {
+				'stashes.count': data.items.length,
+			},
+		});
+	}
+
+	private emitTagsShownTelemetry(): void {
+		if (this._tagsShownEmitted || this.activePanel !== 'tags') return;
+
+		const resource = this._actions?.state.panels.tags;
+		// Wait for a successful fetch (mirrors emitWorktreesShownTelemetry): on reactivation the
+		// resource still holds the previous visit's value while the switch-triggered fetch is in
+		// flight — emitting off that would report stale counts.
+		if (resource?.status.get() !== 'success') return;
+
+		const data = resource.value.get();
+		if (data?.panel !== 'tags') return;
+
+		this._tagsShownEmitted = true;
+		emitTelemetrySentEvent<'graph/tags/shown'>(this, {
+			name: 'graph/tags/shown',
+			data: {
+				layout: data.layout ?? 'list',
+				'tags.count': data.items.length,
+				'tags.annotated.count': data.items.filter(t => t.annotated).length,
 			},
 		});
 	}
@@ -1337,6 +1403,14 @@ export class GlGraphSidebarPanel extends SignalWatcher(LitElement) {
 		if (this.activePanel === 'remotes') {
 			this.emitRemotesFilteredTelemetryDebounced();
 		}
+
+		if (this.activePanel === 'stashes') {
+			this.emitStashesFilteredTelemetryDebounced();
+		}
+
+		if (this.activePanel === 'tags') {
+			this.emitTagsFilteredTelemetryDebounced();
+		}
 	};
 
 	private handleSearchBoxFilterChanged = (e: CustomEvent<boolean>) => {
@@ -1401,17 +1475,44 @@ export class GlGraphSidebarPanel extends SignalWatcher(LitElement) {
 			}
 		}
 
+		if (this.activePanel === 'stashes') {
+			const action =
+				command === 'gitlens.stashSave:views'
+					? 'stashAll'
+					: command === 'gitlens.stashesApply:views'
+						? 'applyStash'
+						: undefined;
+			if (action != null) {
+				emitTelemetrySentEvent<'graph/stashes/headerAction'>(this, {
+					name: 'graph/stashes/headerAction',
+					data: { action: action },
+				});
+			}
+		}
+
+		if (this.activePanel === 'tags') {
+			const action = command === 'gitlens.views.title.createTag' ? 'createTag' : undefined;
+			if (action != null) {
+				emitTelemetrySentEvent<'graph/tags/headerAction'>(this, {
+					name: 'graph/tags/headerAction',
+					data: { action: action },
+				});
+			}
+		}
+
 		this._actions?.executeAction(command, undefined, args);
 	}
 
 	private handleToggleLayout() {
 		if (this.activePanel == null) return;
 
-		// Compute the worktrees/branches/remotes layout before toggling — the service update is async,
-		// so the resource value still reflects the old layout here; invert it to get the new one.
+		// Compute the panel layout before toggling — the service update is async, so the
+		// resource value still reflects the old layout here; invert it to get the new one.
 		const worktreesData =
 			this.activePanel === 'worktrees' ? this._actions?.state.panels.worktrees?.value.get() : undefined;
 		const worktreesNewLayout = worktreesData?.layout === 'tree' ? 'list' : 'tree';
+		const tagsData = this.activePanel === 'tags' ? this._actions?.state.panels.tags?.value.get() : undefined;
+		const tagsNewLayout = tagsData?.layout === 'tree' ? 'list' : 'tree';
 
 		const branchesData =
 			this.activePanel === 'branches' ? this._actions?.state.panels.branches?.value.get() : undefined;
@@ -1463,6 +1564,16 @@ export class GlGraphSidebarPanel extends SignalWatcher(LitElement) {
 				},
 			});
 		}
+
+		if (this.activePanel === 'tags') {
+			emitTelemetrySentEvent<'graph/tags/layoutToggled'>(this, {
+				name: 'graph/tags/layoutToggled',
+				data: {
+					layout: tagsNewLayout,
+					'tags.count': tagsData?.items.length ?? 0,
+				},
+			});
+		}
 	}
 
 	private handleRefresh() {
@@ -1503,6 +1614,20 @@ export class GlGraphSidebarPanel extends SignalWatcher(LitElement) {
 			});
 		}
 
+		if (this.activePanel === 'stashes') {
+			emitTelemetrySentEvent<'graph/stashes/headerAction'>(this, {
+				name: 'graph/stashes/headerAction',
+				data: { action: 'refresh' },
+			});
+		}
+
+		if (this.activePanel === 'tags') {
+			emitTelemetrySentEvent<'graph/tags/headerAction'>(this, {
+				name: 'graph/tags/headerAction',
+				data: { action: 'refresh' },
+			});
+		}
+
 		this._actions?.refresh(this.activePanel);
 	}
 
@@ -1536,6 +1661,14 @@ export class GlGraphSidebarPanel extends SignalWatcher(LitElement) {
 
 		if (this.activePanel === 'remotes') {
 			this.emitRemotesTreeItemActionTelemetry(command, useAlt);
+		}
+
+		if (this.activePanel === 'stashes') {
+			this.emitStashesTreeItemActionTelemetry(command, useAlt);
+		}
+
+		if (this.activePanel === 'tags') {
+			this.emitTagsTreeItemActionTelemetry(command, useAlt);
 		}
 
 		this._actions?.executeAction(command, node.contextData as string | undefined, args);
@@ -1585,6 +1718,14 @@ export class GlGraphSidebarPanel extends SignalWatcher(LitElement) {
 
 		if (this.activePanel === 'worktrees') {
 			this.emitWorktreesSelectedTelemetry(sha);
+		}
+
+		if (this.activePanel === 'stashes') {
+			this.emitStashesSelectedTelemetry(sha);
+		}
+
+		if (this.activePanel === 'tags') {
+			this.emitTagsSelectedTelemetry(sha, e.detail.node?.path);
 		}
 
 		this.dispatchEvent(
@@ -1751,6 +1892,40 @@ export class GlGraphSidebarPanel extends SignalWatcher(LitElement) {
 		});
 	}, 500);
 
+	private getStashesCount(): number {
+		const data = this._actions?.state.panels.stashes?.value.get();
+		return data?.panel === 'stashes' ? data.items.length : 0;
+	}
+
+	private readonly emitStashesFilteredTelemetryDebounced = debounce(() => {
+		const filterText = this._actions.filterText;
+		emitTelemetrySentEvent<'graph/stashes/filtered'>(this, {
+			name: 'graph/stashes/filtered',
+			data: {
+				hasFilter: filterText.length > 0,
+				'filter.length': filterText.length,
+				'stashes.count': this.getStashesCount(),
+			},
+		});
+	}, 500);
+
+	private getTagsCount(): number {
+		const data = this._actions?.state.panels.tags?.value.get();
+		return data?.panel === 'tags' ? data.items.length : 0;
+	}
+
+	private readonly emitTagsFilteredTelemetryDebounced = debounce(() => {
+		const filterText = this._actions.filterText;
+		emitTelemetrySentEvent<'graph/tags/filtered'>(this, {
+			name: 'graph/tags/filtered',
+			data: {
+				hasFilter: filterText.length > 0,
+				'filter.length': filterText.length,
+				'tags.count': this.getTagsCount(),
+			},
+		});
+	}, 500);
+
 	private emitWorktreesSelectedTelemetry(wipSha: string): void {
 		const data = this._actions?.state.panels.worktrees?.value.get();
 		if (data?.panel !== 'worktrees') return;
@@ -1868,6 +2043,62 @@ export class GlGraphSidebarPanel extends SignalWatcher(LitElement) {
 
 		emitTelemetrySentEvent<'graph/remotes/remoteAction'>(this, {
 			name: 'graph/remotes/remoteAction',
+			data: { action: action, alt: alt },
+		});
+	}
+
+	private emitStashesSelectedTelemetry(sha: string): void {
+		const data = this._actions?.state.panels.stashes?.value.get();
+		if (data?.panel !== 'stashes') return;
+
+		const stash = data.items.find(s => s.sha === sha);
+		if (stash == null) return;
+
+		emitTelemetrySentEvent<'graph/stashes/stashSelected'>(this, {
+			name: 'graph/stashes/stashSelected',
+			data: {
+				hasStashOnRef: stash.stashOnRef != null,
+			},
+		});
+	}
+
+	private emitTagsSelectedTelemetry(sha: string, path: string | undefined): void {
+		const data = this._actions?.state.panels.tags?.value.get();
+		if (data?.panel !== 'tags') return;
+
+		// Multiple tags can point at the same commit (`sha` is the peeled commit sha), so a sha
+		// match can resolve to the wrong tag and mis-report `annotated`. Prefer the clicked node's
+		// path, which uniquely identifies the tag — `flat:<sha>:<name>` in list mode; in tree mode
+		// `makeHierarchical`'s `relativePath`, which is the tag name with a leading slash (the
+		// join fold seeds from '') — and fall back to the first sha match.
+		const name = path?.startsWith('flat:') ? path.substring(path.indexOf(':', 5) + 1) : path?.replace(/^\//, '');
+		const tag = data.items.find(t => t.name === name) ?? data.items.find(t => t.sha === sha);
+		if (tag == null) return;
+
+		emitTelemetrySentEvent<'graph/tags/tagSelected'>(this, {
+			name: 'graph/tags/tagSelected',
+			data: {
+				annotated: tag.annotated,
+			},
+		});
+	}
+
+	private emitStashesTreeItemActionTelemetry(command: GlCommands, alt: boolean): void {
+		const action = stashActionMap[command];
+		if (action == null) return;
+
+		emitTelemetrySentEvent<'graph/stashes/stashAction'>(this, {
+			name: 'graph/stashes/stashAction',
+			data: { action: action, alt: alt },
+		});
+	}
+
+	private emitTagsTreeItemActionTelemetry(command: GlCommands, alt: boolean): void {
+		const action = tagActionMap[command];
+		if (action == null) return;
+
+		emitTelemetrySentEvent<'graph/tags/tagAction'>(this, {
+			name: 'graph/tags/tagAction',
 			data: { action: action, alt: alt },
 		});
 	}

--- a/src/webviews/apps/plus/graph/sidebar/sidebarTelemetry.utils.ts
+++ b/src/webviews/apps/plus/graph/sidebar/sidebarTelemetry.utils.ts
@@ -1,0 +1,31 @@
+/**
+ * Extracts a sidebar tag's name from the clicked tree-node path.
+ *
+ * The path encodes the tag differently per layout:
+ * - list mode: `flat:<sha>:<name>` (see `buildItemTree`'s flat branch) — the name is everything
+ *   after the second colon, so tag names containing `:` survive.
+ * - tree mode: `makeHierarchical`'s `relativePath`, which is the tag name with a leading slash
+ *   (the join fold seeds from `''`), e.g. `/v1.0` or `/release/1.0`.
+ *
+ * Returns undefined when there's no path to resolve from.
+ */
+export function getSidebarTagNameFromPath(path: string | undefined): string | undefined {
+	if (path == null) return undefined;
+	return path.startsWith('flat:') ? path.substring(path.indexOf(':', 5) + 1) : path.replace(/^\//, '');
+}
+
+/**
+ * Resolves the selected tag from the clicked node's path, falling back to a sha match.
+ *
+ * Multiple tags can point at the same commit (`sha` is the peeled commit sha), so a sha match alone
+ * can resolve to the wrong tag. The node path uniquely identifies the clicked tag, so prefer a
+ * name match and only fall back to sha when the path doesn't resolve (e.g. an unexpected format).
+ */
+export function resolveSelectedTag<T extends { name: string; sha?: string }>(
+	items: readonly T[],
+	sha: string,
+	path: string | undefined,
+): T | undefined {
+	const name = getSidebarTagNameFromPath(path);
+	return items.find(t => t.name === name) ?? items.find(t => t.sha === sha);
+}

--- a/src/webviews/plus/graph/graphWebview.ts
+++ b/src/webviews/plus/graph/graphWebview.ts
@@ -3966,7 +3966,7 @@ export class GraphWebviewProvider implements WebviewProvider<State, State, Graph
 			name: t.name,
 			sha: t.sha,
 			message: t.message || undefined,
-			annotated: t.message != null && t.message.length > 0,
+			annotated: t.annotated,
 			date: t.date?.getTime(),
 			context: {
 				webview: this.host.id,


### PR DESCRIPTION
Part of #5356 (Sidebar → Stashes, Tags)

## Summary

- Instruments the Graph sidebar **Stashes** and **Tags** panels, which previously emitted no telemetry beyond the tab switch (`graph/action/sidebar`).
- Follows the pattern established by the overview, agents, worktrees, remotes, and branches panels: flat `graph/stashes/*` / `graph/tags/*` event keys, `Sidebar` retained in the type-layer interface names, dot-notation for counts and camelCase for booleans/enums.
- All emission is client-side via `emitTelemetrySentEvent`, guarded by `this.activePanel === 'stashes' | 'tags'` in the shared `sidebar-panel.ts`; `shown` uses the per-activation guard fired from `updated()` and `filtered` uses the 500ms debounce (cancelled on panel switch/disconnect), both matching the worktrees implementation.
- Telemetry docs auto-regenerated via `pnpm run generate:docs:telemetry`.

### New events

| Event | When | Notable payload |
|---|---|---|
| `graph/stashes/shown` | Stashes panel becomes visible | `stashes.count` |
| `graph/stashes/stashSelected` | Click on a stash row | `hasStashOnRef` |
| `graph/stashes/stashAction` | Inline action on a stash | `action` (`apply`/`delete`), `alt` |
| `graph/stashes/headerAction` | Header button | `action` (`stashAll`/`applyStash`/`refresh`) |
| `graph/stashes/filtered` | Typing in the filter box | `hasFilter`, `filter.length`, `stashes.count` |
| `graph/tags/shown` | Tags panel becomes visible | `layout`, `tags.count`, `tags.annotated.count` |
| `graph/tags/tagSelected` | Click on a tag row | `annotated` |
| `graph/tags/tagAction` | Inline action on a tag | `action` (`switchTo`), `alt` |
| `graph/tags/headerAction` | Header button | `action` (`createTag`/`refresh`) |
| `graph/tags/layoutToggled` | Tree/list toggle | `layout` (new), `tags.count` |
| `graph/tags/filtered` | Typing in the filter box | `hasFilter`, `filter.length`, `tags.count` |

### Out of scope / notes

- **No `graph/stashes/layoutToggled`** — the stashes panel renders as a flat list and is excluded from `hasLayout`, so the toggle never shows for it.
- **Context-menu-only commands** (drop/rename stash, delete tag from context menu, etc.) bypass the webview's `handleTreeItemAction` and go straight to VS Code; instrumenting them would require host-side hooks. Deferred, consistent with the other panels' scoping.
- `tagAction.action` is a single-value union today; typed as a union for forward-compat.

## Test plan

- [ ] Open the Stashes panel — `graph/stashes/shown` fires once with correct `stashes.count`; switching away and back re-fires; intra-activation re-renders do not.
- [ ] Click a stash row — `stashSelected` with `hasStashOnRef`; inline Apply/Pop and Delete — `stashAction` with `apply`/`delete`.
- [ ] Header Stash All / Apply-Pop / Refresh — `headerAction` with `stashAll`/`applyStash`/`refresh`.
- [ ] Open the Tags panel — `graph/tags/shown` with `layout`, `tags.count`, `tags.annotated.count`.
- [ ] Click a tag row — `tagSelected` with `annotated`; inline Switch to Tag — `tagAction` with `switchTo`.
- [ ] Header Create Tag / Refresh — `headerAction`; toggle tree/list — `layoutToggled` with the new layout.
- [ ] Type in a filter box, then switch panels within 500ms — no misattributed `filtered` event.
- [ ] Payloads carry no stash messages, tag names, or refs.
- [x] `pnpm run check` clean; full build compiles; docs regenerated with no manual edits.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
