### PR TITLE
Fixes stale counts in Graph Worktrees sidebar shown telemetry

### DIFF
--- a/src/webviews/apps/plus/graph/sidebar/sidebar-panel.ts
+++ b/src/webviews/apps/plus/graph/sidebar/sidebar-panel.ts
@@ -554,7 +554,15 @@ export class GlGraphSidebarPanel extends SignalWatcher(LitElement) {
 	private emitWorktreesShownTelemetry(): void {
 		if (this._worktreesShownEmitted || this.activePanel !== 'worktrees') return;
 
-		const data = this._actions?.state.panels.worktrees?.value.get();
+		const resource = this._actions?.state.panels.worktrees;
+		// Wait for a successful fetch (mirrors maybeEmitBranchesShownTelemetry): on reactivation
+		// the resource still holds the previous visit's value while the switch-triggered fetch is
+		// in flight — emitting off that would report stale counts. 'idle' (webview boot, before
+		// the RPC service exists) and 'error' (a later retry may still succeed) also hold; the
+		// guard is only latched on emit, so this just delays until fresh data lands.
+		if (resource?.status.get() !== 'success') return;
+
+		const data = resource.value.get();
 		if (data?.panel !== 'worktrees') return;
 
 		this._worktreesShownEmitted = true;


### PR DESCRIPTION
# Description

Fixes a stale-counts hole in the `graph/worktrees/shown` telemetry that shipped with the Worktrees sidebar panel instrumentation (73dfa62f2, "Sidebar › Worktrees" of #5356).

**Problem:** the event fired as soon as the panel's resource held any non-null value. On panel *reactivation* the resource still holds the previous visit's data while the switch-triggered fetch is in flight, so the event reported `worktrees.count` from the prior visit — arguably the most common "panel becomes visible" path after first open.

**Fix:** gate the emit on the resource reaching `status === 'success'`, mirroring the Branches panel's `shown` mechanism from #5421:

- *reactivation* — the switch-triggered fetch flips `loading` synchronously before `updated()` runs, so the emit now waits for fresh data instead of reading the retained value
- *webview boot* — `'idle'` (RPC service not yet available) holds the emit until `initialize()` refetches
- *transient errors* — `'error'` holds rather than drops, so a successful retry within the same activation still records the impression
- the existing once-per-activation `_worktreesShownEmitted` latch is unchanged — it was already only set at emit time, which gives the hold-until-success behavior without restructuring

Relies on the panel resources reporting honest statuses (`refresh()`/`invalidateAll()` resetting to `'idle'` instead of `mutate(undefined)`'s `'success'`-with-no-value), which landed in #5421. A WIP-push `mutate` during an in-flight fetch cannot slip a stale emit through, since `mutate` does not clear `loading`.

No event shape changes — payload and docs are untouched, so no CHANGELOG entry (telemetry-only, not user-facing).

# Checklist

- [x] I have followed the guidelines in the Contributing document
- [x] My changes follow the coding style of this project
- [x] My changes build without any errors or warnings
- [x] My changes have been formatted and linted
- [x] My changes include any required corresponding changes to the documentation (including CHANGELOG.md and README.md)
- [x] My changes have been rebased and squashed to the minimal number (typically 1) of relevant commits
- [x] My changes have a descriptive commit message with a short title, including a `Fixes $XXX -` or `Closes #XXX -` prefix to auto-close the issue that your PR addresses

🤖 Generated with [Claude Code](https://claude.com/claude-code)
