### PR TITLE
Adds experimental hidden flag for the Graph home header (off by default)

### DIFF
--- a/docs/telemetry-events.md
+++ b/docs/telemetry-events.md
@@ -3239,6 +3239,7 @@ background-upgraded the extension while the host kept running the old build
   'context.config.details.location': 'auto' | 'right' | 'bottom',
   'context.config.dimMergeCommits': boolean,
   'context.config.editorOpeningBehavior': 'active' | 'auto',
+  'context.config.experimental.homeHeader.enabled': boolean,
   'context.config.experimental.kanban.enabled': boolean,
   'context.config.experimental.visualizations.activityDecay': '30s' | '1m' | '2m' | '5m' | '10m' | '30m',
   'context.config.experimental.visualizations.enabled': boolean,

--- a/package.json
+++ b/package.json
@@ -1348,6 +1348,16 @@
 						"scope": "window",
 						"order": 1000
 					},
+					"gitlens.graph.experimental.homeHeader.enabled": {
+						"type": "boolean",
+						"default": false,
+						"markdownDescription": "(Experimental) Specifies whether to show the home header (account and integrations status) at the top of the _Commit Graph_",
+						"scope": "window",
+						"order": 1090,
+						"tags": [
+							"experimental"
+						]
+					},
 					"gitlens.graph.experimental.kanban.enabled": {
 						"type": "boolean",
 						"default": true,

--- a/src/config.ts
+++ b/src/config.ts
@@ -430,6 +430,9 @@ export interface GraphConfig {
 	readonly dimMergeCommits: boolean;
 	readonly editorOpeningBehavior: 'auto' | 'active';
 	readonly experimental: {
+		readonly homeHeader: {
+			readonly enabled: boolean;
+		};
 		readonly kanban: {
 			readonly enabled: boolean;
 		};

--- a/src/webviews/apps/plus/graph/graph-app.ts
+++ b/src/webviews/apps/plus/graph/graph-app.ts
@@ -378,9 +378,15 @@ export class GraphApp extends SignalWatcher(LitElement) {
 		context: aiContext,
 		initialValue: this._aiState,
 	});
-	/** One-shot guard mirroring `_launchpadInitialized` for the account-bar context wiring. */
+	/** Guards the account-bar context wiring. Set true while wired (see `updated()`); reset by the
+	 *  disarm branch when the home-header flag flips off so it can re-arm. */
 	private _accountContextsInitialized = false;
 	private _accountUnsubscribe: (() => void) | undefined;
+	/** Bumped on every `initAccountContexts` entry. Because the flag can flip off→on faster than the
+	 *  service promises resolve, two inits can be in flight at once; a completing init only stores its
+	 *  subscriptions if it's still the latest generation, so an interleaved stale init tears itself down
+	 *  instead of overwriting (and leaking) the live one. */
+	private _accountInitGeneration = 0;
 
 	@consume({ context: ipcContext })
 	private readonly _ipc!: typeof ipcContext.__context__;
@@ -554,6 +560,8 @@ export class GraphApp extends SignalWatcher(LitElement) {
 	 *  state, and subscribes to change events. Mirrors the Home view (see `home.ts` / `actions.ts`
 	 *  / `events.ts`). A failed subscription must not break the graph. */
 	private async initAccountContexts(services: NonNullable<typeof this.services>): Promise<void> {
+		// Claim this generation up front; a later init (from an off→on re-arm mid-await) supersedes us.
+		const generation = ++this._accountInitGeneration;
 		// Wiring the account bar must never break the graph, so guard the whole pipeline: a rejected
 		// service promise or a failed subscription just leaves the bar without live state.
 		try {
@@ -616,10 +624,12 @@ export class GraphApp extends SignalWatcher(LitElement) {
 				async () => ai.onStateChanged(state => this._aiState.state.set(state)),
 			]);
 
-			// Guard against late completion: if the element disconnected while awaiting, `disconnectedCallback`
-			// already ran with `_accountUnsubscribe` still undefined, so tear down here to avoid leaking host
-			// subscriptions on a disposed graph.
-			if (!this.isConnected) {
+			// Guard against late completion: tear down (rather than store) if, while we were awaiting, the
+			// element disconnected (`disconnectedCallback`), the home-header flag was toggled back off (the
+			// disarm branch resets `_accountContextsInitialized`), or a newer init superseded us (off→on
+			// re-arm — `generation` is stale). Otherwise a stale init would overwrite and orphan the live
+			// subscription, leaking its host change-event traffic until graph disconnect.
+			if (!this.isConnected || !this._accountContextsInitialized || generation !== this._accountInitGeneration) {
 				unsubscribe?.();
 				return;
 			}
@@ -1391,11 +1401,20 @@ export class GraphApp extends SignalWatcher(LitElement) {
 			void this.initLaunchpad(this.services);
 		}
 
-		// Start the account-bar context wiring once `services` first resolves (same one-shot
+		// Account-bar context wiring, gated on the experimental home-header flag: the bar only renders
+		// when the flag is on, so there's nothing to wire when it's off. `updated()` re-runs when the
+		// config pushes, so this arms/disarms symmetrically as the flag flips (same `services` one-shot
 		// pattern as the Launchpad pipeline above — `services` is a `@consume`d context value).
-		if (!this._accountContextsInitialized && this.services != null) {
+		const homeHeaderEnabled = this.graphState.config?.experimentalHomeHeaderEnabled ?? false;
+		if (homeHeaderEnabled && !this._accountContextsInitialized && this.services != null) {
 			this._accountContextsInitialized = true;
 			void this.initAccountContexts(this.services);
+		} else if (!homeHeaderEnabled && this._accountContextsInitialized) {
+			// Flag turned off mid-session: tear down the host subscriptions so a hidden bar doesn't keep
+			// consuming change traffic, and re-arm cleanly if it's turned back on.
+			this._accountUnsubscribe?.();
+			this._accountUnsubscribe = undefined;
+			this._accountContextsInitialized = false;
 		}
 
 		// Invalidate any captured scope-restore mode on repo switch: a captured `_modeBeforeScope`
@@ -1555,7 +1574,10 @@ export class GraphApp extends SignalWatcher(LitElement) {
 		const { single, multi } = this.activeSelection;
 		return html`
 			<div class="graph">
-				<gl-account-bar class="graph__account-bar"></gl-account-bar>
+				${when(
+					this.graphState.config?.experimentalHomeHeaderEnabled ?? false,
+					() => html`<gl-account-bar class="graph__account-bar"></gl-account-bar>`,
+				)}
 				<gl-graph-header
 					class="graph__header"
 					.selectCommits=${this.selectCommits}

--- a/src/webviews/plus/graph/graphWebview.ts
+++ b/src/webviews/plus/graph/graphWebview.ts
@@ -8108,6 +8108,7 @@ export class GraphWebviewProvider implements WebviewProvider<State, State, Graph
 			detailsLocation: configuration.get('graph.details.location') ?? 'auto',
 			enabledRefMetadataTypes: this.getEnabledRefMetadataTypes(),
 			dimMergeCommits: configuration.get('graph.dimMergeCommits'),
+			experimentalHomeHeaderEnabled: configuration.get('graph.experimental.homeHeader.enabled') ?? false,
 			experimentalKanbanEnabled: configuration.get('graph.experimental.kanban.enabled') ?? false,
 			experimentalVisualizationsEnabled: configuration.get('graph.experimental.visualizations.enabled') ?? false,
 			activityDecay: configuration.get('graph.experimental.visualizations.activityDecay') ?? '5m',

--- a/src/webviews/plus/graph/protocol.ts
+++ b/src/webviews/plus/graph/protocol.ts
@@ -484,6 +484,7 @@ export interface GraphComponentConfig {
 	detailsLocation?: 'auto' | 'right' | 'bottom';
 	dimMergeCommits?: boolean;
 	enabledRefMetadataTypes?: GraphRefMetadataType[];
+	experimentalHomeHeaderEnabled?: boolean;
 	experimentalKanbanEnabled?: boolean;
 	experimentalVisualizationsEnabled?: boolean;
 	/** Raw setting value for the Activity-mode treemap decay window — drives the picker selection. */


### PR DESCRIPTION
## Summary

Puts the Commit Graph "home header" — the `<gl-account-bar>` (account chip + integrations status) that renders at the top of the graph, extracted from `<gl-home-header>` for reuse in #5411 — behind a hidden experimental setting, **off by default**. This lets us keep iterating on the in-Graph home header without exposing it to all users.

Mirrors the existing `gitlens.graph.experimental.kanban.enabled` precedent end-to-end.

## Behavior change

⚠️ The account bar previously rendered **unconditionally**. After this change it is **hidden by default** — existing users will no longer see it in the Graph unless they opt in via the new setting. This is intentional (dark-shipping an experimental surface), but worth calling out for release notes.

## What changed

- **`gitlens.graph.experimental.homeHeader.enabled`** — new boolean setting, `default: false`, `scope: window`, tagged `experimental` (grouped under the experimental filter, not surfaced in the normal settings list).
- Gated the `<gl-account-bar>` render in `graph-app.ts` behind the flag (`when(...)`).
- Gated the account-context host wiring (`initAccountContexts`) on the same flag so it's **truly off** when disabled, not merely hidden — and re-arms/disarms symmetrically as the flag flips at runtime (the existing catch-all `graph` config-change push re-renders the webview; no dedicated handler or reload needed).
- Async-race hardening: a `_accountInitGeneration` token so that toggling off→on faster than the service promises resolve can't leave an orphaned (leaked) subscription — a superseded init tears itself down instead of overwriting the live one.

## Files

- `package.json` — setting registration
- `src/config.ts` — `GraphConfig.experimental.homeHeader.enabled` type
- `src/webviews/plus/graph/graphWebview.ts` — read into `GraphComponentConfig`
- `src/webviews/plus/graph/protocol.ts` — state field
- `src/webviews/apps/plus/graph/graph-app.ts` — render gate + wiring arm/disarm + race guard
- `docs/telemetry-events.md` — regenerated (config feeds the telemetry context)

## Test plan

Verified live (`/live-inspect`, reactive — no reload, toggled via settings):

- [x] Flag **off** (default): `.graph` renders `[gl-graph-header, workspace]`, no `gl-account-bar`; graph header unaffected.
- [x] Flag **on**: `gl-account-bar` renders as the first child of `.graph`, visible, with `gl-account-chip` + `gl-integrations-chip` populated.
- [x] Flag **off** again: bar removed, back to `[gl-graph-header, workspace]`.
- [x] No related console errors.
- [x] `pnpm run build` (type-check + unit-test compile) passes clean.

## Follow-ups

- [ ] CHANGELOG entry (note the default-off behavior change).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
