### PR TITLE
Surface truncation for org/repo hierarchy listing when the 20-page backstop is hit

### DIFF
--- a/packages/plus/integrations/src/models/gitHostIntegration.ts
+++ b/packages/plus/integrations/src/models/gitHostIntegration.ts
@@ -20,6 +20,7 @@ import type {
 	PagedProjectInput,
 	PagedRepoInput,
 	ProviderAccount,
+	ProviderHierarchyResult,
 	ProviderIssue,
 	ProviderOrganization,
 	ProviderPullRequest,
@@ -177,9 +178,13 @@ export abstract class GitHostIntegration<
 		cancellation?: AbortSignal,
 	): Promise<RepositoryMetadata | undefined>;
 
-	/** Lists the organizations (orgs/workspaces/groups) the current user belongs to on this host. */
+	/**
+	 * Lists the organizations (orgs/workspaces/groups) the current user belongs to on this host.
+	 * `truncated === true` means the defensive page-drain backstop stopped before the upstream listing
+	 * was exhausted.
+	 */
 	@trace()
-	async getOrganizationsForUser(): Promise<ProviderOrganization[] | undefined> {
+	async getOrganizationsForUser(): Promise<ProviderHierarchyResult<ProviderOrganization> | undefined> {
 		const scope = getScopedLogger();
 
 		const connected = this.maybeConnected ?? (await this.isConnected());
@@ -199,20 +204,21 @@ export abstract class GitHostIntegration<
 
 	protected getProviderOrganizationsForUser?(
 		session: ProviderAuthenticationSession,
-	): Promise<ProviderOrganization[] | undefined>;
+	): Promise<ProviderHierarchyResult<ProviderOrganization> | undefined>;
 
 	/**
 	 * Lists repositories under the given organization (org/workspace/group) one page at a time — follow
-	 * `paging.cursor` to page, or drain with `collectPagedResults` from `@gitlens/utils/paging.js`.
+	 * `paging.cursor` to page, or drain with the integrations provider paging helper.
 	 * `options.project` is only meaningful for Azure DevOps, whose repos are scoped by `org` + `project`;
 	 * every other host ignores it. (Azure without a project can't page its cross-project merge, so it
-	 * returns all matches in a single page.)
+	 * returns all matches in a single page.) `truncated === true` means the defensive page-drain
+	 * backstop stopped before the upstream listing was exhausted.
 	 */
 	@trace()
 	async getRepositoriesForOrg(
 		org: string,
 		options?: { project?: string; cursor?: string },
-	): Promise<PagedResult<ProviderRepository> | undefined> {
+	): Promise<ProviderHierarchyResult<ProviderRepository> | undefined> {
 		const scope = getScopedLogger();
 
 		const connected = this.maybeConnected ?? (await this.isConnected());
@@ -234,7 +240,7 @@ export abstract class GitHostIntegration<
 		session: ProviderAuthenticationSession,
 		org: string,
 		options?: { project?: string; cursor?: string },
-	): Promise<PagedResult<ProviderRepository> | undefined>;
+	): Promise<ProviderHierarchyResult<ProviderRepository> | undefined>;
 
 	async mergePullRequest(pr: PullRequest, options?: { mergeMethod?: PullRequestMergeMethod }): Promise<boolean> {
 		const scope = getScopedLogger();

--- a/packages/plus/integrations/src/providers/__tests__/hierarchyResults.test.ts
+++ b/packages/plus/integrations/src/providers/__tests__/hierarchyResults.test.ts
@@ -92,6 +92,32 @@ suite('provider hierarchy results', () => {
 		});
 	});
 
+	test('GitLab organization listing propagates truncation', async () => {
+		const api: {
+			getGitlabGroupsForCurrentUser: () => Promise<{
+				values: { id: string; fullPath: string; webUrl: string }[];
+				truncated?: boolean;
+			}>;
+		} = {
+			getGitlabGroupsForCurrentUser: async () => ({
+				values: [{ id: '1', fullPath: 'acme/platform', webUrl: 'https://gitlab.com/acme/platform' }],
+				truncated: true,
+			}),
+		};
+		const integration = new GitLabIntegration(
+			createFakeRuntime(),
+			{} as never,
+			async () => api as never,
+			new Emitter(),
+		);
+		setSession(integration, createSession('gitlab.com'));
+
+		const result = await integration.getOrganizationsForUser();
+
+		assert.equal(result?.truncated, true);
+		assert.equal(result?.values.length, 1);
+	});
+
 	test('Azure cross-project repo listing reports truncation without exposing paging', async () => {
 		const api: {
 			getReposForAzureProject: (

--- a/packages/plus/integrations/src/providers/__tests__/hierarchyResults.test.ts
+++ b/packages/plus/integrations/src/providers/__tests__/hierarchyResults.test.ts
@@ -1,0 +1,134 @@
+import * as assert from 'node:assert/strict';
+import { suite, test } from 'mocha';
+import { Emitter } from '@gitlens/utils/event.js';
+import { createFakeRuntime } from '../../__tests__/fakeRuntime.js';
+import type { ProviderAuthenticationSession } from '../../authentication/models.js';
+import { AzureDevOpsIntegration } from '../azureDevOps.js';
+import { GitHubIntegration } from '../github.js';
+import { GitLabIntegration } from '../gitlab.js';
+
+function createSession(domain: string): ProviderAuthenticationSession {
+	return {
+		id: 'session-id',
+		accessToken: 'token',
+		account: { id: 'account-id', label: 'Test User' },
+		scopes: [],
+		cloud: true,
+		type: undefined,
+		domain: domain,
+		expiresAt: new Date(Date.now() + 60_000),
+	};
+}
+
+function setSession(integration: object, session: ProviderAuthenticationSession): void {
+	(integration as { _session: ProviderAuthenticationSession })._session = session;
+}
+
+suite('provider hierarchy results', () => {
+	test('GitHub organization listing returns normalized organizations', async () => {
+		const api: {
+			getGitHubOrgsForCurrentUser: () => Promise<{ values: { id: string; username: string }[] }>;
+		} = {
+			getGitHubOrgsForCurrentUser: async () => ({ values: [{ id: '1', username: 'acme' }] }),
+		};
+		const integration = new GitHubIntegration(
+			createFakeRuntime(),
+			{} as never,
+			async () => api as never,
+			new Emitter(),
+		);
+		setSession(integration, createSession('github.com'));
+
+		const result = await integration.getOrganizationsForUser();
+
+		assert.deepEqual(result, { values: [{ id: '1', name: 'acme', url: 'https://github.com/acme' }] });
+	});
+
+	test('GitHub organization listing propagates truncation', async () => {
+		const api: {
+			getGitHubOrgsForCurrentUser: () => Promise<{
+				values: { id: string; username: string }[];
+				truncated?: boolean;
+			}>;
+		} = {
+			getGitHubOrgsForCurrentUser: async () => ({ values: [{ id: '1', username: 'acme' }], truncated: true }),
+		};
+		const integration = new GitHubIntegration(
+			createFakeRuntime(),
+			{} as never,
+			async () => api as never,
+			new Emitter(),
+		);
+		setSession(integration, createSession('github.com'));
+
+		const result = await integration.getOrganizationsForUser();
+
+		assert.equal(result?.truncated, true);
+		assert.equal(result?.values.length, 1);
+	});
+
+	test('GitLab organization listing returns normalized organizations', async () => {
+		const api: {
+			getGitlabGroupsForCurrentUser: () => Promise<{
+				values: { id: string; fullPath: string; webUrl: string }[];
+			}>;
+		} = {
+			getGitlabGroupsForCurrentUser: async () => ({
+				values: [{ id: '1', fullPath: 'acme/platform', webUrl: 'https://gitlab.com/acme/platform' }],
+			}),
+		};
+		const integration = new GitLabIntegration(
+			createFakeRuntime(),
+			{} as never,
+			async () => api as never,
+			new Emitter(),
+		);
+		setSession(integration, createSession('gitlab.com'));
+
+		const result = await integration.getOrganizationsForUser();
+
+		assert.deepEqual(result, {
+			values: [{ id: '1', name: 'acme/platform', url: 'https://gitlab.com/acme/platform' }],
+		});
+	});
+
+	test('Azure cross-project repo listing reports truncation without exposing paging', async () => {
+		const api: {
+			getReposForAzureProject: (
+				_token: unknown,
+				_org: string,
+				project: string,
+				options?: { cursor?: string },
+			) => Promise<{ values: { id: string; name: string }[]; paging?: { cursor: string; more: boolean } }>;
+		} = {
+			getReposForAzureProject: async (_token, _org, project, options) => {
+				if (project === 'project-a') return { values: [{ id: 'a-1', name: 'repo-a' }] };
+
+				const page = options?.cursor == null ? 0 : Number(options.cursor);
+				return {
+					values: [{ id: `b-${page}`, name: `repo-b-${page}` }],
+					paging: { cursor: String(page + 1), more: true },
+				};
+			},
+		};
+		const integration = new AzureDevOpsIntegration(
+			createFakeRuntime(),
+			{} as never,
+			async () => api as never,
+			new Emitter(),
+		);
+		setSession(integration, createSession('dev.azure.com'));
+		(integration as any).getProviderResourcesForUser = async () => [{ id: 'org-1', name: 'acme' }];
+		(integration as any).getProviderProjectsForResources = async () => [
+			{ id: 'project-a', name: 'project-a', resourceId: 'org-1', resourceName: 'acme', key: 'project-a' },
+			{ id: 'project-b', name: 'project-b', resourceId: 'org-1', resourceName: 'acme', key: 'project-b' },
+		];
+
+		const result = await integration.getRepositoriesForOrg('acme');
+
+		assert.equal(result?.truncated, true);
+		assert.equal(result?.paging, undefined);
+		assert.equal(result?.values.length, 21);
+		assert.equal(result?.values[0].id, 'a-1');
+	});
+});

--- a/packages/plus/integrations/src/providers/__tests__/providerPaging.test.ts
+++ b/packages/plus/integrations/src/providers/__tests__/providerPaging.test.ts
@@ -1,0 +1,66 @@
+import * as assert from 'node:assert/strict';
+import { suite, test } from 'mocha';
+import type { PagedResult } from '@gitlens/utils/paging.js';
+import { collectProviderPagedResult } from '../utils/providerPaging.js';
+
+suite('collectProviderPagedResult', () => {
+	test('marks the result truncated and preserves paging when maxPages is reached', async () => {
+		const pages: PagedResult<string>[] = [
+			{ values: ['a'], paging: { cursor: '1', more: true } },
+			{ values: ['b'], paging: { cursor: '2', more: true } },
+		];
+		let call = 0;
+
+		const result = await collectProviderPagedResult(async () => pages[call++], 2);
+
+		assert.deepEqual(result, {
+			values: ['a', 'b'],
+			paging: { cursor: '2', more: true },
+			truncated: true,
+		});
+	});
+
+	test('keeps draining empty pages while paging.more remains true', async () => {
+		const pages: PagedResult<string>[] = [
+			{ values: [], paging: { cursor: '1', more: true } },
+			{ values: ['a'], paging: { cursor: '2', more: true } },
+			{ values: ['b'] },
+		];
+		let call = 0;
+
+		const result = await collectProviderPagedResult(async () => pages[call++]);
+
+		assert.deepEqual(result, { values: ['a', 'b'] });
+	});
+
+	test('marks the result truncated and drops paging when the cursor stalls', async () => {
+		const pages: PagedResult<string>[] = [
+			{ values: ['a'], paging: { cursor: 'same-cursor', more: true } },
+			{ values: ['b'], paging: { cursor: 'same-cursor', more: true } },
+		];
+		let call = 0;
+
+		const result = await collectProviderPagedResult(async () => pages[call++]);
+
+		assert.deepEqual(result, {
+			values: ['a', 'b'],
+			truncated: true,
+		});
+	});
+
+	test('propagates provider errors instead of translating them to truncation', async () => {
+		const error = new Error('boom');
+
+		await assert.rejects(
+			() =>
+				collectProviderPagedResult(async cursor => {
+					if (cursor == null) {
+						return { values: ['a'], paging: { cursor: '1', more: true } };
+					}
+
+					throw error;
+				}),
+			error,
+		);
+	});
+});

--- a/packages/plus/integrations/src/providers/azureDevOps.ts
+++ b/packages/plus/integrations/src/providers/azureDevOps.ts
@@ -6,8 +6,6 @@ import type { PullRequest, PullRequestMergeMethod, PullRequestState } from '@git
 import type { RepositoryMetadata } from '@gitlens/git/models/repositoryMetadata.js';
 import { base64 } from '@gitlens/utils/base64.js';
 import type { Emitter } from '@gitlens/utils/event.js';
-import type { PagedResult } from '@gitlens/utils/paging.js';
-import { collectPagedResults } from '@gitlens/utils/paging.js';
 import { flatSettled } from '@gitlens/utils/promise.js';
 import type { IntegrationAuthenticationProviderDescriptor } from '../authentication/integrationAuthenticationProvider.js';
 import type { IntegrationAuthenticationService } from '../authentication/integrationAuthenticationService.js';
@@ -29,9 +27,15 @@ import type {
 	AzureRemoteRepositoryDescriptor,
 	AzureRepositoryDescriptor,
 } from './azure/models.js';
-import type { ProviderOrganization, ProviderPullRequest, ProviderRepository } from './models.js';
+import type {
+	ProviderHierarchyResult,
+	ProviderOrganization,
+	ProviderPullRequest,
+	ProviderRepository,
+} from './models.js';
 import { fromProviderIssue, fromProviderPullRequest, providersMetadata } from './models.js';
 import type { ProvidersApi } from './providersApi.js';
+import { collectProviderPagedResult } from './utils/providerPaging.js';
 
 export abstract class AzureDevOpsIntegrationBase<
 	TIntegrationId extends GitCloudHostIntegrationId.AzureDevOps | GitSelfManagedHostIntegrationId.AzureDevOpsServer,
@@ -207,22 +211,27 @@ export abstract class AzureDevOpsIntegrationBase<
 
 	protected override async getProviderOrganizationsForUser(
 		session: ProviderAuthenticationSession,
-	): Promise<ProviderOrganization[] | undefined> {
+	): Promise<ProviderHierarchyResult<ProviderOrganization> | undefined> {
 		const orgs = await this.getProviderResourcesForUser(session);
-		return orgs?.map(o => ({ id: o.id, name: o.name, url: `${this.apiBaseUrl}/${o.name}` }));
+		if (orgs == null) return undefined;
+
+		return {
+			values: orgs.map(o => ({ id: o.id, name: o.name, url: `${this.apiBaseUrl}/${o.name}` })),
+		};
 	}
 
 	/**
 	 * With `options.project`, returns one page of that project's repos (follow `paging.cursor` to page).
 	 * Without a project it fans out across every project under `org` and returns them all at once — there's
 	 * no single cursor to page a parallel merge — skipping any project that fails to list rather than
-	 * failing the whole org.
+	 * failing the whole org. If any successful project drain hits the defensive page backstop, the merged
+	 * result is marked `truncated` without exposing a synthetic cursor.
 	 */
 	protected override async getProviderRepositoriesForOrg(
 		session: ProviderAuthenticationSession,
 		org: string,
 		options?: { project?: string; cursor?: string },
-	): Promise<PagedResult<ProviderRepository> | undefined> {
+	): Promise<ProviderHierarchyResult<ProviderRepository> | undefined> {
 		const api = await this.getProvidersApi();
 		const { tokenWithInfo, options: apiOptions } = this.getApiOptions(session);
 
@@ -239,14 +248,27 @@ export abstract class AzureDevOpsIntegrationBase<
 		const projects = await this.getProviderProjectsForResources(session, [orgDescriptor]);
 		if (!projects?.length) return { values: [] };
 
-		const values = await flatSettled(
+		const results = await Promise.allSettled(
 			projects.map(p =>
-				collectPagedResults(cursor =>
+				collectProviderPagedResult(cursor =>
 					api.getReposForAzureProject(tokenWithInfo, org, p.name, { ...apiOptions, cursor: cursor }),
 				),
 			),
 		);
-		return { values: values };
+
+		const values: ProviderRepository[] = [];
+		let truncated = false;
+		for (const result of results) {
+			if (result.status !== 'fulfilled') continue;
+
+			values.push(...result.value.values);
+			truncated ||= result.value.truncated === true;
+		}
+
+		return {
+			values: values,
+			...(truncated ? { truncated: true } : {}),
+		};
 	}
 
 	protected override async mergeProviderPullRequest(

--- a/packages/plus/integrations/src/providers/bitbucket.ts
+++ b/packages/plus/integrations/src/providers/bitbucket.ts
@@ -7,7 +7,6 @@ import type { GitRemote } from '@gitlens/git/models/remote.js';
 import type { RepositoryMetadata } from '@gitlens/git/models/repositoryMetadata.js';
 import { md5 } from '@gitlens/utils/crypto.js';
 import { uniqueBy } from '@gitlens/utils/iterable.js';
-import type { PagedResult } from '@gitlens/utils/paging.js';
 import { flatSettled, nonnullSettled } from '@gitlens/utils/promise.js';
 import type { IntegrationAuthenticationProviderDescriptor } from '../authentication/integrationAuthenticationProvider.js';
 import type {
@@ -18,7 +17,7 @@ import { toTokenWithInfo } from '../authentication/models.js';
 import { GitCloudHostIntegrationId } from '../constants.js';
 import { GitHostIntegration } from '../models/gitHostIntegration.js';
 import type { BitbucketRepositoryDescriptor, BitbucketWorkspaceDescriptor } from './bitbucket/models.js';
-import type { ProviderOrganization, ProviderRepository } from './models.js';
+import type { ProviderHierarchyResult, ProviderOrganization, ProviderRepository } from './models.js';
 import { fromProviderPullRequest, providersMetadata } from './models.js';
 
 const metadata = providersMetadata[GitCloudHostIntegrationId.Bitbucket];
@@ -221,16 +220,20 @@ export class BitbucketIntegration extends GitHostIntegration<
 
 	protected override async getProviderOrganizationsForUser(
 		session: ProviderAuthenticationSession,
-	): Promise<ProviderOrganization[] | undefined> {
+	): Promise<ProviderHierarchyResult<ProviderOrganization> | undefined> {
 		const workspaces = await this.getProviderResourcesForCurrentUser(session);
-		return workspaces?.map(w => ({ id: w.id, name: w.slug, url: `https://bitbucket.org/${w.slug}` }));
+		if (workspaces == null) return undefined;
+
+		return {
+			values: workspaces.map(w => ({ id: w.id, name: w.slug, url: `https://bitbucket.org/${w.slug}` })),
+		};
 	}
 
 	protected override async getProviderRepositoriesForOrg(
 		session: ProviderAuthenticationSession,
 		org: string,
 		options?: { cursor?: string },
-	): Promise<PagedResult<ProviderRepository> | undefined> {
+	): Promise<ProviderHierarchyResult<ProviderRepository> | undefined> {
 		const api = await this.getProvidersApi();
 		return api.getReposForBitbucketWorkspace(toTokenWithInfo(this.id, session), org, {
 			cursor: options?.cursor,

--- a/packages/plus/integrations/src/providers/github.ts
+++ b/packages/plus/integrations/src/providers/github.ts
@@ -7,7 +7,6 @@ import type { RepositoryMetadata } from '@gitlens/git/models/repositoryMetadata.
 import type { RepositoryDescriptor } from '@gitlens/git/models/resourceDescriptor.js';
 import type { PullRequestUrlIdentity } from '@gitlens/git/utils/pullRequest.utils.js';
 import type { Emitter } from '@gitlens/utils/event.js';
-import type { PagedResult } from '@gitlens/utils/paging.js';
 import type { IntegrationAuthenticationProviderDescriptor } from '../authentication/integrationAuthenticationProvider.js';
 import type { IntegrationAuthenticationService } from '../authentication/integrationAuthenticationService.js';
 import type { ProviderAuthenticationSession } from '../authentication/models.js';
@@ -18,7 +17,7 @@ import type { IntegrationConnectionChangeEvent } from '../integrationService.js'
 import { GitHostIntegration } from '../models/gitHostIntegration.js';
 import type { GitHubIntegrationIds } from './github/github.utils.js';
 import { getGitHubPullRequestIdentityFromMaybeUrl } from './github/github.utils.js';
-import type { ProviderOrganization, ProviderRepository } from './models.js';
+import type { ProviderHierarchyResult, ProviderOrganization, ProviderRepository } from './models.js';
 import { providersMetadata } from './models.js';
 import type { ProvidersApi } from './providersApi.js';
 
@@ -214,19 +213,26 @@ abstract class GitHubIntegrationBase<ID extends GitHubIntegrationIds> extends Gi
 
 	protected override async getProviderOrganizationsForUser(
 		session: ProviderAuthenticationSession,
-	): Promise<ProviderOrganization[] | undefined> {
+	): Promise<ProviderHierarchyResult<ProviderOrganization> | undefined> {
 		const api = await this.getProvidersApi();
-		const orgs = await api.getGitHubOrgsForCurrentUser(toTokenWithInfo(this.id, session), {
+		const result = await api.getGitHubOrgsForCurrentUser(toTokenWithInfo(this.id, session), {
 			baseUrl: this.apiBaseUrl,
 		});
-		return orgs?.map(o => ({ id: o.id, name: o.username, url: `https://${this.domain}/${o.username}` }));
+		return {
+			values: result.values.map(o => ({
+				id: o.id,
+				name: o.username,
+				url: `https://${this.domain}/${o.username}`,
+			})),
+			...(result.truncated ? { truncated: true } : {}),
+		};
 	}
 
 	protected override async getProviderRepositoriesForOrg(
 		session: ProviderAuthenticationSession,
 		org: string,
 		options?: { cursor?: string },
-	): Promise<PagedResult<ProviderRepository> | undefined> {
+	): Promise<ProviderHierarchyResult<ProviderRepository> | undefined> {
 		const api = await this.getProvidersApi();
 		return api.getReposForOrg(toTokenWithInfo(this.id, session), org, {
 			baseUrl: this.apiBaseUrl,

--- a/packages/plus/integrations/src/providers/gitlab.ts
+++ b/packages/plus/integrations/src/providers/gitlab.ts
@@ -8,7 +8,6 @@ import type { RepositoryDescriptor } from '@gitlens/git/models/resourceDescripto
 import type { PullRequestUrlIdentity } from '@gitlens/git/utils/pullRequest.utils.js';
 import type { Emitter } from '@gitlens/utils/event.js';
 import { uniqueBy } from '@gitlens/utils/iterable.js';
-import type { PagedResult } from '@gitlens/utils/paging.js';
 import type { IntegrationAuthenticationProviderDescriptor } from '../authentication/integrationAuthenticationProvider.js';
 import type { IntegrationAuthenticationService } from '../authentication/integrationAuthenticationService.js';
 import type { ProviderAuthenticationSession } from '../authentication/models.js';
@@ -20,7 +19,7 @@ import { GitHostIntegration } from '../models/gitHostIntegration.js';
 import type { GitLabIntegrationIds } from './gitlab/gitlab.utils.js';
 import { getGitLabPullRequestIdentityFromMaybeUrl, matchesGitLabOrgNamespace } from './gitlab/gitlab.utils.js';
 import { fromGitLabMergeRequestProvidersApi } from './gitlab/models.js';
-import type { ProviderOrganization, ProviderRepository } from './models.js';
+import type { ProviderHierarchyResult, ProviderOrganization, ProviderRepository } from './models.js';
 import { ProviderPullRequestReviewState, providersMetadata, toIssueShape } from './models.js';
 import type { ProvidersApi } from './providersApi.js';
 
@@ -244,13 +243,16 @@ abstract class GitLabIntegrationBase<ID extends GitLabIntegrationIds> extends Gi
 
 	protected override async getProviderOrganizationsForUser(
 		session: ProviderAuthenticationSession,
-	): Promise<ProviderOrganization[] | undefined> {
+	): Promise<ProviderHierarchyResult<ProviderOrganization> | undefined> {
 		const api = await this.getProvidersApi();
-		const groups = await api.getGitlabGroupsForCurrentUser(toTokenWithInfo(this.id, session), {
+		const result = await api.getGitlabGroupsForCurrentUser(toTokenWithInfo(this.id, session), {
 			isPAT: this.isEnterprise,
 			baseUrl: this.isEnterprise ? `https://${this.domain}` : undefined,
 		});
-		return groups?.map(g => ({ id: g.id, name: g.fullPath, url: g.webUrl }));
+		return {
+			values: result.values.map(g => ({ id: g.id, name: g.fullPath, url: g.webUrl })),
+			...(result.truncated ? { truncated: true } : {}),
+		};
 	}
 
 	/**
@@ -265,7 +267,7 @@ abstract class GitLabIntegrationBase<ID extends GitLabIntegrationIds> extends Gi
 		session: ProviderAuthenticationSession,
 		org: string,
 		options?: { cursor?: string },
-	): Promise<PagedResult<ProviderRepository> | undefined> {
+	): Promise<ProviderHierarchyResult<ProviderRepository> | undefined> {
 		const api = await this.getProvidersApi();
 		const result = await api.getReposForCurrentUser(toTokenWithInfo(this.id, session), {
 			isPAT: this.isEnterprise,
@@ -274,7 +276,7 @@ abstract class GitLabIntegrationBase<ID extends GitLabIntegrationIds> extends Gi
 		});
 		return {
 			values: result.values.filter(r => matchesGitLabOrgNamespace(r.namespace, org)),
-			paging: result.paging,
+			...(result.paging != null ? { paging: result.paging } : {}),
 		};
 	}
 

--- a/packages/plus/integrations/src/providers/models.ts
+++ b/packages/plus/integrations/src/providers/models.ts
@@ -61,6 +61,7 @@ import {
 } from '@gitlens/git/models/pullRequest.js';
 import type { Provider, ProviderReference } from '@gitlens/git/models/remoteProvider.js';
 import { gitSuffixRegex } from '@gitlens/git/utils/remote.utils.js';
+import type { PagedResult } from '@gitlens/utils/paging.js';
 import { equalsIgnoreCase } from '@gitlens/utils/string.js';
 import type { IntegrationIds } from '../constants.js';
 import {
@@ -94,6 +95,9 @@ export type ProviderAzureResource = AzureOrganization;
 export type ProviderBitbucketResource = BitbucketWorkspaceStub;
 export type ProviderGitHubOrganization = Organization;
 export type ProviderGitLabGroup = GitLabGroup;
+export type ProviderHierarchyResult<T> = PagedResult<T> & {
+	readonly truncated?: boolean;
+};
 
 /**
  * Normalized org/workspace/group shape returned by `GitHostIntegration.getOrganizationsForUser`.

--- a/packages/plus/integrations/src/providers/providersApi.ts
+++ b/packages/plus/integrations/src/providers/providersApi.ts
@@ -2,7 +2,6 @@ import ProviderApis from '@gitkraken/provider-apis';
 import type { PullRequest, PullRequestMergeMethod } from '@gitlens/git/models/pullRequest.js';
 import { base64 } from '@gitlens/utils/base64.js';
 import type { PagedResult } from '@gitlens/utils/paging.js';
-import { collectPagedResults } from '@gitlens/utils/paging.js';
 import type { IntegrationAuthenticationService } from '../authentication/integrationAuthenticationService.js';
 import type { TokenOptInfo, TokenWithInfo } from '../authentication/models.js';
 import { toTokenWithInfo } from '../authentication/models.js';
@@ -39,6 +38,7 @@ import type {
 	ProviderBitbucketResource,
 	ProviderGitHubOrganization,
 	ProviderGitLabGroup,
+	ProviderHierarchyResult,
 	ProviderInfo,
 	ProviderIssue,
 	ProviderJiraProject,
@@ -56,6 +56,7 @@ import type {
 	PullRequestFilter,
 } from './models.js';
 import { providersMetadata } from './models.js';
+import { collectProviderPagedResult } from './utils/providerPaging.js';
 
 // `@gitkraken/provider-apis` is published as CommonJS with its factory on the `default` export.
 // How that surfaces depends on the consuming bundler's CJS->ESM interop: esbuild yields the
@@ -797,14 +798,15 @@ export class ProvidersApi {
 			GitCloudHostIntegrationId.GitHub | GitSelfManagedHostIntegrationId.CloudGitHubEnterprise
 		>,
 		options?: { isPAT?: boolean; baseUrl?: string },
-	): Promise<ProviderGitHubOrganization[] | undefined> {
+	): Promise<ProviderHierarchyResult<ProviderGitHubOrganization>> {
 		const { provider, tokenWithInfo } = await this.ensureProviderTokenAndFunction(
 			tokenOptInfo,
 			'getOrgsForCurrentUserFn',
 		);
 
-		// Drain all pages so a user in many orgs doesn't lose everything past the first page.
-		return collectPagedResults(cursor =>
+		// Drain all pages so a user in many orgs doesn't lose everything past the first page, while
+		// surfacing `truncated` when the defensive backstop stops before the listing is exhausted.
+		const result = await collectProviderPagedResult(cursor =>
 			this.getPagedResult<ProviderGitHubOrganization>(
 				{},
 				provider.getOrgsForCurrentUserFn,
@@ -814,6 +816,9 @@ export class ProvidersApi {
 				options?.baseUrl,
 			),
 		);
+		// This method drains internally and takes no cursor, so a backstop cursor isn't resumable by
+		// callers — keep only the truncation signal rather than exposing a misleading `paging`.
+		return { values: result.values, ...(result.truncated ? { truncated: true } : {}) };
 	}
 
 	async getReposForOrg(
@@ -881,14 +886,15 @@ export class ProvidersApi {
 			GitCloudHostIntegrationId.GitLab | GitSelfManagedHostIntegrationId.CloudGitLabSelfHosted
 		>,
 		options?: { topLevelOnly?: boolean; isPAT?: boolean; baseUrl?: string },
-	): Promise<ProviderGitLabGroup[] | undefined> {
+	): Promise<ProviderHierarchyResult<ProviderGitLabGroup>> {
 		const { provider, tokenWithInfo } = await this.ensureProviderTokenAndFunction(
 			tokenOptInfo,
 			'getGroupsForCurrentUserFn',
 		);
 
-		// Drain all pages so a user in many groups doesn't lose everything past the first page.
-		return collectPagedResults(cursor =>
+		// Drain all pages so a user in many groups doesn't lose everything past the first page, while
+		// surfacing `truncated` when the defensive backstop stops before the listing is exhausted.
+		const result = await collectProviderPagedResult(cursor =>
 			this.getPagedResult<ProviderGitLabGroup>(
 				{ topLevelOnly: options?.topLevelOnly },
 				provider.getGroupsForCurrentUserFn,
@@ -898,6 +904,9 @@ export class ProvidersApi {
 				options?.baseUrl,
 			),
 		);
+		// This method drains internally and takes no cursor, so a backstop cursor isn't resumable by
+		// callers — keep only the truncation signal rather than exposing a misleading `paging`.
+		return { values: result.values, ...(result.truncated ? { truncated: true } : {}) };
 	}
 
 	async getPullRequestsForRepos(

--- a/packages/plus/integrations/src/providers/utils/providerPaging.ts
+++ b/packages/plus/integrations/src/providers/utils/providerPaging.ts
@@ -1,0 +1,40 @@
+import type { PagedResult } from '@gitlens/utils/paging.js';
+import type { ProviderHierarchyResult } from '../models.js';
+
+/**
+ * Drains a provider paged fetcher into a single result while preserving enough metadata to
+ * signal whether the defensive backstop interrupted the drain.
+ */
+export async function collectProviderPagedResult<T>(
+	fetch: (cursor: string | undefined) => Promise<PagedResult<T> | undefined>,
+	maxPages = 20,
+): Promise<ProviderHierarchyResult<T>> {
+	const values: NonNullable<T>[] = [];
+	let cursor: string | undefined;
+
+	for (let page = 0; page < maxPages; page++) {
+		const result = await fetch(cursor);
+		if (result == null) return { values: values };
+
+		values.push(...result.values);
+		if (!result.paging?.more) return { values: values };
+
+		if (result.paging.cursor === cursor) {
+			return {
+				values: values,
+				truncated: true,
+			};
+		}
+
+		cursor = result.paging.cursor;
+		if (page === maxPages - 1) {
+			return {
+				values: values,
+				paging: result.paging,
+				truncated: true,
+			};
+		}
+	}
+
+	return { values: values };
+}


### PR DESCRIPTION
## Description

Follow-up to #5434 (see review discussion [here](https://github.com/gitkraken/vscode-gitlens/pull/5434#discussion_r3520008645)). The org/repo hierarchy listing bounds each pagination loop to a 20-page backstop against an unbounded loop. When that cap is hit, results were silently truncated with no signal a caller could use to detect incompleteness.

This adds a `ProviderHierarchyResult` type and a paging helper, confined to the integrations package so the shared `PagedResult` contract stays untouched. The helper reports a `truncated` flag when the backstop interrupts a drain, and only preserves `paging` when the cursor is actually resumable.

Affected sites:
- `getGithubOrgsForCurrentUser` and `getGitlabGroupsForCurrentUser` in `providersApi.ts` now propagate paging/truncation metadata instead of returning bare arrays.
- Azure DevOps cross-project repo listing (`getProviderRepositoriesForOrg`, no-`project` fan-out) marks merged results as truncated without exposing a synthetic cursor, since there's no single resumable cursor across the per-project streams.
- Bitbucket is aligned to the new contract with no behavior change.

Closes #5436.

## Testing

Added unit tests for the paging helper, provider mappings, and the Azure cross-project truncation case.