### PR TITLE
Expose a lightweight, token-scoped GitHostIntegration entry point

### DIFF
--- a/packages/core/CHANGELOG.md
+++ b/packages/core/CHANGELOG.md
@@ -10,6 +10,12 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/) and this p
 
 - Adds multiple simultaneous connections (multi-account) per provider integration — `ConfiguredIntegrationDescriptor` now carries a stable per-connection `id` (backend `tokenId`) plus `primary`, `type`, and `accountName`; `IntegrationService` gains `setPrimaryConnection`, `deleteConnection`, and `refreshConnections`; cloud sync fans out over every backend connection (primary + secondaries) and resolves account names with a backend → cache → provider-API precedence. Existing single-connection sessions keep working with zero secret migration ([#5430](https://github.com/gitkraken/vscode-gitlens/issues/5430)) (plus/integrations)
 - Adds per-connection reads for multi-account integrations — issue/PR search and issue-tracker resource reads (`searchMyIssues`, `searchMyPullRequests`, `searchPullRequests`, `getIssuesForProject`, `getAccountForResource`, `getResourcesForUser`, `getProjectsForResources`) accept an optional `connectionId` that reads with that specific connection's token instead of the provider's primary (mirrors the `gk` CLI's `--connection`); omitting it preserves the existing primary behavior ([#5430](https://github.com/gitkraken/vscode-gitlens/issues/5430)) (plus/integrations)
+- Adds a lightweight, token-scoped entry point `createTokenScopedGitHostIntegration` at `plus/integrations/lite.js` — fetches `RepositoryMetadata` and `DefaultBranch` for GitHub, GitLab, Bitbucket, and Azure DevOps from just an access token + a `fetch`, without constructing an `IntegrationServiceContext` or running any session/OAuth lifecycle (plus/integrations)
+- Adds `getRepositoryMetadata` and `getDefaultBranch` to the Bitbucket and Azure DevOps API clients (plus/integrations)
+
+### Changed
+
+- Decouples the `GitLabApi`, `BitbucketApi`, and `AzureDevOpsApi` clients from `IntegrationServiceContext`, taking a narrow `ProviderApiConfig` instead (mirroring `GitHubApiConfig`); the manager wires them via new `createGitLabApi`/`createBitbucketApi`/`createAzureDevOpsApi` factories (plus/integrations)
 
 ## [0.4.0] - 2026-06-30
 

--- a/packages/plus/integrations/src/__tests__/lite.test.ts
+++ b/packages/plus/integrations/src/__tests__/lite.test.ts
@@ -46,7 +46,7 @@ suite('createTokenScopedGitHostIntegration — token-scoped reads', () => {
 		assert.deepEqual(metadata.parent, { owner: 'upstream', name: 'hello-world' });
 		assert.equal(metadata.provider.id, 'github');
 		assert.ok(
-			fetch.calls[0].startsWith('https://api.github.com'),
+			new URL(fetch.calls[0]).origin === 'https://api.github.com',
 			`GitHub cloud should hit api.github.com, got ${fetch.calls[0]}`,
 		);
 	});

--- a/packages/plus/integrations/src/__tests__/lite.test.ts
+++ b/packages/plus/integrations/src/__tests__/lite.test.ts
@@ -1,0 +1,236 @@
+import * as assert from 'node:assert/strict';
+import { suite, test } from 'mocha';
+import { GitCloudHostIntegrationId, GitSelfManagedHostIntegrationId } from '../constants.js';
+import { createTokenScopedGitHostIntegration } from '../lite.js';
+
+type FakeFetch = ((input: string | URL, init?: RequestInit) => Promise<Response>) & { calls: string[] };
+
+/** A `fetch` that returns `body` as JSON for any request, recording the URLs it was called with. */
+function fakeFetch(body: unknown, status = 200): FakeFetch {
+	const calls: string[] = [];
+	const fn = (input: string | URL) => {
+		calls.push(input.toString());
+		return Promise.resolve(
+			new Response(JSON.stringify(body), {
+				status: status,
+				headers: { 'content-type': 'application/json; charset=utf-8' },
+			}),
+		);
+	};
+	return Object.assign(fn, { calls: calls });
+}
+
+suite('createTokenScopedGitHostIntegration — token-scoped reads', () => {
+	test('GitHub: maps repository metadata (fork with parent) without an IntegrationServiceContext', async () => {
+		const fetch = fakeFetch({
+			data: {
+				repository: {
+					owner: { login: 'octocat' },
+					name: 'hello-world',
+					parent: { owner: { login: 'upstream' }, name: 'hello-world' },
+				},
+			},
+		});
+
+		const gh = createTokenScopedGitHostIntegration(
+			GitCloudHostIntegrationId.GitHub,
+			{ accessToken: 'tok' },
+			{ fetch: fetch },
+		);
+		const metadata = await gh.getRepositoryMetadata('octocat', 'hello-world');
+
+		assert.ok(metadata != null);
+		assert.equal(metadata.owner, 'octocat');
+		assert.equal(metadata.name, 'hello-world');
+		assert.equal(metadata.isFork, true);
+		assert.deepEqual(metadata.parent, { owner: 'upstream', name: 'hello-world' });
+		assert.equal(metadata.provider.id, 'github');
+		assert.ok(
+			fetch.calls[0].startsWith('https://api.github.com'),
+			`GitHub cloud should hit api.github.com, got ${fetch.calls[0]}`,
+		);
+	});
+
+	test('GitLab: maps repository metadata (non-fork)', async () => {
+		// GitLab resolves the numeric project id via GraphQL first, then fetches the project over REST.
+		const fetch = (input: string | URL) => {
+			const url = input.toString();
+			const body = url.includes('/graphql')
+				? { data: { project: { id: 'gid://gitlab/Project/42' } } }
+				: { id: '42', path: 'my-repo', namespace: { full_path: 'my-group' }, forked_from_project: null };
+			return Promise.resolve(
+				new Response(JSON.stringify(body), { headers: { 'content-type': 'application/json' } }),
+			);
+		};
+
+		const gl = createTokenScopedGitHostIntegration(
+			GitCloudHostIntegrationId.GitLab,
+			{ accessToken: 'tok' },
+			{ fetch: fetch },
+		);
+		const metadata = await gl.getRepositoryMetadata('my-group', 'my-repo');
+
+		assert.ok(metadata != null);
+		assert.equal(metadata.owner, 'my-group');
+		assert.equal(metadata.name, 'my-repo');
+		assert.equal(metadata.isFork, false);
+		assert.equal(metadata.parent, undefined);
+	});
+
+	test('Bitbucket: maps repository metadata and default branch', async () => {
+		const repo = {
+			slug: 'my-repo',
+			workspace: { slug: 'my-workspace' },
+			parent: null,
+			mainbranch: { name: 'develop' },
+		};
+
+		const bb = createTokenScopedGitHostIntegration(
+			GitCloudHostIntegrationId.Bitbucket,
+			{ accessToken: 'tok' },
+			{ fetch: fakeFetch(repo) },
+		);
+
+		const metadata = await bb.getRepositoryMetadata('my-workspace', 'my-repo');
+		assert.ok(metadata != null);
+		assert.equal(metadata.owner, 'my-workspace');
+		assert.equal(metadata.name, 'my-repo');
+		assert.equal(metadata.isFork, false);
+
+		const branch = await bb.getDefaultBranch('my-workspace', 'my-repo');
+		assert.deepEqual(branch, { provider: metadata.provider, name: 'develop' });
+	});
+
+	test('Bitbucket: default branch is undefined when mainbranch is absent', async () => {
+		const bb = createTokenScopedGitHostIntegration(
+			GitCloudHostIntegrationId.Bitbucket,
+			{ accessToken: 'tok' },
+			{ fetch: fakeFetch({ slug: 'r', workspace: { slug: 'w' }, parent: null }) },
+		);
+
+		assert.equal(await bb.getDefaultBranch('w', 'r'), undefined);
+	});
+
+	test('Azure: derives org/project/repo and normalizes the default branch', async () => {
+		const fetch = fakeFetch({
+			id: 'guid',
+			name: 'my-repo',
+			project: { id: 'p', name: 'my-project' },
+			defaultBranch: 'refs/heads/main',
+			isFork: false,
+		});
+
+		const az = createTokenScopedGitHostIntegration(
+			GitCloudHostIntegrationId.AzureDevOps,
+			{ accessToken: 'tok' },
+			{ fetch: fetch },
+		);
+
+		const metadata = await az.getRepositoryMetadata('my-org', 'my-project/_git/my-repo');
+		assert.ok(metadata != null);
+		assert.equal(metadata.owner, 'my-org');
+		assert.equal(metadata.name, 'my-repo');
+		assert.equal(metadata.isFork, false);
+
+		const branch = await az.getDefaultBranch('my-org', 'my-project/_git/my-repo');
+		assert.deepEqual(branch, { provider: metadata.provider, name: 'main' });
+		assert.ok(
+			fetch.calls[0].includes('my-org/my-project/_apis/git/repositories/my-repo'),
+			`Azure URL should encode org/project/repo, got ${fetch.calls[0]}`,
+		);
+	});
+
+	test('Azure: a fork maps its parent name, but never falls back to naming itself its own parent', async () => {
+		const forkOfNamed = createTokenScopedGitHostIntegration(
+			GitCloudHostIntegrationId.AzureDevOps,
+			{ accessToken: 'tok' },
+			{ fetch: fakeFetch({ name: 'my-repo', isFork: true, parentRepository: { id: 'up', name: 'upstream' } }) },
+		);
+		const withParent = await forkOfNamed.getRepositoryMetadata('my-org', 'my-project/_git/my-repo');
+		assert.equal(withParent?.isFork, true);
+		assert.deepEqual(withParent?.parent, { owner: 'my-org', name: 'upstream' });
+
+		// A fork whose payload omits parentRepository.name must report `isFork` but no bogus self-parent.
+		const forkMissingParent = createTokenScopedGitHostIntegration(
+			GitCloudHostIntegrationId.AzureDevOps,
+			{ accessToken: 'tok' },
+			{ fetch: fakeFetch({ name: 'my-repo', isFork: true }) },
+		);
+		const noParent = await forkMissingParent.getRepositoryMetadata('my-org', 'my-project/_git/my-repo');
+		assert.equal(noParent?.isFork, true);
+		assert.equal(noParent?.parent, undefined);
+	});
+
+	test('throws for a self-managed id when no domain is supplied', () => {
+		assert.throws(
+			() =>
+				createTokenScopedGitHostIntegration(
+					GitSelfManagedHostIntegrationId.CloudGitHubEnterprise,
+					{ accessToken: 'tok' },
+					{ fetch: fakeFetch({}) },
+				),
+			/requires 'token.domain'/,
+		);
+	});
+
+	test('Azure: a malformed repo descriptor returns undefined without issuing a bogus request', async () => {
+		const fetch = fakeFetch({});
+		const az = createTokenScopedGitHostIntegration(
+			GitCloudHostIntegrationId.AzureDevOps,
+			{ accessToken: 'tok' },
+			{ fetch: fetch },
+		);
+
+		assert.equal(await az.getRepositoryMetadata('my-org', 'not-a-descriptor'), undefined);
+		assert.equal(
+			fetch.calls.length,
+			0,
+			`no request should be issued for a malformed descriptor, got ${fetch.calls}`,
+		);
+	});
+
+	test('Azure DevOps Server: honors an explicit scheme in the domain and keeps it out of the DTO', async () => {
+		const fetch = fakeFetch({ name: 'my-repo', defaultBranch: 'refs/heads/main', isFork: false });
+		const az = createTokenScopedGitHostIntegration(
+			GitSelfManagedHostIntegrationId.AzureDevOpsServer,
+			{ accessToken: 'tok', domain: 'http://tfs.example.com' },
+			{ fetch: fetch },
+		);
+
+		const metadata = await az.getRepositoryMetadata('my-org', 'my-project/_git/my-repo');
+		assert.ok(metadata != null);
+		// The DTO's provider domain must be the bare host, never carry the scheme.
+		assert.equal(metadata.provider.domain, 'tfs.example.com');
+		assert.ok(
+			fetch.calls[0].startsWith('http://tfs.example.com/my-org/my-project/_apis/'),
+			`Azure Server should honor the http scheme, got ${fetch.calls[0]}`,
+		);
+	});
+
+	test('GitHub Enterprise: an accidental scheme in the domain does not produce a malformed base URL', async () => {
+		const fetch = fakeFetch({ data: { repository: { owner: { login: 'o' }, name: 'r', parent: null } } });
+		const ghe = createTokenScopedGitHostIntegration(
+			GitSelfManagedHostIntegrationId.CloudGitHubEnterprise,
+			{ accessToken: 'tok', domain: 'https://ghe.example.com' },
+			{ fetch: fetch },
+		);
+
+		await ghe.getRepositoryMetadata('o', 'r');
+		assert.ok(
+			fetch.calls[0].startsWith('https://ghe.example.com/'),
+			`GHE should hit the bare host, got ${fetch.calls[0]}`,
+		);
+		// The scheme must not be doubled up (e.g. `https://https://...`) when the domain already carries one.
+		assert.ok(!/https:\/\/[^/]*:\/\//.test(fetch.calls[0]), `base URL is malformed: ${fetch.calls[0]}`);
+	});
+
+	test('returns undefined on a 404 rather than throwing', async () => {
+		const gh = createTokenScopedGitHostIntegration(
+			GitCloudHostIntegrationId.GitHub,
+			{ accessToken: 'tok' },
+			{ fetch: fakeFetch({ message: 'Not Found' }, 404) },
+		);
+
+		assert.equal(await gh.getRepositoryMetadata('nope', 'nope'), undefined);
+	});
+});

--- a/packages/plus/integrations/src/__tests__/lite.test.ts
+++ b/packages/plus/integrations/src/__tests__/lite.test.ts
@@ -185,7 +185,7 @@ suite('createTokenScopedGitHostIntegration — token-scoped reads', () => {
 		assert.equal(
 			fetch.calls.length,
 			0,
-			`no request should be issued for a malformed descriptor, got ${fetch.calls}`,
+			`no request should be issued for a malformed descriptor, got ${JSON.stringify(fetch.calls)}`,
 		);
 	});
 

--- a/packages/plus/integrations/src/index.ts
+++ b/packages/plus/integrations/src/index.ts
@@ -1,7 +1,10 @@
 // Public facade for `@gitlens/integrations`.
 //
 // External consumers should import from this entry point only, not from the
-// package's internal subpaths. The internal classes (IntegrationService,
+// package's internal subpaths, with one exception: the lightweight, token-scoped
+// read API is a supported public subpath (`./lite.js`). It's kept out of this
+// facade on purpose so importing the session-managed manager doesn't eagerly pull
+// in every provider API client. The internal classes (IntegrationService,
 // IntegrationAuthenticationService, etc.) are not part of the public API and
 // may be refactored without semver bumps.
 

--- a/packages/plus/integrations/src/lite.ts
+++ b/packages/plus/integrations/src/lite.ts
@@ -1,0 +1,213 @@
+// A lightweight, token-scoped entry point for stateless single-shot provider reads.
+//
+// Unlike `createIntegrationManager`, this does NOT build an `IntegrationServiceContext`
+// (no storage/account/config/cache/repositories/hooks) and runs no session/OAuth lifecycle.
+// A consumer that already holds a provider access token (obtained by its own means, e.g.
+// the GitKraken account backend's `v1/provider-tokens/{provider}` endpoint) can call the
+// per-provider API client directly and get back the same DTOs the session-managed
+// `GitHostIntegration` returns.
+//
+// Provider notes:
+// - Azure DevOps encodes the repository as the composite string `"{project}/_git/{repoName}"`
+//   in the `repo` argument (matching the descriptor `GitHostIntegration` uses); `owner` is the
+//   organization. Pass `repo` in that shape for Azure.
+// - Bitbucket Cloud `getDefaultBranch`/`getRepositoryMetadata` depend on `mainbranch`/`parent`
+//   fields the API may omit for some repos; they resolve to `undefined` when absent.
+// - Bitbucket Server (`bitbucket-server`) is not supported here — its reads use a different
+//   REST surface that this token-scoped path doesn't wire up.
+
+import type { GitHubApiConfig } from '@gitlens/git-github/api/config.js';
+import { GitHubApi } from '@gitlens/git-github/api/github.js';
+import type { DefaultBranch } from '@gitlens/git/models/defaultBranch.js';
+import type { Provider } from '@gitlens/git/models/remoteProvider.js';
+import type { RepositoryMetadata } from '@gitlens/git/models/repositoryMetadata.js';
+import type { TokenWithInfo } from './authentication/models.js';
+import { toTokenInfo } from './authentication/models.js';
+import { GitCloudHostIntegrationId, GitSelfManagedHostIntegrationId } from './constants.js';
+import type { ProviderApiConfig } from './providers/apiConfig.js';
+import { AzureDevOpsApi } from './providers/azure/azure.js';
+import { BitbucketApi } from './providers/bitbucket/bitbucket.js';
+import { GitLabApi } from './providers/gitlab/gitlab.js';
+import { providersMetadata } from './providers/models.js';
+
+/** The git-hosting integrations that expose a token-scoped read path here. */
+export type TokenScopedGitHostId =
+	| GitCloudHostIntegrationId.GitHub
+	| GitCloudHostIntegrationId.GitLab
+	| GitCloudHostIntegrationId.Bitbucket
+	| GitCloudHostIntegrationId.AzureDevOps
+	| GitSelfManagedHostIntegrationId.CloudGitHubEnterprise
+	| GitSelfManagedHostIntegrationId.CloudGitLabSelfHosted
+	| GitSelfManagedHostIntegrationId.AzureDevOpsServer;
+
+export interface TokenScopedGitHostToken {
+	/** The provider access token the consumer already holds. */
+	readonly accessToken: string;
+	/**
+	 * Host domain for self-managed instances (e.g. `git.example.com`). Ignored for cloud ids. For an Azure
+	 * DevOps Server reachable over plain HTTP, include the scheme (e.g. `http://tfs.example.com`); otherwise
+	 * `https` is assumed.
+	 */
+	readonly domain?: string;
+	/** Optional scopes carried by the token, surfaced only in logging metadata. */
+	readonly scopes?: readonly string[];
+	/** Whether the token came from a GK-cloud connection (vs a raw PAT). Defaults to `true`. */
+	readonly cloud?: boolean;
+}
+
+export interface TokenScopedHttpConfig {
+	/** The `fetch` implementation to use for HTTP requests. */
+	fetch(input: string | URL, init?: RequestInit): Promise<Response>;
+	/**
+	 * Wrap an async op so TLS validation is disabled when `ignoreSSLErrors` is `'force'`. Optional —
+	 * defaults to a pass-through, which is correct for the browser and for any consumer not toggling SSL.
+	 */
+	wrapForForcedInsecureSSL?<T>(ignoreSSLErrors: boolean | 'force', fn: () => Promise<T> | PromiseLike<T>): Promise<T>;
+	/** Whether to ignore SSL certificate errors on requests. Defaults to `false`. */
+	ignoreSSLErrors?: boolean | 'force';
+	/**
+	 * Whether the consumer runs in a web worker / browser (vs Node.js). GitHub uses this to drop the
+	 * `user-agent` header, which browsers reject and warn about. Defaults to `false`.
+	 */
+	isWeb?: boolean;
+}
+
+/** The stateless reads a token-scoped integration exposes. */
+export interface TokenScopedGitHostIntegration {
+	getRepositoryMetadata(
+		owner: string,
+		repo: string,
+		cancellation?: AbortSignal,
+	): Promise<RepositoryMetadata | undefined>;
+	getDefaultBranch(owner: string, repo: string, cancellation?: AbortSignal): Promise<DefaultBranch | undefined>;
+}
+
+/**
+ * Build a token-scoped git-host integration for a single provider, backed only by a `fetch` + a token —
+ * no `IntegrationServiceContext`, no session/OAuth lifecycle. The returned DTOs match those from the
+ * session-managed {@link GitHostIntegration}.
+ */
+export function createTokenScopedGitHostIntegration(
+	id: TokenScopedGitHostId,
+	token: TokenScopedGitHostToken,
+	http: TokenScopedHttpConfig,
+): TokenScopedGitHostIntegration {
+	// `token.domain` only applies to self-managed ids; cloud ids always use their canonical domain.
+	const selfManaged =
+		id === GitSelfManagedHostIntegrationId.CloudGitHubEnterprise ||
+		id === GitSelfManagedHostIntegrationId.CloudGitLabSelfHosted ||
+		id === GitSelfManagedHostIntegrationId.AzureDevOpsServer;
+	// Self-managed ids carry no canonical domain (`providersMetadata[id].domain` is empty), so a missing
+	// `token.domain` would silently build a malformed base URL (e.g. `https:///api/v3`). Fail fast instead.
+	if (selfManaged && !token.domain) {
+		throw new Error(`A token-scoped integration for the self-managed host '${id}' requires 'token.domain'.`);
+	}
+	const rawDomain = (selfManaged && token.domain) || providersMetadata[id].domain;
+	// The provider/DTO domain drops the scheme (a subpath/collection is preserved for Azure Server and subpath
+	// installs); only Azure DevOps Server's base URL honors an explicit scheme (per its doc). Stripping keeps a
+	// scheme out of the DTO and prevents a malformed base URL (e.g. `https://http://host/api/v3`) if one is
+	// accidentally passed for GHE/GitLab.
+	const host = stripScheme(rawDomain);
+	const provider = createProviderStub(id, host, http.ignoreSSLErrors ?? false);
+	const tokenInfo = buildTokenWithInfo(id, token);
+	const baseUrl = resolveApiBaseUrl(id, rawDomain, host);
+
+	const wrapForForcedInsecureSSL: NonNullable<TokenScopedHttpConfig['wrapForForcedInsecureSSL']> =
+		// `Promise.resolve().then(fn)` (not `Promise.resolve(fn())`) so a synchronous throw in `fn` surfaces as
+		// a rejected promise, honoring the `Promise<T>` contract.
+		http.wrapForForcedInsecureSSL ?? ((_ignore, fn) => Promise.resolve().then(fn));
+
+	// GitHub has its own VS Code-free config type and a `getDefaultBranch` without a cancellation param.
+	if (id === GitCloudHostIntegrationId.GitHub || id === GitSelfManagedHostIntegrationId.CloudGitHubEnterprise) {
+		const config: GitHubApiConfig = {
+			isWeb: http.isWeb ?? false,
+			fetch: (url, init) => http.fetch(url, init),
+			wrapForForcedInsecureSSL: wrapForForcedInsecureSSL,
+		};
+		const api = new GitHubApi(config);
+		return {
+			getRepositoryMetadata: (owner, repo, cancellation) =>
+				api.getRepositoryMetadata(provider, tokenInfo, owner, repo, { baseUrl: baseUrl }, cancellation),
+			// `GitHubApi.getDefaultBranch` has no cancellation param; accept and intentionally ignore it here so
+			// the signature matches the other providers and the drop is explicit at the call site.
+			getDefaultBranch: (owner, repo, _cancellation) =>
+				api.getDefaultBranch(provider, tokenInfo, owner, repo, { baseUrl: baseUrl }),
+		};
+	}
+
+	// GitLab, Bitbucket, and Azure DevOps share the `ProviderApiConfig` client shape and identical read signatures.
+	const config = toProviderApiConfig(http, wrapForForcedInsecureSSL);
+	const api =
+		id === GitCloudHostIntegrationId.GitLab || id === GitSelfManagedHostIntegrationId.CloudGitLabSelfHosted
+			? new GitLabApi(config)
+			: id === GitCloudHostIntegrationId.Bitbucket
+				? new BitbucketApi(config)
+				: new AzureDevOpsApi(config);
+	return {
+		getRepositoryMetadata: (owner, repo, cancellation) =>
+			api.getRepositoryMetadata(provider, tokenInfo, owner, repo, { baseUrl: baseUrl }, cancellation),
+		getDefaultBranch: (owner, repo, cancellation) =>
+			api.getDefaultBranch(provider, tokenInfo, owner, repo, { baseUrl: baseUrl }, cancellation),
+	};
+}
+
+function toProviderApiConfig(
+	http: TokenScopedHttpConfig,
+	wrapForForcedInsecureSSL: NonNullable<TokenScopedHttpConfig['wrapForForcedInsecureSSL']>,
+): ProviderApiConfig {
+	return {
+		fetch: (input, init) => http.fetch(input, init),
+		wrapForForcedInsecureSSL: wrapForForcedInsecureSSL,
+	};
+}
+
+function buildTokenWithInfo(id: TokenScopedGitHostId, token: TokenScopedGitHostToken): TokenWithInfo {
+	const cloud = token.cloud ?? true;
+	return {
+		...toTokenInfo(id, token.accessToken, { cloud: cloud, type: undefined, scopes: token.scopes }),
+		accessToken: token.accessToken,
+	};
+}
+
+/** A minimal {@link Provider} for the API clients: identity + no-op reauth/telemetry, SSL from config. */
+function createProviderStub(id: TokenScopedGitHostId, domain: string, ignoreSSLErrors: boolean | 'force'): Provider {
+	const metadata = providersMetadata[id];
+	return {
+		id: id,
+		name: metadata.name,
+		domain: domain,
+		icon: metadata.iconKey,
+		getIgnoreSSLErrors: () => ignoreSSLErrors,
+		reauthenticate: () => Promise.resolve(),
+		trackRequestException: () => {},
+	};
+}
+
+/** Strips a leading `scheme://` and any trailing slashes; a subpath/collection (e.g. `host/tfs/Col`) is preserved. */
+function stripScheme(domain: string): string {
+	return domain.replace(/^[a-z][\w+.-]*:\/\//i, '').replace(/\/+$/, '');
+}
+
+/**
+ * Mirrors the per-provider `apiBaseUrl` getters on the `GitHostIntegration` subclasses. `rawDomain` may
+ * carry a scheme (only Azure DevOps Server honors it); `host` is the bare host used everywhere else.
+ */
+function resolveApiBaseUrl(id: TokenScopedGitHostId, rawDomain: string, host: string): string {
+	switch (id) {
+		case GitCloudHostIntegrationId.GitHub:
+			return 'https://api.github.com';
+		case GitSelfManagedHostIntegrationId.CloudGitHubEnterprise:
+			return `https://${host}/api/v3`;
+		case GitCloudHostIntegrationId.GitLab:
+			return 'https://gitlab.com/api';
+		case GitSelfManagedHostIntegrationId.CloudGitLabSelfHosted:
+			return `https://${host}/api`;
+		case GitCloudHostIntegrationId.Bitbucket:
+			return 'https://api.bitbucket.org/2.0';
+		case GitCloudHostIntegrationId.AzureDevOps:
+			return 'https://dev.azure.com';
+		case GitSelfManagedHostIntegrationId.AzureDevOpsServer:
+			// Mirror the session-managed getter, which honors the connection protocol; default to https.
+			return rawDomain.includes('://') ? rawDomain.replace(/\/+$/, '') : `https://${host}`;
+	}
+}

--- a/packages/plus/integrations/src/lite.ts
+++ b/packages/plus/integrations/src/lite.ts
@@ -102,6 +102,7 @@ export function createTokenScopedGitHostIntegration(
 	if (selfManaged && !token.domain) {
 		throw new Error(`A token-scoped integration for the self-managed host '${id}' requires 'token.domain'.`);
 	}
+
 	const rawDomain = (selfManaged && token.domain) || providersMetadata[id].domain;
 	// The provider/DTO domain drops the scheme (a subpath/collection is preserved for Azure Server and subpath
 	// installs); only Azure DevOps Server's base URL honors an explicit scheme (per its doc). Stripping keeps a

--- a/packages/plus/integrations/src/providers/apiClients.ts
+++ b/packages/plus/integrations/src/providers/apiClients.ts
@@ -49,23 +49,20 @@ export function createApiClients(ctx: IntegrationServiceContext, disposables: Di
 			));
 		},
 		get gitlab() {
-			return (gitlab ??= build(
-				async () =>
-					new (await import(/* webpackChunkName: "integrations" */ './gitlab/gitlab.js')).GitLabApi(ctx),
+			return (gitlab ??= build(async () =>
+				(await import(/* webpackChunkName: "integrations" */ './gitlab/gitlab.js')).createGitLabApi(ctx),
 			));
 		},
 		get bitbucket() {
-			return (bitbucket ??= build(
-				async () =>
-					new (await import(/* webpackChunkName: "integrations" */ './bitbucket/bitbucket.js')).BitbucketApi(
-						ctx,
-					),
+			return (bitbucket ??= build(async () =>
+				(await import(/* webpackChunkName: "integrations" */ './bitbucket/bitbucket.js')).createBitbucketApi(
+					ctx,
+				),
 			));
 		},
 		get azure() {
-			return (azure ??= build(
-				async () =>
-					new (await import(/* webpackChunkName: "integrations" */ './azure/azure.js')).AzureDevOpsApi(ctx),
+			return (azure ??= build(async () =>
+				(await import(/* webpackChunkName: "integrations" */ './azure/azure.js')).createAzureDevOpsApi(ctx),
 			));
 		},
 	};

--- a/packages/plus/integrations/src/providers/apiConfig.ts
+++ b/packages/plus/integrations/src/providers/apiConfig.ts
@@ -1,0 +1,71 @@
+import type { IntegrationServiceContext } from '../context.js';
+
+/**
+ * VS Code-free configuration for the package-owned provider API clients
+ * ({@link GitLabApi}, {@link BitbucketApi}, {@link AzureDevOpsApi}).
+ *
+ * Mirrors the role {@link import('@gitlens/git-github/api/config.js').GitHubApiConfig}
+ * plays for `GitHubApi`: instead of taking the full {@link IntegrationServiceContext},
+ * a client takes only the narrow HTTP + callback surface it actually uses. The
+ * `createIntegrationManager` path wires this from `ctx` (see the `create*Api`
+ * factories); a token-scoped consumer builds it from a `fetch` plus a
+ * `wrapForForcedInsecureSSL` (a pass-through is fine when not toggling SSL).
+ *
+ * Every field beyond `fetch`/`wrapForForcedInsecureSSL` is optional — a client omits
+ * the call when unset, so a minimal consumer only supplies the two required members.
+ */
+export interface ProviderApiConfig {
+	/** The `fetch` implementation to use for HTTP requests. */
+	fetch(input: string | URL, init?: RequestInit): Promise<Response>;
+
+	/**
+	 * Wraps an async operation so that TLS certificate validation is disabled when the
+	 * provider's `getIgnoreSSLErrors()` returns `'force'`. On the browser it's a no-op.
+	 */
+	wrapForForcedInsecureSSL<T>(ignoreSSLErrors: boolean | 'force', fn: () => Promise<T> | PromiseLike<T>): Promise<T>;
+
+	/**
+	 * Fires when the HTTP proxy configuration changes, so the client can reset its HTTP caches.
+	 * The factory filters the underlying config-change event down to the keys the client cares about.
+	 */
+	onConfigChanged?(listener: () => void): { dispose(): void };
+
+	/**
+	 * Ask the consumer to confirm reauthentication after an auth/permission failure (401/403). Resolves to
+	 * the user's choice; the client performs the actual `provider.reauthenticate()` when this is truthy.
+	 * Only GitLab wires this today.
+	 */
+	onReauthenticationRequired?(message: string): Promise<boolean | undefined>;
+
+	/** A non-fatal error to surface (debug display / notification). */
+	onError?(message: string): void;
+
+	/** The provider API returned a server-side (500-level) error. */
+	onRequestFailed?(message: string): void;
+
+	/** The provider API request timed out; `providerName` names the integration for the message. */
+	onRequestTimedOut?(providerName: string): void;
+
+	/** Bitbucket's "Pull Requests for Commit" app isn't installed; `revLink` opens the install page. */
+	onBitbucketCommitLinksAppMissing?(revLink: string): void;
+}
+
+/**
+ * The `ctx` → {@link ProviderApiConfig} mapping shared by every `create*Api` factory. Each provider
+ * spreads this and layers on its own deltas (GitLab also resets on `remotes` + wires reauth/timeout;
+ * Bitbucket adds the commit-links-app hook). Resets HTTP caches on HTTP proxy config changes.
+ */
+export function baseProviderApiConfig(ctx: IntegrationServiceContext): ProviderApiConfig {
+	return {
+		fetch: ctx.http.fetch.bind(ctx.http),
+		wrapForForcedInsecureSSL: ctx.http.wrapForForcedInsecureSSL.bind(ctx.http),
+		onConfigChanged: listener =>
+			ctx.config.onDidChange(e => {
+				if (e.httpProxy) {
+					listener();
+				}
+			}),
+		onError: message => ctx.hooks?.ui?.onError?.(message),
+		onRequestFailed: message => ctx.hooks?.ui?.onRequestFailed?.(message),
+	};
+}

--- a/packages/plus/integrations/src/providers/azure/azure.ts
+++ b/packages/plus/integrations/src/providers/azure/azure.ts
@@ -89,19 +89,15 @@ class WorkItemStates {
 }
 
 export class AzureDevOpsApi implements Disposable {
-	private readonly _disposable: Disposable;
+	private readonly _disposable: Disposable | undefined;
 	private _workItemStates: WorkItemStates = new WorkItemStates();
 
-	constructor(private readonly ctx: IntegrationServiceContext) {
-		this._disposable = ctx.config.onDidChange(e => {
-			if (e.httpProxy) {
-				this.resetCaches();
-			}
-		});
+	constructor(private readonly config: ProviderApiConfig) {
+		this._disposable = config.onConfigChanged?.(() => this.resetCaches());
 	}
 
 	dispose(): void {
-		this._disposable.dispose();
+		this._disposable?.dispose();
 	}
 
 	private resetCaches(): void {
@@ -593,8 +589,8 @@ export class AzureDevOpsApi implements Disposable {
 			try {
 				if (cancellation?.aborted) throw new CancellationError();
 
-				rsp = await this.ctx.http.wrapForForcedInsecureSSL(provider.getIgnoreSSLErrors(), () =>
-					this.ctx.http.fetch(url, {
+				rsp = await this.config.wrapForForcedInsecureSSL(provider.getIgnoreSSLErrors(), () =>
+					this.config.fetch(url, {
 						headers: {
 							Authorization: `Basic ${base64(`PAT:${accessToken}`)}`,
 							'Content-Type': 'application/json',
@@ -616,7 +612,7 @@ export class AzureDevOpsApi implements Disposable {
 			if (ex instanceof ProviderFetchError || ex.name === 'AbortError') {
 				this.handleRequestError(provider, tokenInfo, ex, scope);
 			} else if (Logger.isDebugging) {
-				this.ctx.hooks?.ui?.onError?.(`AzureDevOps request failed: ${ex.message}`);
+				this.config.onError?.(`AzureDevOps request failed: ${ex.message}`);
 			}
 
 			throw ex;
@@ -658,7 +654,7 @@ export class AzureDevOpsApi implements Disposable {
 				scope?.error(ex);
 				if (ex.response != null) {
 					provider?.trackRequestException();
-					this.ctx.hooks?.ui?.onRequestFailed?.(
+					this.config.onRequestFailed?.(
 						`${provider?.name ?? 'AzureDevOps'} failed to respond and might be experiencing issues.${
 							provider == null || provider.id === 'azure'
 								? ' Please visit the [AzureDevOps status page](https://status.dev.azure.com) for more information.'
@@ -683,9 +679,14 @@ export class AzureDevOpsApi implements Disposable {
 
 		scope?.error(ex);
 		if (Logger.isDebugging) {
-			this.ctx.hooks?.ui?.onError?.(
+			this.config.onError?.(
 				`AzureDevOps request failed: ${(ex.response as any)?.errors?.[0]?.message ?? ex.message}`,
 			);
 		}
 	}
+}
+
+/** Wires an {@link AzureDevOpsApi} from the full runtime context, mapping `ctx` down to the narrow config. */
+export function createAzureDevOpsApi(ctx: IntegrationServiceContext): AzureDevOpsApi {
+	return new AzureDevOpsApi(baseProviderApiConfig(ctx));
 }

--- a/packages/plus/integrations/src/providers/azure/azure.ts
+++ b/packages/plus/integrations/src/providers/azure/azure.ts
@@ -1,8 +1,10 @@
 import type { UnidentifiedAuthor } from '@gitlens/git/models/author.js';
+import type { DefaultBranch } from '@gitlens/git/models/defaultBranch.js';
 import type { Issue } from '@gitlens/git/models/issue.js';
 import type { IssueOrPullRequest, IssueOrPullRequestType } from '@gitlens/git/models/issueOrPullRequest.js';
 import type { PullRequest } from '@gitlens/git/models/pullRequest.js';
 import type { Provider } from '@gitlens/git/models/remoteProvider.js';
+import type { RepositoryMetadata } from '@gitlens/git/models/repositoryMetadata.js';
 import { base64 } from '@gitlens/utils/base64.js';
 import { CancellationError } from '@gitlens/utils/cancellation.js';
 import { trace } from '@gitlens/utils/decorators/log.js';
@@ -20,11 +22,14 @@ import {
 	RequestClientError,
 	RequestNotFoundError,
 } from '../../errors.js';
+import type { ProviderApiConfig } from '../apiConfig.js';
+import { baseProviderApiConfig } from '../apiConfig.js';
 import type {
 	AzureGitCommit,
 	AzureProjectDescriptor,
 	AzurePullRequest,
 	AzurePullRequestWithLinks,
+	AzureRepositoryWithMetadata,
 	AzureWorkItemState,
 	AzureWorkItemStateCategory,
 	WorkItem,
@@ -37,6 +42,7 @@ import {
 	getAzurePullRequestWebUrl,
 	isClosedAzurePullRequestStatus,
 	isClosedAzureWorkItemStateCategory,
+	normalizeAzureBranchName,
 } from './models.js';
 
 class WorkItemStates {
@@ -568,6 +574,128 @@ export class AzureDevOpsApi implements Disposable {
 			scope?.error(ex);
 			return [];
 		}
+	}
+
+	@trace({
+		args: (provider, token, owner, repo) => ({
+			provider: provider.name,
+			token: `<token:${token.microHash}>`,
+			owner: owner,
+			repo: repo,
+		}),
+	})
+	async getRepositoryMetadata(
+		provider: Provider,
+		token: TokenWithInfo,
+		owner: string,
+		repo: string,
+		options: {
+			baseUrl: string;
+		},
+		cancellation?: AbortSignal,
+	): Promise<RepositoryMetadata | undefined> {
+		const scope = getScopedLogger();
+
+		try {
+			const response = await this.getRepository(
+				provider,
+				token,
+				owner,
+				repo,
+				options.baseUrl,
+				scope,
+				cancellation,
+			);
+			if (response == null) return undefined;
+
+			// Azure's `parentRepository` only reliably carries the repo name and its project; a fork's parent
+			// lives in the same organization, so the org (`owner`) is the parent owner. Only report `parent`
+			// when the parent's name is actually present — never fall back to the fork's own name.
+			return {
+				provider: provider,
+				owner: owner,
+				// Prefer the API's canonical name over parsing the composite `repo` descriptor string.
+				name: response.name,
+				isFork: response.isFork ?? false,
+				parent:
+					response.isFork && response.parentRepository?.name != null
+						? { owner: owner, name: response.parentRepository.name }
+						: undefined,
+			} satisfies RepositoryMetadata;
+		} catch (ex) {
+			// Cancellations and 404s are expected outcomes for a probe; don't log them as errors.
+			if (!(ex instanceof CancellationError) && !(ex instanceof RequestNotFoundError)) scope?.error(ex);
+			return undefined;
+		}
+	}
+
+	@trace({
+		args: (provider, token, owner, repo) => ({
+			provider: provider.name,
+			token: `<token:${token.microHash}>`,
+			owner: owner,
+			repo: repo,
+		}),
+	})
+	async getDefaultBranch(
+		provider: Provider,
+		token: TokenWithInfo,
+		owner: string,
+		repo: string,
+		options: {
+			baseUrl: string;
+		},
+		cancellation?: AbortSignal,
+	): Promise<DefaultBranch | undefined> {
+		const scope = getScopedLogger();
+
+		try {
+			const response = await this.getRepository(
+				provider,
+				token,
+				owner,
+				repo,
+				options.baseUrl,
+				scope,
+				cancellation,
+			);
+			if (response?.defaultBranch == null) return undefined;
+
+			return {
+				provider: provider,
+				name: normalizeAzureBranchName(response.defaultBranch),
+			} satisfies DefaultBranch;
+		} catch (ex) {
+			// Cancellations and 404s are expected outcomes for a probe; don't log them as errors.
+			if (!(ex instanceof CancellationError) && !(ex instanceof RequestNotFoundError)) scope?.error(ex);
+			return undefined;
+		}
+	}
+
+	private getRepository(
+		provider: Provider,
+		token: TokenWithInfo,
+		owner: string,
+		repo: string,
+		baseUrl: string,
+		scope: ScopedLogger | undefined,
+		cancellation?: AbortSignal,
+	): Promise<AzureRepositoryWithMetadata | undefined> {
+		const parts = repo.split('/');
+		const [projectName, segment, repoName] = parts;
+		// The descriptor must be exactly `"{project}/_git/{repoName}"`; bail before issuing a bogus request.
+		if (parts.length !== 3 || segment !== '_git' || !projectName || !repoName) {
+			throw new Error(`Invalid Azure repository descriptor '${repo}'; expected '{project}/_git/{repoName}'.`);
+		}
+		return this.request<AzureRepositoryWithMetadata>(
+			provider,
+			token,
+			baseUrl,
+			`${owner}/${projectName}/_apis/git/repositories/${repoName}?api-version=7.1`,
+			{ method: 'GET' },
+			scope,
+			cancellation,
+		);
 	}
 
 	private async request<T>(

--- a/packages/plus/integrations/src/providers/azure/azure.ts
+++ b/packages/plus/integrations/src/providers/azure/azure.ts
@@ -6,7 +6,7 @@ import type { PullRequest } from '@gitlens/git/models/pullRequest.js';
 import type { Provider } from '@gitlens/git/models/remoteProvider.js';
 import type { RepositoryMetadata } from '@gitlens/git/models/repositoryMetadata.js';
 import { base64 } from '@gitlens/utils/base64.js';
-import { CancellationError } from '@gitlens/utils/cancellation.js';
+import { CancellationError, isCancellationError } from '@gitlens/utils/cancellation.js';
 import { trace } from '@gitlens/utils/decorators/log.js';
 import type { Disposable } from '@gitlens/utils/disposable.js';
 import { Logger } from '@gitlens/utils/logger.js';
@@ -624,7 +624,9 @@ export class AzureDevOpsApi implements Disposable {
 			} satisfies RepositoryMetadata;
 		} catch (ex) {
 			// Cancellations and 404s are expected outcomes for a probe; don't log them as errors.
-			if (!(ex instanceof CancellationError) && !(ex instanceof RequestNotFoundError)) scope?.error(ex);
+			if (!isCancellationError(ex) && !(ex instanceof RequestNotFoundError)) {
+				scope?.error(ex);
+			}
 			return undefined;
 		}
 	}
@@ -667,7 +669,9 @@ export class AzureDevOpsApi implements Disposable {
 			} satisfies DefaultBranch;
 		} catch (ex) {
 			// Cancellations and 404s are expected outcomes for a probe; don't log them as errors.
-			if (!(ex instanceof CancellationError) && !(ex instanceof RequestNotFoundError)) scope?.error(ex);
+			if (!isCancellationError(ex) && !(ex instanceof RequestNotFoundError)) {
+				scope?.error(ex);
+			}
 			return undefined;
 		}
 	}

--- a/packages/plus/integrations/src/providers/azure/models.ts
+++ b/packages/plus/integrations/src/providers/azure/models.ts
@@ -202,6 +202,18 @@ export interface AzureRepository {
 	isInMaintenance: boolean;
 }
 
+/** The `GET .../_apis/git/repositories/{repositoryId or name}` response, adding fork/default-branch fields to {@link AzureRepository}. */
+export interface AzureRepositoryWithMetadata extends AzureRepository {
+	/** Fully-qualified ref, e.g. `refs/heads/main`. */
+	defaultBranch?: string;
+	isFork?: boolean;
+	parentRepository?: {
+		id: string;
+		name: string;
+		project?: { id: string; name: string };
+	};
+}
+
 export interface AzureGitUser {
 	date?: string;
 	email?: string;
@@ -496,7 +508,7 @@ export function fromAzureReviewerToPullRequestMember(reviewer: AzureUser): PullR
 	};
 }
 
-function normalizeAzureBranchName(branchName: string): string {
+export function normalizeAzureBranchName(branchName: string): string {
 	return branchName.startsWith('refs/heads/') ? branchName.replace('refs/heads/', '') : branchName;
 }
 

--- a/packages/plus/integrations/src/providers/azure/models.ts
+++ b/packages/plus/integrations/src/providers/azure/models.ts
@@ -209,7 +209,7 @@ export interface AzureRepositoryWithMetadata extends AzureRepository {
 	isFork?: boolean;
 	parentRepository?: {
 		id: string;
-		name: string;
+		name?: string;
 		project?: { id: string; name: string };
 	};
 }

--- a/packages/plus/integrations/src/providers/azureDevOps.ts
+++ b/packages/plus/integrations/src/providers/azureDevOps.ts
@@ -310,10 +310,18 @@ export abstract class AzureDevOpsIntegrationBase<
 	}
 
 	protected override async getProviderDefaultBranch(
-		_session: AuthenticationSession,
-		_repo: AzureRepositoryDescriptor,
+		session: ProviderAuthenticationSession,
+		repo: AzureRepositoryDescriptor,
+		cancellation?: AbortSignal,
 	): Promise<DefaultBranch | undefined> {
-		return Promise.resolve(undefined);
+		return (await this.authenticationService.apis.azure)?.getDefaultBranch(
+			this,
+			toTokenWithInfo(this.id, session),
+			repo.owner,
+			repo.name,
+			{ baseUrl: this.apiBaseUrl },
+			cancellation,
+		);
 	}
 
 	protected override async getProviderLinkedIssueOrPullRequest(
@@ -412,11 +420,18 @@ export abstract class AzureDevOpsIntegrationBase<
 	}
 
 	protected override async getProviderRepositoryMetadata(
-		_session: AuthenticationSession,
-		_repo: AzureRepositoryDescriptor,
-		_cancellation?: AbortSignal,
+		session: ProviderAuthenticationSession,
+		repo: AzureRepositoryDescriptor,
+		cancellation?: AbortSignal,
 	): Promise<RepositoryMetadata | undefined> {
-		return Promise.resolve(undefined);
+		return (await this.authenticationService.apis.azure)?.getRepositoryMetadata(
+			this,
+			toTokenWithInfo(this.id, session),
+			repo.owner,
+			repo.name,
+			{ baseUrl: this.apiBaseUrl },
+			cancellation,
+		);
 	}
 
 	protected override async searchProviderMyPullRequests(

--- a/packages/plus/integrations/src/providers/bitbucket.ts
+++ b/packages/plus/integrations/src/providers/bitbucket.ts
@@ -86,10 +86,18 @@ export class BitbucketIntegration extends GitHostIntegration<
 	}
 
 	protected override async getProviderDefaultBranch(
-		_session: AuthenticationSession,
-		_repo: BitbucketRepositoryDescriptor,
+		session: ProviderAuthenticationSession,
+		repo: BitbucketRepositoryDescriptor,
+		cancellation?: AbortSignal,
 	): Promise<DefaultBranch | undefined> {
-		return Promise.resolve(undefined);
+		return (await this.authenticationService.apis.bitbucket)?.getDefaultBranch(
+			this,
+			toTokenWithInfo(this.id, session),
+			repo.owner,
+			repo.name,
+			{ baseUrl: this.apiBaseUrl },
+			cancellation,
+		);
 	}
 
 	protected override async getProviderLinkedIssueOrPullRequest(
@@ -161,11 +169,18 @@ export class BitbucketIntegration extends GitHostIntegration<
 	}
 
 	protected override async getProviderRepositoryMetadata(
-		_session: AuthenticationSession,
-		_repo: BitbucketRepositoryDescriptor,
-		_cancellation?: AbortSignal,
+		session: ProviderAuthenticationSession,
+		repo: BitbucketRepositoryDescriptor,
+		cancellation?: AbortSignal,
 	): Promise<RepositoryMetadata | undefined> {
-		return Promise.resolve(undefined);
+		return (await this.authenticationService.apis.bitbucket)?.getRepositoryMetadata(
+			this,
+			toTokenWithInfo(this.id, session),
+			repo.owner,
+			repo.name,
+			{ baseUrl: this.apiBaseUrl },
+			cancellation,
+		);
 	}
 
 	private _accounts: Map<string, Account | undefined> | undefined;

--- a/packages/plus/integrations/src/providers/bitbucket/bitbucket.ts
+++ b/packages/plus/integrations/src/providers/bitbucket/bitbucket.ts
@@ -20,6 +20,8 @@ import {
 	RequestClientError,
 	RequestNotFoundError,
 } from '../../errors.js';
+import type { ProviderApiConfig } from '../apiConfig.js';
+import { baseProviderApiConfig } from '../apiConfig.js';
 import type { BitbucketServerCommit, BitbucketServerPullRequest } from '../bitbucket-server/models.js';
 import { normalizeBitbucketServerPullRequest } from '../bitbucket-server/models.js';
 import { fromProviderPullRequest } from '../models.js';
@@ -32,18 +34,14 @@ import {
 } from './models.js';
 
 export class BitbucketApi implements Disposable {
-	private readonly _disposable: Disposable;
+	private readonly _disposable: Disposable | undefined;
 
-	constructor(private readonly ctx: IntegrationServiceContext) {
-		this._disposable = ctx.config.onDidChange(e => {
-			if (e.httpProxy) {
-				this.resetCaches();
-			}
-		});
+	constructor(private readonly config: ProviderApiConfig) {
+		this._disposable = config.onConfigChanged?.(() => this.resetCaches());
 	}
 
 	dispose(): void {
-		this._disposable.dispose();
+		this._disposable?.dispose();
 	}
 
 	private resetCaches(): void {}
@@ -521,7 +519,7 @@ export class BitbucketApi implements Disposable {
 					// TODO: In future get it on to home as an warning on the integration itself "this integration has issues"
 					// even user suppresses the message it's still visible with some capacity. It's a broader thing to get other errors.
 					const commitWebUrl = `https://bitbucket.org/${owner}/${repo}/commits/${rev}`;
-					this.ctx.hooks?.ui?.onBitbucketCommitLinksAppMissing?.(commitWebUrl);
+					this.config.onBitbucketCommitLinksAppMissing?.(commitWebUrl);
 					return undefined;
 				}
 			}
@@ -679,8 +677,8 @@ export class BitbucketApi implements Disposable {
 			try {
 				if (cancellation?.aborted) throw new CancellationError();
 
-				rsp = await this.ctx.http.wrapForForcedInsecureSSL(provider.getIgnoreSSLErrors(), () =>
-					this.ctx.http.fetch(url, {
+				rsp = await this.config.wrapForForcedInsecureSSL(provider.getIgnoreSSLErrors(), () =>
+					this.config.fetch(url, {
 						headers: { Authorization: `Bearer ${accessToken}`, 'Content-Type': 'application/json' },
 						signal: cancellation,
 						...options,
@@ -699,7 +697,7 @@ export class BitbucketApi implements Disposable {
 			if (ex instanceof ProviderFetchError || ex.name === 'AbortError') {
 				this.handleRequestError(provider, tokenInfo, ex, scope);
 			} else if (Logger.isDebugging) {
-				this.ctx.hooks?.ui?.onError?.(`Bitbucket request failed: ${ex.message}`);
+				this.config.onError?.(`Bitbucket request failed: ${ex.message}`);
 			}
 
 			throw ex;
@@ -741,7 +739,7 @@ export class BitbucketApi implements Disposable {
 				scope?.error(ex);
 				if (ex.response != null) {
 					provider?.trackRequestException();
-					this.ctx.hooks?.ui?.onRequestFailed?.(
+					this.config.onRequestFailed?.(
 						`${provider?.name ?? 'Bitbucket'} failed to respond and might be experiencing issues.${
 							provider == null || provider.id === 'bitbucket'
 								? ' Please visit the [Bitbucket status page](https://bitbucket.status.atlassian.com/) for more information.'
@@ -766,9 +764,19 @@ export class BitbucketApi implements Disposable {
 
 		scope?.error(ex);
 		if (Logger.isDebugging) {
-			this.ctx.hooks?.ui?.onError?.(
+			this.config.onError?.(
 				`Bitbucket request failed: ${(ex.response as any)?.errors?.[0]?.message ?? ex.message}`,
 			);
 		}
 	}
+}
+
+/** Wires a {@link BitbucketApi} from the full runtime context, mapping `ctx` down to the narrow config. */
+export function createBitbucketApi(ctx: IntegrationServiceContext): BitbucketApi {
+	const config: ProviderApiConfig = {
+		...baseProviderApiConfig(ctx),
+		onBitbucketCommitLinksAppMissing: revLink => ctx.hooks?.ui?.onBitbucketCommitLinksAppMissing?.(revLink),
+	};
+
+	return new BitbucketApi(config);
 }

--- a/packages/plus/integrations/src/providers/bitbucket/bitbucket.ts
+++ b/packages/plus/integrations/src/providers/bitbucket/bitbucket.ts
@@ -1,4 +1,5 @@
 import type { Account, CommitAuthor, UnidentifiedAuthor } from '@gitlens/git/models/author.js';
+import type { DefaultBranch } from '@gitlens/git/models/defaultBranch.js';
 import type { Issue } from '@gitlens/git/models/issue.js';
 import type { IssueOrPullRequest, IssueOrPullRequestType } from '@gitlens/git/models/issueOrPullRequest.js';
 import type { PullRequest } from '@gitlens/git/models/pullRequest.js';
@@ -407,6 +408,122 @@ export class BitbucketApi implements Disposable {
 			scope?.error(ex);
 			return undefined;
 		}
+	}
+
+	@trace({
+		args: (provider, token, owner, repo) => ({
+			provider: provider.name,
+			token: `<token:${token.microHash}>`,
+			owner: owner,
+			repo: repo,
+		}),
+	})
+	async getRepositoryMetadata(
+		provider: Provider,
+		token: TokenWithInfo,
+		owner: string,
+		repo: string,
+		options: {
+			baseUrl: string;
+		},
+		cancellation?: AbortSignal,
+	): Promise<RepositoryMetadata | undefined> {
+		const scope = getScopedLogger();
+
+		try {
+			const response = await this.getRepository(
+				provider,
+				token,
+				owner,
+				repo,
+				options.baseUrl,
+				scope,
+				cancellation,
+			);
+			if (response == null) return undefined;
+
+			let parent: RepositoryMetadata['parent'];
+			if (response.parent != null) {
+				// Derive the parent from `full_name` ("owner/repo") rather than `parent.workspace`, which is a
+				// requested field expansion Bitbucket doesn't always honor (an unexpanded parent would otherwise
+				// throw and null out the whole result).
+				const [parentOwner, parentName] = response.parent.full_name.split('/');
+				parent = { owner: parentOwner, name: parentName };
+			}
+
+			return {
+				provider: provider,
+				owner: response.workspace.slug,
+				name: response.slug,
+				isFork: response.parent != null,
+				parent: parent,
+			} satisfies RepositoryMetadata;
+		} catch (ex) {
+			// Cancellations and 404s are expected outcomes for a probe; don't log them as errors.
+			if (!(ex instanceof CancellationError) && !(ex instanceof RequestNotFoundError)) scope?.error(ex);
+			return undefined;
+		}
+	}
+
+	@trace({
+		args: (provider, token, owner, repo) => ({
+			provider: provider.name,
+			token: `<token:${token.microHash}>`,
+			owner: owner,
+			repo: repo,
+		}),
+	})
+	async getDefaultBranch(
+		provider: Provider,
+		token: TokenWithInfo,
+		owner: string,
+		repo: string,
+		options: {
+			baseUrl: string;
+		},
+		cancellation?: AbortSignal,
+	): Promise<DefaultBranch | undefined> {
+		const scope = getScopedLogger();
+
+		try {
+			const response = await this.getRepository(
+				provider,
+				token,
+				owner,
+				repo,
+				options.baseUrl,
+				scope,
+				cancellation,
+			);
+			const name = response?.mainbranch?.name;
+			if (name == null) return undefined;
+
+			return { provider: provider, name: name } satisfies DefaultBranch;
+		} catch (ex) {
+			// Cancellations and 404s are expected outcomes for a probe; don't log them as errors.
+			if (!(ex instanceof CancellationError) && !(ex instanceof RequestNotFoundError)) scope?.error(ex);
+			return undefined;
+		}
+	}
+
+	private getRepository(
+		provider: Provider,
+		token: TokenWithInfo,
+		owner: string,
+		repo: string,
+		baseUrl: string,
+		scope: ScopedLogger | undefined,
+		cancellation?: AbortSignal,
+	): Promise<BitbucketRepository | undefined> {
+		return this.request<BitbucketRepository>(
+			provider,
+			token,
+			baseUrl,
+			`repositories/${owner}/${repo}`,
+			{ method: 'GET' },
+			scope,
+			cancellation,
+		);
 	}
 
 	@trace({

--- a/packages/plus/integrations/src/providers/bitbucket/bitbucket.ts
+++ b/packages/plus/integrations/src/providers/bitbucket/bitbucket.ts
@@ -5,7 +5,7 @@ import type { IssueOrPullRequest, IssueOrPullRequestType } from '@gitlens/git/mo
 import type { PullRequest } from '@gitlens/git/models/pullRequest.js';
 import type { Provider } from '@gitlens/git/models/remoteProvider.js';
 import type { RepositoryMetadata } from '@gitlens/git/models/repositoryMetadata.js';
-import { CancellationError } from '@gitlens/utils/cancellation.js';
+import { CancellationError, isCancellationError } from '@gitlens/utils/cancellation.js';
 import { trace } from '@gitlens/utils/decorators/log.js';
 import type { Disposable } from '@gitlens/utils/disposable.js';
 import { Logger } from '@gitlens/utils/logger.js';
@@ -460,7 +460,9 @@ export class BitbucketApi implements Disposable {
 			} satisfies RepositoryMetadata;
 		} catch (ex) {
 			// Cancellations and 404s are expected outcomes for a probe; don't log them as errors.
-			if (!(ex instanceof CancellationError) && !(ex instanceof RequestNotFoundError)) scope?.error(ex);
+			if (!isCancellationError(ex) && !(ex instanceof RequestNotFoundError)) {
+				scope?.error(ex);
+			}
 			return undefined;
 		}
 	}
@@ -501,7 +503,9 @@ export class BitbucketApi implements Disposable {
 			return { provider: provider, name: name } satisfies DefaultBranch;
 		} catch (ex) {
 			// Cancellations and 404s are expected outcomes for a probe; don't log them as errors.
-			if (!(ex instanceof CancellationError) && !(ex instanceof RequestNotFoundError)) scope?.error(ex);
+			if (!isCancellationError(ex) && !(ex instanceof RequestNotFoundError)) {
+				scope?.error(ex);
+			}
 			return undefined;
 		}
 	}

--- a/packages/plus/integrations/src/providers/bitbucket/bitbucket.ts
+++ b/packages/plus/integrations/src/providers/bitbucket/bitbucket.ts
@@ -447,8 +447,12 @@ export class BitbucketApi implements Disposable {
 				// Derive the parent from `full_name` ("owner/repo") rather than `parent.workspace`, which is a
 				// requested field expansion Bitbucket doesn't always honor (an unexpanded parent would otherwise
 				// throw and null out the whole result).
+				// `full_name` is "owner/repo"; only report a parent when both parts are present so a malformed
+				// value doesn't produce a parent with an undefined owner/name while `isFork` stays true.
 				const [parentOwner, parentName] = response.parent.full_name.split('/');
-				parent = { owner: parentOwner, name: parentName };
+				if (parentOwner && parentName) {
+					parent = { owner: parentOwner, name: parentName };
+				}
 			}
 
 			return {

--- a/packages/plus/integrations/src/providers/gitlab/gitlab.ts
+++ b/packages/plus/integrations/src/providers/gitlab/gitlab.ts
@@ -23,6 +23,8 @@ import {
 	RequestNotFoundError,
 	RequestRateLimitError,
 } from '../../errors.js';
+import type { ProviderApiConfig } from '../apiConfig.js';
+import { baseProviderApiConfig } from '../apiConfig.js';
 import { selectGitLabUserForCommit } from './gitlab.utils.js';
 import type {
 	GitLabCommit,
@@ -47,19 +49,15 @@ function buildGitLabUserId(id: string | number | undefined): string | undefined 
 }
 
 export class GitLabApi implements Disposable {
-	private readonly _disposable: Disposable;
+	private readonly _disposable: Disposable | undefined;
 	private _projectIds = new Map<string, Promise<string | undefined>>();
 
-	constructor(private readonly ctx: IntegrationServiceContext) {
-		this._disposable = ctx.config.onDidChange(e => {
-			if (e.httpProxy || e.remotes) {
-				this.resetCaches();
-			}
-		});
+	constructor(private readonly config: ProviderApiConfig) {
+		this._disposable = config.onConfigChanged?.(() => this.resetCaches());
 	}
 
 	dispose(): void {
-		this._disposable.dispose();
+		this._disposable?.dispose();
 	}
 
 	private resetCaches(): void {
@@ -1034,8 +1032,8 @@ $search: String!
 			try {
 				if (cancellation?.aborted) throw new CancellationError();
 
-				rsp = await this.ctx.http.wrapForForcedInsecureSSL(provider.getIgnoreSSLErrors(), () =>
-					this.ctx.http.fetch(`${baseUrl ?? 'https://gitlab.com/api'}/graphql`, {
+				rsp = await this.config.wrapForForcedInsecureSSL(provider.getIgnoreSSLErrors(), () =>
+					this.config.fetch(`${baseUrl ?? 'https://gitlab.com/api'}/graphql`, {
 						method: 'POST',
 						headers: { Authorization: `Bearer ${accessToken}`, 'Content-Type': 'application/json' },
 						signal: cancellation,
@@ -1061,7 +1059,7 @@ $search: String!
 			if (ex instanceof ProviderFetchError || ex.name === 'AbortError') {
 				this.handleRequestError(provider, token, ex, scope);
 			} else if (Logger.isDebugging) {
-				this.ctx.hooks?.ui?.onError?.(`GitLab request failed: ${ex.message}`);
+				this.config.onError?.(`GitLab request failed: ${ex.message}`);
 			}
 
 			throw ex;
@@ -1087,8 +1085,8 @@ $search: String!
 			try {
 				if (cancellation?.aborted) throw new CancellationError();
 
-				rsp = await this.ctx.http.wrapForForcedInsecureSSL(provider.getIgnoreSSLErrors(), () =>
-					this.ctx.http.fetch(url, {
+				rsp = await this.config.wrapForForcedInsecureSSL(provider.getIgnoreSSLErrors(), () =>
+					this.config.fetch(url, {
 						headers: { Authorization: `Bearer ${accessToken}`, 'Content-Type': 'application/json' },
 						signal: cancellation,
 						...options,
@@ -1107,7 +1105,7 @@ $search: String!
 			if (ex instanceof ProviderFetchError || ex.name === 'AbortError') {
 				this.handleRequestError(provider, token, ex, scope);
 			} else if (Logger.isDebugging) {
-				this.ctx.hooks?.ui?.onError?.(`GitLab request failed: ${ex.message}`);
+				this.config.onError?.(`GitLab request failed: ${ex.message}`);
 			}
 
 			throw ex;
@@ -1150,7 +1148,7 @@ $search: String!
 				scope?.error(ex);
 				if (ex.response != null) {
 					provider?.trackRequestException();
-					this.ctx.hooks?.ui?.onRequestFailed?.(
+					this.config.onRequestFailed?.(
 						`${provider?.name ?? 'GitLab'} failed to respond and might be experiencing issues.${
 							provider == null || provider.id === 'gitlab'
 								? ' Please visit the [GitLab status page](https://status.gitlab.com) for more information.'
@@ -1164,7 +1162,7 @@ $search: String!
 				// GitHub seems to return this status code for timeouts
 				if (ex.message.includes('timeout')) {
 					provider?.trackRequestException();
-					this.ctx.hooks?.ui?.onRequestTimedOut?.(provider?.name ?? 'GitLab');
+					this.config.onRequestTimedOut?.(provider?.name ?? 'GitLab');
 					return;
 				}
 				break;
@@ -1175,9 +1173,7 @@ $search: String!
 
 		scope?.error(ex);
 		if (Logger.isDebugging) {
-			this.ctx.hooks?.ui?.onError?.(
-				`GitLab request failed: ${(ex.response as any)?.errors?.[0]?.message ?? ex.message}`,
-			);
+			this.config.onError?.(`GitLab request failed: ${(ex.response as any)?.errors?.[0]?.message ?? ex.message}`);
 		}
 	}
 
@@ -1193,7 +1189,7 @@ $search: String!
 
 	private async showAuthenticationErrorMessage(ex: AuthenticationError, provider: Provider) {
 		if (ex.reason === AuthenticationErrorReason.Unauthorized || ex.reason === AuthenticationErrorReason.Forbidden) {
-			const reauthenticate = await this.ctx.hooks?.onReauthenticationRequired?.(
+			const reauthenticate = await this.config.onReauthenticationRequired?.(
 				`${ex.message}. Would you like to try reauthenticating${
 					ex.reason === AuthenticationErrorReason.Forbidden ? ' to provide additional access' : ''
 				}?`,
@@ -1204,7 +1200,26 @@ $search: String!
 				this.resetCaches();
 			}
 		} else {
-			this.ctx.hooks?.ui?.onError?.(ex.message);
+			this.config.onError?.(ex.message);
 		}
 	}
+}
+
+/** Wires a {@link GitLabApi} from the full runtime context, mapping `ctx` down to the narrow config. */
+export function createGitLabApi(ctx: IntegrationServiceContext): GitLabApi {
+	const config: ProviderApiConfig = {
+		...baseProviderApiConfig(ctx),
+		// Self-hosted GitLab keys its API base off `remotes`, so reset on both HTTP proxy and remotes changes.
+		onConfigChanged: listener =>
+			ctx.config.onDidChange(e => {
+				if (e.httpProxy || e.remotes) {
+					listener();
+				}
+			}),
+		onReauthenticationRequired: message =>
+			ctx.hooks?.onReauthenticationRequired?.(message) ?? Promise.resolve(false),
+		onRequestTimedOut: providerName => ctx.hooks?.ui?.onRequestTimedOut?.(providerName),
+	};
+
+	return new GitLabApi(config);
 }


### PR DESCRIPTION
Closes #5442.

Adds a lightweight, token-scoped entry point so a consumer that already holds a provider access token (obtained by its own means, e.g. the GitKraken account backend's `v1/provider-tokens/{provider}` endpoint) can run stateless single-shot provider reads without constructing a full `IntegrationServiceContext` (no `storage`/`account`/`config`/`cache`/`repositories`/`hooks`) and with no session/OAuth lifecycle. Unblocks `gitkraken/kepler#1329`.

The returned DTOs (`RepositoryMetadata`, `DefaultBranch`) match those from the session-managed `GitHostIntegration`, so consumer mapping code doesn't fork between the two paths.

## What's in here

Three commits:

1. **Decouples provider API clients from `IntegrationServiceContext`** — `GitLabApi`/`BitbucketApi`/`AzureDevOpsApi` now take a narrow `ProviderApiConfig` (just the HTTP + optional callback surface they actually use), mirroring `GitHubApiConfig`. The manager wires them from `ctx` via new `createGitLabApi`/`createBitbucketApi`/`createAzureDevOpsApi` factories, preserving every prior hook (including GitLab's cache reset on `remotes` and Bitbucket's commit-links-app hook).
2. **Adds `getRepositoryMetadata` + `getDefaultBranch` to the Bitbucket and Azure DevOps API clients** — previously stubbed to `undefined`. Bitbucket derives the parent from `full_name` rather than the unreliable `parent.workspace` expansion; Azure reports a fork's parent only when its name is actually present (never self-parents).
3. **Adds `createTokenScopedGitHostIntegration`** at `plus/integrations/lite.js`, backed only by a `fetch` + a token, covering GitHub, GitLab, Bitbucket, and Azure DevOps (cloud + self-managed where applicable). Base URLs and domains mirror the session-managed `apiBaseUrl` getters exactly.

`GitHostIntegration`/`IntegrationService` stay the primary session-managed API; this is purely additive for consumers that own their own account/session lifecycle.

## Notes

- Self-managed ids (GitHub Enterprise, GitLab Self-Hosted, Azure DevOps Server) require `token.domain`; the entry point fails fast with a clear error if it's omitted, rather than building a malformed base URL.
- Bitbucket Server is intentionally not wired up here (its reads use a different REST surface).

## Testing

Adds `lite.test.ts` covering GitHub/GitLab/Bitbucket/Azure metadata + default-branch mapping, fork/parent edge cases, the self-managed domain guard, and 404 handling. Full package suite green (58 passing), build clean.