### PR TITLE
Per-connection support for paginated/providersApi reads + read-API parity for Kepler (#5435)

### DIFF
--- a/docs/kepler-read-api-parity.md
+++ b/docs/kepler-read-api-parity.md
@@ -1,0 +1,100 @@
+# Kepler read-API parity
+
+Authoritative decision record for the read-API parity gaps tracked in
+[#5435](https://github.com/gitkraken/vscode-gitlens/issues/5435) (follow-up to #5430), so Kepler
+([gitkraken/kepler#1325](https://github.com/gitkraken/kepler/issues/1325), epic
+[#1322](https://github.com/gitkraken/kepler/issues/1322)) can migrate its provider reads off the `gk` CLI
+onto `@gitkraken/core-gitlens` with a clear contract.
+
+The provider-side prerequisites landed in `@gitkraken/provider-apis` **0.50.0** (GKDEV-3535, GKDEV-3536,
+GKDEV-3537, GKDEV-3538); core-gitlens consumes them from that version on.
+
+Verdict legend: **first-class** (honored) · **best-effort** (honored where the provider exposes it cheaply,
+otherwise `undefined`) · **n/a** (provider has no such concept).
+
+## 1. Per-connection reads
+
+`getMyIssuesForRepos` / `getMyPullRequestsForRepos` accept an optional trailing `connectionId` and read with
+that connection's token (mirroring the `connectionId` added to the session-based `searchMy*` reads in #5430).
+Omitting it preserves the provider's primary-connection behavior. The `providersApi` token path
+(`TokenOptInfo` → `getProviderToken` → `getSession`) resolves the requested connection's cloud session; an
+unresolvable or locally-disconnected connection degrades to "no results" without calling the provider.
+
+## 2. Pagination
+
+`PagedResult.paging` now carries `page` / `pageSize` / `nextPage` / `totalPages` / `totalCount` alongside the
+existing `cursor` / `more`. Reads accept `page` / `pageSize`.
+
+| Provider         | Paging   | `hasMore`   | `currentPage` / `totalPages` / `totalCount` | `pageSize` honored  |
+| ---------------- | -------- | ----------- | ------------------------------------------- | ------------------- |
+| GitHub           | cursor   | first-class | `undefined` (cursor)                        | yes (`maxPageSize`) |
+| GitLab           | cursor   | first-class | `undefined` (cursor)                        | yes (`first`)       |
+| Jira             | cursor   | first-class | `undefined` (cursor)                        | yes (`maxResults`)  |
+| Bitbucket        | numbered | first-class | first-class                                 | yes                 |
+| Bitbucket Server | numbered | first-class | first-class                                 | yes                 |
+| Azure DevOps     | numbered | first-class | first-class                                 | yes                 |
+
+**Kepler mapping:** cursor providers can't report a page number; consume `hasMore` for "next page exists" and
+carry the opaque `cursor` forward. For numbered providers, `currentPage` + `totalPages`/`totalCount` map
+directly to Kepler's `{ currentPage, itemsPerPage }`.
+
+## 3. PR state selector (open / closed / merged)
+
+`getMyPullRequestsForRepos` and `searchMyPullRequests` accept a `PullRequestStateFilter`
+(`open`|`closed`|`merged`|`all`); issue reads accept an `IssueStateFilter` (`open`|`closed`|`all`). Omitted =
+open-only (unchanged). All providers honor it (providers that can't express an arbitrary combination in one
+query filter the normalized results).
+
+| Provider         | Paginated (`getMy*ForRepos`) | Search (`searchMyPullRequests`)                                          |
+| ---------------- | ---------------------------- | ------------------------------------------------------------------------ |
+| GitHub           | first-class (SDK `states`)   | first-class (search query `is:open`/`is:closed is:unmerged`/`is:merged`) |
+| GitLab           | first-class                  | first-class (SDK `states`)                                               |
+| Bitbucket        | first-class                  | first-class (BBQL state clause + authored `states`)                      |
+| Bitbucket Server | first-class                  | first-class (SDK `states`)                                               |
+| Azure DevOps     | first-class                  | first-class (SDK `states`)                                               |
+| Jira (issues)    | first-class                  | n/a (Jira has no PRs)                                                    |
+
+## 4. Assignee / reviewer filters
+
+- **`includeAllAssignees` (issues):** `getMyIssuesForRepos` option; when `true` it drops the current-user
+  assignee constraint (returns all-assignee issues). First-class for all issue providers (it is an omission).
+- **Reviewer inclusion (PRs):** the `ReviewRequested` filter routes to the field each provider reads.
+
+| Provider         | Reviewer filter                                      | Keyed by   |
+| ---------------- | ---------------------------------------------------- | ---------- |
+| GitHub           | `reviewRequestedLogin`                               | login      |
+| GitLab           | `reviewRequestedLogin` (multi-assignee also honored) | login      |
+| Bitbucket        | `reviewerId`                                         | account id |
+| Bitbucket Server | `reviewerLogin`                                      | login      |
+| Azure DevOps     | `reviewerId`                                         | account id |
+
+**Caveat:** the reviewer key differs (login vs account id); `getMyPullRequestsForRepos` picks the right one
+per provider from the resolved current user, so callers don't special-case it.
+
+## 5. Clone URLs + fork / cross-repository
+
+`PullRequestRef` carries optional `cloneHttps` / `cloneSsh` / `isFork`; `PullRequest.refs.isCrossRepository`
+is always present.
+
+| Provider         | Clone URLs                               | `isCrossRepository` | `isFork`                   |
+| ---------------- | ---------------------------------------- | ------------------- | -------------------------- |
+| GitHub           | first-class                              | first-class         | best-effort                |
+| GitLab           | first-class                              | first-class         | `undefined`                |
+| Bitbucket        | first-class                              | first-class         | `undefined`                |
+| Bitbucket Server | first-class                              | first-class         | `undefined`                |
+| Azure DevOps     | first-class **with `includeRemoteInfo`** | first-class         | best-effort (`forkSource`) |
+
+**Caveats:** Azure clone URLs require an opt-in extra lookup; `getMyPullRequestsForRepos` requests
+`includeRemoteInfo` for Azure automatically. Where clone URLs are unavailable the fields are `undefined`;
+reconstruct from the repository `webUrl`. Prefer `isCrossRepository` (always present) over `isFork`
+(best-effort, provider-dependent).
+
+## 6. Org / project scoping
+
+`ProviderScope { org?, project?, resourceId?, repos? }` is a single normalized scope. `resolveProviderScope`
+dispatches on the provider's `PagingMode` to the provider-appropriate inputs (project inputs for
+Azure-issues/Jira; repo inputs for the rest). The underlying `ProviderReposInput` / `PagingMode` are
+unchanged.
+
+**Caveat:** Azure DevOps is scoped within a single organization; multi-org scoping remains unsupported (the
+existing single-org guard stands).

--- a/docs/kepler-read-api-parity.md
+++ b/docs/kepler-read-api-parity.md
@@ -38,6 +38,13 @@ existing `cursor` / `more`. Reads accept `page` / `pageSize`.
 carry the opaque `cursor` forward. For numbered providers, `currentPage` + `totalPages`/`totalCount` map
 directly to Kepler's `{ currentPage, itemsPerPage }`.
 
+**Multi-repo caveat:** the repo-mode providers (GitLab, Bitbucket, Bitbucket Server, Azure) fan a
+`getMy*ForRepos` call out across repos and aggregate the results under a single composite cursor. There the
+numbered metadata (`currentPage`/`totalPages`/`totalCount`) is not aggregated — pagination continues via
+that composite cursor plus `hasMore`. An explicit `page` applies only to the first request per repo; on
+continuation the per-repo cursor takes over (it is not clobbered). The numbered metadata is surfaced on the
+direct single-call read path.
+
 ## 3. PR state selector (open / closed / merged)
 
 `getMyPullRequestsForRepos` and `searchMyPullRequests` accept a `PullRequestStateFilter`

--- a/package.json
+++ b/package.json
@@ -29343,7 +29343,7 @@
 		"@gitkraken/compose-tools": "0.4.0",
 		"@gitkraken/conflict-tools": "0.2.3",
 		"@gitkraken/gitkraken-components": "13.0.0-vnext.38",
-		"@gitkraken/provider-apis": "0.49.0",
+		"@gitkraken/provider-apis": "0.50.0",
 		"@gitkraken/shared-tools": "0.2.0",
 		"@gitlens/agents": "workspace:*",
 		"@gitlens/ai": "workspace:*",

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -196,7 +196,7 @@
 		}
 	},
 	"dependencies": {
-		"@gitkraken/provider-apis": "0.49.0",
+		"@gitkraken/provider-apis": "0.50.0",
 		"@octokit/graphql": "9.0.3",
 		"@octokit/request": "10.0.10",
 		"@octokit/request-error": "7.1.0",

--- a/packages/git/src/models/issue.ts
+++ b/packages/git/src/models/issue.ts
@@ -4,6 +4,9 @@ import type { IssueOrPullRequest, IssueOrPullRequestState } from './issueOrPullR
 import type { ProviderReference } from './remoteProvider.js';
 import type { RepositoryIdentityDescriptor } from './repositoryIdentities.js';
 
+/** Selects which issue states a read should include. `all` covers open + closed. */
+export type IssueStateFilter = 'open' | 'closed' | 'all';
+
 export interface IssueShape extends IssueOrPullRequest {
 	author: IssueMember;
 	assignees: IssueMember[];

--- a/packages/git/src/models/pullRequest.ts
+++ b/packages/git/src/models/pullRequest.ts
@@ -132,6 +132,9 @@ export interface PullRequestMember {
 	url?: string;
 }
 
+/** Selects which pull request states a read should include. `all` covers open + closed + merged. */
+export type PullRequestStateFilter = 'open' | 'closed' | 'merged' | 'all';
+
 export interface PullRequestRef {
 	owner: string;
 	repo: string;

--- a/packages/git/src/models/pullRequest.ts
+++ b/packages/git/src/models/pullRequest.ts
@@ -139,6 +139,12 @@ export interface PullRequestRef {
 	sha: string;
 	exists: boolean;
 	url: string;
+	/** HTTPS clone URL of the ref's repository, when the provider exposes it. */
+	cloneHttps?: string;
+	/** SSH clone URL of the ref's repository, when the provider exposes it. */
+	cloneSsh?: string;
+	/** Best-effort flag: whether the ref's repository is a fork. `undefined` when the provider can't tell. */
+	isFork?: boolean;
 }
 
 export interface PullRequestRefs {

--- a/packages/git/src/models/resourceDescriptor.ts
+++ b/packages/git/src/models/resourceDescriptor.ts
@@ -9,3 +9,20 @@ export type RepositoryDescriptor = ResourceDescriptor & {
 	owner: string;
 	name: string;
 };
+
+/**
+ * A normalized read scope that unifies the three provider scoping representations (repo-level
+ * `ProviderReposInput`, per-provider `PagingMode`, and org/project `ResourceDescriptor`s). Consumers pass
+ * this single shape; the integration resolves it to the provider-appropriate inputs. At least one field
+ * should be set:
+ * - `org`: GitHub login / Bitbucket workspace / Azure organization / GitLab namespace
+ * - `project`: Azure project / Jira project key
+ * - `resourceId`: Jira/Azure resource id
+ * - `repos`: explicit repositories to scope to
+ */
+export type ProviderScope = {
+	org?: string;
+	project?: string;
+	resourceId?: string;
+	repos?: RepositoryDescriptor[];
+};

--- a/packages/git/src/utils/pullRequest.utils.ts
+++ b/packages/git/src/utils/pullRequest.utils.ts
@@ -116,6 +116,9 @@ export function serializePullRequest(value: PullRequest): PullRequestShape {
 						sha: value.refs.head.sha,
 						branch: value.refs.head.branch,
 						url: value.refs.head.url,
+						cloneHttps: value.refs.head.cloneHttps,
+						cloneSsh: value.refs.head.cloneSsh,
+						isFork: value.refs.head.isFork,
 					},
 					base: {
 						exists: value.refs.base.exists,
@@ -124,6 +127,9 @@ export function serializePullRequest(value: PullRequest): PullRequestShape {
 						sha: value.refs.base.sha,
 						branch: value.refs.base.branch,
 						url: value.refs.base.url,
+						cloneHttps: value.refs.base.cloneHttps,
+						cloneSsh: value.refs.base.cloneSsh,
+						isFork: value.refs.base.isFork,
 					},
 					isCrossRepository: value.refs.isCrossRepository,
 				}

--- a/packages/plus/git-github/src/api/github.ts
+++ b/packages/plus/git-github/src/api/github.ts
@@ -132,10 +132,12 @@ baseRefOid
 headRefName
 headRefOid
 headRepository {
+	isFork
 	name
 	owner {
 		login
 	}
+	sshUrl
 	url
 }
 isCrossRepository
@@ -148,6 +150,7 @@ repository {
 	owner {
 		login
 	}
+	sshUrl
 	url
 	viewerPermission
 }

--- a/packages/plus/git-github/src/api/github.ts
+++ b/packages/plus/git-github/src/api/github.ts
@@ -13,7 +13,7 @@ import type { Account, UnidentifiedAuthor } from '@gitlens/git/models/author.js'
 import type { DefaultBranch } from '@gitlens/git/models/defaultBranch.js';
 import type { Issue, IssueShape } from '@gitlens/git/models/issue.js';
 import type { IssueOrPullRequest } from '@gitlens/git/models/issueOrPullRequest.js';
-import type { PullRequest } from '@gitlens/git/models/pullRequest.js';
+import type { PullRequest, PullRequestStateFilter } from '@gitlens/git/models/pullRequest.js';
 import { PullRequestMergeMethod } from '@gitlens/git/models/pullRequest.js';
 import type { Provider } from '@gitlens/git/models/remoteProvider.js';
 import type { RepositoryMetadata } from '@gitlens/git/models/repositoryMetadata.js';
@@ -3320,6 +3320,7 @@ export class GitHubApi {
 			baseUrl?: string;
 			avatarSize?: number;
 			silent?: boolean;
+			state?: PullRequestStateFilter;
 		},
 		cancellation?: AbortSignal,
 	): Promise<PullRequest[]> {
@@ -3383,12 +3384,27 @@ export class GitHubApi {
 				}
 			}
 
+			// Map the requested state to a GitHub search qualifier; `all` omits it, default stays open-only.
+			// `is:closed` alone also matches merged PRs, so pair it with `is:unmerged` to keep `closed` and
+			// `merged` disjoint (mirroring the paginated path's states=[Closed], which excludes merged).
+			const stateQualifier =
+				options?.state === 'closed'
+					? 'is:closed is:unmerged'
+					: options?.state === 'merged'
+						? 'is:merged'
+						: options?.state === 'all'
+							? ''
+							: 'is:open';
+
 			const rsp = await this.graphql<SearchResult>(
 				provider,
 				token,
 				query,
 				{
-					search: `is:open is:pr involves:@me archived:false ${search}`.trim(),
+					search: [stateQualifier, 'is:pr involves:@me archived:false', search]
+						.filter(Boolean)
+						.join(' ')
+						.trim(),
 					baseUrl: options?.baseUrl,
 					avatarSize: options?.avatarSize,
 				},

--- a/packages/plus/git-github/src/models.ts
+++ b/packages/plus/git-github/src/models.ts
@@ -137,10 +137,12 @@ export interface GitHubPullRequestLite extends Omit<GitHubIssueOrPullRequest, '_
 	headRefName: string;
 	headRefOid: string;
 	headRepository: {
+		isFork: boolean;
 		name: string;
 		owner: {
 			login: string;
 		};
+		sshUrl: string;
 		url: string;
 	};
 
@@ -155,6 +157,7 @@ export interface GitHubPullRequestLite extends Omit<GitHubIssueOrPullRequest, '_
 		owner: {
 			login: string;
 		};
+		sshUrl: string;
 		url: string;
 		viewerPermission: GitHubViewerPermission;
 	};
@@ -261,6 +264,9 @@ export function fromGitHubPullRequestLite(pr: GitHubPullRequestLite, provider: P
 				sha: pr.headRefOid,
 				branch: pr.headRefName,
 				url: pr.headRepository?.url,
+				cloneHttps: pr.headRepository != null ? `${pr.headRepository.url}.git` : undefined,
+				cloneSsh: pr.headRepository?.sshUrl,
+				isFork: pr.headRepository?.isFork,
 			},
 			base: {
 				exists: pr.repository != null,
@@ -269,6 +275,9 @@ export function fromGitHubPullRequestLite(pr: GitHubPullRequestLite, provider: P
 				sha: pr.baseRefOid,
 				branch: pr.baseRefName,
 				url: pr.repository?.url,
+				cloneHttps: pr.repository != null ? `${pr.repository.url}.git` : undefined,
+				cloneSsh: pr.repository?.sshUrl,
+				isFork: pr.repository?.isFork,
 			},
 			isCrossRepository: pr.isCrossRepository,
 		},
@@ -405,6 +414,9 @@ export function fromGitHubPullRequest(pr: GitHubPullRequest, provider: Provider)
 				sha: pr.headRefOid,
 				branch: pr.headRefName,
 				url: pr.headRepository?.url,
+				cloneHttps: pr.headRepository != null ? `${pr.headRepository.url}.git` : undefined,
+				cloneSsh: pr.headRepository?.sshUrl,
+				isFork: pr.headRepository?.isFork,
 			},
 			base: {
 				exists: pr.repository != null,
@@ -413,6 +425,9 @@ export function fromGitHubPullRequest(pr: GitHubPullRequest, provider: Provider)
 				sha: pr.baseRefOid,
 				branch: pr.baseRefName,
 				url: pr.repository?.url,
+				cloneHttps: pr.repository != null ? `${pr.repository.url}.git` : undefined,
+				cloneSsh: pr.repository?.sshUrl,
+				isFork: pr.repository?.isFork,
 			},
 			isCrossRepository: pr.isCrossRepository,
 		},

--- a/packages/plus/integrations/package.json
+++ b/packages/plus/integrations/package.json
@@ -60,7 +60,7 @@
 		"dist"
 	],
 	"dependencies": {
-		"@gitkraken/provider-apis": "0.49.0",
+		"@gitkraken/provider-apis": "0.50.0",
 		"@gitlens/git": "workspace:*",
 		"@gitlens/git-github": "workspace:*",
 		"@gitlens/utils": "workspace:*"

--- a/packages/plus/integrations/src/__tests__/perConnectionReads.test.ts
+++ b/packages/plus/integrations/src/__tests__/perConnectionReads.test.ts
@@ -296,6 +296,72 @@ suite('per-connection reads (#5430)', () => {
 		manager.dispose();
 	});
 
+	test('getMyIssuesForRepos treats an empty-string connectionId as the primary when refreshing', async () => {
+		const runtime = createFakeRuntime();
+		runtime.account.getAccount = async () => ({ id: 'me' });
+		await runtime.storage.store('integrations:configured', {
+			github: [{ id: 'primary-tok', cloud: true, integrationId: 'github', scopes: 'repo', primary: true }],
+		});
+		await runtime.storage.storeSecret(
+			'integration.auth.cloud:github|primary-tok',
+			JSON.stringify({
+				id: 'primary-tok',
+				accessToken: 'stale-primary',
+				scopes: ['repo'],
+				cloud: true,
+				type: 'oauth',
+				domain: 'github.com',
+				expiresAt: new Date(Date.now() - 60_000).toISOString(),
+			}),
+		);
+
+		const fetches: string[] = [];
+		runtime.account.fetchGkApi = (path: string) => {
+			fetches.push(path);
+			if (path === 'v1/provider-tokens/github') {
+				return Promise.resolve(
+					new Response(
+						JSON.stringify({
+							data: {
+								tokenId: 'primary-tok',
+								accessToken: 'fresh-primary',
+								expiresIn: 3600,
+								scopes: 'repo',
+								type: 'oauth',
+								domain: 'github.com',
+							},
+						}),
+						{ status: 200 },
+					),
+				);
+			}
+
+			return Promise.resolve(new Response(JSON.stringify({ error: 'unexpected path' }), { status: 404 }));
+		};
+
+		const manager = createIntegrationManager(runtime);
+		const gh = await manager.get(GitCloudHostIntegrationId.GitHub);
+
+		const captured = { token: undefined as string | undefined, called: false };
+		await captureReposApiToken(gh, ['getIssuesForReposFn', 'getIssuesForRepoFn'], captured);
+
+		await (
+			gh as unknown as {
+				getMyIssuesForRepos: (
+					repos: { namespace: string; name: string }[],
+					options: undefined,
+					connectionId: string,
+				) => Promise<unknown>;
+			}
+		).getMyIssuesForRepos([{ namespace: 'octo', name: 'repo' }], undefined, '');
+
+		assert.equal(captured.called, true, 'the paginated issue read reached the provider');
+		assert.equal(captured.token, 'fresh-primary', 'empty-string connectionId falls back to the primary token');
+		assert.deepEqual(fetches, ['v1/provider-tokens/github'], 'refresh stayed on the provider-primary path');
+
+		manager.dispose();
+	});
+
 	test('GitLab PR search resolves the username from the read session, not the primary account', async () => {
 		const runtime = createFakeRuntime();
 		// A secondary GitLab connection whose token differs from the (absent) primary.

--- a/packages/plus/integrations/src/__tests__/perConnectionReads.test.ts
+++ b/packages/plus/integrations/src/__tests__/perConnectionReads.test.ts
@@ -173,6 +173,129 @@ suite('per-connection reads (#5430)', () => {
 		manager.dispose();
 	});
 
+	// The paginated reads (getMy*ForRepos) resolve their token INSIDE ProvidersApi rather than from a
+	// session passed in, so we intercept the provider function table on the real ProvidersApi instance and
+	// capture the token it was invoked with. Overriding both the *Repos and *Repo variants keeps the test
+	// robust regardless of the provider's paging mode.
+	type CapturingProvider = Record<string, (input: unknown, options?: { token?: string }) => Promise<unknown>>;
+	async function captureReposApiToken(
+		gh: Awaited<ReturnType<ReturnType<typeof createIntegrationManager>['get']>>,
+		fnNames: string[],
+		ref: { token?: string; called: boolean },
+	): Promise<void> {
+		const api = await (
+			gh as unknown as { getProvidersApi(): Promise<{ providers: Record<string, unknown> }> }
+		).getProvidersApi();
+		const provider = api.providers.github as CapturingProvider;
+		for (const fnName of fnNames) {
+			provider[fnName] = (_input, options) => {
+				ref.called = true;
+				ref.token = options?.token;
+				return Promise.resolve({ data: [], pageInfo: undefined });
+			};
+		}
+	}
+
+	test('getMyPullRequestsForRepos reads with the specified connection token, not the primary', async () => {
+		const runtime = createFakeRuntime();
+		await seedConnectionSecret(runtime, 'sec-tok', 'token-secondary');
+		const manager = createIntegrationManager(runtime);
+		const gh = await manager.get(GitCloudHostIntegrationId.GitHub);
+
+		const captured = { token: undefined as string | undefined, called: false };
+		await captureReposApiToken(gh, ['getPullRequestsForReposFn', 'getPullRequestsForRepoFn'], captured);
+
+		await (
+			gh as unknown as {
+				getMyPullRequestsForRepos: (
+					repos: { namespace: string; name: string }[],
+					options: undefined,
+					connectionId: string,
+				) => Promise<unknown>;
+			}
+		).getMyPullRequestsForRepos([{ namespace: 'octo', name: 'repo' }], undefined, 'sec-tok');
+
+		assert.equal(captured.called, true, 'the paginated PR read reached the provider');
+		assert.equal(captured.token, 'token-secondary', 'PR read used the specified connection token');
+
+		manager.dispose();
+	});
+
+	test('getMyIssuesForRepos reads with the specified connection token, not the primary', async () => {
+		const runtime = createFakeRuntime();
+		await seedConnectionSecret(runtime, 'sec-tok', 'token-secondary');
+		const manager = createIntegrationManager(runtime);
+		const gh = await manager.get(GitCloudHostIntegrationId.GitHub);
+
+		const captured = { token: undefined as string | undefined, called: false };
+		await captureReposApiToken(gh, ['getIssuesForReposFn', 'getIssuesForRepoFn'], captured);
+
+		await (
+			gh as unknown as {
+				getMyIssuesForRepos: (
+					repos: { namespace: string; name: string }[],
+					options: undefined,
+					connectionId: string,
+				) => Promise<unknown>;
+			}
+		).getMyIssuesForRepos([{ namespace: 'octo', name: 'repo' }], undefined, 'sec-tok');
+
+		assert.equal(captured.called, true, 'the paginated issue read reached the provider');
+		assert.equal(captured.token, 'token-secondary', 'issue read used the specified connection token');
+
+		manager.dispose();
+	});
+
+	test('getMyPullRequestsForRepos on an unknown connection degrades to undefined without calling the provider', async () => {
+		const runtime = createFakeRuntime();
+		const manager = createIntegrationManager(runtime);
+		const gh = await manager.get(GitCloudHostIntegrationId.GitHub);
+
+		const captured = { token: undefined as string | undefined, called: false };
+		await captureReposApiToken(gh, ['getPullRequestsForReposFn', 'getPullRequestsForRepoFn'], captured);
+
+		const result = await (
+			gh as unknown as {
+				getMyPullRequestsForRepos: (
+					repos: { namespace: string; name: string }[],
+					options: undefined,
+					connectionId: string,
+				) => Promise<unknown>;
+			}
+		).getMyPullRequestsForRepos([{ namespace: 'octo', name: 'repo' }], undefined, 'does-not-exist');
+
+		assert.equal(result, undefined, 'unresolvable connection yields no results');
+		assert.equal(captured.called, false, 'provider read not attempted without a session');
+
+		manager.dispose();
+	});
+
+	test('getMyIssuesForRepos is blocked when the provider is locally disconnected even if the secret remains', async () => {
+		const runtime = createFakeRuntime();
+		await seedConnectionSecret(runtime, 'sec-tok', 'token-secondary');
+		await runtime.storage.storeWorkspace('connected:github', false);
+		const manager = createIntegrationManager(runtime);
+		const gh = await manager.get(GitCloudHostIntegrationId.GitHub);
+
+		const captured = { token: undefined as string | undefined, called: false };
+		await captureReposApiToken(gh, ['getIssuesForReposFn', 'getIssuesForRepoFn'], captured);
+
+		const result = await (
+			gh as unknown as {
+				getMyIssuesForRepos: (
+					repos: { namespace: string; name: string }[],
+					options: undefined,
+					connectionId: string,
+				) => Promise<unknown>;
+			}
+		).getMyIssuesForRepos([{ namespace: 'octo', name: 'repo' }], undefined, 'sec-tok');
+
+		assert.equal(result, undefined, 'locally disconnected provider yields no results');
+		assert.equal(captured.called, false, 'provider read not attempted while locally disconnected');
+
+		manager.dispose();
+	});
+
 	test('GitLab PR search resolves the username from the read session, not the primary account', async () => {
 		const runtime = createFakeRuntime();
 		// A secondary GitLab connection whose token differs from the (absent) primary.

--- a/packages/plus/integrations/src/authentication/models.ts
+++ b/packages/plus/integrations/src/authentication/models.ts
@@ -77,7 +77,9 @@ export function toTokenWithInfo<T extends IntegrationIds>(
 
 export type TokenOptInfo<T extends IntegrationIds = IntegrationIds> =
 	| TokenWithInfo<T>
-	| { providerId: T; accessToken?: undefined };
+	// `connectionId` targets a specific connection (multi-account) when the token still has to be resolved.
+	// Omitted resolves the provider's primary connection, preserving the pre-multi-account behavior.
+	| { providerId: T; accessToken?: undefined; connectionId?: string };
 
 export interface ConfiguredIntegrationDescriptor {
 	/**

--- a/packages/plus/integrations/src/models/gitHostIntegration.ts
+++ b/packages/plus/integrations/src/models/gitHostIntegration.ts
@@ -351,7 +351,7 @@ export abstract class GitHostIntegration<
 
 	async getMyIssuesForRepos(
 		reposOrRepoIds: ProviderReposInput,
-		options?: { filters?: IssueFilter[]; cursor?: string; customUrl?: string },
+		options?: { filters?: IssueFilter[]; cursor?: string; customUrl?: string; page?: number; pageSize?: number },
 		connectionId?: string,
 	): Promise<PagedResult<ProviderIssue> | undefined> {
 		const scope = getScopedLogger();
@@ -451,6 +451,8 @@ export abstract class GitHostIntegration<
 							{
 								...getIssuesOptions,
 								cursor: projectInput.cursor,
+								page: options?.page,
+								pageSize: options?.pageSize,
 							},
 						);
 						data.push(...results.values);
@@ -525,6 +527,8 @@ export abstract class GitHostIntegration<
 								...getIssuesOptions,
 								cursor: repoInput.cursor,
 								baseUrl: options?.customUrl,
+								page: options?.page,
+								pageSize: options?.pageSize,
 							},
 						);
 						data.push(...results.values);
@@ -553,6 +557,8 @@ export abstract class GitHostIntegration<
 				...getIssuesOptions,
 				cursor: options?.cursor,
 				baseUrl: options?.customUrl,
+				page: options?.page,
+				pageSize: options?.pageSize,
 			});
 		} catch (ex) {
 			Logger.error(ex, 'getIssuesForRepos');
@@ -562,7 +568,13 @@ export abstract class GitHostIntegration<
 
 	async getMyPullRequestsForRepos(
 		reposOrRepoIds: ProviderReposInput,
-		options?: { filters?: PullRequestFilter[]; cursor?: string; customUrl?: string },
+		options?: {
+			filters?: PullRequestFilter[];
+			cursor?: string;
+			customUrl?: string;
+			page?: number;
+			pageSize?: number;
+		},
 		connectionId?: string,
 	): Promise<PagedResult<ProviderPullRequest> | undefined> {
 		const scope = getScopedLogger();
@@ -682,6 +694,8 @@ export abstract class GitHostIntegration<
 								...getPullRequestsOptions,
 								cursor: repoInput.cursor,
 								baseUrl: options?.customUrl,
+								page: options?.page,
+								pageSize: options?.pageSize,
 								// Azure DevOps only populates clone URLs on request (extra call); no-op elsewhere.
 								includeRemoteInfo:
 									providerId === GitCloudHostIntegrationId.AzureDevOps ? true : undefined,
@@ -716,6 +730,8 @@ export abstract class GitHostIntegration<
 					...getPullRequestsOptions,
 					cursor: options?.cursor,
 					baseUrl: options?.customUrl,
+					page: options?.page,
+					pageSize: options?.pageSize,
 					// Azure DevOps only populates clone URLs on request (extra call); no-op elsewhere.
 					includeRemoteInfo: providerId === GitCloudHostIntegrationId.AzureDevOps ? true : undefined,
 				},

--- a/packages/plus/integrations/src/models/gitHostIntegration.ts
+++ b/packages/plus/integrations/src/models/gitHostIntegration.ts
@@ -352,13 +352,14 @@ export abstract class GitHostIntegration<
 	async getMyIssuesForRepos(
 		reposOrRepoIds: ProviderReposInput,
 		options?: { filters?: IssueFilter[]; cursor?: string; customUrl?: string },
+		connectionId?: string,
 	): Promise<PagedResult<ProviderIssue> | undefined> {
 		const scope = getScopedLogger();
 		const providerId = this.authProvider.id;
-		const connected = this.maybeConnected ?? (await this.isConnected());
-		if (!connected) return undefined;
-
-		await this.refreshSessionIfExpired(scope);
+		// `connectionId` targets a specific account (multi-account); omitted reads the primary. The session
+		// is resolved here for connectivity/bail; the connection's token is applied per API call below.
+		const session = await this.resolveReadSession(connectionId, scope);
+		if (session == null) return undefined;
 
 		const api = await this.getProvidersApi();
 		if (
@@ -398,7 +399,10 @@ export abstract class GitHostIntegration<
 
 				let userAccount: ProviderAccount | undefined;
 				try {
-					userAccount = await api.getCurrentUserForInstance({ providerId: providerId }, organization);
+					userAccount = await api.getCurrentUserForInstance(
+						{ providerId: providerId, connectionId: connectionId },
+						organization,
+					);
 				} catch (ex) {
 					Logger.error(ex, 'getIssuesForRepos');
 					return undefined;
@@ -441,7 +445,7 @@ export abstract class GitHostIntegration<
 				await Promise.all(
 					projectInputs.map(async projectInput => {
 						const results = await api.getIssuesForAzureProject(
-							{ providerId: providerId },
+							{ providerId: providerId, connectionId: connectionId },
 							projectInput.namespace,
 							projectInput.project,
 							{
@@ -476,7 +480,7 @@ export abstract class GitHostIntegration<
 		if (options?.filters != null) {
 			let userAccount: ProviderAccount | undefined;
 			try {
-				userAccount = await api.getCurrentUser({ providerId: providerId });
+				userAccount = await api.getCurrentUser({ providerId: providerId, connectionId: connectionId });
 			} catch (ex) {
 				Logger.error(ex, 'getIssuesForRepos');
 				return undefined;
@@ -514,11 +518,15 @@ export abstract class GitHostIntegration<
 				const data: ProviderIssue[] = [];
 				await Promise.all(
 					repoInputs.map(async repoInput => {
-						const results = await api.getIssuesForRepo({ providerId: providerId }, repoInput.repo, {
-							...getIssuesOptions,
-							cursor: repoInput.cursor,
-							baseUrl: options?.customUrl,
-						});
+						const results = await api.getIssuesForRepo(
+							{ providerId: providerId, connectionId: connectionId },
+							repoInput.repo,
+							{
+								...getIssuesOptions,
+								cursor: repoInput.cursor,
+								baseUrl: options?.customUrl,
+							},
+						);
 						data.push(...results.values);
 						if (results.paging?.more) {
 							hasMore = true;
@@ -541,7 +549,7 @@ export abstract class GitHostIntegration<
 		}
 
 		try {
-			return await api.getIssuesForRepos({ providerId: providerId }, reposOrRepoIds, {
+			return await api.getIssuesForRepos({ providerId: providerId, connectionId: connectionId }, reposOrRepoIds, {
 				...getIssuesOptions,
 				cursor: options?.cursor,
 				baseUrl: options?.customUrl,
@@ -555,13 +563,14 @@ export abstract class GitHostIntegration<
 	async getMyPullRequestsForRepos(
 		reposOrRepoIds: ProviderReposInput,
 		options?: { filters?: PullRequestFilter[]; cursor?: string; customUrl?: string },
+		connectionId?: string,
 	): Promise<PagedResult<ProviderPullRequest> | undefined> {
 		const scope = getScopedLogger();
 		const providerId = this.authProvider.id;
-		const connected = this.maybeConnected ?? (await this.isConnected());
-		if (!connected) return undefined;
-
-		await this.refreshSessionIfExpired(scope);
+		// `connectionId` targets a specific account (multi-account); omitted reads the primary. The session
+		// is resolved here for connectivity/bail; the connection's token is applied per API call below.
+		const session = await this.resolveReadSession(connectionId, scope);
+		if (session == null) return undefined;
 
 		const api = await this.getProvidersApi();
 		if (
@@ -601,14 +610,17 @@ export abstract class GitHostIntegration<
 
 				const organization: string = first(organizations.values())!;
 				try {
-					userAccount = await api.getCurrentUserForInstance({ providerId: providerId }, organization);
+					userAccount = await api.getCurrentUserForInstance(
+						{ providerId: providerId, connectionId: connectionId },
+						organization,
+					);
 				} catch (ex) {
 					Logger.error(ex, 'getPullRequestsForRepos');
 					return undefined;
 				}
 			} else {
 				try {
-					userAccount = await api.getCurrentUser({ providerId: providerId });
+					userAccount = await api.getCurrentUser({ providerId: providerId, connectionId: connectionId });
 				} catch (ex) {
 					Logger.error(ex, 'getPullRequestsForRepos');
 					return undefined;
@@ -663,11 +675,15 @@ export abstract class GitHostIntegration<
 				const data: ProviderPullRequest[] = [];
 				await Promise.all(
 					repoInputs.map(async repoInput => {
-						const results = await api.getPullRequestsForRepo({ providerId: providerId }, repoInput.repo, {
-							...getPullRequestsOptions,
-							cursor: repoInput.cursor,
-							baseUrl: options?.customUrl,
-						});
+						const results = await api.getPullRequestsForRepo(
+							{ providerId: providerId, connectionId: connectionId },
+							repoInput.repo,
+							{
+								...getPullRequestsOptions,
+								cursor: repoInput.cursor,
+								baseUrl: options?.customUrl,
+							},
+						);
 						data.push(...results.values);
 						if (results.paging?.more) {
 							hasMore = true;
@@ -690,11 +706,15 @@ export abstract class GitHostIntegration<
 		}
 
 		try {
-			return await api.getPullRequestsForRepos({ providerId: providerId }, reposOrRepoIds, {
-				...getPullRequestsOptions,
-				cursor: options?.cursor,
-				baseUrl: options?.customUrl,
-			});
+			return await api.getPullRequestsForRepos(
+				{ providerId: providerId, connectionId: connectionId },
+				reposOrRepoIds,
+				{
+					...getPullRequestsOptions,
+					cursor: options?.cursor,
+					baseUrl: options?.customUrl,
+				},
+			);
 		} catch (ex) {
 			Logger.error(ex, 'getPullRequestsForRepos');
 			return undefined;

--- a/packages/plus/integrations/src/models/gitHostIntegration.ts
+++ b/packages/plus/integrations/src/models/gitHostIntegration.ts
@@ -682,6 +682,9 @@ export abstract class GitHostIntegration<
 								...getPullRequestsOptions,
 								cursor: repoInput.cursor,
 								baseUrl: options?.customUrl,
+								// Azure DevOps only populates clone URLs on request (extra call); no-op elsewhere.
+								includeRemoteInfo:
+									providerId === GitCloudHostIntegrationId.AzureDevOps ? true : undefined,
 							},
 						);
 						data.push(...results.values);
@@ -713,6 +716,8 @@ export abstract class GitHostIntegration<
 					...getPullRequestsOptions,
 					cursor: options?.cursor,
 					baseUrl: options?.customUrl,
+					// Azure DevOps only populates clone URLs on request (extra call); no-op elsewhere.
+					includeRemoteInfo: providerId === GitCloudHostIntegrationId.AzureDevOps ? true : undefined,
 				},
 			);
 		} catch (ex) {

--- a/packages/plus/integrations/src/models/gitHostIntegration.ts
+++ b/packages/plus/integrations/src/models/gitHostIntegration.ts
@@ -472,7 +472,9 @@ export abstract class GitHostIntegration<
 							{
 								...getIssuesOptions,
 								cursor: projectInput.cursor,
-								page: options?.page,
+								// Continuation is driven by the per-project cursor; only apply an explicit page on the
+								// first request so it can't clobber a continuation cursor on later pages.
+								page: projectInput.cursor == null ? options?.page : undefined,
 								pageSize: options?.pageSize,
 								states: states,
 							},
@@ -552,7 +554,9 @@ export abstract class GitHostIntegration<
 								...getIssuesOptions,
 								cursor: repoInput.cursor,
 								baseUrl: options?.customUrl,
-								page: options?.page,
+								// Continuation is driven by the per-repo cursor; only apply an explicit page on the
+								// first request so it can't clobber a continuation cursor on later pages.
+								page: repoInput.cursor == null ? options?.page : undefined,
 								pageSize: options?.pageSize,
 								states: states,
 							},
@@ -746,7 +750,9 @@ export abstract class GitHostIntegration<
 								...getPullRequestsOptions,
 								cursor: repoInput.cursor,
 								baseUrl: options?.customUrl,
-								page: options?.page,
+								// Continuation is driven by the per-repo cursor; only apply an explicit page on the
+								// first request so it can't clobber a continuation cursor on later pages.
+								page: repoInput.cursor == null ? options?.page : undefined,
 								pageSize: options?.pageSize,
 								states: states,
 								// Azure DevOps only populates clone URLs on request (extra call); no-op elsewhere.

--- a/packages/plus/integrations/src/models/gitHostIntegration.ts
+++ b/packages/plus/integrations/src/models/gitHostIntegration.ts
@@ -1,7 +1,8 @@
 import type { Account, UnidentifiedAuthor } from '@gitlens/git/models/author.js';
 import type { DefaultBranch } from '@gitlens/git/models/defaultBranch.js';
+import type { IssueStateFilter } from '@gitlens/git/models/issue.js';
 import type { IssueOrPullRequestState as PullRequestState } from '@gitlens/git/models/issueOrPullRequest.js';
-import type { PullRequest, PullRequestMergeMethod } from '@gitlens/git/models/pullRequest.js';
+import type { PullRequest, PullRequestMergeMethod, PullRequestStateFilter } from '@gitlens/git/models/pullRequest.js';
 import type { RepositoryMetadata } from '@gitlens/git/models/repositoryMetadata.js';
 import type { ResourceDescriptor } from '@gitlens/git/models/resourceDescriptor.js';
 import type { PullRequestUrlIdentity } from '@gitlens/git/utils/pullRequest.utils.js';
@@ -28,7 +29,13 @@ import type {
 	ProviderReposInput,
 	ProviderRepository,
 } from '../providers/models.js';
-import { IssueFilter, PagingMode, PullRequestFilter } from '../providers/models.js';
+import {
+	IssueFilter,
+	PagingMode,
+	PullRequestFilter,
+	toProviderIssueStates,
+	toProviderPullRequestStates,
+} from '../providers/models.js';
 import type { IntegrationResult, IntegrationType } from './integration.js';
 import { IntegrationBase } from './integration.js';
 
@@ -359,11 +366,14 @@ export abstract class GitHostIntegration<
 			pageSize?: number;
 			/** When true, don't constrain to the current user's assigned issues even if the Assignee filter is set. */
 			includeAllAssignees?: boolean;
+			/** Issue states to include; when omitted the provider returns its default (open only). */
+			state?: IssueStateFilter;
 		},
 		connectionId?: string,
 	): Promise<PagedResult<ProviderIssue> | undefined> {
 		const scope = getScopedLogger();
 		const providerId = this.authProvider.id;
+		const states = toProviderIssueStates(options?.state);
 		// `connectionId` targets a specific account (multi-account); omitted reads the primary. The session
 		// is resolved here for connectivity/bail; the connection's token is applied per API call below.
 		const session = await this.resolveReadSession(connectionId, scope);
@@ -464,6 +474,7 @@ export abstract class GitHostIntegration<
 								cursor: projectInput.cursor,
 								page: options?.page,
 								pageSize: options?.pageSize,
+								states: states,
 							},
 						);
 						data.push(...results.values);
@@ -543,6 +554,7 @@ export abstract class GitHostIntegration<
 								baseUrl: options?.customUrl,
 								page: options?.page,
 								pageSize: options?.pageSize,
+								states: states,
 							},
 						);
 						data.push(...results.values);
@@ -573,6 +585,7 @@ export abstract class GitHostIntegration<
 				baseUrl: options?.customUrl,
 				page: options?.page,
 				pageSize: options?.pageSize,
+				states: states,
 			});
 		} catch (ex) {
 			Logger.error(ex, 'getIssuesForRepos');
@@ -588,11 +601,14 @@ export abstract class GitHostIntegration<
 			customUrl?: string;
 			page?: number;
 			pageSize?: number;
+			/** PR states to include; when omitted the provider returns its default (open only). */
+			state?: PullRequestStateFilter;
 		},
 		connectionId?: string,
 	): Promise<PagedResult<ProviderPullRequest> | undefined> {
 		const scope = getScopedLogger();
 		const providerId = this.authProvider.id;
+		const states = toProviderPullRequestStates(options?.state);
 		// `connectionId` targets a specific account (multi-account); omitted reads the primary. The session
 		// is resolved here for connectivity/bail; the connection's token is applied per API call below.
 		const session = await this.resolveReadSession(connectionId, scope);
@@ -732,6 +748,7 @@ export abstract class GitHostIntegration<
 								baseUrl: options?.customUrl,
 								page: options?.page,
 								pageSize: options?.pageSize,
+								states: states,
 								// Azure DevOps only populates clone URLs on request (extra call); no-op elsewhere.
 								includeRemoteInfo:
 									providerId === GitCloudHostIntegrationId.AzureDevOps ? true : undefined,
@@ -768,6 +785,7 @@ export abstract class GitHostIntegration<
 					baseUrl: options?.customUrl,
 					page: options?.page,
 					pageSize: options?.pageSize,
+					states: states,
 					// Azure DevOps only populates clone URLs on request (extra call); no-op elsewhere.
 					includeRemoteInfo: providerId === GitCloudHostIntegrationId.AzureDevOps ? true : undefined,
 				},
@@ -783,12 +801,14 @@ export abstract class GitHostIntegration<
 		cancellation?: AbortSignal,
 		silent?: boolean,
 		connectionId?: string,
+		state?: PullRequestStateFilter,
 	): Promise<IntegrationResult<PullRequest[] | undefined>>;
 	async searchMyPullRequests(
 		repos?: T[],
 		cancellation?: AbortSignal,
 		silent?: boolean,
 		connectionId?: string,
+		state?: PullRequestStateFilter,
 	): Promise<IntegrationResult<PullRequest[] | undefined>>;
 	@trace()
 	async searchMyPullRequests(
@@ -796,6 +816,7 @@ export abstract class GitHostIntegration<
 		cancellation?: AbortSignal,
 		silent?: boolean,
 		connectionId?: string,
+		state?: PullRequestStateFilter,
 	): Promise<IntegrationResult<PullRequest[] | undefined>> {
 		const scope = getScopedLogger();
 		// `connectionId` targets a specific account (multi-account); omitted reads the primary.
@@ -809,6 +830,7 @@ export abstract class GitHostIntegration<
 				repos != null ? (Array.isArray(repos) ? repos : [repos]) : undefined,
 				cancellation,
 				silent,
+				state,
 			);
 			this.resetRequestExceptionCount('searchMyPullRequests');
 			return { value: pullRequests, duration: performance.now() - start };
@@ -824,11 +846,14 @@ export abstract class GitHostIntegration<
 		}
 	}
 
+	// `state` selects which PR states to include (open/closed/merged/all). Providers that cannot express it
+	// in a single query filter the normalized results; omitted preserves the historical open-only behavior.
 	protected abstract searchProviderMyPullRequests(
 		session: ProviderAuthenticationSession,
 		repos?: T[],
 		cancellation?: AbortSignal,
 		silent?: boolean,
+		state?: PullRequestStateFilter,
 	): Promise<PullRequest[] | undefined>;
 
 	async searchPullRequests(

--- a/packages/plus/integrations/src/models/gitHostIntegration.ts
+++ b/packages/plus/integrations/src/models/gitHostIntegration.ts
@@ -13,7 +13,7 @@ import { getScopedLogger } from '@gitlens/utils/logger.scoped.js';
 import type { PagedResult } from '@gitlens/utils/paging.js';
 import type { ProviderAuthenticationSession } from '../authentication/models.js';
 import type { IntegrationIds } from '../constants.js';
-import { GitCloudHostIntegrationId } from '../constants.js';
+import { GitCloudHostIntegrationId, GitSelfManagedHostIntegrationId } from '../constants.js';
 import type {
 	GetIssuesOptions,
 	GetPullRequestsOptions,
@@ -351,7 +351,15 @@ export abstract class GitHostIntegration<
 
 	async getMyIssuesForRepos(
 		reposOrRepoIds: ProviderReposInput,
-		options?: { filters?: IssueFilter[]; cursor?: string; customUrl?: string; page?: number; pageSize?: number },
+		options?: {
+			filters?: IssueFilter[];
+			cursor?: string;
+			customUrl?: string;
+			page?: number;
+			pageSize?: number;
+			/** When true, don't constrain to the current user's assigned issues even if the Assignee filter is set. */
+			includeAllAssignees?: boolean;
+		},
 		connectionId?: string,
 	): Promise<PagedResult<ProviderIssue> | undefined> {
 		const scope = getScopedLogger();
@@ -422,7 +430,10 @@ export abstract class GitHostIntegration<
 
 				getIssuesOptions = {
 					authorLogin: options.filters.includes(IssueFilter.Author) ? userFilterProperty : undefined,
-					assigneeLogins: options.filters.includes(IssueFilter.Assignee) ? [userFilterProperty] : undefined,
+					assigneeLogins:
+						!options.includeAllAssignees && options.filters.includes(IssueFilter.Assignee)
+							? [userFilterProperty]
+							: undefined,
 					mentionLogin: options.filters.includes(IssueFilter.Mention) ? userFilterProperty : undefined,
 				};
 			}
@@ -501,7 +512,10 @@ export abstract class GitHostIntegration<
 
 			getIssuesOptions = {
 				authorLogin: options.filters.includes(IssueFilter.Author) ? userFilterProperty : undefined,
-				assigneeLogins: options.filters.includes(IssueFilter.Assignee) ? [userFilterProperty] : undefined,
+				assigneeLogins:
+					!options.includeAllAssignees && options.filters.includes(IssueFilter.Assignee)
+						? [userFilterProperty]
+						: undefined,
 				mentionLogin: options.filters.includes(IssueFilter.Mention) ? userFilterProperty : undefined,
 			};
 		}
@@ -660,12 +674,34 @@ export abstract class GitHostIntegration<
 				return undefined;
 			}
 
+			// Route the "review requested from me" filter to the field each provider actually reads:
+			// GitHub/GitLab expect a login (reviewRequestedLogin), Bitbucket/Azure an account id (reviewerId),
+			// and Bitbucket Server a login (reviewerLogin). `userFilterProperty` is already the account id for
+			// Bitbucket/Azure and the username for the rest.
+			let reviewRequestedLogin: string | undefined;
+			let reviewerId: string | undefined;
+			let reviewerLogin: string | undefined;
+			if (options.filters.includes(PullRequestFilter.ReviewRequested)) {
+				switch (providerId) {
+					case GitCloudHostIntegrationId.Bitbucket:
+					case GitCloudHostIntegrationId.AzureDevOps:
+						reviewerId = userFilterProperty;
+						break;
+					case GitSelfManagedHostIntegrationId.BitbucketServer:
+						reviewerLogin = userFilterProperty;
+						break;
+					default:
+						reviewRequestedLogin = userFilterProperty;
+						break;
+				}
+			}
+
 			getPullRequestsOptions = {
 				authorLogin: options.filters.includes(PullRequestFilter.Author) ? userFilterProperty : undefined,
 				assigneeLogins: options.filters.includes(PullRequestFilter.Assignee) ? [userFilterProperty] : undefined,
-				reviewRequestedLogin: options.filters.includes(PullRequestFilter.ReviewRequested)
-					? userFilterProperty
-					: undefined,
+				reviewRequestedLogin: reviewRequestedLogin,
+				reviewerId: reviewerId,
+				reviewerLogin: reviewerLogin,
 				mentionLogin: options.filters.includes(PullRequestFilter.Mention) ? userFilterProperty : undefined,
 			};
 		}

--- a/packages/plus/integrations/src/models/gitHostIntegration.ts
+++ b/packages/plus/integrations/src/models/gitHostIntegration.ts
@@ -39,6 +39,15 @@ import {
 import type { IntegrationResult, IntegrationType } from './integration.js';
 import { IntegrationBase } from './integration.js';
 
+function isAzureDevOpsProvider(
+	providerId: IntegrationIds,
+): providerId is GitCloudHostIntegrationId.AzureDevOps | GitSelfManagedHostIntegrationId.AzureDevOpsServer {
+	return (
+		providerId === GitCloudHostIntegrationId.AzureDevOps ||
+		providerId === GitSelfManagedHostIntegrationId.AzureDevOpsServer
+	);
+}
+
 export abstract class GitHostIntegration<
 	ID extends IntegrationIds = IntegrationIds,
 	T extends ResourceDescriptor = ResourceDescriptor,
@@ -383,7 +392,7 @@ export abstract class GitHostIntegration<
 		if (
 			providerId !== GitCloudHostIntegrationId.GitLab &&
 			(api.isRepoIdsInput(reposOrRepoIds) ||
-				(providerId === GitCloudHostIntegrationId.AzureDevOps &&
+				(isAzureDevOpsProvider(providerId) &&
 					!reposOrRepoIds.every(repo => repo.project != null && repo.namespace != null)))
 		) {
 			Logger.warn(`Unsupported input for provider ${providerId}`, 'getIssuesForRepos');
@@ -391,7 +400,7 @@ export abstract class GitHostIntegration<
 		}
 
 		let getIssuesOptions: GetIssuesOptions | undefined;
-		if (providerId === GitCloudHostIntegrationId.AzureDevOps) {
+		if (isAzureDevOpsProvider(providerId)) {
 			const organizations = new Set<string>();
 			const projects = new Set<string>();
 			for (const repo of reposOrRepoIds as ProviderRepoInput[]) {
@@ -622,7 +631,7 @@ export abstract class GitHostIntegration<
 		if (
 			providerId !== GitCloudHostIntegrationId.GitLab &&
 			(api.isRepoIdsInput(reposOrRepoIds) ||
-				(providerId === GitCloudHostIntegrationId.AzureDevOps &&
+				(isAzureDevOpsProvider(providerId) &&
 					!reposOrRepoIds.every(repo => repo.project != null && repo.namespace != null)))
 		) {
 			Logger.warn(`Unsupported input for provider ${providerId}`);
@@ -637,7 +646,7 @@ export abstract class GitHostIntegration<
 			}
 
 			let userAccount: ProviderAccount | undefined;
-			if (providerId === GitCloudHostIntegrationId.AzureDevOps) {
+			if (isAzureDevOpsProvider(providerId)) {
 				const organizations = new Set<string>();
 				for (const repo of reposOrRepoIds as ProviderRepoInput[]) {
 					organizations.add(repo.namespace);
@@ -682,6 +691,7 @@ export abstract class GitHostIntegration<
 			switch (providerId) {
 				case GitCloudHostIntegrationId.Bitbucket:
 				case GitCloudHostIntegrationId.AzureDevOps:
+				case GitSelfManagedHostIntegrationId.AzureDevOpsServer:
 					userFilterProperty = userAccount.id;
 					break;
 				default:
@@ -705,6 +715,7 @@ export abstract class GitHostIntegration<
 				switch (providerId) {
 					case GitCloudHostIntegrationId.Bitbucket:
 					case GitCloudHostIntegrationId.AzureDevOps:
+					case GitSelfManagedHostIntegrationId.AzureDevOpsServer:
 						reviewerId = userFilterProperty;
 						break;
 					case GitSelfManagedHostIntegrationId.BitbucketServer:
@@ -756,8 +767,7 @@ export abstract class GitHostIntegration<
 								pageSize: options?.pageSize,
 								states: states,
 								// Azure DevOps only populates clone URLs on request (extra call); no-op elsewhere.
-								includeRemoteInfo:
-									providerId === GitCloudHostIntegrationId.AzureDevOps ? true : undefined,
+								includeRemoteInfo: isAzureDevOpsProvider(providerId) ? true : undefined,
 							},
 						);
 						data.push(...results.values);
@@ -793,7 +803,7 @@ export abstract class GitHostIntegration<
 					pageSize: options?.pageSize,
 					states: states,
 					// Azure DevOps only populates clone URLs on request (extra call); no-op elsewhere.
-					includeRemoteInfo: providerId === GitCloudHostIntegrationId.AzureDevOps ? true : undefined,
+					includeRemoteInfo: isAzureDevOpsProvider(providerId) ? true : undefined,
 				},
 			);
 		} catch (ex) {

--- a/packages/plus/integrations/src/providers/__tests__/pagedResult.test.ts
+++ b/packages/plus/integrations/src/providers/__tests__/pagedResult.test.ts
@@ -1,0 +1,104 @@
+import * as assert from 'node:assert/strict';
+import { suite, test } from 'mocha';
+import { createFakeRuntime } from '../../__tests__/fakeRuntime.js';
+import { GitCloudHostIntegrationId } from '../../constants.js';
+import { createIntegrationManager } from '../../index.js';
+
+/**
+ * Covers the page-number pagination surface added for read-API parity (#5435): getPagedResult must forward
+ * an explicit page/pageSize to the provider (pageSize as both pageSize and GitHub's maxPageSize) and surface
+ * numbered-page metadata (currentPage/nextPage/totalPages/totalCount) back on PagedResult.paging.
+ */
+async function seedGitHubConnection(runtime: ReturnType<typeof createFakeRuntime>, tokenId: string, token: string) {
+	await runtime.storage.storeSecret(
+		`integration.auth.cloud:github|${tokenId}`,
+		JSON.stringify({
+			id: tokenId,
+			accessToken: token,
+			scopes: ['repo'],
+			cloud: true,
+			type: 'oauth',
+			domain: 'github.com',
+		}),
+	);
+}
+
+type CapturingProvider = Record<string, (input: unknown, options?: { token?: string }) => Promise<unknown>>;
+
+suite('page-number pagination (#5435)', () => {
+	test('forwards page/pageSize to the provider and surfaces numbered-page metadata', async () => {
+		const runtime = createFakeRuntime();
+		await seedGitHubConnection(runtime, 'sec-tok', 'token-secondary');
+		const manager = createIntegrationManager(runtime);
+		const gh = await manager.get(GitCloudHostIntegrationId.GitHub);
+
+		let capturedInput: { page?: number; pageSize?: number; maxPageSize?: number } | undefined;
+		const api = await (
+			gh as unknown as { getProvidersApi(): Promise<{ providers: Record<string, unknown> }> }
+		).getProvidersApi();
+		(api.providers.github as CapturingProvider).getPullRequestsForReposFn = input => {
+			capturedInput = input as typeof capturedInput;
+			return Promise.resolve({
+				data: [],
+				pageInfo: { hasNextPage: true, nextPage: 3, currentPage: 2, totalPages: 5, totalCount: 42 },
+			});
+		};
+
+		const result = await (
+			gh as unknown as {
+				getMyPullRequestsForRepos: (
+					repos: { namespace: string; name: string }[],
+					options: { page?: number; pageSize?: number },
+					connectionId: string,
+				) => Promise<{ paging?: Record<string, unknown> } | undefined>;
+			}
+		).getMyPullRequestsForRepos([{ namespace: 'octo', name: 'repo' }], { page: 2, pageSize: 20 }, 'sec-tok');
+
+		assert.equal(capturedInput?.page, 2, 'explicit page forwarded to the provider');
+		assert.equal(capturedInput?.pageSize, 20, 'pageSize forwarded for numbered providers');
+		assert.equal(capturedInput?.maxPageSize, 20, 'pageSize also mapped to GitHub maxPageSize');
+
+		assert.equal(result?.paging?.more, true);
+		assert.equal(result?.paging?.page, 2, 'currentPage surfaced as page');
+		assert.equal(result?.paging?.pageSize, 20);
+		assert.equal(result?.paging?.nextPage, 3);
+		assert.equal(result?.paging?.totalPages, 5);
+		assert.equal(result?.paging?.totalCount, 42);
+
+		manager.dispose();
+	});
+
+	test('leaves numbered metadata undefined for a cursor-based result', async () => {
+		const runtime = createFakeRuntime();
+		await seedGitHubConnection(runtime, 'sec-tok', 'token-secondary');
+		const manager = createIntegrationManager(runtime);
+		const gh = await manager.get(GitCloudHostIntegrationId.GitHub);
+
+		const api = await (
+			gh as unknown as { getProvidersApi(): Promise<{ providers: Record<string, unknown> }> }
+		).getProvidersApi();
+		(api.providers.github as CapturingProvider).getPullRequestsForReposFn = () =>
+			Promise.resolve({ data: [], pageInfo: { hasNextPage: true, endCursor: 'abc' } });
+
+		const result = await (
+			gh as unknown as {
+				getMyPullRequestsForRepos: (
+					repos: { namespace: string; name: string }[],
+					options: undefined,
+					connectionId: string,
+				) => Promise<{ paging?: Record<string, unknown> } | undefined>;
+			}
+		).getMyPullRequestsForRepos([{ namespace: 'octo', name: 'repo' }], undefined, 'sec-tok');
+
+		assert.equal(result?.paging?.more, true);
+		assert.equal(result?.paging?.page, undefined, 'no currentPage for cursor providers');
+		assert.equal(result?.paging?.totalPages, undefined);
+		assert.equal(
+			result?.paging?.cursor,
+			JSON.stringify({ value: 'abc', type: 'cursor' }),
+			'cursor round-trip preserved',
+		);
+
+		manager.dispose();
+	});
+});

--- a/packages/plus/integrations/src/providers/__tests__/prFilters.test.ts
+++ b/packages/plus/integrations/src/providers/__tests__/prFilters.test.ts
@@ -1,7 +1,7 @@
 import * as assert from 'node:assert/strict';
 import { suite, test } from 'mocha';
 import { createFakeRuntime } from '../../__tests__/fakeRuntime.js';
-import { GitCloudHostIntegrationId } from '../../constants.js';
+import { GitCloudHostIntegrationId, GitSelfManagedHostIntegrationId } from '../../constants.js';
 import { createIntegrationManager } from '../../index.js';
 import { IssueFilter, PullRequestFilter } from '../models.js';
 
@@ -44,6 +44,7 @@ async function stubProvider(
 	).getProvidersApi();
 	const provider = api.providers[providerKey] as CapturingProvider;
 	provider.getCurrentUserFn = () => Promise.resolve({ data: account });
+	provider.getCurrentUserForInstanceFn = () => Promise.resolve({ data: account });
 	for (const fnName of listFnNames) {
 		provider[fnName] = input => {
 			captured.input = input as Record<string, unknown>;
@@ -84,6 +85,49 @@ suite('PR/issue filter routing (#5435)', () => {
 
 		assert.equal(captured.input?.reviewerId, 'acc-uuid', 'reviewer filter keyed by account id');
 		assert.equal(captured.input?.reviewRequestedLogin, undefined, 'login field not used for Bitbucket');
+
+		manager.dispose();
+	});
+
+	test('Azure DevOps Server review-requested filter is keyed by account id and includes remote info', async () => {
+		const runtime = createFakeRuntime();
+		await seedConnection(
+			runtime,
+			GitSelfManagedHostIntegrationId.AzureDevOpsServer,
+			'ado.example.com',
+			'ado-sec',
+			'token-secondary',
+		);
+		const manager = createIntegrationManager(runtime);
+		const ado = await manager.get(GitSelfManagedHostIntegrationId.AzureDevOpsServer, 'ado.example.com');
+		assert.ok(ado != null, 'Azure DevOps Server integration resolves');
+
+		const captured: { input?: Record<string, unknown> } = {};
+		await stubProvider(
+			ado,
+			GitSelfManagedHostIntegrationId.AzureDevOpsServer,
+			{ id: 'ado-account-id', username: 'octo' },
+			['getPullRequestsForRepoFn'],
+			captured,
+		);
+
+		await (
+			ado as unknown as {
+				getMyPullRequestsForRepos: (
+					repos: { namespace: string; project: string; name: string }[],
+					options: { filters: PullRequestFilter[] },
+					connectionId: string,
+				) => Promise<unknown>;
+			}
+		).getMyPullRequestsForRepos(
+			[{ namespace: 'collection', project: 'project', name: 'repo' }],
+			{ filters: [PullRequestFilter.ReviewRequested] },
+			'ado-sec',
+		);
+
+		assert.equal(captured.input?.reviewerId, 'ado-account-id', 'reviewer filter keyed by account id');
+		assert.equal(captured.input?.reviewRequestedLogin, undefined, 'login field not used for Azure DevOps Server');
+		assert.equal(captured.input?.includeRemoteInfo, true, 'remote info requested for PR clone URL enrichment');
 
 		manager.dispose();
 	});

--- a/packages/plus/integrations/src/providers/__tests__/prFilters.test.ts
+++ b/packages/plus/integrations/src/providers/__tests__/prFilters.test.ts
@@ -1,0 +1,153 @@
+import * as assert from 'node:assert/strict';
+import { suite, test } from 'mocha';
+import { createFakeRuntime } from '../../__tests__/fakeRuntime.js';
+import { GitCloudHostIntegrationId } from '../../constants.js';
+import { createIntegrationManager } from '../../index.js';
+import { IssueFilter, PullRequestFilter } from '../models.js';
+
+/**
+ * Covers the reviewer/assignee filter routing (#5435): the "review requested from me" filter must reach the
+ * field each provider actually reads (reviewRequestedLogin for GitHub/GitLab, reviewerId for Bitbucket/Azure),
+ * and includeAllAssignees must drop the current-user assignee constraint on issue reads.
+ */
+async function seedConnection(
+	runtime: ReturnType<typeof createFakeRuntime>,
+	provider: string,
+	domain: string,
+	tokenId: string,
+	token: string,
+) {
+	await runtime.storage.storeSecret(
+		`integration.auth.cloud:${provider}|${tokenId}`,
+		JSON.stringify({
+			id: tokenId,
+			accessToken: token,
+			scopes: ['repo'],
+			cloud: true,
+			type: 'oauth',
+			domain: domain,
+		}),
+	);
+}
+
+type CapturingProvider = Record<string, (input: unknown, options?: { token?: string }) => Promise<unknown>>;
+
+async function stubProvider(
+	gh: Awaited<ReturnType<ReturnType<typeof createIntegrationManager>['get']>>,
+	providerKey: string,
+	account: { id: string; username: string },
+	listFnNames: string[],
+	captured: { input?: Record<string, unknown> },
+): Promise<void> {
+	const api = await (
+		gh as unknown as { getProvidersApi(): Promise<{ providers: Record<string, unknown> }> }
+	).getProvidersApi();
+	const provider = api.providers[providerKey] as CapturingProvider;
+	provider.getCurrentUserFn = () => Promise.resolve({ data: account });
+	for (const fnName of listFnNames) {
+		provider[fnName] = input => {
+			captured.input = input as Record<string, unknown>;
+			return Promise.resolve({ data: [], pageInfo: undefined });
+		};
+	}
+}
+
+suite('PR/issue filter routing (#5435)', () => {
+	test('Bitbucket review-requested filter is keyed by account id (reviewerId), not reviewRequestedLogin', async () => {
+		const runtime = createFakeRuntime();
+		await seedConnection(runtime, 'bitbucket', 'bitbucket.org', 'sec-tok', 'token-secondary');
+		const manager = createIntegrationManager(runtime);
+		const bb = await manager.get(GitCloudHostIntegrationId.Bitbucket);
+
+		const captured: { input?: Record<string, unknown> } = {};
+		await stubProvider(
+			bb,
+			'bitbucket',
+			{ id: 'acc-uuid', username: 'octo' },
+			['getPullRequestsForRepoFn', 'getPullRequestsForReposFn'],
+			captured,
+		);
+
+		await (
+			bb as unknown as {
+				getMyPullRequestsForRepos: (
+					repos: { namespace: string; name: string }[],
+					options: { filters: PullRequestFilter[] },
+					connectionId: string,
+				) => Promise<unknown>;
+			}
+		).getMyPullRequestsForRepos(
+			[{ namespace: 'octo', name: 'repo' }],
+			{ filters: [PullRequestFilter.ReviewRequested] },
+			'sec-tok',
+		);
+
+		assert.equal(captured.input?.reviewerId, 'acc-uuid', 'reviewer filter keyed by account id');
+		assert.equal(captured.input?.reviewRequestedLogin, undefined, 'login field not used for Bitbucket');
+
+		manager.dispose();
+	});
+
+	test('GitHub review-requested filter is keyed by login (reviewRequestedLogin)', async () => {
+		const runtime = createFakeRuntime();
+		await seedConnection(runtime, 'github', 'github.com', 'sec-tok', 'token-secondary');
+		const manager = createIntegrationManager(runtime);
+		const gh = await manager.get(GitCloudHostIntegrationId.GitHub);
+
+		const captured: { input?: Record<string, unknown> } = {};
+		await stubProvider(
+			gh,
+			'github',
+			{ id: 'acc-id', username: 'octocat' },
+			['getPullRequestsForReposFn'],
+			captured,
+		);
+
+		await (
+			gh as unknown as {
+				getMyPullRequestsForRepos: (
+					repos: { namespace: string; name: string }[],
+					options: { filters: PullRequestFilter[] },
+					connectionId: string,
+				) => Promise<unknown>;
+			}
+		).getMyPullRequestsForRepos(
+			[{ namespace: 'octo', name: 'repo' }],
+			{ filters: [PullRequestFilter.ReviewRequested] },
+			'sec-tok',
+		);
+
+		assert.equal(captured.input?.reviewRequestedLogin, 'octocat', 'reviewer filter keyed by login');
+		assert.equal(captured.input?.reviewerId, undefined, 'account-id field not used for GitHub');
+
+		manager.dispose();
+	});
+
+	test('includeAllAssignees drops the current-user assignee constraint on issue reads', async () => {
+		const runtime = createFakeRuntime();
+		await seedConnection(runtime, 'github', 'github.com', 'sec-tok', 'token-secondary');
+		const manager = createIntegrationManager(runtime);
+		const gh = await manager.get(GitCloudHostIntegrationId.GitHub);
+
+		const captured: { input?: Record<string, unknown> } = {};
+		await stubProvider(gh, 'github', { id: 'acc-id', username: 'octocat' }, ['getIssuesForReposFn'], captured);
+
+		await (
+			gh as unknown as {
+				getMyIssuesForRepos: (
+					repos: { namespace: string; name: string }[],
+					options: { filters: IssueFilter[]; includeAllAssignees: boolean },
+					connectionId: string,
+				) => Promise<unknown>;
+			}
+		).getMyIssuesForRepos(
+			[{ namespace: 'octo', name: 'repo' }],
+			{ filters: [IssueFilter.Assignee], includeAllAssignees: true },
+			'sec-tok',
+		);
+
+		assert.equal(captured.input?.assigneeLogins, undefined, 'assignee constraint suppressed');
+
+		manager.dispose();
+	});
+});

--- a/packages/plus/integrations/src/providers/__tests__/providerScope.test.ts
+++ b/packages/plus/integrations/src/providers/__tests__/providerScope.test.ts
@@ -1,0 +1,30 @@
+import * as assert from 'node:assert/strict';
+import { suite, test } from 'mocha';
+import { PagingMode, resolveProviderScope } from '../models.js';
+
+/**
+ * Covers the org/project scope façade (#5435): a single ProviderScope resolves to the provider-appropriate
+ * inputs based on the provider's PagingMode.
+ */
+suite('resolveProviderScope (#5435)', () => {
+	test('project-mode providers produce projectInputs from org + project', () => {
+		const result = resolveProviderScope({ org: 'my-org', project: 'my-proj' }, PagingMode.Project);
+		assert.deepEqual(result, { projectInputs: [{ namespace: 'my-org', project: 'my-proj' }] });
+	});
+
+	test('project-mode without org/project yields no inputs', () => {
+		assert.deepEqual(resolveProviderScope({ org: 'my-org' }, PagingMode.Project), {});
+	});
+
+	test('repo-mode providers produce a repo input list carrying the project', () => {
+		const result = resolveProviderScope(
+			{ project: 'my-proj', repos: [{ key: 'a', owner: 'o', name: 'r' }] },
+			PagingMode.Repo,
+		);
+		assert.deepEqual(result, { reposInput: [{ namespace: 'o', name: 'r', project: 'my-proj' }] });
+	});
+
+	test('repos-mode with no repos yields an undefined repos input', () => {
+		assert.deepEqual(resolveProviderScope({ org: 'o' }, PagingMode.Repos), { reposInput: undefined });
+	});
+});

--- a/packages/plus/integrations/src/providers/__tests__/pullRequestMapping.test.ts
+++ b/packages/plus/integrations/src/providers/__tests__/pullRequestMapping.test.ts
@@ -1,0 +1,117 @@
+import * as assert from 'node:assert/strict';
+import { GitPullRequestMergeableState, GitPullRequestState } from '@gitkraken/provider-apis';
+import { suite, test } from 'mocha';
+import type { Provider } from '@gitlens/git/models/remoteProvider.js';
+import type { ProviderPullRequest } from '../models.js';
+import { fromProviderPullRequest, toProviderPullRequest } from '../models.js';
+
+/**
+ * Covers the clone-URL / fork / cross-repository plumbing added for read-API parity (#5435): the SDK's
+ * remoteInfo + isCrossRepository + headRepository.isFork must flow onto PullRequestRefs, and the reverse
+ * mapping must reconstruct remoteInfo from the ref clone URLs so round-trips (e.g. Launchpad) don't lose them.
+ */
+const fakeProvider = {
+	id: 'github',
+	name: 'GitHub',
+	domain: 'github.com',
+	icon: 'github',
+} as unknown as Provider;
+
+function createProviderPullRequest(overrides?: Partial<ProviderPullRequest>): ProviderPullRequest {
+	return {
+		id: '1',
+		number: 1,
+		title: 'PR',
+		description: null,
+		url: 'https://github.com/base/repo/pull/1',
+		state: GitPullRequestState.Open,
+		isDraft: false,
+		createdDate: new Date(0),
+		updatedDate: new Date(0),
+		closedDate: null,
+		mergedDate: null,
+		baseRef: { name: 'main', oid: 'base-sha' },
+		headRef: { name: 'feature', oid: 'head-sha' },
+		commentCount: null,
+		upvoteCount: null,
+		commitCount: null,
+		fileCount: null,
+		additions: null,
+		deletions: null,
+		author: null,
+		assignees: null,
+		reviews: null,
+		reviewDecision: null,
+		isCrossRepository: true,
+		repository: {
+			id: 'base-id',
+			name: 'repo',
+			owner: { login: 'base' },
+			remoteInfo: {
+				cloneUrlHTTPS: 'https://github.com/base/repo.git',
+				cloneUrlSSH: 'git@github.com:base/repo.git',
+			},
+		},
+		headRepository: {
+			id: 'head-id',
+			name: 'repo',
+			owner: { login: 'fork' },
+			remoteInfo: {
+				cloneUrlHTTPS: 'https://github.com/fork/repo.git',
+				cloneUrlSSH: 'git@github.com:fork/repo.git',
+			},
+			isFork: true,
+		},
+		headCommit: null,
+		mergeableState: GitPullRequestMergeableState.Unknown,
+		permissions: null,
+		...overrides,
+	};
+}
+
+suite('pull request ref mapping (#5435 clone URLs + fork)', () => {
+	test('fromProviderPullRequest maps clone URLs, isFork, and isCrossRepository onto refs', () => {
+		const pr = fromProviderPullRequest(createProviderPullRequest(), fakeProvider);
+
+		assert.equal(pr.refs?.isCrossRepository, true, 'isCrossRepository comes from the SDK field');
+		assert.equal(pr.refs?.base.cloneHttps, 'https://github.com/base/repo.git');
+		assert.equal(pr.refs?.base.cloneSsh, 'git@github.com:base/repo.git');
+		assert.equal(pr.refs?.head.cloneHttps, 'https://github.com/fork/repo.git');
+		assert.equal(pr.refs?.head.cloneSsh, 'git@github.com:fork/repo.git');
+		assert.equal(pr.refs?.head.isFork, true, 'head fork flag propagates');
+	});
+
+	test('toProviderPullRequest reconstructs remoteInfo and cross-repo flag from the refs', () => {
+		const roundTrip = toProviderPullRequest(fromProviderPullRequest(createProviderPullRequest(), fakeProvider));
+
+		assert.equal(roundTrip.isCrossRepository, true, 'cross-repo flag preserved on the reverse mapping');
+		assert.deepEqual(roundTrip.repository.remoteInfo, {
+			cloneUrlHTTPS: 'https://github.com/base/repo.git',
+			cloneUrlSSH: 'git@github.com:base/repo.git',
+		});
+		assert.deepEqual(roundTrip.headRepository?.remoteInfo, {
+			cloneUrlHTTPS: 'https://github.com/fork/repo.git',
+			cloneUrlSSH: 'git@github.com:fork/repo.git',
+		});
+		assert.equal(roundTrip.headRepository?.isFork, true);
+	});
+
+	test('remoteInfo is left null when a ref carries only a partial clone URL pair', () => {
+		const roundTrip = toProviderPullRequest(
+			fromProviderPullRequest(
+				createProviderPullRequest({
+					repository: {
+						id: 'base-id',
+						name: 'repo',
+						owner: { login: 'base' },
+						// Only HTTPS present: the reverse mapping must not fabricate an SSH URL.
+						remoteInfo: { cloneUrlHTTPS: 'https://github.com/base/repo.git', cloneUrlSSH: '' },
+					},
+				}),
+				fakeProvider,
+			),
+		);
+
+		assert.equal(roundTrip.repository.remoteInfo, null, 'partial clone info does not produce a remoteInfo');
+	});
+});

--- a/packages/plus/integrations/src/providers/__tests__/stateFilter.test.ts
+++ b/packages/plus/integrations/src/providers/__tests__/stateFilter.test.ts
@@ -1,0 +1,108 @@
+import * as assert from 'node:assert/strict';
+import { GitIssueState, GitPullRequestState } from '@gitkraken/provider-apis';
+import { suite, test } from 'mocha';
+import { createFakeRuntime } from '../../__tests__/fakeRuntime.js';
+import { GitCloudHostIntegrationId } from '../../constants.js';
+import { createIntegrationManager } from '../../index.js';
+
+/**
+ * Covers the open/closed/merged state selector (#5435) on the paginated read path: a PullRequestStateFilter /
+ * IssueStateFilter must map to the SDK `states` input (open-only preserved when omitted).
+ */
+async function seedGitHubConnection(runtime: ReturnType<typeof createFakeRuntime>, tokenId: string, token: string) {
+	await runtime.storage.storeSecret(
+		`integration.auth.cloud:github|${tokenId}`,
+		JSON.stringify({
+			id: tokenId,
+			accessToken: token,
+			scopes: ['repo'],
+			cloud: true,
+			type: 'oauth',
+			domain: 'github.com',
+		}),
+	);
+}
+
+type CapturingProvider = Record<string, (input: unknown, options?: { token?: string }) => Promise<unknown>>;
+
+async function captureInput(
+	gh: Awaited<ReturnType<ReturnType<typeof createIntegrationManager>['get']>>,
+	fnName: string,
+	captured: { input?: Record<string, unknown> },
+): Promise<void> {
+	const api = await (
+		gh as unknown as { getProvidersApi(): Promise<{ providers: Record<string, unknown> }> }
+	).getProvidersApi();
+	(api.providers.github as CapturingProvider)[fnName] = input => {
+		captured.input = input as Record<string, unknown>;
+		return Promise.resolve({ data: [], pageInfo: undefined });
+	};
+}
+
+suite('PR/issue state selector (#5435)', () => {
+	test('getMyPullRequestsForRepos maps state=closed to the SDK states input', async () => {
+		const runtime = createFakeRuntime();
+		await seedGitHubConnection(runtime, 'sec-tok', 'token-secondary');
+		const manager = createIntegrationManager(runtime);
+		const gh = await manager.get(GitCloudHostIntegrationId.GitHub);
+
+		const captured: { input?: Record<string, unknown> } = {};
+		await captureInput(gh, 'getPullRequestsForReposFn', captured);
+
+		await (
+			gh as unknown as {
+				getMyPullRequestsForRepos: (
+					repos: { namespace: string; name: string }[],
+					options: { state: 'closed' },
+					connectionId: string,
+				) => Promise<unknown>;
+			}
+		).getMyPullRequestsForRepos([{ namespace: 'octo', name: 'repo' }], { state: 'closed' }, 'sec-tok');
+
+		assert.deepEqual(captured.input?.states, [GitPullRequestState.Closed]);
+	});
+
+	test('getMyPullRequestsForRepos leaves states undefined when no state is requested', async () => {
+		const runtime = createFakeRuntime();
+		await seedGitHubConnection(runtime, 'sec-tok', 'token-secondary');
+		const manager = createIntegrationManager(runtime);
+		const gh = await manager.get(GitCloudHostIntegrationId.GitHub);
+
+		const captured: { input?: Record<string, unknown> } = {};
+		await captureInput(gh, 'getPullRequestsForReposFn', captured);
+
+		await (
+			gh as unknown as {
+				getMyPullRequestsForRepos: (
+					repos: { namespace: string; name: string }[],
+					options: undefined,
+					connectionId: string,
+				) => Promise<unknown>;
+			}
+		).getMyPullRequestsForRepos([{ namespace: 'octo', name: 'repo' }], undefined, 'sec-tok');
+
+		assert.equal(captured.input?.states, undefined, 'omitted state preserves the open-only default');
+	});
+
+	test('getMyIssuesForRepos maps state=all to the SDK issue states input', async () => {
+		const runtime = createFakeRuntime();
+		await seedGitHubConnection(runtime, 'sec-tok', 'token-secondary');
+		const manager = createIntegrationManager(runtime);
+		const gh = await manager.get(GitCloudHostIntegrationId.GitHub);
+
+		const captured: { input?: Record<string, unknown> } = {};
+		await captureInput(gh, 'getIssuesForReposFn', captured);
+
+		await (
+			gh as unknown as {
+				getMyIssuesForRepos: (
+					repos: { namespace: string; name: string }[],
+					options: { state: 'all' },
+					connectionId: string,
+				) => Promise<unknown>;
+			}
+		).getMyIssuesForRepos([{ namespace: 'octo', name: 'repo' }], { state: 'all' }, 'sec-tok');
+
+		assert.deepEqual(captured.input?.states, [GitIssueState.Open, GitIssueState.Closed]);
+	});
+});

--- a/packages/plus/integrations/src/providers/azureDevOps.ts
+++ b/packages/plus/integrations/src/providers/azureDevOps.ts
@@ -2,7 +2,12 @@ import type { Account, UnidentifiedAuthor } from '@gitlens/git/models/author.js'
 import type { DefaultBranch } from '@gitlens/git/models/defaultBranch.js';
 import type { Issue, IssueShape } from '@gitlens/git/models/issue.js';
 import type { IssueOrPullRequest, IssueOrPullRequestType } from '@gitlens/git/models/issueOrPullRequest.js';
-import type { PullRequest, PullRequestMergeMethod, PullRequestState } from '@gitlens/git/models/pullRequest.js';
+import type {
+	PullRequest,
+	PullRequestMergeMethod,
+	PullRequestState,
+	PullRequestStateFilter,
+} from '@gitlens/git/models/pullRequest.js';
 import type { RepositoryMetadata } from '@gitlens/git/models/repositoryMetadata.js';
 import { base64 } from '@gitlens/utils/base64.js';
 import type { Emitter } from '@gitlens/utils/event.js';
@@ -33,7 +38,12 @@ import type {
 	ProviderPullRequest,
 	ProviderRepository,
 } from './models.js';
-import { fromProviderIssue, fromProviderPullRequest, providersMetadata } from './models.js';
+import {
+	fromProviderIssue,
+	fromProviderPullRequest,
+	providersMetadata,
+	toProviderPullRequestStates,
+} from './models.js';
 import type { ProvidersApi } from './providersApi.js';
 import { collectProviderPagedResult } from './utils/providerPaging.js';
 
@@ -459,12 +469,17 @@ export abstract class AzureDevOpsIntegrationBase<
 	protected override async searchProviderMyPullRequests(
 		session: ProviderAuthenticationSession,
 		repos?: AzureRepositoryDescriptor[],
+		_cancellation?: AbortSignal,
+		_silent?: boolean,
+		state?: PullRequestStateFilter,
 	): Promise<PullRequest[] | undefined> {
 		const api = await this.getProvidersApi();
 		if (repos != null) {
 			// TODO: implement repos version
 			return undefined;
 		}
+
+		const states = toProviderPullRequestStates(state);
 
 		const user = await this.getProviderCurrentAccount(session);
 		if (user?.username == null) return undefined;
@@ -487,12 +502,14 @@ export abstract class AzureDevOpsIntegrationBase<
 			await api.getPullRequestsForAzureProjects(tokenWithInfo, projectInputs, {
 				...options,
 				assigneeLogins: [user.username],
+				states: states,
 			})
 		)?.map(pr => this.fromAzureProviderPullRequest(pr, repoDescriptors, projects));
 		const authoredPrs = (
 			await api.getPullRequestsForAzureProjects(tokenWithInfo, projectInputs, {
 				...options,
 				authorLogin: user.username,
+				states: states,
 			})
 		)?.map(pr => this.fromAzureProviderPullRequest(pr, repoDescriptors, projects));
 		const prsById = new Map<string, PullRequest>();

--- a/packages/plus/integrations/src/providers/bitbucket-server.ts
+++ b/packages/plus/integrations/src/providers/bitbucket-server.ts
@@ -2,7 +2,12 @@ import type { Account, UnidentifiedAuthor } from '@gitlens/git/models/author.js'
 import type { DefaultBranch } from '@gitlens/git/models/defaultBranch.js';
 import type { Issue, IssueShape } from '@gitlens/git/models/issue.js';
 import type { IssueOrPullRequest, IssueOrPullRequestType } from '@gitlens/git/models/issueOrPullRequest.js';
-import type { PullRequest, PullRequestMergeMethod, PullRequestState } from '@gitlens/git/models/pullRequest.js';
+import type {
+	PullRequest,
+	PullRequestMergeMethod,
+	PullRequestState,
+	PullRequestStateFilter,
+} from '@gitlens/git/models/pullRequest.js';
 import type { RepositoryMetadata } from '@gitlens/git/models/repositoryMetadata.js';
 import { md5 } from '@gitlens/utils/crypto.js';
 import type { Emitter } from '@gitlens/utils/event.js';
@@ -20,7 +25,7 @@ import { GitHostIntegration } from '../models/gitHostIntegration.js';
 import type { IntegrationKey } from '../models/integration.js';
 import type { BitbucketRepositoryDescriptor } from './bitbucket/models.js';
 import type { ProviderRepository } from './models.js';
-import { fromProviderPullRequest, providersMetadata } from './models.js';
+import { fromProviderPullRequest, providersMetadata, toProviderPullRequestStates } from './models.js';
 import type { ProvidersApi } from './providersApi.js';
 
 const metadata = providersMetadata[GitSelfManagedHostIntegrationId.BitbucketServer];
@@ -219,6 +224,9 @@ export class BitbucketServerIntegration extends GitHostIntegration<
 	protected override async searchProviderMyPullRequests(
 		session: ProviderAuthenticationSession,
 		repos?: BitbucketRepositoryDescriptor[],
+		_cancellation?: AbortSignal,
+		_silent?: boolean,
+		state?: PullRequestStateFilter,
 	): Promise<PullRequest[] | undefined> {
 		if (repos != null) {
 			// TODO: implement repos version
@@ -233,6 +241,7 @@ export class BitbucketServerIntegration extends GitHostIntegration<
 		const prs = await api.getBitbucketServerPullRequestsForCurrentUser(
 			toTokenWithInfo(this.id, session),
 			this.apiBaseUrl,
+			{ states: toProviderPullRequestStates(state) },
 		);
 		return prs?.map(pr => fromProviderPullRequest(pr, this));
 	}

--- a/packages/plus/integrations/src/providers/bitbucket-server/models.ts
+++ b/packages/plus/integrations/src/providers/bitbucket-server/models.ts
@@ -193,6 +193,7 @@ export const normalizeBitbucketServerPullRequest = (pr: BitbucketServerPullReque
 		description: pr.description ?? null,
 		url: pr.links.self[0].href,
 		state: bitbucketStateToGitState[pr.state],
+		isCrossRepository: pr.toRef.repository.id !== pr.fromRef.repository.id,
 		isDraft: false,
 		createdDate: new Date(pr.createdDate),
 		updatedDate: new Date(pr.updatedDate),

--- a/packages/plus/integrations/src/providers/bitbucket.ts
+++ b/packages/plus/integrations/src/providers/bitbucket.ts
@@ -2,7 +2,12 @@ import type { Account, UnidentifiedAuthor } from '@gitlens/git/models/author.js'
 import type { DefaultBranch } from '@gitlens/git/models/defaultBranch.js';
 import type { Issue, IssueShape } from '@gitlens/git/models/issue.js';
 import type { IssueOrPullRequest, IssueOrPullRequestType } from '@gitlens/git/models/issueOrPullRequest.js';
-import type { PullRequest, PullRequestMergeMethod, PullRequestState } from '@gitlens/git/models/pullRequest.js';
+import type {
+	PullRequest,
+	PullRequestMergeMethod,
+	PullRequestState,
+	PullRequestStateFilter,
+} from '@gitlens/git/models/pullRequest.js';
 import type { GitRemote } from '@gitlens/git/models/remote.js';
 import type { RepositoryMetadata } from '@gitlens/git/models/repositoryMetadata.js';
 import { md5 } from '@gitlens/utils/crypto.js';
@@ -18,7 +23,7 @@ import { GitCloudHostIntegrationId } from '../constants.js';
 import { GitHostIntegration } from '../models/gitHostIntegration.js';
 import type { BitbucketRepositoryDescriptor, BitbucketWorkspaceDescriptor } from './bitbucket/models.js';
 import type { ProviderHierarchyResult, ProviderOrganization, ProviderRepository } from './models.js';
-import { fromProviderPullRequest, providersMetadata } from './models.js';
+import { fromProviderPullRequest, providersMetadata, toProviderPullRequestStates } from './models.js';
 
 const metadata = providersMetadata[GitCloudHostIntegrationId.Bitbucket];
 const authProvider = Object.freeze({ id: metadata.id, scopes: metadata.scopes });
@@ -258,11 +263,25 @@ export class BitbucketIntegration extends GitHostIntegration<
 	protected override async searchProviderMyPullRequests(
 		session: ProviderAuthenticationSession,
 		repos?: BitbucketRepositoryDescriptor[],
+		_cancellation?: AbortSignal,
+		_silent?: boolean,
+		state?: PullRequestStateFilter,
 	): Promise<PullRequest[] | undefined> {
 		if (repos != null) {
 			// TODO: implement repos version
 			return undefined;
 		}
+
+		const states = toProviderPullRequestStates(state);
+		// Bitbucket's reviewing PRs use a raw BBQL query; map the requested state to its state clause.
+		const stateClause =
+			state === 'closed'
+				? '(state="DECLINED" OR state="SUPERSEDED")'
+				: state === 'merged'
+					? 'state="MERGED"'
+					: state === 'all'
+						? undefined
+						: 'state="OPEN"';
 
 		const api = await this.getProvidersApi();
 		if (!api) {
@@ -289,13 +308,15 @@ export class BitbucketIntegration extends GitHostIntegration<
 				toTokenWithInfo(this.id, session),
 				user.id,
 				ws.slug,
+				{ states: states },
 			);
 			return prs?.map(pr => fromProviderPullRequest(pr, this));
 		});
 
+		const reviewerClause = `reviewers.uuid="${user.id}"`;
 		const reviewingPrs = api
 			.getPullRequestsForRepos(toTokenWithInfo(this.id, session), workspaceRepos, {
-				query: `state="OPEN" AND reviewers.uuid="${user.id}"`,
+				query: stateClause ? `${stateClause} AND ${reviewerClause}` : reviewerClause,
 			})
 			.then(r => r.values?.map(pr => fromProviderPullRequest(pr, this)));
 

--- a/packages/plus/integrations/src/providers/github.ts
+++ b/packages/plus/integrations/src/providers/github.ts
@@ -2,7 +2,12 @@ import type { Account, UnidentifiedAuthor } from '@gitlens/git/models/author.js'
 import type { DefaultBranch } from '@gitlens/git/models/defaultBranch.js';
 import type { Issue, IssueShape } from '@gitlens/git/models/issue.js';
 import type { IssueOrPullRequest } from '@gitlens/git/models/issueOrPullRequest.js';
-import type { PullRequest, PullRequestMergeMethod, PullRequestState } from '@gitlens/git/models/pullRequest.js';
+import type {
+	PullRequest,
+	PullRequestMergeMethod,
+	PullRequestState,
+	PullRequestStateFilter,
+} from '@gitlens/git/models/pullRequest.js';
 import type { RepositoryMetadata } from '@gitlens/git/models/repositoryMetadata.js';
 import type { RepositoryDescriptor } from '@gitlens/git/models/resourceDescriptor.js';
 import type { PullRequestUrlIdentity } from '@gitlens/git/utils/pullRequest.utils.js';
@@ -245,6 +250,7 @@ abstract class GitHubIntegrationBase<ID extends GitHubIntegrationIds> extends Gi
 		repos?: GitHubRepositoryDescriptor[],
 		cancellation?: AbortSignal,
 		silent?: boolean,
+		state?: PullRequestStateFilter,
 	): Promise<PullRequest[] | undefined> {
 		return (await this.authenticationService.apis.github)?.searchMyPullRequests(
 			this,
@@ -253,6 +259,7 @@ abstract class GitHubIntegrationBase<ID extends GitHubIntegrationIds> extends Gi
 				repos: repos?.map(r => `${r.owner}/${r.name}`),
 				baseUrl: this.apiBaseUrl,
 				silent: silent,
+				state: state,
 			},
 			cancellation,
 		);

--- a/packages/plus/integrations/src/providers/gitlab.ts
+++ b/packages/plus/integrations/src/providers/gitlab.ts
@@ -2,7 +2,12 @@ import type { Account } from '@gitlens/git/models/author.js';
 import type { DefaultBranch } from '@gitlens/git/models/defaultBranch.js';
 import type { Issue, IssueShape } from '@gitlens/git/models/issue.js';
 import type { IssueOrPullRequest } from '@gitlens/git/models/issueOrPullRequest.js';
-import type { PullRequest, PullRequestMergeMethod, PullRequestState } from '@gitlens/git/models/pullRequest.js';
+import type {
+	PullRequest,
+	PullRequestMergeMethod,
+	PullRequestState,
+	PullRequestStateFilter,
+} from '@gitlens/git/models/pullRequest.js';
 import type { RepositoryMetadata } from '@gitlens/git/models/repositoryMetadata.js';
 import type { RepositoryDescriptor } from '@gitlens/git/models/resourceDescriptor.js';
 import type { PullRequestUrlIdentity } from '@gitlens/git/utils/pullRequest.utils.js';
@@ -20,7 +25,12 @@ import type { GitLabIntegrationIds } from './gitlab/gitlab.utils.js';
 import { getGitLabPullRequestIdentityFromMaybeUrl, matchesGitLabOrgNamespace } from './gitlab/gitlab.utils.js';
 import { fromGitLabMergeRequestProvidersApi } from './gitlab/models.js';
 import type { ProviderHierarchyResult, ProviderOrganization, ProviderRepository } from './models.js';
-import { ProviderPullRequestReviewState, providersMetadata, toIssueShape } from './models.js';
+import {
+	ProviderPullRequestReviewState,
+	providersMetadata,
+	toIssueShape,
+	toProviderPullRequestStates,
+} from './models.js';
 import type { ProvidersApi } from './providersApi.js';
 
 const metadata = providersMetadata[GitCloudHostIntegrationId.GitLab];
@@ -283,6 +293,9 @@ abstract class GitLabIntegrationBase<ID extends GitLabIntegrationIds> extends Gi
 	protected override async searchProviderMyPullRequests(
 		session: ProviderAuthenticationSession,
 		repos?: GitLabRepositoryDescriptor[],
+		_cancellation?: AbortSignal,
+		_silent?: boolean,
+		state?: PullRequestStateFilter,
 	): Promise<PullRequest[] | undefined> {
 		const api = await this.getProvidersApi();
 		// Resolve the username from THIS session's token (multi-account: `session` may be a non-primary
@@ -295,6 +308,7 @@ abstract class GitLabIntegrationBase<ID extends GitLabIntegrationIds> extends Gi
 		const apiResult = await api.getPullRequestsForUser(toTokenWithInfo(this.id, session), username, {
 			isPAT: this.isEnterprise,
 			baseUrl: this.isEnterprise ? `https://${this.domain}` : undefined,
+			states: toProviderPullRequestStates(state),
 		});
 
 		if (apiResult == null) {

--- a/packages/plus/integrations/src/providers/models.ts
+++ b/packages/plus/integrations/src/providers/models.ts
@@ -161,6 +161,10 @@ export interface GetPullRequestsOptions {
 	query?: string;
 	cursor?: string; // stringified JSON object of type { type: 'cursor' | 'page'; value: string | number } | {}
 	baseUrl?: string;
+	// 1-based page to request from numbered-page providers; takes precedence over a page-typed cursor.
+	page?: number;
+	// Items to request per page (numbered-page providers, plus GitHub's maxPageSize).
+	pageSize?: number;
 	// Opt in to repository remote metadata (clone URLs) when the PR payload lacks it. Only Azure DevOps
 	// acts on this today (extra API call); it is a no-op for the other providers.
 	includeRemoteInfo?: boolean;
@@ -198,6 +202,10 @@ export interface GetIssuesOptions {
 	mentionLogin?: string;
 	cursor?: string; // stringified JSON object of type { type: 'cursor' | 'page'; value: string | number } | {}
 	baseUrl?: string;
+	// 1-based page to request from numbered-page providers; takes precedence over a page-typed cursor.
+	page?: number;
+	// Items to request per page (numbered-page providers, plus GitHub's maxPageSize).
+	pageSize?: number;
 }
 
 export interface GetIssuesForRepoInput extends GetIssuesOptions {
@@ -235,6 +243,10 @@ export interface PageInfo {
 	hasNextPage: boolean;
 	endCursor?: string | null;
 	nextPage?: number | null;
+	// Numbered-page providers (Bitbucket, Bitbucket Server, Azure DevOps) additionally report these.
+	currentPage?: number | null;
+	totalPages?: number | null;
+	totalCount?: number | null;
 }
 
 export type GetRepoFn = (

--- a/packages/plus/integrations/src/providers/models.ts
+++ b/packages/plus/integrations/src/providers/models.ts
@@ -886,6 +886,7 @@ export function toProviderPullRequest(pr: PullRequest): ProviderPullRequest {
 		description: null,
 		url: pr.url,
 		state: toProviderPullRequestState(pr.state),
+		isCrossRepository: pr.refs?.isCrossRepository ?? false,
 		isDraft: pr.isDraft ?? false,
 		createdDate: pr.createdDate,
 		updatedDate: pr.updatedDate,

--- a/packages/plus/integrations/src/providers/models.ts
+++ b/packages/plus/integrations/src/providers/models.ts
@@ -64,6 +64,7 @@ import {
 	PullRequestStatusCheckRollupState,
 } from '@gitlens/git/models/pullRequest.js';
 import type { Provider, ProviderReference } from '@gitlens/git/models/remoteProvider.js';
+import type { ProviderScope } from '@gitlens/git/models/resourceDescriptor.js';
 import { gitSuffixRegex } from '@gitlens/git/utils/remote.utils.js';
 import type { PagedResult } from '@gitlens/utils/paging.js';
 import { equalsIgnoreCase } from '@gitlens/utils/string.js';
@@ -944,6 +945,28 @@ export function toProviderIssueStates(state: IssueStateFilter | undefined): GitI
 		default:
 			return undefined;
 	}
+}
+
+/**
+ * Resolves a normalized {@link ProviderScope} to the provider-appropriate read inputs, dispatching on the
+ * provider's {@link PagingMode} (the authoritative per-provider scoping selector). Project-mode providers
+ * (Azure issues, Jira) produce `projectInputs` from `org` + `project`; repo/repos-mode providers produce a
+ * repo `GetRepoInput[]` from `scope.repos` (carrying `project` where relevant, e.g. Azure). This is the
+ * single public entry point consumers can use instead of hand-building the three underlying representations.
+ */
+export function resolveProviderScope(
+	scope: ProviderScope,
+	pagingMode: PagingMode | undefined,
+): { reposInput?: GetRepoInput[]; projectInputs?: { namespace: string; project: string }[] } {
+	if (pagingMode === PagingMode.Project) {
+		if (scope.org != null && scope.project != null) {
+			return { projectInputs: [{ namespace: scope.org, project: scope.project }] };
+		}
+		return {};
+	}
+
+	const reposInput = scope.repos?.map(r => ({ namespace: r.owner, name: r.name, project: scope.project }));
+	return { reposInput: reposInput };
 }
 
 function toProviderRemoteInfo(ref: PullRequestRef | undefined): GitRepositoryRemoteInfo | null {

--- a/packages/plus/integrations/src/providers/models.ts
+++ b/packages/plus/integrations/src/providers/models.ts
@@ -37,6 +37,7 @@ import type {
 } from '@gitkraken/provider-apis';
 import {
 	GitBuildStatusState,
+	GitIssueState,
 	GitPullRequestMergeableState,
 	GitPullRequestReviewState,
 	GitPullRequestState,
@@ -44,7 +45,7 @@ import {
 import { EntityIdentifierUtils } from '@gitkraken/provider-apis/entity-identifiers';
 import { GitProviderUtils } from '@gitkraken/provider-apis/provider-utils';
 import type { Account as UserAccount } from '@gitlens/git/models/author.js';
-import type { IssueMember, IssueProject, IssueShape } from '@gitlens/git/models/issue.js';
+import type { IssueMember, IssueProject, IssueShape, IssueStateFilter } from '@gitlens/git/models/issue.js';
 import { Issue, RepositoryAccessLevel } from '@gitlens/git/models/issue.js';
 import type {
 	PullRequestMember,
@@ -53,6 +54,7 @@ import type {
 	PullRequestRepositoryIdentityDescriptor,
 	PullRequestReviewer,
 	PullRequestState,
+	PullRequestStateFilter,
 } from '@gitlens/git/models/pullRequest.js';
 import {
 	PullRequest,
@@ -162,6 +164,8 @@ export interface GetPullRequestsOptions {
 	reviewerId?: string;
 	reviewerLogin?: string;
 	mentionLogin?: string;
+	// PR states to include; when omitted the provider returns its default (open only).
+	states?: GitPullRequestState[];
 	query?: string;
 	cursor?: string; // stringified JSON object of type { type: 'cursor' | 'page'; value: string | number } | {}
 	baseUrl?: string;
@@ -178,6 +182,8 @@ export interface GetPullRequestsForUserOptions {
 	includeFromArchivedRepos?: boolean;
 	cursor?: string; // stringified JSON object of type { type: 'cursor' | 'page'; value: string | number } | {}
 	baseUrl?: string;
+	// PR states to include; when omitted the provider returns its default (open only).
+	states?: GitPullRequestState[];
 }
 
 export interface GetPullRequestsForUserInput extends GetPullRequestsForUserOptions {
@@ -204,6 +210,8 @@ export interface GetIssuesOptions {
 	authorLogin?: string;
 	assigneeLogins?: string[];
 	mentionLogin?: string;
+	// Issue states to include; when omitted the provider returns its default (open only).
+	states?: GitIssueState[];
 	cursor?: string; // stringified JSON object of type { type: 'cursor' | 'page'; value: string | number } | {}
 	baseUrl?: string;
 	// 1-based page to request from numbered-page providers; takes precedence over a page-typed cursor.
@@ -411,6 +419,7 @@ export type GetBitbucketPullRequestsAuthoredByUserForWorkspaceFn = (
 	input: {
 		userId: string;
 		workspaceSlug: string;
+		states?: GitPullRequestState[];
 	} & NumberedPageInput,
 	options?: EnterpriseOptions,
 ) => Promise<{
@@ -421,7 +430,7 @@ export type GetBitbucketPullRequestsAuthoredByUserForWorkspaceFn = (
 	data: GitPullRequest[];
 }>;
 export type GetBitbucketServerPullRequestsForCurrentUserFn = (
-	input: NumberedPageInput,
+	input: { states?: GitPullRequestState[] } & NumberedPageInput,
 	options?: EnterpriseOptions,
 ) => Promise<{
 	pageInfo: {
@@ -903,6 +912,38 @@ export function toProviderPullRequestState(state: PullRequestState): GitPullRequ
 
 export function fromProviderPullRequestState(state: GitPullRequestState): PullRequestState {
 	return state === GitPullRequestState.Open ? 'opened' : state === GitPullRequestState.Closed ? 'closed' : 'merged';
+}
+
+/** Maps a PR state filter to the SDK's `states` input. `undefined`/omitted preserves the open-only default. */
+export function toProviderPullRequestStates(
+	state: PullRequestStateFilter | undefined,
+): GitPullRequestState[] | undefined {
+	switch (state) {
+		case 'open':
+			return [GitPullRequestState.Open];
+		case 'closed':
+			return [GitPullRequestState.Closed];
+		case 'merged':
+			return [GitPullRequestState.Merged];
+		case 'all':
+			return [GitPullRequestState.Open, GitPullRequestState.Closed, GitPullRequestState.Merged];
+		default:
+			return undefined;
+	}
+}
+
+/** Maps an issue state filter to the SDK's `states` input. `undefined`/omitted preserves the open-only default. */
+export function toProviderIssueStates(state: IssueStateFilter | undefined): GitIssueState[] | undefined {
+	switch (state) {
+		case 'open':
+			return [GitIssueState.Open];
+		case 'closed':
+			return [GitIssueState.Closed];
+		case 'all':
+			return [GitIssueState.Open, GitIssueState.Closed];
+		default:
+			return undefined;
+	}
 }
 
 function toProviderRemoteInfo(ref: PullRequestRef | undefined): GitRepositoryRemoteInfo | null {

--- a/packages/plus/integrations/src/providers/models.ts
+++ b/packages/plus/integrations/src/providers/models.ts
@@ -157,6 +157,10 @@ export interface GetPullRequestsOptions {
 	authorLogin?: string;
 	assigneeLogins?: string[];
 	reviewRequestedLogin?: string;
+	// Reviewer filters keyed differently per provider: GitHub/GitLab use reviewRequestedLogin (login),
+	// Bitbucket/Azure DevOps use reviewerId (account id), Bitbucket Server uses reviewerLogin (login).
+	reviewerId?: string;
+	reviewerLogin?: string;
 	mentionLogin?: string;
 	query?: string;
 	cursor?: string; // stringified JSON object of type { type: 'cursor' | 'page'; value: string | number } | {}
@@ -568,8 +572,8 @@ export const providersMetadata: ProvidersMetadata = {
 		type: 'git',
 		iconKey: GitCloudHostIntegrationId.Bitbucket,
 		pullRequestsPagingMode: PagingMode.Repo,
-		// Use 'id' property on account for PR filters
-		supportedPullRequestFilters: [PullRequestFilter.Author],
+		// Use 'id' property on account for PR filters (reviewer filter keyed by account id / reviewerId)
+		supportedPullRequestFilters: [PullRequestFilter.Author, PullRequestFilter.ReviewRequested],
 		scopes: ['account:read', 'repository:read', 'pullrequest:read', 'issue:read'],
 	},
 	[GitSelfManagedHostIntegrationId.BitbucketServer]: {
@@ -589,8 +593,12 @@ export const providersMetadata: ProvidersMetadata = {
 		iconKey: GitCloudHostIntegrationId.AzureDevOps,
 		issuesPagingMode: PagingMode.Project,
 		pullRequestsPagingMode: PagingMode.Repo,
-		// Use 'id' property on account for PR filters
-		supportedPullRequestFilters: [PullRequestFilter.Author, PullRequestFilter.Assignee],
+		// Use 'id' property on account for PR filters (reviewer filter keyed by account id / reviewerId)
+		supportedPullRequestFilters: [
+			PullRequestFilter.Author,
+			PullRequestFilter.Assignee,
+			PullRequestFilter.ReviewRequested,
+		],
 		// Use 'name' property on account for issue filters
 		supportedIssueFilters: [IssueFilter.Author, IssueFilter.Assignee, IssueFilter.Mention],
 		scopes: ['vso.code', 'vso.identity', 'vso.project', 'vso.profile', 'vso.work'],
@@ -603,8 +611,12 @@ export const providersMetadata: ProvidersMetadata = {
 		iconKey: GitCloudHostIntegrationId.AzureDevOps,
 		issuesPagingMode: PagingMode.Project,
 		pullRequestsPagingMode: PagingMode.Repo,
-		// Use 'id' property on account for PR filters
-		supportedPullRequestFilters: [PullRequestFilter.Author, PullRequestFilter.Assignee],
+		// Use 'id' property on account for PR filters (reviewer filter keyed by account id / reviewerId)
+		supportedPullRequestFilters: [
+			PullRequestFilter.Author,
+			PullRequestFilter.Assignee,
+			PullRequestFilter.ReviewRequested,
+		],
 		// Use 'name' property on account for issue filters
 		supportedIssueFilters: [IssueFilter.Author, IssueFilter.Assignee, IssueFilter.Mention],
 		scopes: ['vso.code', 'vso.identity', 'vso.project', 'vso.profile', 'vso.work'],

--- a/packages/plus/integrations/src/providers/models.ts
+++ b/packages/plus/integrations/src/providers/models.ts
@@ -18,6 +18,7 @@ import type {
 	GitMergeStrategy,
 	GitPullRequest,
 	GitRepository,
+	GitRepositoryRemoteInfo,
 	Jira,
 	JiraProject,
 	JiraResource,
@@ -47,6 +48,7 @@ import type { IssueMember, IssueProject, IssueShape } from '@gitlens/git/models/
 import { Issue, RepositoryAccessLevel } from '@gitlens/git/models/issue.js';
 import type {
 	PullRequestMember,
+	PullRequestRef,
 	PullRequestRefs,
 	PullRequestRepositoryIdentityDescriptor,
 	PullRequestReviewer,
@@ -159,6 +161,9 @@ export interface GetPullRequestsOptions {
 	query?: string;
 	cursor?: string; // stringified JSON object of type { type: 'cursor' | 'page'; value: string | number } | {}
 	baseUrl?: string;
+	// Opt in to repository remote metadata (clone URLs) when the PR payload lacks it. Only Azure DevOps
+	// acts on this today (extra API call); it is a no-op for the other providers.
+	includeRemoteInfo?: boolean;
 }
 
 export interface GetPullRequestsForUserOptions {
@@ -876,6 +881,11 @@ export function fromProviderPullRequestState(state: GitPullRequestState): PullRe
 	return state === GitPullRequestState.Open ? 'opened' : state === GitPullRequestState.Closed ? 'closed' : 'merged';
 }
 
+function toProviderRemoteInfo(ref: PullRequestRef | undefined): GitRepositoryRemoteInfo | null {
+	// Match the SDK convention: only populate remoteInfo when both clone URLs are known.
+	return ref?.cloneHttps && ref?.cloneSsh ? { cloneUrlHTTPS: ref.cloneHttps, cloneUrlSSH: ref.cloneSsh } : null;
+}
+
 export function toProviderPullRequest(pr: PullRequest): ProviderPullRequest {
 	const prReviews = [...(pr.reviewRequests ?? []), ...(pr.latestReviews ?? [])];
 	return {
@@ -924,7 +934,7 @@ export function toProviderPullRequest(pr: PullRequest): ProviderPullRequest {
 						owner: {
 							login: pr.repository.owner,
 						},
-						remoteInfo: null, // TODO: Add the urls to our model
+						remoteInfo: toProviderRemoteInfo(pr.refs?.base),
 					}
 				: {
 						id: '',
@@ -942,7 +952,8 @@ export function toProviderPullRequest(pr: PullRequest): ProviderPullRequest {
 						owner: {
 							login: pr.refs.head.owner,
 						},
-						remoteInfo: null,
+						remoteInfo: toProviderRemoteInfo(pr.refs.head),
+						isFork: pr.refs.head.isFork,
 					}
 				: null,
 		headCommit:
@@ -1016,6 +1027,8 @@ export function fromProviderPullRequest(
 				url: pr.repository.remoteInfo?.cloneUrlHTTPS
 					? pr.repository.remoteInfo.cloneUrlHTTPS.replace(gitSuffixRegex, '')
 					: '',
+				cloneHttps: pr.repository.remoteInfo?.cloneUrlHTTPS || undefined,
+				cloneSsh: pr.repository.remoteInfo?.cloneUrlSSH || undefined,
 			},
 			head: {
 				branch: pr.headRef?.name ?? '',
@@ -1026,8 +1039,11 @@ export function fromProviderPullRequest(
 				url: pr.headRepository?.remoteInfo?.cloneUrlHTTPS
 					? pr.headRepository.remoteInfo.cloneUrlHTTPS.replace(gitSuffixRegex, '')
 					: '',
+				cloneHttps: pr.headRepository?.remoteInfo?.cloneUrlHTTPS || undefined,
+				cloneSsh: pr.headRepository?.remoteInfo?.cloneUrlSSH || undefined,
+				isFork: pr.headRepository?.isFork,
 			},
-			isCrossRepository: pr.headRepository?.id !== pr.repository.id,
+			isCrossRepository: pr.isCrossRepository,
 		},
 		pr.isDraft,
 		pr.additions ?? undefined,

--- a/packages/plus/integrations/src/providers/providersApi.ts
+++ b/packages/plus/integrations/src/providers/providersApi.ts
@@ -326,10 +326,10 @@ export class ProvidersApi {
 	): Promise<TokenWithInfo<T> | undefined> {
 		// When a specific connection is requested, resolve that connection's cloud session (mirroring
 		// `Integration.resolveReadSession`); otherwise keep the plain descriptor so the primary is resolved.
-		const providerDescriptor =
-			options?.connectionId != null
-				? { domain: provider.domain, scopes: provider.scopes, connectionId: options.connectionId, cloud: true }
-				: { domain: provider.domain, scopes: provider.scopes };
+		// An empty string is not a real target, so it must also fall through to the primary path.
+		const providerDescriptor = options?.connectionId
+			? { domain: provider.domain, scopes: provider.scopes, connectionId: options.connectionId, cloud: true }
+			: { domain: provider.domain, scopes: provider.scopes };
 		try {
 			const authProvider = await this.authenticationService.get(provider.id);
 			const session = await authProvider.getSession(providerDescriptor, {

--- a/packages/plus/integrations/src/providers/providersApi.ts
+++ b/packages/plus/integrations/src/providers/providersApi.ts
@@ -454,16 +454,29 @@ export class ProvidersApi {
 		}
 		const cursorValue = cursorInfo.value;
 		const cursorType = cursorInfo.type;
+		// An explicit numbered `page` request wins over a page-typed cursor; otherwise follow the cursor. A
+		// live cursor-typed cursor still takes precedence so an in-flight continuation is never clobbered.
+		const requestedPage: number | undefined = typeof args?.page === 'number' ? args.page : undefined;
+		const requestedPageSize: number | undefined = typeof args?.pageSize === 'number' ? args.pageSize : undefined;
 		let cursorOrPage = {};
-		if (cursorType === 'page') {
+		if (requestedPage != null && cursorType !== 'cursor') {
+			cursorOrPage = { page: requestedPage };
+		} else if (cursorType === 'page') {
 			cursorOrPage = { page: cursorValue };
 		} else if (cursorType === 'cursor') {
 			cursorOrPage = { cursor: cursorValue };
 		}
 
+		// Strip the caller's paging keys so `getPagedResult` fully controls them; otherwise `args.page` could
+		// survive alongside a resolved `cursor` (or the raw serialized wrapper `args.cursor` could leak in when
+		// following a page), letting the provider clobber the continuation we intended.
+		const { page: _page, pageSize: _pageSize, cursor: _cursor, ...restArgs } = args ?? {};
 		const input = {
-			...args,
+			...restArgs,
 			...cursorOrPage,
+			// `pageSize` is honored by numbered providers; GitHub reads `maxPageSize`. Set both so whichever
+			// the resolved provider understands takes effect; the other is ignored.
+			...(requestedPageSize != null ? { pageSize: requestedPageSize, maxPageSize: requestedPageSize } : {}),
 		};
 
 		try {
@@ -476,13 +489,14 @@ export class ProvidersApi {
 				return { values: [] };
 			}
 
-			const hasMore = result.pageInfo?.hasNextPage ?? false;
+			const pageInfo = result.pageInfo;
+			const hasMore = pageInfo?.hasNextPage ?? false;
 
 			let nextCursor = '{}';
-			if (result.pageInfo?.endCursor != null) {
-				nextCursor = JSON.stringify({ value: result.pageInfo?.endCursor, type: 'cursor' });
-			} else if (result.pageInfo?.nextPage != null) {
-				nextCursor = JSON.stringify({ value: result.pageInfo?.nextPage, type: 'page' });
+			if (pageInfo?.endCursor != null) {
+				nextCursor = JSON.stringify({ value: pageInfo.endCursor, type: 'cursor' });
+			} else if (pageInfo?.nextPage != null) {
+				nextCursor = JSON.stringify({ value: pageInfo.nextPage, type: 'page' });
 			}
 
 			return {
@@ -490,6 +504,13 @@ export class ProvidersApi {
 				paging: {
 					cursor: nextCursor,
 					more: hasMore,
+					// Numbered-page metadata; left undefined by cursor-based providers (which don't report a
+					// currentPage), so we never echo the requested page for a provider that ignored it.
+					page: pageInfo?.currentPage ?? undefined,
+					pageSize: requestedPageSize,
+					nextPage: pageInfo?.nextPage ?? undefined,
+					totalPages: pageInfo?.totalPages ?? undefined,
+					totalCount: pageInfo?.totalCount ?? undefined,
 				},
 			};
 		} catch (e) {

--- a/packages/plus/integrations/src/providers/providersApi.ts
+++ b/packages/plus/integrations/src/providers/providersApi.ts
@@ -321,9 +321,14 @@ export class ProvidersApi {
 
 	private async getProviderToken<T extends IntegrationIds>(
 		provider: ProviderInfo & { id: T },
-		options?: { createSessionIfNeeded?: boolean },
+		options?: { createSessionIfNeeded?: boolean; connectionId?: string },
 	): Promise<TokenWithInfo<T> | undefined> {
-		const providerDescriptor = { domain: provider.domain, scopes: provider.scopes };
+		// When a specific connection is requested, resolve that connection's cloud session (mirroring
+		// `Integration.resolveReadSession`); otherwise keep the plain descriptor so the primary is resolved.
+		const providerDescriptor =
+			options?.connectionId != null
+				? { domain: provider.domain, scopes: provider.scopes, connectionId: options.connectionId, cloud: true }
+				: { domain: provider.domain, scopes: provider.scopes };
 		try {
 			const authProvider = await this.authenticationService.get(provider.id);
 			const session = await authProvider.getSession(providerDescriptor, {
@@ -356,9 +361,12 @@ export class ProvidersApi {
 			throw new Error(`Provider id mismatch: expected ${providerId} but got ${provider.id}`);
 		}
 
+		const connectionId = 'connectionId' in tokenOptInfo ? tokenOptInfo.connectionId : undefined;
 		const tokenWithInfo = tokenOptInfo?.accessToken
 			? tokenOptInfo
-			: await this.getProviderToken<T>(provider as ProviderInfo & { id: T });
+			: await this.getProviderToken<T>(provider as ProviderInfo & { id: T }, {
+					connectionId: connectionId,
+				});
 		if (tokenWithInfo == null) {
 			throw new Error(`Not connected to provider ${providerId}`);
 		}

--- a/packages/plus/integrations/src/providers/providersApi.ts
+++ b/packages/plus/integrations/src/providers/providersApi.ts
@@ -1,4 +1,5 @@
 import ProviderApis from '@gitkraken/provider-apis';
+import type { GitPullRequestState } from '@gitkraken/provider-apis';
 import type { PullRequest, PullRequestMergeMethod } from '@gitlens/git/models/pullRequest.js';
 import { base64 } from '@gitlens/utils/base64.js';
 import type { PagedResult } from '@gitlens/utils/paging.js';
@@ -714,6 +715,7 @@ export class ProvidersApi {
 		tokenOptInfo: TokenWithInfo<GitCloudHostIntegrationId.Bitbucket>,
 		userId: string,
 		workspaceSlug: string,
+		options?: { states?: GitPullRequestState[] },
 	): Promise<ProviderPullRequest[] | undefined> {
 		const { provider, tokenWithInfo } = await this.ensureProviderTokenAndFunction(
 			tokenOptInfo,
@@ -724,7 +726,7 @@ export class ProvidersApi {
 		try {
 			return (
 				await provider.getBitbucketPullRequestsAuthoredByUserForWorkspaceFn?.(
-					{ userId: userId, workspaceSlug: workspaceSlug },
+					{ userId: userId, workspaceSlug: workspaceSlug, states: options?.states },
 					{ token: token },
 				)
 			)?.data;
@@ -736,6 +738,7 @@ export class ProvidersApi {
 	async getBitbucketServerPullRequestsForCurrentUser(
 		tokenOptInfo: TokenWithInfo<GitSelfManagedHostIntegrationId.BitbucketServer>,
 		baseUrl: string,
+		options?: { states?: GitPullRequestState[] },
 	): Promise<ProviderPullRequest[] | undefined> {
 		const { provider, tokenWithInfo } = await this.ensureProviderTokenAndFunction(
 			tokenOptInfo,
@@ -744,7 +747,10 @@ export class ProvidersApi {
 		const token = tokenWithInfo.accessToken;
 		try {
 			return (
-				await provider.getBitbucketServerPullRequestsForCurrentUserFn?.({}, { token: token, baseUrl: baseUrl })
+				await provider.getBitbucketServerPullRequestsForCurrentUserFn?.(
+					{ states: options?.states },
+					{ token: token, baseUrl: baseUrl },
+				)
 			)?.data;
 		} catch (e) {
 			return this.handleProviderError(tokenWithInfo, e);
@@ -1024,6 +1030,7 @@ export class ProvidersApi {
 		options?: {
 			authorLogin?: string;
 			assigneeLogins?: string[];
+			states?: GitPullRequestState[];
 			isPAT?: boolean;
 			baseUrl?: string;
 		},

--- a/packages/utils/src/paging.ts
+++ b/packages/utils/src/paging.ts
@@ -4,6 +4,16 @@ export interface PagedResult<T> {
 	readonly paging?: {
 		readonly cursor: string;
 		readonly more: boolean;
+		/** 1-based page that produced this result. Populated by numbered-page providers only. */
+		readonly page?: number;
+		/** Items requested per page, when known. */
+		readonly pageSize?: number;
+		/** Next page number, when the provider pages by number. */
+		readonly nextPage?: number;
+		/** Total number of pages, when the provider reports totals. */
+		readonly totalPages?: number;
+		/** Total number of items across all pages, when the provider reports totals. */
+		readonly totalCount?: number;
 	};
 	readonly values: NonNullable<T>[];
 }
@@ -13,6 +23,10 @@ export const emptyPagedResult: PagedResult<any> = Object.freeze({ values: [] });
 
 export interface PagingOptions {
 	cursor?: string;
+	/** 1-based page to request from numbered-page providers. */
+	page?: number;
+	/** Items to request per page (numbered-page providers, and GitHub's cursor pages). */
+	pageSize?: number;
 }
 
 export class PageableResult<T> {

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -72,8 +72,8 @@ importers:
         specifier: 13.0.0-vnext.38
         version: 13.0.0-vnext.38(dragula@3.7.3)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
       '@gitkraken/provider-apis':
-        specifier: 0.49.0
-        version: 0.49.0(encoding@0.1.13)
+        specifier: 0.50.0
+        version: 0.50.0(encoding@0.1.13)
       '@gitkraken/shared-tools':
         specifier: 0.2.0
         version: 0.2.0
@@ -418,8 +418,8 @@ importers:
   packages/core:
     dependencies:
       '@gitkraken/provider-apis':
-        specifier: 0.49.0
-        version: 0.49.0(encoding@0.1.13)
+        specifier: 0.50.0
+        version: 0.50.0(encoding@0.1.13)
       '@octokit/graphql':
         specifier: 9.0.3
         version: 9.0.3
@@ -592,8 +592,8 @@ importers:
   packages/plus/integrations:
     dependencies:
       '@gitkraken/provider-apis':
-        specifier: 0.49.0
-        version: 0.49.0(encoding@0.1.13)
+        specifier: 0.50.0
+        version: 0.50.0(encoding@0.1.13)
       '@gitlens/git':
         specifier: workspace:*
         version: link:../../git
@@ -1095,8 +1095,8 @@ packages:
       react: 19.2.4
       react-dom: 19.2.4
 
-  '@gitkraken/provider-apis@0.49.0':
-    resolution: {integrity: sha512-bXxQmodleHugAXnryXaoYthI+uIBSYC4ktDxpZsIkXhreuhF2jtrbWpW4bIBN4Y7IRC+MfPPK1O+V453jL9f+Q==}
+  '@gitkraken/provider-apis@0.50.0':
+    resolution: {integrity: sha512-rhOY+Rmzt50LbV2jlIZlNo7VytquFK7sNo1iYXEOU6JqZrN67ZOaA5Ml7xJmBCehCee1rJRNKgVIiCTr4biX7w==}
     engines: {node: '>= 20'}
 
   '@gitkraken/shared-tools@0.2.0':
@@ -7788,7 +7788,7 @@ snapshots:
       react-dragula: 1.1.17
       react-onclickoutside: 6.13.2(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
 
-  '@gitkraken/provider-apis@0.49.0(encoding@0.1.13)':
+  '@gitkraken/provider-apis@0.50.0(encoding@0.1.13)':
     dependencies:
       '@linear/sdk': 58.1.0(encoding@0.1.13)
       diff: 8.0.4


### PR DESCRIPTION
Follow-up to #5430. Closes #5435.

Makes the `providersApi` read layer connection-aware and closes the read-API parity gaps that block Kepler (gitkraken/kepler#1325) from migrating its provider reads off the `gk` CLI onto `@gitkraken/core-gitlens`.

## What's in here

- **Per-connection reads** — `getMyIssuesForRepos` / `getMyPullRequestsForRepos` (and the `providersApi` `TokenOptInfo` → `getProviderToken` → `getSession` path) accept an optional trailing `connectionId` and read with that connection's token. Omitting it preserves the primary-connection behavior.
- **Page-number pagination** — `PagedResult.paging` now carries `page` / `pageSize` / `nextPage` / `totalPages` / `totalCount` alongside `cursor` / `more`; reads accept `page` / `pageSize`.
- **PR/issue state selector** — `open` / `closed` / `merged` / `all` for PRs, `open` / `closed` / `all` for issues, across all providers.
- **Assignee / reviewer filters** — `includeAllAssignees` for issues; reviewer-inclusion routed to the field each provider actually reads (login vs account id).
- **PR clone URLs + fork / cross-repository** — `PullRequestRef.cloneHttps` / `cloneSsh` / `isFork`; `refs.isCrossRepository` always present.
- **Org / project scoping** — a normalized `ProviderScope` façade resolved to the provider-appropriate inputs by `PagingMode`.
- Bumps `@gitkraken/provider-apis` to 0.50.0 and documents every parity decision in `docs/kepler-read-api-parity.md`.

## Review fixes folded in

An `xhigh` review pass surfaced these, each squashed into the commit it belongs to:

- **serializePullRequest dropped the new refs fields.** `cloneHttps` / `cloneSsh` / `isFork` were added to the model but not copied by the serializer, so they were silently lost on every serialized boundary (gk CLI, webviews, Launchpad) — the exact path Kepler consumes. Now carried on both head and base refs.
- **GitHub search `closed` also matched merged PRs.** The search path mapped `closed` to `is:closed`, which on GitHub includes merged PRs, so `closed` and `merged` overlapped and disagreed with the paginated path's `states=[Closed]`. Now `is:closed is:unmerged` keeps them disjoint.
- **Explicit `page` could clobber an in-flight cursor.** In `getPagedResult` a numbered `page` overrode a live cursor-typed cursor, contradicting the documented "otherwise follow the cursor" contract. A real continuation cursor now takes precedence.
- **`paging.page` echoed the requested page for cursor providers.** A cursor provider that ignored `page` still reported it, so a consumer treating it as numbered pagination could loop. `page` is now only surfaced from a provider-reported `currentPage`.
- **`includeRemoteInfo` clarity.** Replaced the `=== X || undefined` idiom with an explicit ternary.

## Known gap (not fixed here)

`resolveProviderScope` doesn't read `scope.resourceId` and requires `org` + `project` for the project branch, so it can't yet produce valid Jira inputs despite the JSDoc advertising it. The façade has no in-repo consumer today (only tests); wiring `resourceId` needs the downstream Jira/Azure input contract decided with Kepler, so it's left for the consumer-integration step.

## Testing

- `tsc -b` clean across `git` / `git-github` / `utils` / `integrations`.
- 122 integration unit tests passing (including the new `#5435` suites: pagination, state selector, filter routing, provider scope, PR-ref mapping, per-connection reads).