### PR TITLE
Adds Resolve Conflicts action to the rebase editor

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,6 +24,7 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/) and this p
 - Adds a _Copy Changes (Patch)_ action to commits and stashes in the _Inspect_ and _Commit Graph_ details &mdash; copies a patch of the entire commit or stash to the clipboard ([#5455](https://github.com/gitkraken/vscode-gitlens/issues/5455))
 - Adds per-file added/removed line counts to the working changes (WIP) file list in the _Commit Graph_ details, loaded lazily when the list is visible ([#5456](https://github.com/gitkraken/vscode-gitlens/issues/5456))
 - Adds a `gitlens.sortWorkingChangesBy` setting to sort working changes (WIP) by their Git staged/unstaged state in the _Commit Graph_ details ([#5454](https://github.com/gitkraken/vscode-gitlens/issues/5454))
+- Adds a _Resolve Conflicts in Commit Graph_ action to the interactive rebase editor's conflicted files panel &mdash; opens the _Commit Graph_ in AI **Resolve** mode for the rebase's conflicts; available when AI features are enabled ([#5413](https://github.com/gitkraken/vscode-gitlens/issues/5413))
 
 ### Changed
 

--- a/docs/telemetry-events.md
+++ b/docs/telemetry-events.md
@@ -6015,6 +6015,27 @@ void
 }
 ```
 
+### rebaseEditor/action/resolveConflictsInGraph
+
+> Sent when the user opens the Commit Graph resolve mode from the conflict panel
+
+```typescript
+{
+  'context.ascending': boolean,
+  'context.done.count': number,
+  'context.hasConflicts': boolean,
+  'context.isPaused': boolean,
+  'context.isRebasing': boolean,
+  'context.preservesMerges': boolean,
+  'context.session.start': string,
+  'context.todo.count': number,
+  'context.webview.host': 'view' | 'editor' | 'panel',
+  'context.webview.id': string,
+  'context.webview.instanceId': string,
+  'context.webview.type': string
+}
+```
+
 ### rebaseEditor/action/revealRef
 
 > Sent when the user reveals a ref (commit/branch) in graph or commit details

--- a/src/constants.telemetry.ts
+++ b/src/constants.telemetry.ts
@@ -575,6 +575,8 @@ export interface TelemetryEvents extends WebviewShowAbortedEvents, WebviewShownE
 	'rebaseEditor/action/stageConflict': RebaseEditorStageConflictEvent;
 	/** Sent when the user resolves all conflict files by taking one side */
 	'rebaseEditor/action/resolveAllConflicts': RebaseEditorResolveAllConflictsEvent;
+	/** Sent when the user opens the Commit Graph resolve mode from the conflict panel */
+	'rebaseEditor/action/resolveConflictsInGraph': RebaseEditorContextEventData;
 	/** Sent when the user reveals a ref (commit/branch) in graph or commit details */
 	'rebaseEditor/action/revealRef': RebaseEditorRevealRefEvent;
 
@@ -2307,6 +2309,7 @@ export type RebaseEditorTelemetryEvent =
 	| 'rebaseEditor/action/resolveConflict'
 	| 'rebaseEditor/action/stageConflict'
 	| 'rebaseEditor/action/resolveAllConflicts'
+	| 'rebaseEditor/action/resolveConflictsInGraph'
 	| 'rebaseEditor/action/revealRef'
 	| 'rebaseEditor/entries/changed'
 	| 'rebaseEditor/entries/moved'

--- a/src/webviews/apps/rebase/rebase.ts
+++ b/src/webviews/apps/rebase/rebase.ts
@@ -37,6 +37,7 @@ import {
 	RecomposeCommand,
 	ReorderCommand,
 	ResolveAllConflictsCommand,
+	ResolveConflictsInGraphCommand,
 	RevealRefCommand,
 	SearchCommand,
 	ShiftEntriesCommand,
@@ -1558,6 +1559,17 @@ export class GlRebaseEditor extends GlAppHost<State, RebaseStateProvider> {
 			<div class="conflict-panel__header">
 				<code-icon icon="warning" aria-hidden="true"></code-icon>
 				<span>${pluralize('conflicted file', conflictFiles.length)}</span>
+				${this.state?.aiAllowed
+					? html`<gl-button
+							appearance="toolbar"
+							density="compact"
+							tooltip="Resolve Conflicts in Commit Graph"
+							aria-label="Resolve Conflicts in Commit Graph"
+							@click=${this.onResolveConflictsInGraph}
+							><code-icon icon="gl-merge" slot="prefix" aria-hidden="true"></code-icon>Resolve
+							Conflicts</gl-button
+						>`
+					: nothing}
 				<gl-button
 					appearance="toolbar"
 					density="compact"
@@ -1707,6 +1719,10 @@ export class GlRebaseEditor extends GlAppHost<State, RebaseStateProvider> {
 				break;
 		}
 	}
+
+	private onResolveConflictsInGraph = () => {
+		this._ipc.sendCommand(ResolveConflictsInGraphCommand, undefined);
+	};
 
 	private onStageAllCurrent = () => {
 		this._ipc.sendCommand(ResolveAllConflictsCommand, { resolution: 'current' });

--- a/src/webviews/rebase/protocol.ts
+++ b/src/webviews/rebase/protocol.ts
@@ -57,6 +57,9 @@ export interface State extends WebviewState<'gitlens.rebase'> {
 
 	/** Whether the close-warning banner has been dismissed */
 	closeWarningDismissed?: boolean;
+
+	/** Whether AI features are allowed (user-enabled and org-permitted) — gates the Resolve Conflicts action */
+	aiAllowed?: boolean;
 }
 
 export interface ConflictFileInfo {
@@ -229,6 +232,8 @@ export interface ResolveAllConflictsParams {
 	resolution: 'current' | 'incoming';
 }
 export const ResolveAllConflictsCommand = new IpcCommand<ResolveAllConflictsParams>(scope, 'conflicts/resolveAll');
+
+export const ResolveConflictsInGraphCommand = new IpcCommand(scope, 'conflicts/resolveInGraph');
 
 // REQUESTS
 

--- a/src/webviews/rebase/rebaseWebviewProvider.ts
+++ b/src/webviews/rebase/rebaseWebviewProvider.ts
@@ -17,6 +17,7 @@ import { getSettledValue } from '@gitlens/utils/promise.js';
 import { pluralize } from '@gitlens/utils/string.js';
 import { getAvatarUri, getAvatarUriFromGravatarEmail } from '../../avatars.js';
 import type { DiffWithCommandArgs } from '../../commands/diffWith.js';
+import type { ResolveConflictsCommandArgs } from '../../commands/resolveConflicts.js';
 import type { GlWebviewCommandsOrCommandsWithSuffix } from '../../constants.commands.js';
 import type { RebaseEditorTelemetryContext } from '../../constants.telemetry.js';
 import type { Container } from '../../container.js';
@@ -45,6 +46,7 @@ import type { Subscription } from '../../plus/gk/models/subscription.js';
 import { isSubscriptionTrialOrPaidFromState } from '../../plus/gk/utils/subscription.utils.js';
 import { executeCommand, executeCoreCommand } from '../../system/-webview/command.js';
 import { configuration } from '../../system/-webview/configuration.js';
+import { getContext, onDidChangeContext } from '../../system/-webview/context.js';
 import { closeTab } from '../../system/-webview/vscode/tabs.js';
 import { exists } from '../../system/-webview/vscode/uris.js';
 import { createCommandDecorator, getWebviewCommand } from '../../system/decorators/command.js';
@@ -86,6 +88,7 @@ import {
 	ReorderCommand,
 	ResolveAllConflictsCommand,
 	ResolveConflictCommand,
+	ResolveConflictsInGraphCommand,
 	RevealRefCommand,
 	SearchCommand,
 	ShiftEntriesCommand,
@@ -185,6 +188,11 @@ export class RebaseWebviewProvider implements Disposable {
 			}),
 			this.container.onboarding.onDidChange(e => {
 				if (e.key === 'rebaseEditor:closeWarning') {
+					this.updateState();
+				}
+			}),
+			onDidChangeContext(key => {
+				if (key === 'gitlens:ai:allowed') {
 					this.updateState();
 				}
 			}),
@@ -574,6 +582,19 @@ export class RebaseWebviewProvider implements Disposable {
 				}
 			}
 		}
+	}
+
+	@ipcCommand(ResolveConflictsInGraphCommand)
+	@debug()
+	private async onResolveConflictsInGraph(): Promise<void> {
+		if (!this.container.ai.allowed) return;
+
+		this.host.sendTelemetryEvent('rebaseEditor/action/resolveConflictsInGraph');
+
+		await executeCommand<ResolveConflictsCommandArgs>('gitlens.ai.resolveConflicts', {
+			repoPath: this.repoPath,
+			source: 'rebaseEditor',
+		});
 	}
 
 	private async applyConflictResolution(
@@ -1113,6 +1134,7 @@ export class RebaseWebviewProvider implements Disposable {
 			subscription: subscription,
 			conflictFiles: conflictFiles,
 			closeWarningDismissed: this.container.onboarding.isDismissed('rebaseEditor:closeWarning'),
+			aiAllowed: getContext('gitlens:ai:allowed', false),
 		};
 	}
 


### PR DESCRIPTION
## Description

Closes #5413

Adds a **Resolve Conflicts in Commit Graph** action to the interactive rebase editor's conflicted files panel — the first button in the panel header, using the established `gl-merge` resolve-conflicts icon. Clicking it opens the Commit Graph in AI **Resolve** mode for the rebase's conflicts, delegating to the existing `gitlens.ai.resolveConflicts` command with `source: 'rebaseEditor'`.

The button is gated on AI enablement (matching the `gitlens:ai:allowed` gating of every other resolve entry point) via a new `aiAllowed` flag on the rebase webview state, which live-updates when `gitlens.ai.enabled` or the org AI context changes.

### Changes

<img width="451" height="110" alt="image" src="https://github.com/user-attachments/assets/d9bf1197-b1ab-48ac-943a-6363f332a450" />


- `src/webviews/rebase/protocol.ts` — new `ResolveConflictsInGraphCommand` IPC command and `State.aiAllowed`
- `src/webviews/rebase/rebaseWebviewProvider.ts` — state flag + config/context listeners, and the IPC handler delegating to `gitlens.ai.resolveConflicts`
- `src/webviews/apps/rebase/rebase.ts` — the conflict panel header button
- `src/constants.telemetry.ts` — `rebaseEditor/action/resolveConflictsInGraph` event

## Checklist

- [x] Verified live: paused conflicting interactive rebase → button renders first in the conflict panel header; clicking opens the Graph in Resolve mode listing the conflicted files; toggling `gitlens.ai.enabled` hides/shows the button live; second click is idempotent
- [x] `pnpm run check` passes
- [x] CHANGELOG entry added