### PR TITLE
Fixes AI Resolve mode for conflicts without an active operation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -71,6 +71,7 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/) and this p
 - Fixes the _Commit Graph_ showing an incorrect worktree count when a worktree fetch fails or is unsupported
 - Fixes the commit-message headline occasionally rendering at the wrong size before autolinks finish loading in the commit details
 - Fixes stray menu-popover styling leaking onto nested tooltips
+- Fixes AI conflict resolution (**Resolve** mode in the _Commit Graph_ WIP details panel) failing with _No active merge, rebase, or cherry-pick conflicts to resolve_ when conflicts exist without an in-progress Git operation &mdash; conflicts from a `git stash pop`/`apply`, a `git pull` with autostash, or after `git merge --quit` can now be resolved, re-resolved with feedback, and applied ([#5487](https://github.com/gitkraken/vscode-gitlens/issues/5487))
 
 ## [18.2.0] - 2026-06-15
 

--- a/src/webviews/plus/graph/graphWebview.ts
+++ b/src/webviews/plus/graph/graphWebview.ts
@@ -218,6 +218,8 @@ import type { ConflictToolsIntegration } from '../../../plus/coretools/conflict/
 import type {
 	ConflictProgressEvent,
 	Resolution as ConflictToolsResolution,
+	ResolutionContext,
+	ResolutionRefs,
 } from '../../../plus/coretools/conflict/types.js';
 import { showPatchesView } from '../../../plus/drafts/actions.js';
 import type { FeaturePreviewChangeEvent, SubscriptionChangeEvent } from '../../../plus/gk/subscriptionService.js';
@@ -2231,19 +2233,17 @@ export class GraphWebviewProvider implements WebviewProvider<State, State, Graph
 					}
 
 					const svc = this.container.git.getRepositoryService(repoPath);
-					const status = await svc.pausedOps?.getPausedOperationStatus?.();
-					if (status == null) {
-						return { error: { message: 'No active merge, rebase, or cherry-pick conflicts to resolve.' } };
-					}
+					// Conflicts can exist WITHOUT a paused operation (stash pop/apply, a `pull --rebase --autostash`
+					// re-apply, or `merge --quit`) — refs are optional enrichment, so a missing status must not block
+					// the run. The `targets.length === 0` check below handles the truly-nothing-to-resolve case.
+					const refs = getResolutionRefs(await svc.pausedOps?.getPausedOperationStatus?.());
 
-					const refs = {
-						ours: status.HEAD?.ref ?? 'HEAD',
-						theirs: status.incoming?.ref ?? 'MERGE_HEAD',
-						...(status.mergeBase != null ? { base: status.mergeBase } : {}),
-					};
 					// `instructions` (whole-run "Refine" feedback) rides conflict-tools' first-class
 					// `ResolutionContext.userGuidance`, which 0.2.0 renders into the prompt.
-					const context = { refs: refs, ...(instructions ? { userGuidance: instructions } : {}) };
+					const context: ResolutionContext = {
+						...(refs != null ? { refs: refs } : {}),
+						...(instructions ? { userGuidance: instructions } : {}),
+					};
 
 					const { token, dispose: disposeCancellation } = fromAbortSignal(signal, this._aiCancellations);
 					const resolveSignal = toAbortSignal(token);
@@ -2447,16 +2447,9 @@ export class GraphWebviewProvider implements WebviewProvider<State, State, Graph
 					}
 
 					const svc = this.container.git.getRepositoryService(repoPath);
-					const status = await svc.pausedOps?.getPausedOperationStatus?.();
-					if (status == null) {
-						return { error: { message: 'The merge, rebase, or cherry-pick is no longer in progress.' } };
-					}
-
-					const refs = {
-						ours: status.HEAD?.ref ?? 'HEAD',
-						theirs: status.incoming?.ref ?? 'MERGE_HEAD',
-						...(status.mergeBase != null ? { base: status.mergeBase } : {}),
-					};
+					// No paused-op requirement — see `resolveConflicts` above. Staleness is covered by the
+					// session check above and the `entry == null` check below.
+					const refs = getResolutionRefs(await svc.pausedOps?.getPausedOperationStatus?.());
 
 					const { token, dispose: disposeCancellation } = fromAbortSignal(signal, this._aiCancellations);
 					const resolveSignal = toAbortSignal(token);
@@ -2486,7 +2479,7 @@ export class GraphWebviewProvider implements WebviewProvider<State, State, Graph
 							{
 								svc: svc,
 								conflict: conflict,
-								context: { refs: refs, userGuidance: feedback },
+								context: { ...(refs != null ? { refs: refs } : {}), userGuidance: feedback },
 								signal: resolveSignal,
 								// Same conversation as the run being retried (an active session implies
 								// the ID exists; minting here is just a defensive fallback).
@@ -2561,20 +2554,6 @@ export class GraphWebviewProvider implements WebviewProvider<State, State, Graph
 
 					const svc = this.container.git.getRepositoryService(repoPath);
 					try {
-						// Stale guard: if the paused op ended externally (merge aborted/committed) between
-						// generation and apply, the cached resolutions are stale — refuse rather than write
-						// AI content over a working tree the user has since changed.
-						const pausedOp = await svc.pausedOps?.getPausedOperationStatus?.();
-						if (pausedOp == null) {
-							this.discardResolveSession(repoPath);
-							return {
-								error: {
-									message:
-										'The merge, rebase, or cherry-pick is no longer in progress — resolutions were not applied.',
-								},
-							};
-						}
-
 						const included = includedFilePaths != null ? new Set(includedFilePaths) : undefined;
 						// Never apply 'skipped' files — they were intentionally left conflicted.
 						const selected = session.resolutions.filter(
@@ -2584,9 +2563,13 @@ export class GraphWebviewProvider implements WebviewProvider<State, State, Graph
 							return { error: { message: 'No applicable resolutions were selected.' } };
 						}
 
-						// Per-file stale guard: only apply files still unmerged. A file resolved externally
-						// (manually or via another tool) since generation must not be clobbered with stale
-						// AI content. Skipped files are surfaced in the result.
+						// Per-file stale guard — the sole staleness defense: only apply files still unmerged.
+						// A file resolved externally (manually, via another tool, or by an op ending — abort/
+						// continue/reset all clear unmerged entries) since generation must not be clobbered
+						// with stale AI content. Deliberately NOT gated on a paused operation existing:
+						// op-less conflicts (stash pop, autostash) never have one, and `merge --quit` removes
+						// the op while the files remain genuinely conflicted. Skipped files are surfaced in
+						// the result.
 						const stillConflicted = await integration.listUnmergedPaths(svc);
 						const toApply = selected.filter(r => stillConflicted.has(r.filePath));
 						const skipped = selected.length - toApply.length;
@@ -12539,6 +12522,21 @@ type GraphItemRefs<T> = {
 	active: T | undefined;
 	selection: T[];
 };
+
+/** Derives the AI conflict resolver's ours/theirs/base refs from a paused operation's status.
+ *  Returns `undefined` when no operation is active — conflicts can exist without one (stash
+ *  pop/apply, `pull --rebase --autostash` re-apply, `merge --quit`), and there is no reliable
+ *  ref to name for `theirs` (e.g. `stash@{0}` may be the wrong stash). Guessing would feed the
+ *  resolver a misleading three-way diff; without refs, conflict-tools skips that diff and
+ *  resolves from the conflict markers, which is the safe degradation. */
+function getResolutionRefs(status: GitPausedOperationStatus | undefined): ResolutionRefs | undefined {
+	if (status == null) return undefined;
+	return {
+		ours: status.HEAD?.ref ?? 'HEAD',
+		theirs: status.incoming?.ref ?? 'MERGE_HEAD',
+		...(status.mergeBase != null ? { base: status.mergeBase } : {}),
+	};
+}
 
 /** Logs each resolution's AI token usage (when the provider reported it) plus a run total to the
  *  debug logs — usage is diagnostic detail, so it stays out of the resolve results UI. */


### PR DESCRIPTION
Fixes #5487

## Problem

The **Resolve** mode in the _Commit Graph_ WIP details panel (AI conflict resolution) failed immediately with _"No active merge, rebase, or cherry-pick conflicts to resolve."_ whenever the conflicted files had **no in-progress Git operation** — e.g. a `git stash pop`/`apply` conflict, a `git pull` with autostash where the re-apply conflicts, or the tree left conflicted after `git merge --quit`. In these cases Git records unmerged index entries but writes no `MERGE_HEAD`/`CHERRY_PICK_HEAD`/`REVERT_HEAD`/rebase state, so `getPausedOperationStatus()` correctly returns `undefined`.

The entry point is gated purely on conflict status (correct), but three RPC handlers additionally required a paused operation, so the user could enter the flow only to be kicked out.

## Fix

All changes are in `src/webviews/plus/graph/graphWebview.ts`:

- **`resolveConflicts`** / **`reresolveFile`** — no longer require a paused operation. The status was only used to derive the resolver's ours/theirs/base refs, which `@gitkraken/conflict-tools` treats as **optional** enrichment (without refs it skips the three-way diff and resolves from the conflict markers). Refs are now derived via a small `getResolutionRefs()` helper that returns `undefined` when no operation is active — deliberately not guessing at a stash ref (e.g. `stash@{0}`), which could be wrong and would feed the resolver a misleading three-way diff.
- **`applyResolutions`** — the apply-time paused-op stale guard is removed in favor of the existing per-file `listUnmergedPaths` guard. That guard already covers every external staleness scenario (`merge`/`rebase --abort`, `--continue`, `reset`, external resolution all clear unmerged entries), and the removed guard had false positives (`merge --quit` leaves files conflicted but removes `MERGE_HEAD`) it should never have refused.

No UI, protocol, or telemetry changes are needed — the resolve panel copy is already operation-agnostic, and telemetry records no operation type.

## Testing

`pnpm run check` and `pnpm run test` (1057 passing) both clean.

Verified live against a prepared stash-pop repro (`UU` file, no operation state) across three rounds:

- **Op-less resolve → apply**: run proceeds (no gate error), Take Current fallback → Apply → _"Resolved 1 file."_, disk merged/staged/clean.
- **`reresolveFile`** (per-file retry with feedback): RPC completes, no _"no longer in progress"_ error.
- **Apply staleness guard**: externally `git add`-ing the conflicted file → Apply correctly refuses with _"These files are no longer conflicted — nothing was applied."_, disk untouched.
- **Op-backed regression**: a real merge conflict (`MERGE_HEAD` present) still shows the paused-op banner and resolves normally; after `git merge --abort`, Apply refuses via the per-file guard with disk untouched.

The error string _"No active merge, rebase, or cherry-pick conflicts to resolve."_ never appeared in the panel, console, or logs across all scenarios.