### PR TITLE
Closes #5488 - Unifies how paused/conflicted operations are surfaced

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -48,6 +48,7 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/) and this p
 - Changes copying changes to a worktree to no longer prompt to open that worktree afterward
 - Changes stashing to use the _Commit Graph_ working changes (WIP) commit-box draft message when one is present
 - Renames the _Open Worktree File_ action to _Open File (Worktree)_ for consistency with the new _Open Changes with Working File (Worktree)_ action
+- Changes how paused merge, rebase, cherry-pick, and revert operations with conflicts are surfaced &mdash; a single surface now opens: the _Commit Graph_'s working changes (WIP) details with the conflict banner, or the _Interactive Rebase Editor_ for rebases when the _Commit Graph_ is unavailable. Previously a rebase conflict could simultaneously open the rebase editor, force-focus the _Commits_ view, and show a toast offering to open the already-opening editor. The _Commits_ view is no longer force-focused by any paused operation, the rebase conflict toasts no longer offer _Open Rebase Editor_, and _Show Conflicts_ now consistently opens the _Commit Graph_ from all locations, including inside the rebase editor; interactive rebase pauses (todo editing, `edit`, `reword`, `break`) still open the rebase editor
 
 ### Removed
 

--- a/src/commands/git/cherry-pick.ts
+++ b/src/commands/git/cherry-pick.ts
@@ -11,7 +11,7 @@ import { ensureArray } from '@gitlens/utils/array.js';
 import { Logger } from '@gitlens/utils/logger.js';
 import { pluralize } from '@gitlens/utils/string.js';
 import type { Container } from '../../container.js';
-import { skipPausedOperation } from '../../git/actions/pausedOperation.js';
+import { showPausedOperationStatus, skipPausedOperation } from '../../git/actions/pausedOperation.js';
 import type { GlRepository } from '../../git/models/repository.js';
 import { showGitErrorMessage } from '../../messages.js';
 import { isSubscriptionTrialOrPaidFromState } from '../../plus/gk/utils/subscription.utils.js';
@@ -20,7 +20,6 @@ import type { DirectiveQuickPickItem } from '../../quickpicks/items/directive.js
 import { createDirectiveQuickPickItem, Directive } from '../../quickpicks/items/directive.js';
 import type { FlagsQuickPickItem } from '../../quickpicks/items/flags.js';
 import { createFlagsQuickPickItem } from '../../quickpicks/items/flags.js';
-import { executeCommand } from '../../system/-webview/command.js';
 import type { ViewsWithRepositoryFolders } from '../../views/viewBase.js';
 import type {
 	AsyncStepResultGenerator,
@@ -98,7 +97,7 @@ export class CherryPickGitCommand extends QuickCommand<State> {
 				void window.showWarningMessage(
 					'Unable to cherry-pick due to conflicts. Resolve the conflicts before continuing, or abort the cherry-pick.',
 				);
-				void executeCommand('gitlens.showCommitsView');
+				void showPausedOperationStatus(this.container, state.repo.path);
 			}
 		} catch (ex) {
 			// Don't show an error message if the user intentionally aborted the cherry-pick
@@ -120,7 +119,7 @@ export class CherryPickGitCommand extends QuickCommand<State> {
 				void window.showWarningMessage(
 					'Unable to cherry-pick. A cherry-pick is already in progress. Continue or abort the current cherry-pick first.',
 				);
-				void executeCommand('gitlens.showCommitsView');
+				void showPausedOperationStatus(this.container, state.repo.path);
 				return;
 			}
 
@@ -146,10 +145,10 @@ export class CherryPickGitCommand extends QuickCommand<State> {
 					cancel,
 				);
 				if (result === skip) {
-					return void skipPausedOperation(state.repo.git);
+					return void skipPausedOperation(this.container, state.repo.git);
 				}
 
-				void executeCommand('gitlens.showCommitsView');
+				void showPausedOperationStatus(this.container, state.repo.path);
 				return;
 			}
 

--- a/src/commands/git/merge.ts
+++ b/src/commands/git/merge.ts
@@ -9,6 +9,7 @@ import { createRevisionRange } from '@gitlens/git/utils/revision.utils.js';
 import { Logger } from '@gitlens/utils/logger.js';
 import { pluralize } from '@gitlens/utils/string.js';
 import type { Container } from '../../container.js';
+import { showPausedOperationStatus } from '../../git/actions/pausedOperation.js';
 import type { GlRepository } from '../../git/models/repository.js';
 import { showGitErrorMessage } from '../../messages.js';
 import { isSubscriptionTrialOrPaidFromState } from '../../plus/gk/utils/subscription.utils.js';
@@ -17,7 +18,6 @@ import type { DirectiveQuickPickItem } from '../../quickpicks/items/directive.js
 import { createDirectiveQuickPickItem, Directive } from '../../quickpicks/items/directive.js';
 import type { FlagsQuickPickItem } from '../../quickpicks/items/flags.js';
 import { createFlagsQuickPickItem } from '../../quickpicks/items/flags.js';
-import { executeCommand } from '../../system/-webview/command.js';
 import type { ViewsWithRepositoryFolders } from '../../views/viewBase.js';
 import type {
 	AsyncStepResultGenerator,
@@ -106,7 +106,7 @@ export class MergeGitCommand extends QuickCommand<State> {
 				void window.showWarningMessage(
 					'Unable to merge due to conflicts. Resolve the conflicts before continuing, or abort the merge.',
 				);
-				void executeCommand('gitlens.showCommitsView');
+				void showPausedOperationStatus(this.container, state.repo.path);
 			}
 		} catch (ex) {
 			// Don't show an error message if the user intentionally aborted the merge
@@ -128,7 +128,7 @@ export class MergeGitCommand extends QuickCommand<State> {
 				void window.showWarningMessage(
 					'Unable to merge. A merge is already in progress. Continue or abort the current merge first.',
 				);
-				void executeCommand('gitlens.showCommitsView');
+				void showPausedOperationStatus(this.container, state.repo.path);
 				return;
 			}
 

--- a/src/commands/git/rebase.ts
+++ b/src/commands/git/rebase.ts
@@ -10,12 +10,9 @@ import { createDisposable } from '@gitlens/utils/disposable.js';
 import { Logger } from '@gitlens/utils/logger.js';
 import { pluralize } from '@gitlens/utils/string.js';
 import type { Container } from '../../container.js';
+import { showPausedOperationStatus } from '../../git/actions/pausedOperation.js';
 import type { GlRepository } from '../../git/models/repository.js';
-import {
-	isRebaseTodoEditorEnabled,
-	openRebaseEditor,
-	reopenRebaseTodoEditor,
-} from '../../git/utils/-webview/rebase.utils.js';
+import { isRebaseTodoEditorEnabled, reopenRebaseTodoEditor } from '../../git/utils/-webview/rebase.utils.js';
 import { showGitErrorMessage } from '../../messages.js';
 import { isSubscriptionTrialOrPaidFromState } from '../../plus/gk/utils/subscription.utils.js';
 import { createQuickPickSeparator } from '../../quickpicks/items/common.js';
@@ -23,7 +20,6 @@ import type { DirectiveQuickPickItem } from '../../quickpicks/items/directive.js
 import { createDirectiveQuickPickItem, Directive } from '../../quickpicks/items/directive.js';
 import type { FlagsQuickPickItem } from '../../quickpicks/items/flags.js';
 import { createFlagsQuickPickItem } from '../../quickpicks/items/flags.js';
-import { executeCommand } from '../../system/-webview/command.js';
 import { getHostEditorCommand } from '../../system/-webview/vscode.js';
 import type { ViewsWithRepositoryFolders } from '../../views/viewBase.js';
 import type {
@@ -116,18 +112,10 @@ export class RebaseGitCommand extends QuickCommand<State> {
 				updateRefs: updateRefs,
 			});
 			if (result?.conflicted) {
-				const openEditor = { title: 'Open Rebase Editor' };
-				void window
-					.showWarningMessage(
-						'Unable to rebase due to conflicts. Resolve the conflicts before continuing, or abort the rebase.',
-						openEditor,
-					)
-					.then(r => {
-						if (r === openEditor) {
-							void openRebaseEditor(this.container, state.repo.path);
-						}
-					});
-				void executeCommand('gitlens.showCommitsView');
+				void window.showWarningMessage(
+					'Unable to rebase due to conflicts. Resolve the conflicts before continuing, or abort the rebase.',
+				);
+				void showPausedOperationStatus(this.container, state.repo.path);
 			}
 		} catch (ex) {
 			// Don't show an error message if the user intentionally aborted the rebase
@@ -146,18 +134,10 @@ export class RebaseGitCommand extends QuickCommand<State> {
 			}
 
 			if (RebaseError.is(ex, 'alreadyInProgress')) {
-				const openEditor = { title: 'Open Rebase Editor' };
-				void window
-					.showWarningMessage(
-						'Unable to rebase. A rebase is already in progress. Continue or abort the current rebase first.',
-						openEditor,
-					)
-					.then(result => {
-						if (result === openEditor) {
-							void openRebaseEditor(this.container, state.repo.path);
-						}
-					});
-				void executeCommand('gitlens.showCommitsView');
+				void window.showWarningMessage(
+					'Unable to rebase. A rebase is already in progress. Continue or abort the current rebase first.',
+				);
+				void showPausedOperationStatus(this.container, state.repo.path);
 				return;
 			}
 

--- a/src/commands/git/revert.ts
+++ b/src/commands/git/revert.ts
@@ -6,12 +6,12 @@ import type { GitRevisionReference } from '@gitlens/git/models/reference.js';
 import { getReferenceLabel } from '@gitlens/git/utils/reference.utils.js';
 import { Logger } from '@gitlens/utils/logger.js';
 import type { Container } from '../../container.js';
+import { showPausedOperationStatus } from '../../git/actions/pausedOperation.js';
 import type { GlRepository } from '../../git/models/repository.js';
 import { showGitErrorMessage } from '../../messages.js';
 import { createDirectiveQuickPickItem, Directive } from '../../quickpicks/items/directive.js';
 import type { FlagsQuickPickItem } from '../../quickpicks/items/flags.js';
 import { createFlagsQuickPickItem } from '../../quickpicks/items/flags.js';
-import { executeCommand } from '../../system/-webview/command.js';
 import type { ViewsWithRepositoryFolders } from '../../views/viewBase.js';
 import type {
 	PartialStepState,
@@ -88,7 +88,7 @@ export class RevertGitCommand extends QuickCommand<State> {
 				void window.showWarningMessage(
 					'Unable to revert due to conflicts. Resolve the conflicts before continuing, or abort the revert.',
 				);
-				void executeCommand('gitlens.showCommitsView');
+				void showPausedOperationStatus(this.container, state.repo.path);
 			}
 		} catch (ex) {
 			// Don't show an error message if the user intentionally aborted the revert
@@ -110,7 +110,7 @@ export class RevertGitCommand extends QuickCommand<State> {
 				void window.showWarningMessage(
 					'Unable to revert. A revert is already in progress. Continue or abort the current revert first.',
 				);
-				void executeCommand('gitlens.showCommitsView');
+				void showPausedOperationStatus(this.container, state.repo.path);
 				return;
 			}
 

--- a/src/git/actions/pausedOperation.ts
+++ b/src/git/actions/pausedOperation.ts
@@ -1,9 +1,12 @@
 import { window } from 'vscode';
 import { PausedOperationAbortError, PausedOperationContinueError } from '@gitlens/git/errors.js';
 import type { GitPausedOperationStatus } from '@gitlens/git/models/pausedOperationStatus.js';
+import { uncommitted } from '@gitlens/git/models/revision.js';
 import { getReferenceLabel } from '@gitlens/git/utils/reference.utils.js';
+import type { Source } from '../../constants.telemetry.js';
 import type { Container } from '../../container.js';
 import { showGitErrorMessage } from '../../messages.js';
+import { arePlusFeaturesEnabled } from '../../plus/gk/utils/-webview/plus.utils.js';
 import { executeCommand } from '../../system/-webview/command.js';
 import type { GitRepositoryService } from '../gitRepositoryService.js';
 import { openRebaseEditor } from '../utils/-webview/rebase.utils.js';
@@ -19,15 +22,19 @@ export async function abortPausedOperation(svc: GitRepositoryService, options?: 
 	}
 }
 
-export async function continuePausedOperation(svc: GitRepositoryService): Promise<void> {
-	return continuePausedOperationCore(svc);
+export async function continuePausedOperation(container: Container, svc: GitRepositoryService): Promise<void> {
+	return continuePausedOperationCore(container, svc);
 }
 
-export async function skipPausedOperation(svc: GitRepositoryService): Promise<void> {
-	return continuePausedOperationCore(svc, true);
+export async function skipPausedOperation(container: Container, svc: GitRepositoryService): Promise<void> {
+	return continuePausedOperationCore(container, svc, true);
 }
 
-async function continuePausedOperationCore(svc: GitRepositoryService, skip: boolean = false): Promise<void> {
+async function continuePausedOperationCore(
+	container: Container,
+	svc: GitRepositoryService,
+	skip: boolean = false,
+): Promise<void> {
 	try {
 		return await svc.pausedOps?.continuePausedOperation?.(skip ? { skip: true } : undefined);
 	} catch (ex) {
@@ -39,22 +46,22 @@ async function continuePausedOperationCore(svc: GitRepositoryService, skip: bool
 
 			const pausedAt = getReferenceLabel(operation.incoming, { icon: false, label: true, quoted: true });
 
-			const skip = { title: 'Skip' };
-			const cancel = { title: 'Cancel', isCloseAffordance: true };
+			const skipItem = { title: 'Skip' };
+			const cancelItem = { title: 'Cancel', isCloseAffordance: true };
 
 			// TODO@eamodio: We should offer a continue with allowing an empty commit option
 
 			const result = await window.showInformationMessage(
 				`The ${operation.type} operation cannot be continued because ${pausedAt} resulted in an empty commit.\n\nDo you want to skip ${pausedAt}?`,
 				{ modal: true },
-				skip,
-				cancel,
+				skipItem,
+				cancelItem,
 			);
-			if (result === skip) {
-				return void continuePausedOperationCore(svc, true);
+			if (result === skipItem) {
+				return void continuePausedOperationCore(container, svc, true);
 			}
 
-			void executeCommand('gitlens.showCommitsView');
+			void showPausedOperationStatus(container, svc.path);
 
 			return;
 		}
@@ -70,7 +77,7 @@ async function continuePausedOperationCore(svc: GitRepositoryService, skip: bool
 
 		if (PausedOperationContinueError.is(ex, 'conflicts') || PausedOperationContinueError.is(ex, 'unmergedFiles')) {
 			void window.showWarningMessage(ex.message);
-			void executeCommand('gitlens.showCommitsView');
+			void showPausedOperationStatus(container, svc.path);
 			return;
 		}
 
@@ -79,19 +86,48 @@ async function continuePausedOperationCore(svc: GitRepositoryService, skip: bool
 }
 
 export interface ShowPausedOperationStatusOptions {
-	openRebaseEditor?: boolean;
+	/** When set, the request comes from inside the rebase editor, so always surface the graph */
+	fromRebaseEditor?: boolean;
+	source?: Source;
 }
 
+/**
+ * Surfaces a paused operation (merge/rebase/cherry-pick/revert) in a single, consistent place:
+ * the Graph's WIP details (which renders the paused-op/conflict banner), except for a paused
+ * rebase when the graph is gated — then the rebase editor, since it's the only usable surface.
+ */
 export async function showPausedOperationStatus(
 	container: Container,
 	repoPath: string,
 	options?: ShowPausedOperationStatusOptions,
 ): Promise<void> {
-	if (options?.openRebaseEditor) {
-		await openRebaseEditor(container, repoPath);
+	const svc = container.git.getRepositoryService(repoPath);
+	// Force a fresh read: a caller may invoke this right after mutating paused-op state (e.g. a
+	// wizard conflict) before the `'pausedOp'` FS-watcher event lands, so a cached `undefined`
+	// must not make us silently surface nothing. The readdir-based detection is cheap to repeat.
+	const status = await svc.pausedOps?.getPausedOperationStatus?.({ force: true });
+	if (status == null) return;
+
+	const toGraph =
+		options?.fromRebaseEditor || status.type !== 'rebase' || (await isGraphAccessible(container, repoPath));
+	if (toGraph) {
+		revealPausedOperationInGraph(repoPath, options?.source);
 		return;
 	}
 
-	await container.views.commits.show({ preserveFocus: false });
-	await container.views.commits.revealPausedOperationStatus(repoPath, { focus: true, expand: true, select: true });
+	await openRebaseEditor(container, repoPath);
+}
+
+async function isGraphAccessible(container: Container, repoPath: string): Promise<boolean> {
+	if (!arePlusFeaturesEnabled()) return false;
+
+	return (await container.git.access('graph', repoPath)).allowed !== false;
+}
+
+function revealPausedOperationInGraph(repoPath: string, source?: Source): void {
+	void executeCommand('gitlens.showGraph', {
+		action: 'show-wip',
+		target: { sha: uncommitted, worktreePath: repoPath },
+		source: source,
+	});
 }

--- a/src/views/commitsView.ts
+++ b/src/views/commitsView.ts
@@ -439,24 +439,6 @@ export class CommitsView extends ViewBase<'commits', CommitsViewNode, CommitsVie
 		return node;
 	}
 
-	@gate(() => '')
-	async revealPausedOperationStatus(repoPath: string, options?: RevealOptions): Promise<ViewNode | undefined> {
-		const node = await this.findNode(
-			n => n.is('paused-operation-status') && n.pausedOpStatus.repoPath === repoPath,
-			{
-				maxDepth: 3,
-				canTraverse: n =>
-					n instanceof CommitsViewNode || n instanceof RepositoryFolderNode || n instanceof BranchNode,
-			},
-		);
-
-		if (node !== undefined) {
-			await this.reveal(node, options);
-		}
-
-		return node;
-	}
-
 	private setFilesLayout(layout: ViewFilesLayout) {
 		return configuration.updateEffective(`views.${this.configKey}.files.layout` as const, layout);
 	}

--- a/src/views/viewCommands.ts
+++ b/src/views/viewCommands.ts
@@ -638,7 +638,10 @@ export class ViewCommands implements Disposable {
 	private async continuePausedOperation(node: PausedOperationStatusNode) {
 		if (!node.is('paused-operation-status')) return;
 
-		await continuePausedOperation(this.container.git.getRepositoryService(node.pausedOpStatus.repoPath));
+		await continuePausedOperation(
+			this.container,
+			this.container.git.getRepositoryService(node.pausedOpStatus.repoPath),
+		);
 	}
 
 	@command('gitlens.views.pausedOperation.skip')
@@ -646,7 +649,10 @@ export class ViewCommands implements Disposable {
 	private async skipPausedOperation(node: PausedOperationStatusNode) {
 		if (!node.is('paused-operation-status')) return;
 
-		await skipPausedOperation(this.container.git.getRepositoryService(node.pausedOpStatus.repoPath));
+		await skipPausedOperation(
+			this.container,
+			this.container.git.getRepositoryService(node.pausedOpStatus.repoPath),
+		);
 	}
 
 	@command('gitlens.views.pausedOperation.open')

--- a/src/webviews/home/homeWebview.ts
+++ b/src/webviews/home/homeWebview.ts
@@ -623,13 +623,13 @@ export class HomeWebviewProvider implements WebviewProvider<State, State, HomeWe
 	private async continuePausedOperation(pausedOpArgs: GitPausedOperationStatus) {
 		if (pausedOpArgs.type === 'revert') return;
 
-		await continuePausedOperation(this.container.git.getRepositoryService(pausedOpArgs.repoPath));
+		await continuePausedOperation(this.container, this.container.git.getRepositoryService(pausedOpArgs.repoPath));
 	}
 
 	@command('gitlens.pausedOperation.skip:')
 	@debug({ args: pausedOpArgs => ({ pausedOpArgs: pausedOpArgs.type }) })
 	private async skipPausedOperation(pausedOpArgs: GitPausedOperationStatus) {
-		await skipPausedOperation(this.container.git.getRepositoryService(pausedOpArgs.repoPath));
+		await skipPausedOperation(this.container, this.container.git.getRepositoryService(pausedOpArgs.repoPath));
 	}
 
 	@command('gitlens.pausedOperation.open:')
@@ -649,9 +649,7 @@ export class HomeWebviewProvider implements WebviewProvider<State, State, HomeWe
 	@command('gitlens.pausedOperation.showConflicts:')
 	@debug({ args: pausedOpArgs => ({ pausedOpArgs: pausedOpArgs.type }) })
 	private async showConflicts(pausedOpArgs: GitPausedOperationStatus) {
-		await showPausedOperationStatus(this.container, pausedOpArgs.repoPath, {
-			openRebaseEditor: pausedOpArgs.type === 'rebase',
-		});
+		await showPausedOperationStatus(this.container, pausedOpArgs.repoPath);
 	}
 
 	@command('gitlens.createCloudPatch:')

--- a/src/webviews/plus/graph/graphWebview.ts
+++ b/src/webviews/plus/graph/graphWebview.ts
@@ -10299,7 +10299,7 @@ export class GraphWebviewProvider implements WebviewProvider<State, State, Graph
 		const type = pausedOpArgs?.type ?? (await svc.pausedOps?.getPausedOperationStatus?.())?.type;
 		if (type == null || type === 'revert') return;
 
-		await continuePausedOperation(svc);
+		await continuePausedOperation(this.container, svc);
 	}
 
 	@command('gitlens.pausedOperation.open:')
@@ -10328,15 +10328,13 @@ export class GraphWebviewProvider implements WebviewProvider<State, State, Graph
 		if (repoPath == null) return;
 
 		const svc = this.container.git.getRepositoryService(repoPath);
-		await skipPausedOperation(svc);
+		await skipPausedOperation(this.container, svc);
 	}
 
 	@command('gitlens.pausedOperation.showConflicts:')
 	@debug()
 	private async showConflicts(pausedOpArgs: GitPausedOperationStatus) {
-		await showPausedOperationStatus(this.container, pausedOpArgs.repoPath, {
-			openRebaseEditor: pausedOpArgs.type === 'rebase',
-		});
+		await showPausedOperationStatus(this.container, pausedOpArgs.repoPath);
 	}
 
 	@command('gitlens.graph.stageConflictCurrentChanges:')

--- a/src/webviews/rebase/rebaseEditor.ts
+++ b/src/webviews/rebase/rebaseEditor.ts
@@ -13,6 +13,7 @@ import { Logger } from '@gitlens/utils/logger.js';
 import { getScopedLogger } from '@gitlens/utils/logger.scoped.js';
 import { getSettledValue } from '@gitlens/utils/promise.js';
 import type { Container } from '../../container.js';
+import { showPausedOperationStatus } from '../../git/actions/pausedOperation.js';
 import { getActionablePauseAction, readAndParseRebaseDoneFile } from '../../git/utils/-webview/rebase.parsing.utils.js';
 import {
 	getRepoUriFromRebaseTodo,
@@ -139,7 +140,16 @@ export class RebaseEditorProvider implements CustomTextEditorProvider, Disposabl
 		// `.git/rebase-merge/` is being torn down at the end of a successful rebase, producing
 		// false positives that flicker the editor open with an empty/stale state. Confirm there
 		// is actually user-actionable work to display before opening.
-		if (!(await hasActionableRebaseState(svc))) return;
+		const { actionable, hasConflicts } = await getActionableRebaseState(svc);
+		if (!actionable) return;
+
+		// A conflict pause follows the unified paused-operation surfacing rule (Graph WIP details
+		// when accessible, rebase editor otherwise); only interactive pauses (todo editing /
+		// edit / reword / break) always open the rebase editor below.
+		if (hasConflicts) {
+			await showPausedOperationStatus(this.container, repoPath);
+			return;
+		}
 
 		// `openBehavior` controls the viewColumn:
 		//   - 'auto': reuse an existing non-active editor group if one exists; otherwise open in the
@@ -264,17 +274,19 @@ export class RebaseEditorProvider implements CustomTextEditorProvider, Disposabl
 }
 
 /**
- * Returns true when the rebase has user-actionable state to display:
- *  - active conflicts in the index, or
+ * Determines whether the rebase has user-actionable state to display:
+ *  - active conflicts in the index (also reported via `hasConflicts`), or
  *  - remaining entries in the rebase-todo file, or
  *  - the last completed action was `edit`/`reword`/`break`/`exec` (a deliberate stop point).
  *
  * Used by the auto-open path to filter out the transient teardown window where REBASE_HEAD
  * still exists but the rebase has effectively finished.
  */
-async function hasActionableRebaseState(svc: ReturnType<Container['git']['getRepositoryService']>): Promise<boolean> {
+async function getActionableRebaseState(
+	svc: ReturnType<Container['git']['getRepositoryService']>,
+): Promise<{ actionable: boolean; hasConflicts: boolean }> {
 	const gitDir = await svc.config.getGitDir?.();
-	if (gitDir == null) return false;
+	if (gitDir == null) return { actionable: false, hasConflicts: false };
 
 	const todoUri = Uri.joinPath(gitDir.uri, 'rebase-merge', 'git-rebase-todo');
 
@@ -284,11 +296,13 @@ async function hasActionableRebaseState(svc: ReturnType<Container['git']['getRep
 		readAndParseRebaseDoneFile(todoUri),
 	]);
 
-	if ((getSettledValue(conflictsResult)?.length ?? 0) > 0) return true;
+	if ((getSettledValue(conflictsResult)?.length ?? 0) > 0) return { actionable: true, hasConflicts: true };
 
 	const todoContent = getSettledValue(todoContentResult);
-	if (todoContent != null && parseRebaseTodo(todoContent).entries.length > 0) return true;
+	if (todoContent != null && parseRebaseTodo(todoContent).entries.length > 0) {
+		return { actionable: true, hasConflicts: false };
+	}
 
 	const lastAction = getSettledValue(doneResult)?.entries.at(-1)?.action;
-	return getActionablePauseAction(lastAction) != null;
+	return { actionable: getActionablePauseAction(lastAction) != null, hasConflicts: false };
 }

--- a/src/webviews/rebase/rebaseWebviewProvider.ts
+++ b/src/webviews/rebase/rebaseWebviewProvider.ts
@@ -651,7 +651,7 @@ export class RebaseWebviewProvider implements Disposable {
 		await this._todoDocument.save();
 
 		const svc = this.container.git.getRepositoryService(this.repoPath);
-		await continuePausedOperation(svc);
+		await continuePausedOperation(this.container, svc);
 	}
 
 	@ipcCommand(RecomposeCommand)
@@ -701,7 +701,7 @@ export class RebaseWebviewProvider implements Disposable {
 	@debug()
 	private async onShowConflicts(): Promise<void> {
 		this.host.sendTelemetryEvent('rebaseEditor/action/showConflicts');
-		await showPausedOperationStatus(this.container, this.repoPath);
+		await showPausedOperationStatus(this.container, this.repoPath, { fromRebaseEditor: true });
 	}
 
 	@ipcCommand(SearchCommand)
@@ -714,7 +714,7 @@ export class RebaseWebviewProvider implements Disposable {
 	private async onSkip(): Promise<void> {
 		this.host.sendTelemetryEvent('rebaseEditor/action/skip');
 		const svc = this.container.git.getRepositoryService(this.repoPath);
-		await skipPausedOperation(svc);
+		await skipPausedOperation(this.container, svc);
 	}
 
 	@ipcCommand(StartCommand)


### PR DESCRIPTION
# Description

Closes #5488

Unifies how GitLens surfaces a paused/conflicted Git operation (rebase, merge, cherry-pick, revert) into a single rule and a single code path, eliminating the "triple reaction" and the host-dependent "Show Conflicts" behavior.

## The rule

| Situation | Surface |
|---|---|
| From inside the rebase editor (any op) | _Commit Graph_ WIP details |
| Op is merge / cherry-pick / revert | _Commit Graph_ WIP details (even when the Graph is gated — shows the upsell) |
| Op is rebase, Graph accessible | _Commit Graph_ WIP details |
| Op is rebase, Graph gated | Interactive Rebase Editor |

- **Graph WIP details** = `gitlens.showGraph` `show-wip` — selects the WIP row and forces the details panel visible; the paused-op/conflict banner renders itself for all four op types. Plain reveal, not `enter-resolve` (no forced AI mode).
- **The _Commits_ view is removed entirely** as a paused-op surface — no more unconditional focus-steal.
- **Conflict pauses defer to the Graph; interactive rebase pauses do not** — a rebase that pauses for todo editing / `edit` / `reword` / `break` still opens the rebase editor as today.

## Changes

- **`showPausedOperationStatus`** now owns the rule (Graph WIP details, or the rebase editor for a gated rebase). Adds a colocated `isGraphAccessible` check and `revealPausedOperationInGraph` dispatch; drops the `container.views.commits` reveal. The `openRebaseEditor` option becomes `fromRebaseEditor` (used by the in-editor "Show Conflicts").
- **`onRebaseChanged`** splits by pause type: conflict pauses route through the helper; interactive pauses keep the existing `viewColumn`/`background`/`preserveFocus` reword logic. `hasActionableRebaseState` now also returns `hasConflicts`, avoiding a second status call.
- **Post-conflict handlers** (rebase / merge / cherry-pick / revert) route through the helper instead of `gitlens.showCommitsView`, keep the plain informational toast, and drop the redundant _Open Rebase Editor_ toast buttons.
- **"Show Conflicts" callers** (Home, Graph, rebase editor) drop the per-caller `type`/`openRebaseEditor` decision — the helper decides.
- **Dead-code removal**: `CommitsView.revealPausedOperationStatus`.

The explicit _Open Rebase Editor_ buttons (Home/Graph/tree paused-op nodes), the passive tree/banner renders, and the AI `enter-resolve` flow are intentionally unchanged.

## Testing

Build + `check` + unit tests pass. Live-exercised via `vscode-inspector` on a conflict fixture (subscription/gating simulated) — all six cases pass, no _Commits_ view focus-steal in any of them, console clean (only pre-existing Graph host warnings):

| # | Case | Result |
|---|------|--------|
| 1 | Rebase conflict, Graph accessible (Pro) | ✅ Graph WIP details + conflict banner; no rebase-editor tab; toast has **no** _Open Rebase Editor_ button |
| 2 | Rebase conflict, Graph gated (Community + private) | ✅ Rebase editor opens; no Graph |
| 3 | Merge conflict, Graph gated | ✅ Graph opens with the Pro upsell (type ≠ rebase always routes to the Graph) |
| 4 | _Show Conflicts_ from inside the rebase editor | ✅ Routes to the Graph (`fromRebaseEditor`), never the _Commits_ view |
| 5 | Interactive `edit` pause (no conflict) | ✅ Rebase editor still auto-opens |
| 6 | `openOnPausedRebase: false` + wizard conflict | ✅ Surfaces via the post-conflict handler (the watcher early-returns) |
