### PR TITLE
Adds telemetry for Graph Visualizations and Agent Kanban interactions

### DIFF
--- a/docs/telemetry-events.md
+++ b/docs/telemetry-events.md
@@ -2895,6 +2895,109 @@ background-upgraded the extension while the host kept running the old build
 }
 ```
 
+### graph/kanban/closed
+
+> Sent when the Graph leaves Kanban display mode (close button, sidebar rail, etc.)
+
+```typescript
+{
+  'context.repository.closed': boolean,
+  'context.repository.folder.scheme': string,
+  'context.repository.id': string,
+  'context.repository.provider.id': string,
+  'context.repository.scheme': string,
+  'context.webview.host': 'view' | 'editor' | 'panel',
+  'context.webview.id': string,
+  'context.webview.instanceId': string,
+  'context.webview.type': string
+}
+```
+
+### graph/kanban/permissionResolved
+
+> Sent when the user resolves a permission (Allow/Deny or Approve/Reject) from a kanban session card
+
+```typescript
+{
+  'context.repository.closed': boolean,
+  'context.repository.folder.scheme': string,
+  'context.repository.id': string,
+  'context.repository.provider.id': string,
+  'context.repository.scheme': string,
+  'context.webview.host': 'view' | 'editor' | 'panel',
+  'context.webview.id': string,
+  'context.webview.instanceId': string,
+  'context.webview.type': string,
+  'decision': 'allow' | 'deny',
+  'permission.kind': string
+}
+```
+
+### graph/kanban/sessionAction
+
+> Sent when the user clicks Open Session or View Plan on a kanban session card
+
+```typescript
+{
+  'action': 'openSession' | 'openPlanFile',
+  'context.repository.closed': boolean,
+  'context.repository.folder.scheme': string,
+  'context.repository.id': string,
+  'context.repository.provider.id': string,
+  'context.repository.scheme': string,
+  'context.webview.host': 'view' | 'editor' | 'panel',
+  'context.webview.id': string,
+  'context.webview.instanceId': string,
+  'context.webview.type': string
+}
+```
+
+### graph/kanban/sessionSelected
+
+> Sent when the user clicks a session card in the Agent Kanban to open its worktree WIP
+
+```typescript
+{
+  'column': 'working' | 'needs-input' | 'idle' | 'inactive',
+  'context.repository.closed': boolean,
+  'context.repository.folder.scheme': string,
+  'context.repository.id': string,
+  'context.repository.provider.id': string,
+  'context.repository.scheme': string,
+  'context.webview.host': 'view' | 'editor' | 'panel',
+  'context.webview.id': string,
+  'context.webview.instanceId': string,
+  'context.webview.type': string,
+  'session.category': 'working' | 'needs-input' | 'idle',
+  'session.hasPendingPermission': boolean,
+  'session.phase': string,
+  'session.sameRepo': boolean
+}
+```
+
+### graph/kanban/shown
+
+> Sent when the Agent Kanban becomes visible
+
+```typescript
+{
+  'context.repository.closed': boolean,
+  'context.repository.folder.scheme': string,
+  'context.repository.id': string,
+  'context.repository.provider.id': string,
+  'context.repository.scheme': string,
+  'context.webview.host': 'view' | 'editor' | 'panel',
+  'context.webview.id': string,
+  'context.webview.instanceId': string,
+  'context.webview.type': string,
+  'sessions.count': number,
+  'sessions.idle.count': number,
+  'sessions.inactive.count': number,
+  'sessions.needsInput.count': number,
+  'sessions.working.count': number
+}
+```
+
 ### graph/minimap/day/selected
 
 > Sent when the user selects (clicks on) a day on the minimap on the Commit Graph
@@ -3610,6 +3713,214 @@ background-upgraded the extension while the host kept running the old build
 }
 ```
 
+### graph/timeline/commitSelected
+
+> Sent when the user selects a commit in the embedded Visual History chart (first-paint auto-selections excluded)
+
+```typescript
+{
+  'context.repository.closed': boolean,
+  'context.repository.folder.scheme': string,
+  'context.repository.id': string,
+  'context.repository.provider.id': string,
+  'context.repository.scheme': string,
+  'context.webview.host': 'view' | 'editor' | 'panel',
+  'context.webview.id': string,
+  'context.webview.instanceId': string,
+  'context.webview.type': string,
+  'shift': boolean
+}
+```
+
+### graph/timeline/periodChanged
+
+> Sent when the user changes the period in the embedded Visual History header
+
+```typescript
+{
+  'context.repository.closed': boolean,
+  'context.repository.folder.scheme': string,
+  'context.repository.id': string,
+  'context.repository.provider.id': string,
+  'context.repository.scheme': string,
+  'context.webview.host': 'view' | 'editor' | 'panel',
+  'context.webview.id': string,
+  'context.webview.instanceId': string,
+  'context.webview.type': string,
+  'period.new': string,
+  'period.old': string
+}
+```
+
+### graph/timeline/scopeChanged
+
+> Sent when the user changes the file/folder scope of the embedded Visual History (path picker, clear, or breadcrumb)
+
+```typescript
+{
+  'action': 'choose' | 'clear' | 'breadcrumb',
+  'context.repository.closed': boolean,
+  'context.repository.folder.scheme': string,
+  'context.repository.id': string,
+  'context.repository.provider.id': string,
+  'context.repository.scheme': string,
+  'context.webview.host': 'view' | 'editor' | 'panel',
+  'context.webview.id': string,
+  'context.webview.instanceId': string,
+  'context.webview.type': string,
+  'scope.type': 'file' | 'folder',
+  // Whether a file/folder scope is active AFTER this change
+  'scoped': boolean
+}
+```
+
+### graph/timeline/shown
+
+> Sent when the embedded Visual History (timeline) visualization becomes visible
+
+```typescript
+{
+  'context.repository.closed': boolean,
+  'context.repository.folder.scheme': string,
+  'context.repository.id': string,
+  'context.repository.provider.id': string,
+  'context.repository.scheme': string,
+  'context.webview.host': 'view' | 'editor' | 'panel',
+  'context.webview.id': string,
+  'context.webview.instanceId': string,
+  'context.webview.type': string,
+  'period': string,
+  'scoped': boolean,
+  'sliceBy': 'branch' | 'author'
+}
+```
+
+### graph/timeline/sliceByChanged
+
+> Sent when the user changes the slice-by axis in the embedded Visual History header
+
+```typescript
+{
+  'context.repository.closed': boolean,
+  'context.repository.folder.scheme': string,
+  'context.repository.id': string,
+  'context.repository.provider.id': string,
+  'context.repository.scheme': string,
+  'context.webview.host': 'view' | 'editor' | 'panel',
+  'context.webview.id': string,
+  'context.webview.instanceId': string,
+  'context.webview.type': string,
+  'sliceBy.new': 'branch' | 'author',
+  'sliceBy.old': 'branch' | 'author'
+}
+```
+
+### graph/treemap/decayChanged
+
+> Sent when the user changes the activity decay window in the Agent Activity Treemap
+
+```typescript
+{
+  'context.repository.closed': boolean,
+  'context.repository.folder.scheme': string,
+  'context.repository.id': string,
+  'context.repository.provider.id': string,
+  'context.repository.scheme': string,
+  'context.webview.host': 'view' | 'editor' | 'panel',
+  'context.webview.id': string,
+  'context.webview.instanceId': string,
+  'context.webview.type': string,
+  'decay.new': string,
+  'decay.old': string
+}
+```
+
+### graph/treemap/fileClicked
+
+> Sent when the user clicks a file leaf in the treemap
+
+```typescript
+{
+  'action': 'open' | 'history',
+  'context.repository.closed': boolean,
+  'context.repository.folder.scheme': string,
+  'context.repository.id': string,
+  'context.repository.provider.id': string,
+  'context.repository.scheme': string,
+  'context.webview.host': 'view' | 'editor' | 'panel',
+  'context.webview.id': string,
+  'context.webview.instanceId': string,
+  'context.webview.type': string,
+  'mode': 'commits' | 'files' | 'activity',
+  // Only set in `activity` mode — whether the click also focused an agent session that touched the file
+  'session.focused': boolean
+}
+```
+
+### graph/treemap/periodChanged
+
+> Sent when the user changes the period in the Commits Treemap
+
+```typescript
+{
+  'context.repository.closed': boolean,
+  'context.repository.folder.scheme': string,
+  'context.repository.id': string,
+  'context.repository.provider.id': string,
+  'context.repository.scheme': string,
+  'context.webview.host': 'view' | 'editor' | 'panel',
+  'context.webview.id': string,
+  'context.webview.instanceId': string,
+  'context.webview.type': string,
+  'period.new': string,
+  'period.old': string
+}
+```
+
+### graph/treemap/shown
+
+> Sent when a treemap visualization becomes visible for a repo + mode and its data has loaded
+
+```typescript
+{
+  'context.repository.closed': boolean,
+  'context.repository.folder.scheme': string,
+  'context.repository.id': string,
+  'context.repository.provider.id': string,
+  'context.repository.scheme': string,
+  'context.webview.host': 'view' | 'editor' | 'panel',
+  'context.webview.id': string,
+  'context.webview.instanceId': string,
+  'context.webview.type': string,
+  'files.count': number,
+  'mode': 'commits' | 'files' | 'activity',
+  // Only set in `commits` mode — the other modes have no period axis
+  'period': string
+}
+```
+
+### graph/treemap/zoomed
+
+> Sent when the user zooms the treemap in or out (folder drill-down or breadcrumb)
+
+```typescript
+{
+  'context.repository.closed': boolean,
+  'context.repository.folder.scheme': string,
+  'context.repository.id': string,
+  'context.repository.provider.id': string,
+  'context.repository.scheme': string,
+  'context.webview.host': 'view' | 'editor' | 'panel',
+  'context.webview.id': string,
+  'context.webview.instanceId': string,
+  'context.webview.type': string,
+  // Folder depth of the zoom target; 0 = back at the root
+  'depth': number,
+  'direction': 'in' | 'out',
+  'mode': 'commits' | 'files' | 'activity'
+}
+```
+
 ### graph/virtualFile/failed
 
 > Sent when opening a virtual-FS-backed file fails (e.g. the compose session is no longer registered)
@@ -3652,6 +3963,47 @@ background-upgraded the extension while the host kept running the old build
   'files.count': number,
   // Which open operation the user triggered
   'mode': 'diff' | 'comparePrevious' | 'multiDiff'
+}
+```
+
+### graph/visualizations/closed
+
+> Sent when the Graph leaves Visualizations display mode (close button, sidebar rail, external search request, etc.)
+
+```typescript
+{
+  'context.repository.closed': boolean,
+  'context.repository.folder.scheme': string,
+  'context.repository.id': string,
+  'context.repository.provider.id': string,
+  'context.repository.scheme': string,
+  'context.webview.host': 'view' | 'editor' | 'panel',
+  'context.webview.id': string,
+  'context.webview.instanceId': string,
+  'context.webview.type': string,
+  'mode': 'timeline' | 'treemap-files' | 'treemap-commits' | 'treemap-activity'
+}
+```
+
+### graph/visualizations/modeChanged
+
+> Sent when the user switches the active visualization via the switcher, or when a virtual repo forces a fallback from the Commits Treemap to the Files Treemap
+
+```typescript
+{
+  'context.repository.closed': boolean,
+  'context.repository.folder.scheme': string,
+  'context.repository.id': string,
+  'context.repository.provider.id': string,
+  'context.repository.scheme': string,
+  'context.webview.host': 'view' | 'editor' | 'panel',
+  'context.webview.id': string,
+  'context.webview.instanceId': string,
+  'context.webview.type': string,
+  'mode.new': 'timeline' | 'treemap-files' | 'treemap-commits' | 'treemap-activity',
+  'mode.old': 'timeline' | 'treemap-files' | 'treemap-commits' | 'treemap-activity',
+  // `fallback` when a virtual repo forced Commits → Files on mount (not a user action)
+  'reason': 'user' | 'fallback'
 }
 ```
 
@@ -4794,7 +5146,7 @@ background-upgraded the extension while the host kept running the old build
 ```typescript
 {
   // Which file open/diff operation was triggered
-  'action': 'openOnRemote' | 'comparePrevious' | 'multiDiff' | 'open' | 'compareWorking' | 'compareWip' | 'compareBetween' | 'defaultAction',
+  'action': 'openOnRemote' | 'open' | 'comparePrevious' | 'multiDiff' | 'compareWorking' | 'compareWip' | 'compareBetween' | 'defaultAction',
   'context.repository.closed': boolean,
   'context.repository.folder.scheme': string,
   'context.repository.id': string,

--- a/src/constants.telemetry.ts
+++ b/src/constants.telemetry.ts
@@ -406,6 +406,44 @@ export interface TelemetryEvents extends WebviewShowAbortedEvents, WebviewShownE
 	/** Sent when the user types in the filter box in the sidebar tags panel */
 	'graph/tags/filtered': GraphSidebarTagsFilteredEvent;
 
+	/** Sent when the user switches the active visualization via the switcher, or when a virtual repo forces a fallback from the Commits Treemap to the Files Treemap */
+	'graph/visualizations/modeChanged': GraphVisualizationsModeChangedEvent;
+	/** Sent when the Graph leaves Visualizations display mode (close button, sidebar rail, external search request, etc.) */
+	'graph/visualizations/closed': GraphVisualizationsClosedEvent;
+
+	/** Sent when the embedded Visual History (timeline) visualization becomes visible */
+	'graph/timeline/shown': GraphTimelineShownEvent;
+	/** Sent when the user selects a commit in the embedded Visual History chart (first-paint auto-selections excluded) */
+	'graph/timeline/commitSelected': GraphTimelineCommitSelectedEvent;
+	/** Sent when the user changes the period in the embedded Visual History header */
+	'graph/timeline/periodChanged': GraphTimelinePeriodChangedEvent;
+	/** Sent when the user changes the slice-by axis in the embedded Visual History header */
+	'graph/timeline/sliceByChanged': GraphTimelineSliceByChangedEvent;
+	/** Sent when the user changes the file/folder scope of the embedded Visual History (path picker, clear, or breadcrumb) */
+	'graph/timeline/scopeChanged': GraphTimelineScopeChangedEvent;
+
+	/** Sent when a treemap visualization becomes visible for a repo + mode and its data has loaded */
+	'graph/treemap/shown': GraphTreemapShownEvent;
+	/** Sent when the user zooms the treemap in or out (folder drill-down or breadcrumb) */
+	'graph/treemap/zoomed': GraphTreemapZoomedEvent;
+	/** Sent when the user clicks a file leaf in the treemap */
+	'graph/treemap/fileClicked': GraphTreemapFileClickedEvent;
+	/** Sent when the user changes the period in the Commits Treemap */
+	'graph/treemap/periodChanged': GraphTreemapPeriodChangedEvent;
+	/** Sent when the user changes the activity decay window in the Agent Activity Treemap */
+	'graph/treemap/decayChanged': GraphTreemapDecayChangedEvent;
+
+	/** Sent when the Agent Kanban becomes visible */
+	'graph/kanban/shown': GraphKanbanShownEvent;
+	/** Sent when the Graph leaves Kanban display mode (close button, sidebar rail, etc.) */
+	'graph/kanban/closed': GraphContextEventData;
+	/** Sent when the user clicks a session card in the Agent Kanban to open its worktree WIP */
+	'graph/kanban/sessionSelected': GraphKanbanSessionSelectedEvent;
+	/** Sent when the user clicks Open Session or View Plan on a kanban session card */
+	'graph/kanban/sessionAction': GraphKanbanSessionActionEvent;
+	/** Sent when the user resolves a permission (Allow/Deny or Approve/Reject) from a kanban session card */
+	'graph/kanban/permissionResolved': GraphKanbanPermissionResolvedEvent;
+
 	/** Sent when the integrated graph details panel is expanded */
 	'graphDetails/shown': GraphDetailsShownEvent;
 	/** Sent when the integrated graph details panel is collapsed */
@@ -2018,6 +2056,105 @@ interface GraphSidebarTagsFilteredEvent extends GraphContextEventData {
 	hasFilter: boolean;
 	'filter.length': number;
 	'tags.count': number;
+}
+
+/** Flat key identifying a Graph visualization — collapses the two-axis
+ *  (visualizationMode × treemapMode) state so one field names the active visualization,
+ *  matching the switcher's tab model. */
+type GraphVisualizationKey = 'timeline' | 'treemap-files' | 'treemap-commits' | 'treemap-activity';
+
+interface GraphVisualizationsModeChangedEvent extends GraphContextEventData {
+	'mode.old': GraphVisualizationKey;
+	'mode.new': GraphVisualizationKey;
+	/** `fallback` when a virtual repo forced Commits → Files on mount (not a user action) */
+	reason: 'user' | 'fallback';
+}
+
+interface GraphVisualizationsClosedEvent extends GraphContextEventData {
+	mode: GraphVisualizationKey;
+}
+
+interface GraphTimelineShownEvent extends GraphContextEventData {
+	period: string;
+	sliceBy: 'author' | 'branch';
+	scoped: boolean;
+}
+
+interface GraphTimelineCommitSelectedEvent extends GraphContextEventData {
+	shift: boolean;
+}
+
+interface GraphTimelinePeriodChangedEvent extends GraphContextEventData {
+	'period.old': string;
+	'period.new': string;
+}
+
+interface GraphTimelineSliceByChangedEvent extends GraphContextEventData {
+	'sliceBy.old': 'author' | 'branch';
+	'sliceBy.new': 'author' | 'branch';
+}
+
+interface GraphTimelineScopeChangedEvent extends GraphContextEventData {
+	action: 'choose' | 'clear' | 'breadcrumb';
+	'scope.type'?: 'file' | 'folder';
+	/** Whether a file/folder scope is active AFTER this change */
+	scoped: boolean;
+}
+
+interface GraphTreemapShownEvent extends GraphContextEventData {
+	mode: 'files' | 'commits' | 'activity';
+	'files.count': number;
+	/** Only set in `commits` mode — the other modes have no period axis */
+	period?: string;
+}
+
+interface GraphTreemapZoomedEvent extends GraphContextEventData {
+	mode: 'files' | 'commits' | 'activity';
+	direction: 'in' | 'out';
+	/** Folder depth of the zoom target; 0 = back at the root */
+	depth: number;
+}
+
+interface GraphTreemapFileClickedEvent extends GraphContextEventData {
+	mode: 'files' | 'commits' | 'activity';
+	action: 'open' | 'history';
+	/** Only set in `activity` mode — whether the click also focused an agent session that touched the file */
+	'session.focused'?: boolean;
+}
+
+interface GraphTreemapPeriodChangedEvent extends GraphContextEventData {
+	'period.old': string;
+	'period.new': string;
+}
+
+interface GraphTreemapDecayChangedEvent extends GraphContextEventData {
+	'decay.old': string;
+	'decay.new': string;
+}
+
+interface GraphKanbanShownEvent extends GraphContextEventData {
+	'sessions.count': number;
+	'sessions.working.count': number;
+	'sessions.needsInput.count': number;
+	'sessions.idle.count': number;
+	'sessions.inactive.count': number;
+}
+
+interface GraphKanbanSessionSelectedEvent extends GraphContextEventData {
+	'session.phase': string;
+	'session.category': 'working' | 'needs-input' | 'idle';
+	'session.hasPendingPermission': boolean;
+	'session.sameRepo': boolean;
+	column: 'needs-input' | 'working' | 'idle' | 'inactive';
+}
+
+interface GraphKanbanSessionActionEvent extends GraphContextEventData {
+	action: 'openSession' | 'openPlanFile';
+}
+
+interface GraphKanbanPermissionResolvedEvent extends GraphContextEventData {
+	decision: 'allow' | 'deny';
+	'permission.kind': string;
 }
 
 export type HomeTelemetryContext = WebviewTelemetryContext;

--- a/src/webviews/apps/plus/graph/components/__tests__/visualizations.utils.test.ts
+++ b/src/webviews/apps/plus/graph/components/__tests__/visualizations.utils.test.ts
@@ -1,0 +1,99 @@
+import * as assert from 'assert';
+import type { TreemapNode } from '../../../../../plus/treemap/protocol.js';
+import { classifyTreemapZoom, countFileLeaves, getEffectiveVisualizationKey } from '../visualizations.utils.js';
+
+suite('getEffectiveVisualizationKey', () => {
+	test('flag off forces timeline regardless of persisted treemap state', () => {
+		assert.strictEqual(getEffectiveVisualizationKey('treemap', 'commits', false), 'timeline');
+		assert.strictEqual(getEffectiveVisualizationKey('treemap', 'activity', false), 'timeline');
+		assert.strictEqual(getEffectiveVisualizationKey('timeline', 'files', false), 'timeline');
+	});
+
+	test('flag on returns timeline when the visualization mode is timeline', () => {
+		assert.strictEqual(getEffectiveVisualizationKey('timeline', 'commits', true), 'timeline');
+	});
+
+	test('flag on maps each treemap sub-mode to its key', () => {
+		assert.strictEqual(getEffectiveVisualizationKey('treemap', 'files', true), 'treemap-files');
+		assert.strictEqual(getEffectiveVisualizationKey('treemap', 'commits', true), 'treemap-commits');
+		assert.strictEqual(getEffectiveVisualizationKey('treemap', 'activity', true), 'treemap-activity');
+	});
+
+	test('defaults: undefined mode is timeline; undefined treemapMode is files', () => {
+		assert.strictEqual(getEffectiveVisualizationKey(undefined, undefined, true), 'timeline');
+		assert.strictEqual(getEffectiveVisualizationKey('treemap', undefined, true), 'treemap-files');
+	});
+});
+
+suite('classifyTreemapZoom', () => {
+	const folder = (path: string, children: TreemapNode[] = []): TreemapNode => ({
+		name: path,
+		path: path,
+		size: 1,
+		type: 'folder',
+		children: children,
+	});
+
+	test('identical path (same depth + same leaf) is unchanged — the retry rehydration case', () => {
+		const path = [folder('src'), folder('src/webviews')];
+		const result = classifyTreemapZoom(path, [folder('src'), folder('src/webviews')]);
+		assert.strictEqual(result.changed, false);
+	});
+
+	test('root → root is unchanged', () => {
+		assert.strictEqual(classifyTreemapZoom([], []).changed, false);
+	});
+
+	test('drilling deeper is a changed zoom in', () => {
+		const result = classifyTreemapZoom([folder('src')], [folder('src'), folder('src/webviews')]);
+		assert.deepStrictEqual(result, { changed: true, direction: 'in', depth: 2 });
+	});
+
+	test('breadcrumb up is a changed zoom out', () => {
+		const result = classifyTreemapZoom([folder('src'), folder('src/webviews')], [folder('src')]);
+		assert.deepStrictEqual(result, { changed: true, direction: 'out', depth: 1 });
+	});
+
+	test('zoom all the way out to root reports depth 0', () => {
+		const result = classifyTreemapZoom([folder('src')], []);
+		assert.deepStrictEqual(result, { changed: true, direction: 'out', depth: 0 });
+	});
+
+	test('equal depth but different leaf counts as changed (push/pop makes this unreachable in practice)', () => {
+		const result = classifyTreemapZoom([folder('src')], [folder('docs')]);
+		assert.strictEqual(result.changed, true);
+		assert.strictEqual(result.direction, 'in');
+	});
+});
+
+suite('countFileLeaves', () => {
+	const file = (name: string): TreemapNode => ({ name: name, path: name, size: 1, type: 'file' });
+	const folder = (name: string, children: TreemapNode[]): TreemapNode => ({
+		name: name,
+		path: name,
+		size: 1,
+		type: 'folder',
+		children: children,
+	});
+
+	test('undefined tree is 0', () => {
+		assert.strictEqual(countFileLeaves(undefined), 0);
+	});
+
+	test('a lone file is 1', () => {
+		assert.strictEqual(countFileLeaves(file('a.ts')), 1);
+	});
+
+	test('empty folder is 0', () => {
+		assert.strictEqual(countFileLeaves(folder('src', [])), 0);
+	});
+
+	test('counts leaves across nested folders, ignoring folder nodes', () => {
+		const tree = folder('root', [
+			file('README.md'),
+			folder('src', [file('a.ts'), file('b.ts'), folder('nested', [file('c.ts')])]),
+			folder('empty', []),
+		]);
+		assert.strictEqual(countFileLeaves(tree), 4);
+	});
+});

--- a/src/webviews/apps/plus/graph/components/gl-graph-kanban.ts
+++ b/src/webviews/apps/plus/graph/components/gl-graph-kanban.ts
@@ -18,6 +18,7 @@ import {
 	sortAgentSessions,
 } from '../../../shared/agentUtils.js';
 import { scrollableBase } from '../../../shared/components/styles/lit/base.css.js';
+import { emitTelemetrySentEvent } from '../../../shared/telemetry.js';
 import { graphStateContext } from '../context.js';
 import '../../../shared/components/badges/badge.js';
 import '../../../shared/components/button.js';
@@ -552,6 +553,29 @@ export class GlGraphKanban extends SignalWatcher(LitElement) {
 		this._lastFingerprint = this.computeFingerprint(this.graphState.agentSessions ?? []);
 	}
 
+	/** Impression telemetry — point-in-time snapshot, fired once per mount (the component mounts
+	 *  only while Kanban is the active display mode and remounts per activation, so first-render is
+	 *  one impression). `agentSessions` is a signal initialized to `[]` and populated asynchronously,
+	 *  so on a fast toggle before the first push the counts below may all read 0 and later arrivals
+	 *  do NOT re-fire — treat them as "what was visible at open", not a settled total. Mirrors the
+	 *  agents sidebar's `emitAgentsShownTelemetry` semantics (the same signal makes "not loaded" and
+	 *  "loaded but empty" indistinguishable, so deferring — as the treemap does on `data.root` — isn't
+	 *  possible here). */
+	protected override firstUpdated(): void {
+		const sessions = this.graphState.agentSessions ?? [];
+		const { buckets } = this.buildBuckets(sessions);
+		emitTelemetrySentEvent<'graph/kanban/shown'>(this, {
+			name: 'graph/kanban/shown',
+			data: {
+				'sessions.count': sessions.length,
+				'sessions.working.count': buckets.get('working')?.length ?? 0,
+				'sessions.needsInput.count': buckets.get('needs-input')?.length ?? 0,
+				'sessions.idle.count': buckets.get('idle')?.length ?? 0,
+				'sessions.inactive.count': buckets.get('inactive')?.length ?? 0,
+			},
+		});
+	}
+
 	override connectedCallback(): void {
 		super.connectedCallback?.();
 		this._liveTickHandle = setInterval(() => {
@@ -591,11 +615,34 @@ export class GlGraphKanban extends SignalWatcher(LitElement) {
 		// catches Open Session (in `.card__sub-row`) AND the permission actions (`.card__actions`),
 		// regardless of which subtree they live in — so layout changes can't silently regress the
 		// guard the way `closest('.card__actions')` did when Open Session moved to the sub-row.
+		// The buttons handle their own activation (command links); this delegated listener only
+		// observes the composed click for telemetry — one listener instead of per-render closures.
 		const target = event.target as HTMLElement | null;
-		if (target?.closest('gl-button') != null) return;
+		const actionButton = target?.closest<HTMLElement>('gl-button');
+		if (actionButton != null) {
+			this.emitCardActionTelemetry(actionButton, sessionId);
+			return;
+		}
 
 		const session = (this.graphState.agentSessions ?? []).find(s => s.id === sessionId);
 		if (session == null) return;
+
+		const repo = this.effectiveRepo;
+		const family = repo == null ? undefined : (repo.commonPath ?? repo.path);
+		emitTelemetrySentEvent<'graph/kanban/sessionSelected'>(this, {
+			name: 'graph/kanban/sessionSelected',
+			data: {
+				'session.phase': session.phase,
+				'session.category': agentPhaseToCategory[session.phase],
+				'session.hasPendingPermission': session.pendingPermission != null,
+				// Same repo-family comparison the open-session gate in graph-app applies — a
+				// cross-repo card click is a no-op there, so this flag explains "dead" clicks.
+				'session.sameRepo': family != null && session.commonPath === family,
+				// Prefer the rendered card's column — recomputing via `columnIdForSession` could
+				// disagree with what the user actually saw (idle → inactive is a time threshold).
+				column: (card?.dataset.column as KanbanColumnId | undefined) ?? columnIdForSession(session),
+			},
+		});
 
 		this.dispatchEvent(
 			new CustomEvent('gl-graph-kanban-open-session', {
@@ -609,6 +656,49 @@ export class GlGraphKanban extends SignalWatcher(LitElement) {
 			}),
 		);
 	};
+
+	/** Telemetry for the card's inner action buttons, identified by `data-telemetry-action` —
+	 *  static attributes instead of per-button click closures (see `onCardClick`'s perf note). */
+	private emitCardActionTelemetry(button: HTMLElement, sessionId: string): void {
+		switch (button.dataset.telemetryAction) {
+			case 'open-session':
+				emitTelemetrySentEvent<'graph/kanban/sessionAction'>(this, {
+					name: 'graph/kanban/sessionAction',
+					data: { action: 'openSession' },
+				});
+				break;
+
+			case 'open-plan':
+				emitTelemetrySentEvent<'graph/kanban/sessionAction'>(this, {
+					name: 'graph/kanban/sessionAction',
+					data: { action: 'openPlanFile' },
+				});
+				break;
+
+			case 'permission-allow':
+			case 'permission-deny': {
+				const session = (this.graphState.agentSessions ?? []).find(s => s.id === sessionId);
+				emitTelemetrySentEvent<'graph/kanban/permissionResolved'>(this, {
+					name: 'graph/kanban/permissionResolved',
+					data: {
+						decision: button.dataset.telemetryAction === 'permission-allow' ? 'allow' : 'deny',
+						'permission.kind': session?.pendingPermission?.kind ?? 'unknown',
+					},
+				});
+				break;
+			}
+		}
+	}
+
+	/** Resolves the graph's selected repo exactly as the open-session gate does
+	 *  (`GraphApp.fallbackRepoFamily`): a stale/unmatched `selectedRepository` resolves to
+	 *  `undefined` (NO `?? repos[0]` fallback), so `session.sameRepo` can't report `true` for a
+	 *  click the gate would reject — the flag exists to explain those dead clicks. */
+	private get effectiveRepo() {
+		const repoId = this.graphState.selectedRepository;
+		const repos = this.graphState.repositories;
+		return repoId != null ? repos?.find(r => r.id === repoId) : repos?.[0];
+	}
 
 	private onCardKeydown = (event: KeyboardEvent): void => {
 		// Enter and Space activate the card as an "open WIP details" affordance, matching the
@@ -750,6 +840,7 @@ export class GlGraphKanban extends SignalWatcher(LitElement) {
 					class="card__open"
 					appearance="toolbar"
 					tooltip="Open Session"
+					data-telemetry-action="open-session"
 					href=${createCommandLink('gitlens.agents.openSession', JSON.stringify(session.id))}
 				>
 					<code-icon icon="link-external"></code-icon>
@@ -813,6 +904,7 @@ export class GlGraphKanban extends SignalWatcher(LitElement) {
 					appearance="secondary"
 					density="compact"
 					tooltip=${isPlan ? 'Approve Plan' : 'Allow'}
+					data-telemetry-action="permission-allow"
 					href=${createCommandLink('gitlens.agents.resolvePermission', {
 						sessionId: session.id,
 						decision: 'allow' as const,
@@ -825,6 +917,7 @@ export class GlGraphKanban extends SignalWatcher(LitElement) {
 					appearance="secondary"
 					density="compact"
 					tooltip=${isPlan ? 'Reject Plan' : 'Deny'}
+					data-telemetry-action="permission-deny"
 					href=${createCommandLink('gitlens.agents.resolvePermission', {
 						sessionId: session.id,
 						decision: 'deny' as const,
@@ -837,6 +930,7 @@ export class GlGraphKanban extends SignalWatcher(LitElement) {
 					? html`<gl-button
 							appearance="toolbar"
 							tooltip="View Plan"
+							data-telemetry-action="open-plan"
 							href=${createCommandLink(
 								'gitlens.agents.openPlanFile',
 								JSON.stringify(permission.planFilePath),

--- a/src/webviews/apps/plus/graph/components/gl-graph-timeline.ts
+++ b/src/webviews/apps/plus/graph/components/gl-graph-timeline.ts
@@ -15,6 +15,7 @@ import type {
 } from '../../../../plus/timeline/protocol.js';
 import { periodToMs } from '../../../../plus/timeline/utils/period.js';
 import { ipcContext } from '../../../shared/contexts/ipc.js';
+import { emitTelemetrySentEvent } from '../../../shared/telemetry.js';
 import type { CommitEventDetail, LoadMoreEventDetail } from '../../timeline/components/chart.js';
 import { isPseudoCommitDatum } from '../../timeline/components/chart/timelineData.js';
 import { graphServicesContext, graphStateContext } from '../context.js';
@@ -740,6 +741,21 @@ export class GlGraphTimeline extends SignalWatcher(LitElement) {
 		return this._datumByShaCache.get(sha);
 	}
 
+	/** Impression telemetry — fires once per mount. The component only mounts while the embedded
+	 *  Visual History is the active visualization, and remounts on every activation (mode switch
+	 *  or display-mode entry), so first-render is exactly one impression. The externally-pushed
+	 *  `scope` is adopted into `_localScope` in `willUpdate`, so `scoped` is accurate here. */
+	protected override firstUpdated(): void {
+		emitTelemetrySentEvent<'graph/timeline/shown'>(this, {
+			name: 'graph/timeline/shown',
+			data: {
+				period: this.period,
+				sliceBy: this.effectiveSliceBy,
+				scoped: this._localScope != null,
+			},
+		});
+	}
+
 	private onChartCommitSelected = (e: CustomEvent<CommitEventDetail>): void => {
 		// Skip interim slider scrubs — only commit on release. Mirrors the standalone Visual History
 		// debounce behavior so transient hovers don't churn the details panel.
@@ -747,6 +763,14 @@ export class GlGraphTimeline extends SignalWatcher(LitElement) {
 
 		const sha = e.detail.id;
 		if (sha == null) return;
+
+		// First-paint auto-selections are forwarded to the details panel but are not user actions.
+		if (e.detail.auto !== true) {
+			emitTelemetrySentEvent<'graph/timeline/commitSelected'>(this, {
+				name: 'graph/timeline/commitSelected',
+				data: { shift: e.detail.shift },
+			});
+		}
 
 		const repoPath = this.effectiveRepo?.path ?? '';
 		const datum = this.datumBySha(sha);
@@ -774,10 +798,26 @@ export class GlGraphTimeline extends SignalWatcher(LitElement) {
 	}
 
 	private onHeaderPeriodChange = (e: CustomEvent<{ period: TimelinePeriod }>): void => {
+		const previous = this.period;
+		if (e.detail.period !== previous) {
+			emitTelemetrySentEvent<'graph/timeline/periodChanged'>(this, {
+				name: 'graph/timeline/periodChanged',
+				data: { 'period.old': previous, 'period.new': e.detail.period },
+			});
+		}
 		this.dispatchConfigChange({ period: e.detail.period });
 	};
 
 	private onHeaderSliceByChange = (e: CustomEvent<{ sliceBy: TimelineSliceBy }>): void => {
+		// Compare against the EFFECTIVE slice-by (what the chart actually renders) so a pick that
+		// changes nothing visible isn't counted as a change.
+		const previous = this.effectiveSliceBy;
+		if (e.detail.sliceBy !== previous) {
+			emitTelemetrySentEvent<'graph/timeline/sliceByChanged'>(this, {
+				name: 'graph/timeline/sliceByChanged',
+				data: { 'sliceBy.old': previous, 'sliceBy.new': e.detail.sliceBy },
+			});
+		}
 		this.dispatchConfigChange({ sliceBy: e.detail.sliceBy });
 	};
 
@@ -800,13 +840,26 @@ export class GlGraphTimeline extends SignalWatcher(LitElement) {
 		});
 		if (result?.picked == null) return;
 
-		this._localScope = { type: result.picked.type, relativePath: result.picked.relativePath };
+		const next = { type: result.picked.type, relativePath: result.picked.relativePath };
+		// Guard no-op re-picks (same path chosen again) so telemetry only records real changes —
+		// matches onHeaderChangeScope / period / sliceBy, which all bail on identical values.
+		if (this._localScope?.type === next.type && this._localScope.relativePath === next.relativePath) return;
+
+		this._localScope = next;
+		emitTelemetrySentEvent<'graph/timeline/scopeChanged'>(this, {
+			name: 'graph/timeline/scopeChanged',
+			data: { action: 'choose', 'scope.type': next.type, scoped: true },
+		});
 	};
 
 	private onHeaderClearScope = (): void => {
 		if (this._localScope == null) return;
 
 		this._localScope = undefined;
+		emitTelemetrySentEvent<'graph/timeline/scopeChanged'>(this, {
+			name: 'graph/timeline/scopeChanged',
+			data: { action: 'clear', scoped: false },
+		});
 	};
 
 	/** Folder-crumb click in the path. Standalone Visual History routes this to `actions.changeScope`;
@@ -820,6 +873,10 @@ export class GlGraphTimeline extends SignalWatcher(LitElement) {
 		if (type === 'repo' || !value) {
 			if (this._localScope != null) {
 				this._localScope = undefined;
+				emitTelemetrySentEvent<'graph/timeline/scopeChanged'>(this, {
+					name: 'graph/timeline/scopeChanged',
+					data: { action: 'breadcrumb', scoped: false },
+				});
 			}
 			return;
 		}
@@ -828,6 +885,10 @@ export class GlGraphTimeline extends SignalWatcher(LitElement) {
 		if (this._localScope?.type === next.type && this._localScope.relativePath === next.relativePath) return;
 
 		this._localScope = next;
+		emitTelemetrySentEvent<'graph/timeline/scopeChanged'>(this, {
+			name: 'graph/timeline/scopeChanged',
+			data: { action: 'breadcrumb', 'scope.type': type, scoped: true },
+		});
 	};
 
 	override render(): unknown {

--- a/src/webviews/apps/plus/graph/components/gl-graph-treemap.ts
+++ b/src/webviews/apps/plus/graph/components/gl-graph-treemap.ts
@@ -21,6 +21,7 @@ import type {
 } from '../../../../plus/treemap/protocol.js';
 import { ipcContext } from '../../../shared/contexts/ipc.js';
 import type { Disposable } from '../../../shared/events.js';
+import { emitTelemetrySentEvent } from '../../../shared/telemetry.js';
 import { periodLabels } from '../../timeline/components/header.js';
 import type {
 	GlTreemapChart,
@@ -29,6 +30,7 @@ import type {
 } from '../../treemap/components/treemap-chart.js';
 import type { AppState } from '../context.js';
 import { graphServicesContext, graphStateContext } from '../context.js';
+import { classifyTreemapZoom, countFileLeaves } from './visualizations.utils.js';
 import './gl-details-agent-status.js';
 import './gl-graph-visualizations-switcher.js';
 import '../../treemap/components/treemap-chart.js';
@@ -367,6 +369,10 @@ export class GlGraphTreemap extends SignalWatcher(LitElement) {
 	@state()
 	private _zoomPath: TreemapNode[] = [];
 
+	/** `repoPath::mode` key of the last emitted `graph/treemap/shown` — dedups the impression
+	 *  against same-activation refetches (period/scope changes) while disconnect re-arms it. */
+	private _shownEmittedKey: string | undefined;
+
 	@query('gl-treemap-chart')
 	private _chart?: GlTreemapChart;
 
@@ -483,6 +489,8 @@ export class GlGraphTreemap extends SignalWatcher(LitElement) {
 		this._virtualFallbackEmittedForRepo = undefined;
 		this._activeFilesCache = undefined;
 		this._repoFamilySessionsCache = undefined;
+		// Re-arm the impression telemetry so the next mount records a fresh `shown`.
+		this._shownEmittedKey = undefined;
 	}
 
 	override willUpdate(): void {
@@ -536,6 +544,12 @@ export class GlGraphTreemap extends SignalWatcher(LitElement) {
 				composed: true,
 			}),
 		);
+		// The switcher emits `reason: 'user'` for its clicks; this forced flip is the only
+		// programmatic writer, so label it distinctly to keep user-action counts honest.
+		emitTelemetrySentEvent<'graph/visualizations/modeChanged'>(this, {
+			name: 'graph/visualizations/modeChanged',
+			data: { 'mode.old': 'treemap-commits', 'mode.new': 'treemap-files', reason: 'fallback' },
+		});
 	}
 
 	private readonly handleRetry = (): void => {
@@ -681,6 +695,7 @@ export class GlGraphTreemap extends SignalWatcher(LitElement) {
 			this._dataRepoPath = repo.path;
 			this._lastFingerprint = fingerprint;
 			this._lastErrorFingerprint = undefined;
+			this.maybeEmitShownTelemetry(repo.path, result);
 		} catch {
 			if (this._abortController !== controller) return;
 
@@ -698,6 +713,31 @@ export class GlGraphTreemap extends SignalWatcher(LitElement) {
 				this._loading = false;
 			}
 		}
+	}
+
+	/** Impression telemetry per (repo, mode) activation — deferred to data resolution so
+	 *  `files.count` is accurate (mirrors the branches sidebar panel's deferred `shown`).
+	 *  Same-activation refetches (period/scope changes) don't re-emit; a remount re-arms via
+	 *  `disconnectedCallback` so every fresh activation records an impression. */
+	private maybeEmitShownTelemetry(repoPath: string, data: TreemapData): void {
+		// The host returns a non-null wrapper `{ root: undefined }` when the repo isn't resolvable
+		// yet (same case the refresh dedup guards with `_data?.root != null`). Skip WITHOUT arming
+		// `_shownEmittedKey` so we don't record a phantom `files.count: 0` impression and then
+		// suppress the real one when actual data lands for this repo/mode.
+		if (data.root == null) return;
+
+		const key = `${repoPath}::${this.mode}`;
+		if (key === this._shownEmittedKey) return;
+
+		this._shownEmittedKey = key;
+		emitTelemetrySentEvent<'graph/treemap/shown'>(this, {
+			name: 'graph/treemap/shown',
+			data: {
+				mode: this.mode,
+				'files.count': countFileLeaves(data.root),
+				period: this.mode === 'commits' ? (this.graphState.timeline?.period ?? '1|Y') : undefined,
+			},
+		});
 	}
 
 	/** Per-file activity snapshot for files in the active repo family, surfaced from
@@ -963,8 +1003,13 @@ export class GlGraphTreemap extends SignalWatcher(LitElement) {
 	 *  timeline share `graphState.timelinePeriod` so changing it in either viz keeps both in sync. */
 	private readonly onPeriodMenuSelect = (e: CustomEvent<{ value: string }>): void => {
 		const period = e.detail.value as TimelinePeriod;
-		if ((this.graphState.timeline?.period ?? '1|Y') === period) return;
+		const previous = this.graphState.timeline?.period ?? '1|Y';
+		if (previous === period) return;
 
+		emitTelemetrySentEvent<'graph/treemap/periodChanged'>(this, {
+			name: 'graph/treemap/periodChanged',
+			data: { 'period.old': previous, 'period.new': period },
+		});
 		this.dispatchEvent(
 			new CustomEvent('gl-graph-timeline-config-change', {
 				detail: { period: period },
@@ -981,8 +1026,16 @@ export class GlGraphTreemap extends SignalWatcher(LitElement) {
 	 *  round-trip rather than maintaining a parallel signal. */
 	private readonly onDecayMenuSelect = (e: CustomEvent<{ value: string }>): void => {
 		const decay = e.detail.value as GraphActivityDecay;
-		if (this.graphState.config?.activityDecay === decay) return;
+		// Default to '5m' to match the picker's own default (see render()), so `decay.old` reports
+		// the value the user actually saw selected and re-picking that default is caught as a no-op
+		// rather than emitting a phantom change from `undefined`.
+		const previous = this.graphState.config?.activityDecay ?? '5m';
+		if (previous === decay) return;
 
+		emitTelemetrySentEvent<'graph/treemap/decayChanged'>(this, {
+			name: 'graph/treemap/decayChanged',
+			data: { 'decay.old': previous, 'decay.new': decay },
+		});
 		this._ipc?.sendCommand(UpdateGraphConfigurationCommand, { changes: { activityDecay: decay } });
 	};
 
@@ -1121,7 +1174,19 @@ export class GlGraphTreemap extends SignalWatcher(LitElement) {
 	}
 
 	private readonly onChartZoomChange = (e: CustomEvent<TreemapZoomChangeDetail>): void => {
-		this._zoomPath = e.detail.path;
+		const previous = this._zoomPath;
+		const next = e.detail.path;
+		this._zoomPath = next;
+
+		// The chart re-emits zoom-change when it rehydrates the preserved zoom by name after an
+		// error → retry cycle; `classifyTreemapZoom` reports `changed:false` for that identical path.
+		const zoom = classifyTreemapZoom(previous, next);
+		if (!zoom.changed) return;
+
+		emitTelemetrySentEvent<'graph/treemap/zoomed'>(this, {
+			name: 'graph/treemap/zoomed',
+			data: { mode: this.mode, direction: zoom.direction, depth: zoom.depth },
+		});
 	};
 
 	/** Per-mode primary action for a file-leaf click. Folder clicks zoom (handled in the chart);
@@ -1134,10 +1199,12 @@ export class GlGraphTreemap extends SignalWatcher(LitElement) {
 
 		switch (this.mode) {
 			case 'files':
+				this.emitFileClickTelemetry('files', 'open');
 				this.sendFileAction('open', absPath);
 				return;
 
 			case 'commits':
+				this.emitFileClickTelemetry('commits', 'history');
 				this.sendFileAction('history', absPath);
 				return;
 
@@ -1146,6 +1213,7 @@ export class GlGraphTreemap extends SignalWatcher(LitElement) {
 				// last surface change the user sees — landing on the file matches the click intent
 				// while the kanban session detail quietly slides in beside it.
 				const session = this.findSessionForFile(absPath);
+				this.emitFileClickTelemetry('activity', 'open', session != null);
 				if (session != null) {
 					this.dispatchEvent(
 						new CustomEvent('gl-graph-kanban-open-session', {
@@ -1172,6 +1240,13 @@ export class GlGraphTreemap extends SignalWatcher(LitElement) {
 			}
 		}
 	};
+
+	private emitFileClickTelemetry(mode: TreemapMode, action: 'open' | 'history', sessionFocused?: boolean): void {
+		emitTelemetrySentEvent<'graph/treemap/fileClicked'>(this, {
+			name: 'graph/treemap/fileClicked',
+			data: { mode: mode, action: action, 'session.focused': sessionFocused },
+		});
+	}
 
 	private sendFileAction(action: TreemapFileActionParams['action'], absPath: string): void {
 		// Send the repo-relative path + the repo it belongs to, so the host can scheme-preserve

--- a/src/webviews/apps/plus/graph/components/gl-graph-visualizations-switcher.ts
+++ b/src/webviews/apps/plus/graph/components/gl-graph-visualizations-switcher.ts
@@ -4,15 +4,19 @@ import { css, html, LitElement, nothing } from 'lit';
 import { customElement } from 'lit/decorators.js';
 import type { VisualizationMode } from '../../../../plus/graph/protocol.js';
 import type { TreemapMode } from '../../../../plus/treemap/protocol.js';
+import { emitTelemetrySentEvent } from '../../../shared/telemetry.js';
 import { graphStateContext } from '../context.js';
+import type { GraphVisualizationKey } from './visualizations.utils.js';
+import { getEffectiveVisualizationKey } from './visualizations.utils.js';
 import '../../../shared/components/code-icon.js';
 import '../../../shared/components/overlays/tooltip.js';
 
 /** Flat enumeration of the visualizations the switcher offers. Each entry collapses the two-axis
  *  (mode × treemapMode) state into a single key, so the UI is one tablist instead of two nested
  *  toggles. Add a new visualization by extending this map; the rest of the component derives icon,
- *  tooltip, and dispatch from the entry. */
-type VisualizationKey = 'timeline' | 'treemap-files' | 'treemap-commits' | 'treemap-activity';
+ *  tooltip, and dispatch from the entry. Aliased to the shared {@link GraphVisualizationKey} so the
+ *  switcher, the wrapper's routing, and the `closed` telemetry all name visualizations identically. */
+type VisualizationKey = GraphVisualizationKey;
 
 interface VisualizationConfig {
 	mode: VisualizationMode;
@@ -127,14 +131,23 @@ export class GlGraphVisualizationsSwitcher extends SignalWatcher(LitElement) {
 		return repo?.virtual === true;
 	}
 
-	/** Map current `(mode, treemapMode)` state to the active switcher key. Treemap defaults to
-	 *  `files` when no mode is set so the switcher always has exactly one pressed button. */
+	/** Map current `(mode, treemapMode)` state to the active switcher key via the shared resolver, so
+	 *  the pressed tab, the wrapper's routing, and the `closed` telemetry can't drift. The switcher
+	 *  renders only when the flag is on (see `render`), so the gate is always satisfied here. */
 	private get activeKey(): VisualizationKey {
-		if (this.mode === 'timeline') return 'timeline';
-		return `treemap-${this.treemapMode}`;
+		return getEffectiveVisualizationKey(
+			this.mode,
+			this.treemapMode,
+			this.graphState.config?.experimentalVisualizationsEnabled === true,
+		);
 	}
 
 	private select(key: VisualizationKey): void {
+		// Clicking the already-active tab dispatches nothing today (both per-axis conditions below
+		// are false) — keep that contract explicit so the telemetry can't count no-op clicks.
+		const previous = this.activeKey;
+		if (key === previous) return;
+
 		const config = visualizationConfigs[key];
 		if (this.mode !== config.mode) {
 			this.dispatchEvent(
@@ -154,6 +167,14 @@ export class GlGraphVisualizationsSwitcher extends SignalWatcher(LitElement) {
 				}),
 			);
 		}
+
+		// Emitted here (per click) rather than in graph-app's per-axis handlers — a single switch
+		// like timeline → Commits Treemap can dispatch BOTH events above, which would double-count
+		// the one user action.
+		emitTelemetrySentEvent<'graph/visualizations/modeChanged'>(this, {
+			name: 'graph/visualizations/modeChanged',
+			data: { 'mode.old': previous, 'mode.new': key, reason: 'user' },
+		});
 	}
 
 	private renderButton(

--- a/src/webviews/apps/plus/graph/components/gl-graph-visualizations.ts
+++ b/src/webviews/apps/plus/graph/components/gl-graph-visualizations.ts
@@ -4,6 +4,7 @@ import { css, html, LitElement } from 'lit';
 import { customElement, property } from 'lit/decorators.js';
 import type { VisualizationMode } from '../../../../plus/graph/protocol.js';
 import { graphStateContext } from '../context.js';
+import { getEffectiveVisualizationKey } from './visualizations.utils.js';
 import './gl-graph-timeline.js';
 import './gl-graph-treemap.js';
 
@@ -46,11 +47,17 @@ export class GlGraphVisualizations extends SignalWatcher(LitElement) {
 	private graphState!: typeof graphStateContext.__context__;
 
 	private get mode(): VisualizationMode {
-		// Gate non-timeline modes behind the experimental flag — when it's off, force-route to the
-		// timeline regardless of persisted `visualizationMode`. We don't mutate the stored value here
-		// so re-enabling the flag restores the user's prior choice without an extra round-trip.
-		if (this.graphState.config?.experimentalVisualizationsEnabled !== true) return 'timeline';
-		return this.graphState.visualizationMode ?? 'timeline';
+		// Route through the shared resolver so this render decision, the switcher's active tab, and
+		// the `graph/visualizations/closed` telemetry all gate identically: when the experimental
+		// flag is off it force-routes to the timeline regardless of persisted `visualizationMode`
+		// (the stored value is left untouched so re-enabling restores the user's prior choice).
+		return getEffectiveVisualizationKey(
+			this.graphState.visualizationMode,
+			this.graphState.treemapMode,
+			this.graphState.config?.experimentalVisualizationsEnabled === true,
+		) === 'timeline'
+			? 'timeline'
+			: 'treemap';
 	}
 
 	override render(): unknown {

--- a/src/webviews/apps/plus/graph/components/visualizations.utils.ts
+++ b/src/webviews/apps/plus/graph/components/visualizations.utils.ts
@@ -1,0 +1,51 @@
+import type { VisualizationMode } from '../../../../plus/graph/protocol.js';
+import type { TreemapMode, TreemapNode } from '../../../../plus/treemap/protocol.js';
+
+/** Flat key naming the visualization the user is actually looking at — collapses the two-axis
+ *  (`visualizationMode` × `treemapMode`) state into one value, matching the switcher's tab model. */
+export type GraphVisualizationKey = 'timeline' | 'treemap-files' | 'treemap-commits' | 'treemap-activity';
+
+/** Resolves the effective visualization key, gating non-timeline modes behind the experimental
+ *  flag exactly as `gl-graph-visualizations` routes: when the flag is off, force `timeline`
+ *  regardless of the persisted `visualizationMode`/`treemapMode` (the stored values are preserved
+ *  so re-enabling restores the user's prior choice). Single source of truth for the wrapper's
+ *  render routing, the switcher's active tab, and the `graph/visualizations/closed` telemetry mode
+ *  — so a `timeline shown → treemap closed` mismatch can't arise when the flag is toggled off after
+ *  a treemap was picked. */
+export function getEffectiveVisualizationKey(
+	visualizationMode: VisualizationMode | undefined,
+	treemapMode: TreemapMode | undefined,
+	visualizationsEnabled: boolean,
+): GraphVisualizationKey {
+	if (!visualizationsEnabled) return 'timeline';
+	if ((visualizationMode ?? 'timeline') === 'timeline') return 'timeline';
+	return `treemap-${treemapMode ?? 'files'}`;
+}
+
+export interface TreemapZoomClassification {
+	/** False when the path is unchanged (same depth + same leaf) — the chart re-emits an identical
+	 *  path when it rehydrates the preserved zoom after an error→retry, which is not a user zoom. */
+	changed: boolean;
+	direction: 'in' | 'out';
+	depth: number;
+}
+
+/** Classifies a treemap zoom-path transition for telemetry. Zoom is strictly push/pop (drill
+ *  deeper or breadcrumb up), so once past the equal-path `changed:false` guard the lengths always
+ *  differ — `>=` therefore only ever means a genuine deeper level, never a lateral same-depth jump. */
+export function classifyTreemapZoom(previous: TreemapNode[], next: TreemapNode[]): TreemapZoomClassification {
+	const changed = !(previous.length === next.length && previous.at(-1)?.path === next.at(-1)?.path);
+	return { changed: changed, direction: next.length >= previous.length ? 'in' : 'out', depth: next.length };
+}
+
+/** Counts file (leaf) nodes in a treemap tree — the `files.count` reported by `graph/treemap/shown`. */
+export function countFileLeaves(node: TreemapNode | undefined): number {
+	if (node == null) return 0;
+	if (node.type === 'file') return 1;
+
+	let count = 0;
+	for (const child of node.children ?? []) {
+		count += countFileLeaves(child);
+	}
+	return count;
+}

--- a/src/webviews/apps/plus/graph/graph-app.ts
+++ b/src/webviews/apps/plus/graph/graph-app.ts
@@ -77,6 +77,7 @@ import type {
 import type { GraphTreemapModeChangeDetail } from './components/gl-graph-treemap.js';
 import type { GraphVisualizationModeChangeDetail } from './components/gl-graph-visualizations.js';
 import type { WipBarItem, WipBarSelectDetail, WipBarStatsNeededDetail } from './components/gl-graph-wip-bar.js';
+import { getEffectiveVisualizationKey } from './components/visualizations.utils.js';
 import { pickWipRowAgentStatus } from './components/wipRowAgentStatus.js';
 import type { AppState } from './context.js';
 import { graphServicesContext, graphStateContext } from './context.js';
@@ -1484,6 +1485,29 @@ export class GraphApp extends SignalWatcher(LitElement) {
 		if (displayMode !== this._wasDisplayMode) {
 			if (this._wasDisplayMode != null && this._wasDisplayMode !== 'graph') {
 				this._altModeSelectedCommit = undefined;
+			}
+			// `closed` lifecycle telemetry for the alternate display modes. Entry impressions are
+			// emitted by the mounted components themselves (`graph/timeline|treemap|kanban/shown`);
+			// only the exit is recorded here, since this transition check is the single place every
+			// `displayMode` writer (sidebar rail, close buttons, search-request path) funnels through.
+			if (this._wasDisplayMode === 'visualizations') {
+				// Resolve through the shared gate (NOT raw `visualizationMode`) so the reported mode
+				// matches what was actually shown: with the experimental flag off, the wrapper
+				// force-routes to the timeline regardless of a persisted `treemap*` choice, so reading
+				// the raw value here would emit `treemap-*` for a session where only the timeline was
+				// shown — an inconsistent `timeline shown → treemap closed` funnel.
+				emitTelemetrySentEvent<'graph/visualizations/closed'>(this, {
+					name: 'graph/visualizations/closed',
+					data: {
+						mode: getEffectiveVisualizationKey(
+							this.graphState.visualizationMode,
+							this.graphState.treemapMode,
+							this.graphState.config?.experimentalVisualizationsEnabled === true,
+						),
+					},
+				});
+			} else if (this._wasDisplayMode === 'kanban') {
+				emitTelemetrySentEvent<'graph/kanban/closed'>(this, { name: 'graph/kanban/closed', data: {} });
 			}
 			this._wasDisplayMode = displayMode;
 			// Notify the host so it can fetch row stats when entering Visualizations mode (stats are


### PR DESCRIPTION
Part of #5356 (Visualizations: Visual History, Files/Commits/Agent Activity Treemaps, Agent Kanban)

## Summary

Instruments the Graph's Visualizations surfaces, which previously emitted no telemetry of their own — closing the last uncovered block of the #5356 epic checklist.

- **Visualizations switcher** — one `modeChanged` per switch (not per underlying axis event, so a `timeline → Commits Treemap` switch that dispatches both axis events counts once); virtual-repo Commits→Files auto-fallbacks are labeled `reason: 'fallback'`, distinct from user switches.
- **Visual History (embedded timeline)** — impression + commit selection (first-paint auto-selects and slider scrubs excluded), period / slice-by / scope changes (scope reports type only, never paths).
- **Treemaps (all three modes via a `mode` field)** — impression deferred until data resolves so `files.count` is accurate; zoom drill-downs (error→retry rehydration re-emits filtered out); per-mode file-click actions; period (Commits) and activity-decay (Agent Activity) changes.
- **Agent Kanban** — impression with per-column session counts; card selection (mirrors `graph/agents/*` shapes, including the same repo-family flag the open-session gate applies); session actions and permission resolutions observed via a single delegated listener over the existing command-link buttons.

Lifecycle `closed` events for both alternate display modes fire from graph-app's display-mode transition — the single point every writer (sidebar rail, close buttons, search-request path) funnels through; entry impressions come from the mounted components. Repo/webview context is attached host-side as usual; payloads carry counts, booleans, durations, and enum ids only.

A shared `getEffectiveVisualizationKey` helper backs the wrapper's routing, the switcher's active tab, and the `closed` telemetry mode so they can't drift (in particular, `closed` reports what was actually shown when the experimental flag is off, not the raw persisted treemap choice).

Telemetry docs auto-regenerated via `pnpm run generate:docs:telemetry`.

### New events

| Event | When |
|---|---|
| `graph/visualizations/modeChanged` | Switcher click, or virtual-repo Commits→Files fallback (`reason`) |
| `graph/visualizations/closed` | Graph leaves Visualizations display mode |
| `graph/timeline/shown` | Embedded Visual History becomes visible |
| `graph/timeline/commitSelected` | Commit selected in the chart (auto/interim excluded) |
| `graph/timeline/periodChanged` / `sliceByChanged` / `scopeChanged` | Header period / slice-by / file-folder scope changes |
| `graph/treemap/shown` | A treemap (files/commits/activity) becomes visible + data loaded |
| `graph/treemap/zoomed` | Folder drill-down or breadcrumb |
| `graph/treemap/fileClicked` | File leaf click (per-mode action) |
| `graph/treemap/periodChanged` / `decayChanged` | Commits period / Agent Activity decay changes |
| `graph/kanban/shown` / `closed` | Agent Kanban becomes visible / exits |
| `graph/kanban/sessionSelected` | Session card click |
| `graph/kanban/sessionAction` | Open Session / View Plan |
| `graph/kanban/permissionResolved` | Allow/Deny (Approve/Reject) |

## Test plan

- `npx tsc --noEmit` (node + webview projects) and `pnpm run check` pass.
- New unit tests for the extracted pure helpers (`getEffectiveVisualizationKey`, `classifyTreemapZoom`, `countFileLeaves`) — 14 tests, all passing.
- **Live-verified** each event against a running instance (both experimental flags on, real graph + agent sessions), observing emitted payloads at the `gl-telemetry-fired` boundary: every event fires with correct data and no console errors. The switcher double-count guard, the auto/interim commit-select exclusions, the same-value guards, and the flag-off `closed` reporting `timeline` were all confirmed live. Environment-limited (code-verified): the virtual-repo `reason: 'fallback'` path and the error→retry zoom-dedup negative path.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
