### PR TITLE
Defaults the Graph sidebar to unpinned and removes the Pro badge from the header

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,11 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/) and this p
 ### Changed
 
 - Changes the default _Commit Graph_ lane colors for dark and high-contrast themes to a new vibrant, perceptually-uniform palette &mdash; every lane shares the same perceived brightness so no lane visually dominates; light themes keep the previous colors, and any `gitlens.graphLane1Color`&ndash;`gitlens.graphLane10Color` customizations in `workbench.colorCustomizations` are still honored
+- Changes the _Commit Graph_ sidebar to be unpinned by default &mdash; the sidebar now floats over the graph and auto-collapses when it loses focus; pin it (or set `gitlens.graph.sidebar.pinned` to `true`) to restore the previous shared-space layout ([#5447](https://github.com/gitkraken/vscode-gitlens/issues/5447))
+
+### Removed
+
+- Removes the _Pro_ feature badge from the _Commit Graph_ header &mdash; the _Start New_ menu now occupies that area ([#5447](https://github.com/gitkraken/vscode-gitlens/issues/5447))
 
 ## [18.3.0] - 2026-07-09
 

--- a/package.json
+++ b/package.json
@@ -1133,7 +1133,7 @@
 					},
 					"gitlens.graph.sidebar.pinned": {
 						"type": "boolean",
-						"default": true,
+						"default": false,
 						"markdownDescription": "Specifies whether the _Commit Graph_ sidebar is pinned. When pinned, the sidebar shares space with the graph; when unpinned, the sidebar floats over the graph and auto-collapses when it loses focus",
 						"scope": "window",
 						"order": 301

--- a/src/webviews/apps/plus/graph/graph-app.ts
+++ b/src/webviews/apps/plus/graph/graph-app.ts
@@ -748,7 +748,7 @@ export class GraphApp extends SignalWatcher(LitElement) {
 	}
 
 	private shouldAutoCollapseOverlay(): boolean {
-		if (this.graphState.config?.sidebarPinned !== false) return false;
+		if (this.graphState.config?.sidebarPinned ?? false) return false;
 		if (!this.graphState.sidebar?.visible) return false;
 		return true;
 	}
@@ -1902,7 +1902,7 @@ export class GraphApp extends SignalWatcher(LitElement) {
 	private renderSidebarSplit(hidden = false) {
 		const isOpen = (this.graphState.sidebar?.visible ?? false) && this.graphState.sidebar?.activePanel != null;
 		const sidebarPosition = this.graphState.sidebar?.position ?? sidebarDefaultPct;
-		const sidebarPinned = this.graphState.config?.sidebarPinned ?? true;
+		const sidebarPinned = this.graphState.config?.sidebarPinned ?? false;
 		return html`<gl-split-panel
 			class="graph__sidebar-split"
 			?hidden=${hidden}
@@ -2440,7 +2440,7 @@ export class GraphApp extends SignalWatcher(LitElement) {
 	}
 
 	private handleSidebarTogglePinned = (): void => {
-		const next = !(this.graphState.config?.sidebarPinned ?? true);
+		const next = !(this.graphState.config?.sidebarPinned ?? false);
 		this._ipc.sendCommand(UpdateGraphConfigurationCommand, { changes: { sidebarPinned: next } });
 	};
 

--- a/src/webviews/apps/plus/graph/graph-header.ts
+++ b/src/webviews/apps/plus/graph/graph-header.ts
@@ -15,7 +15,6 @@ import { wait } from '@gitlens/utils/promise.js';
 import type { BranchGitCommandArgs } from '../../../../commands/git/branch.js';
 import { GlyphChars } from '../../../../constants.js';
 import type { RepositoryShape } from '../../../../git/models/repositoryShape.js';
-import { isSubscriptionPaid } from '../../../../plus/gk/utils/subscription.utils.js';
 import { createCommandLink } from '../../../../system/commands.js';
 import type {
 	DidChooseRefParams,
@@ -65,7 +64,6 @@ import { graphHeaderControlStyles, titlebarStyles } from './styles/header.css.js
 import '../../shared/components/branch-name.js';
 import '../../shared/components/button.js';
 import '../../shared/components/code-icon.js';
-import '../../shared/components/feature-badge.js';
 import '../../shared/components/menu/menu-divider.js';
 import '../../shared/components/menu/menu-item.js';
 import '../../shared/components/menu/menu-label.js';
@@ -1064,7 +1062,7 @@ export class GlGraphHeader extends SignalWatcher(LitElement) {
 	private renderTitlebarHeaderRow(repo: RepositoryShape | undefined) {
 		const hasMultipleRepositories = (this.graphState.repositories?.length ?? 0) > 1;
 
-		const { allowed, branch, branchState, config, lastFetched, loading, state, subscription } = this.graphState;
+		const { allowed, branch, branchState, config, lastFetched, loading, state } = this.graphState;
 
 		return html`<div class="titlebar__row titlebar__row--wrap">
 			<div class="titlebar__group">
@@ -1215,15 +1213,6 @@ export class GlGraphHeader extends SignalWatcher(LitElement) {
 				)}
 				${this.renderGraphWalkthroughBanner(state)} ${this.renderStartMenu()}
 				<gl-graph-launchpad-indicator></gl-graph-launchpad-indicator>
-				${when(
-					subscription == null || !isSubscriptionPaid(subscription),
-					() => html`
-						<gl-feature-badge
-							.source=${{ source: 'graph', detail: 'badge' } as const}
-							.subscription=${subscription}
-						></gl-feature-badge>
-					`,
-				)}
 			</div>
 		</div>`;
 	}

--- a/src/webviews/apps/plus/graph/sidebar/sidebar-panel.ts
+++ b/src/webviews/apps/plus/graph/sidebar/sidebar-panel.ts
@@ -707,7 +707,7 @@ export class GlGraphSidebarPanel extends SignalWatcher(LitElement) {
 	}
 
 	private renderHeader(config: PanelConfig, isLoading: boolean) {
-		const pinned = this._state.config?.sidebarPinned ?? true;
+		const pinned = this._state.config?.sidebarPinned ?? false;
 		const pinTooltip = pinned ? 'Unpin Side Bar' : 'Pin Side Bar';
 		const pinIcon = pinned ? 'pinned' : 'pin';
 		return html`<div class="header">

--- a/src/webviews/apps/plus/graph/styles/header.css.ts
+++ b/src/webviews/apps/plus/graph/styles/header.css.ts
@@ -164,10 +164,6 @@ export const titlebarStyles = css`
 	.titlebar__debugging > * {
 		display: inline-block;
 	}
-
-	.titlebar gl-feature-badge {
-		color: var(--color-foreground);
-	}
 `;
 
 export const graphHeaderControlStyles = css`

--- a/src/webviews/plus/graph/graphWebview.ts
+++ b/src/webviews/plus/graph/graphWebview.ts
@@ -3608,7 +3608,7 @@ export class GraphWebviewProvider implements WebviewProvider<State, State, Graph
 			showRemoteNamesOnRefs: configuration.get('graph.showRemoteNames'),
 			showWorktreeWipStats: configuration.get('graph.showWorktreeWipStats'),
 			sidebar: configuration.get('graph.sidebar.enabled') ?? true,
-			sidebarPinned: configuration.get('graph.sidebar.pinned') ?? true,
+			sidebarPinned: configuration.get('graph.sidebar.pinned') ?? false,
 			stickyTimeline: configuration.get('graph.stickyTimeline'),
 			style: configuration.get('graph.style'),
 		};

--- a/tests/e2e/specs/graphHeader.test.ts
+++ b/tests/e2e/specs/graphHeader.test.ts
@@ -7,7 +7,8 @@
  *  - Launchpad indicator: the rocket button, its not-connected state, and the "Open Launchpad"
  *    action.
  *  - Commit-signing indicator in the WIP details (gated on repo commit.gpgsign).
- *  - Pro feature badge visibility gating (shown to non-paid, hidden when paid).
+ *  - Pro feature badge absence — the badge was removed from the header (the Start New menu
+ *    occupies that area), so it must never render regardless of subscription state.
  *
  * These assert on the header→command WIRING (the command: links the menu items carry) rather than
  * invoking the commands, which would open quick-pick wizards — those flows are covered separately
@@ -162,27 +163,20 @@ test.describe('Graph — Header menus', () => {
 		});
 	});
 
-	test('Pro feature badge is hidden for a paid subscription', async ({ vscode }) => {
-		using _ = await vscode.gitlens.startSubscriptionSimulation({
-			state: 6,
-			planId: 'pro',
-		});
-
-		const webview = await openGraph(vscode);
-
-		await expect(webview.locator('gl-feature-badge')).toHaveCount(0);
-	});
-
-	test('Pro feature badge is shown for a non-paid (trial) subscription', async ({ vscode }) => {
+	test('Pro feature badge is not shown in the header, even for a non-paid (trial) subscription', async ({
+		vscode,
+	}) => {
 		using _ = await vscode.gitlens.startSubscriptionSimulation({
 			state: 3 /* Trial */,
 		});
 
 		const webview = await openGraph(vscode);
 
-		await expect(webview.locator('gl-feature-badge').first()).toBeVisible({
+		// The Start New menu takes the badge's place in the header
+		await expect(webview.locator('button[aria-label="Start New"]').first()).toBeVisible({
 			timeout: MaxTimeout,
 		});
+		await expect(webview.locator('.titlebar gl-feature-badge')).toHaveCount(0);
 	});
 
 	test('WIP details show the commit-signing indicator when signing is enabled', async ({ vscode }) => {


### PR DESCRIPTION
Closes #5447 (part of #5391 — turning the Graph into the main GitLens panel)

## Changes

- **Defaults the Commit Graph sidebar to unpinned** — flips the `gitlens.graph.sidebar.pinned` default to `false` (package.json + all fallbacks in `graphWebview.ts`, `graph-app.ts`, `sidebar-panel.ts`), so the sidebar floats over the graph in overlay mode and auto-collapses on focus loss. Users who explicitly set the setting are unaffected.
- **Removes the Pro feature badge from the Graph header titlebar** — the Start New menu (landed in 46bef5e52) already provides the start-work entry point there. The badge in the feature gate (`gate.ts`) is intentionally untouched (gate redesign is a separate #5391 checklist item).
- CHANGELOG entries under `[Unreleased]` for both.

Note on placement: Start New stays in its current slot (left of the Launchpad indicator) — the checklist's "replace" is satisfied functionally by the existing Start New menu.

## Verification

- `pnpm run check` passes
- Live-verified on a fresh profile: `sidebarPinned` resolves to `false`, the sidebar split-panel renders in `overlay` mode (graph keeps full width beneath the floating panel), and clicking back into the graph auto-collapses the open panel
- E2E: the two Pro-badge tests in `graphHeader.test.ts` were rewritten into one ("badge absent even on trial, Start New present") — passes
- E2E full suite: 6 failures (`graphDetails` compare panel, `graphHeader` Launchpad indicator, `graphHeaderGitActions` fetch popover, `graphPin`, `graphReview` branch-row chip, `rebase` keyboard shortcuts) — verified **pre-existing**: the identical set fails on bare `origin/main` (6dc193fdf) in a clean worktree. CI currently skips the E2E job, so these have gone unnoticed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

