### PR TITLE
Fixes stale and platform-broken E2E tests for the Graph and rebase editor

### DIFF
--- a/tests/e2e/specs/graphDetails.test.ts
+++ b/tests/e2e/specs/graphDetails.test.ts
@@ -452,7 +452,7 @@ test.describe('Graph Details - Compare Mode', () => {
 		// Ctrl+Click second commit to multi-select
 		const secondCommit = graphWebview.getByText('Add utils module', { exact: true }).first();
 		await expect(secondCommit).toBeVisible({ timeout: MaxTimeout });
-		await secondCommit.click({ modifiers: ['Control'] });
+		await secondCommit.click({ modifiers: ['ControlOrMeta'] });
 
 		// Compare panel should appear with its header
 		const compareHeader = graphWebview.locator('.compare-header__title').first();
@@ -465,7 +465,7 @@ test.describe('Graph Details - Compare Mode', () => {
 		await selectCommitByMessage(graphWebview, 'Add greeting module');
 		await waitForDetailsLoaded(graphWebview);
 		const secondCommit = graphWebview.getByText('Add utils module', { exact: true }).first();
-		await secondCommit.click({ modifiers: ['Control'] });
+		await secondCommit.click({ modifiers: ['ControlOrMeta'] });
 
 		// Wait for compare panel
 		await expect(graphWebview.locator('.compare-header__title').first()).toBeVisible({ timeout: 15000 });
@@ -481,7 +481,7 @@ test.describe('Graph Details - Compare Mode', () => {
 		await selectCommitByMessage(graphWebview, 'Add greeting module');
 		await waitForDetailsLoaded(graphWebview);
 		const secondCommit = graphWebview.getByText('Add utils module', { exact: true }).first();
-		await secondCommit.click({ modifiers: ['Control'] });
+		await secondCommit.click({ modifiers: ['ControlOrMeta'] });
 
 		await expect(graphWebview.locator('.compare-header__title').first()).toBeVisible({ timeout: 15000 });
 
@@ -502,7 +502,7 @@ test.describe('Graph Details - Compare Mode', () => {
 		await selectCommitByMessage(graphWebview, 'Add greeting module');
 		await waitForDetailsLoaded(graphWebview);
 		const secondCommit = graphWebview.getByText('Add utils module', { exact: true }).first();
-		await secondCommit.click({ modifiers: ['Control'] });
+		await secondCommit.click({ modifiers: ['ControlOrMeta'] });
 
 		await expect(graphWebview.locator('.compare-header__title').first()).toBeVisible({ timeout: 15000 });
 
@@ -516,7 +516,7 @@ test.describe('Graph Details - Compare Mode', () => {
 		await selectCommitByMessage(graphWebview, 'Add greeting module');
 		await waitForDetailsLoaded(graphWebview);
 		const secondCommit = graphWebview.getByText('Add utils module', { exact: true }).first();
-		await secondCommit.click({ modifiers: ['Control'] });
+		await secondCommit.click({ modifiers: ['ControlOrMeta'] });
 
 		await expect(graphWebview.locator('.compare-header__title').first()).toBeVisible({ timeout: 15000 });
 
@@ -532,7 +532,7 @@ test.describe('Graph Details - Compare Mode', () => {
 		await selectCommitByMessage(graphWebview, 'Add greeting module');
 		await waitForDetailsLoaded(graphWebview);
 		const secondCommit = graphWebview.getByText('Add utils module', { exact: true }).first();
-		await secondCommit.click({ modifiers: ['Control'] });
+		await secondCommit.click({ modifiers: ['ControlOrMeta'] });
 
 		await expect(graphWebview.locator('.compare-header__title').first()).toBeVisible({ timeout: 15000 });
 

--- a/tests/e2e/specs/graphHeader.test.ts
+++ b/tests/e2e/specs/graphHeader.test.ts
@@ -150,7 +150,8 @@ test.describe('Graph — Header menus', () => {
 		const webview = await openGraph(vscode);
 
 		// No integration is connected in the test environment, so the indicator advertises that.
-		const launchpadButton = webview.locator('button[aria-label^="Launchpad"]').first();
+		// The indicator's anchor is an <a href> (click opens Launchpad directly), not a <button>.
+		const launchpadButton = webview.locator('.action-button[aria-label^="Launchpad"]').first();
 		await expect(launchpadButton).toBeVisible({ timeout: MaxTimeout });
 		await expect(launchpadButton).toHaveAttribute('aria-label', /connect an integration/i);
 

--- a/tests/e2e/specs/graphPin.test.ts
+++ b/tests/e2e/specs/graphPin.test.ts
@@ -76,6 +76,24 @@ async function getPinnedWebviewItem(webview: FrameLocator): Promise<string | nul
 	return JSON.parse(json) as string | null;
 }
 
+/**
+ * Collapse the details panel if it is open. The panel auto-opens at the bottom of the graph
+ * (WIP initial selection + vertical layout), and in the short E2E panel it squeezes the row
+ * grid to near-zero height — the virtualizer then paints no branch rows, so ref-pill
+ * `data-vscode-context` assertions can never match. Closing it gives the grid the height to
+ * actually render the rows.
+ */
+async function ensureDetailsPanelClosed(webview: FrameLocator): Promise<void> {
+	const toggle = webview.locator('gl-button[aria-label$="Details Panel"]').first();
+	await expect(toggle).toBeVisible({ timeout: 15000 });
+	if ((await toggle.getAttribute('aria-label')) === 'Hide Details Panel') {
+		await toggle.click();
+		await expect(webview.locator('gl-button[aria-label="Show Details Panel"]').first()).toBeVisible({
+			timeout: 15000,
+		});
+	}
+}
+
 const test = base.extend({
 	vscodeOptions: [
 		{
@@ -168,6 +186,8 @@ test.describe('Graph — Pin Branch to Edge', () => {
 		// Verify the webviewItem context includes +pinned (rows re-processed after pin).
 		// The row re-send (updateState) arrives separately from — and later than — the
 		// pinnedRef state update above, so poll until the row context picks up +pinned.
+		// The branch rows must actually be painted for the context to exist in the DOM.
+		await ensureDetailsPanelClosed(graphWebview!);
 		await expect.poll(() => getPinnedWebviewItem(graphWebview!), { timeout: 15000 }).toContain('+pinned');
 	});
 

--- a/tests/e2e/specs/graphReview.test.ts
+++ b/tests/e2e/specs/graphReview.test.ts
@@ -276,9 +276,12 @@ test.describe('Review & Compose Sub-Panels', () => {
 		const branchRow = graphWebview.locator('.graph-details-header__branch-row');
 		await expect(branchRow).toBeVisible({ timeout: 30000 });
 
-		// Create branch icon should be in branch row
-		const createBranchChip = branchRow.locator('gl-action-chip[icon="custom-start-work"]');
-		await expect(createBranchChip).toBeVisible();
+		// Branch actions kebab (hosts the Create Branch... context menu, replacing the old
+		// standalone create-branch chip) should be in branch row
+		const branchActionsChip = branchRow.locator(
+			'gl-action-chip[icon="kebab-vertical"][label="Show Branch Actions"]',
+		);
+		await expect(branchActionsChip).toBeVisible();
 
 		// Review/compose chips should NOT be in branch row
 		const reviewInBranch = branchRow.locator('gl-action-chip[icon="checklist"]');

--- a/tests/e2e/specs/rebase.test.ts
+++ b/tests/e2e/specs/rebase.test.ts
@@ -240,7 +240,7 @@ test.describe('Editor — Core', () => {
 
 			// Test bulk action change: multi-select with Ctrl+Click then drop with 'd'
 			await entries.nth(2).click();
-			await entries.nth(3).click({ modifiers: ['Control'] });
+			await entries.nth(3).click({ modifiers: ['ControlOrMeta'] });
 			await page.keyboard.press('d');
 			await page.waitForTimeout(ShortTimeout / 2);
 			await expect(entries.nth(2).locator('.action-select')).toHaveAttribute('value', 'drop');
@@ -287,7 +287,7 @@ test.describe('Editor — Core', () => {
 
 			// Select oldest then newest (so newest is focused)
 			await oldestEntry.click();
-			await newestEntry.click({ modifiers: ['Control'] });
+			await newestEntry.click({ modifiers: ['ControlOrMeta'] });
 
 			// Press 's' to squash selection
 			await page.keyboard.press('s');
@@ -374,7 +374,7 @@ test.describe('Editor — Core', () => {
 
 			// Test moving commits down: Select 2nd and 3rd entries (Commit C and Commit B)
 			await entries.nth(1).click();
-			await entries.nth(2).click({ modifiers: ['Control'] });
+			await entries.nth(2).click({ modifiers: ['ControlOrMeta'] });
 			await page.keyboard.press('Alt+ArrowDown');
 			await page.waitForTimeout(ShortTimeout / 2);
 
@@ -395,7 +395,7 @@ test.describe('Editor — Core', () => {
 
 			// Test moving commits up: Select repositioned Commit C and Commit B (now at indices 2 and 3)
 			await entries.nth(2).click();
-			await entries.nth(3).click({ modifiers: ['Control'] });
+			await entries.nth(3).click({ modifiers: ['ControlOrMeta'] });
 			await page.keyboard.press('Alt+ArrowUp');
 			await page.waitForTimeout(ShortTimeout / 2);
 


### PR DESCRIPTION
Fixes the 6 E2E test failures currently on `main` (the E2E CI job is `workflow_dispatch`-only, so these accumulated unnoticed). Full suite locally goes from **176 → 197 passing**; the "did not run" tail (tests hidden behind serial aborts) collapses from 20 to 3. **None of the six was a product bug** — all fixes are test-side; no product code is touched.

## Root causes & fixes

| Test | Root cause | Fix |
| --- | --- | --- |
| `graphHeader` Launchpad indicator | Stale after 5292a3c65 changed the indicator's `<button>` to an `<a href>` (click opens Launchpad) | Tag-agnostic `.action-button[aria-label^="Launchpad"]` locator |
| `graphDetails` compare mode (+7 blocked tests) | Test hardcoded `Control` for multi-select; the graph grid requires Cmd on macOS | `ControlOrMeta` modifier |
| `graphReview` branch-row actions | Stale after df7472130 (#5459) replaced the create-branch chip with the *Show Branch Actions* kebab | Assert the kebab chip in the branch row |
| `rebase` keyboard shortcuts | Same Ctrl-vs-Cmd modifier artifact (app logic verified correct via live repro) | `ControlOrMeta` in all 4 multi-select clicks |
| `graphPin` (+2 blocked tests) | Pin pipeline verified healthy end-to-end (host ships `+pinned` rows; webview state holds them) — but in the short e2e panel, WIP auto-selection + the auto-opened bottom details panel (#5402) squeeze the row grid to ~52px, so the virtualizer paints no branch pills and the DOM poll can never match | New `ensureDetailsPanelClosed()` helper before the DOM assertion — the grid gets height, pills render, the meaningful row-context assertion stays |
| `graphHeaderGitActions` fetch gear | Genuine intermittent flake — passes/fails in isolation runs alike | Not fixed here; needs its own investigation |

## Remaining known issues (documented, out of scope)

- `graphHeaderGitActions.test.ts:203` — intermittent flake (see above)
- `rebase.test.ts:509` (squash/fixup execute) — order-dependent flake: passes in isolation, can time out under in-file serial execution; previously always hidden in the "did not run" tail
- `mcp.test.ts` / `mcpGitlensTools.test.ts` — fail when the machine's `gk` CLI doesn't expose `gitlens_commit_composer` (discovery returns only `gitlens_launchpad`/`start_review`/`start_work`); environment/CLI-version dependent, not repo code
- The CI `E2E Tests` job has been `if: workflow_dispatch` since the workflow was introduced (8426e95bc, Jan 2026) — E2E has never run automatically. With the suite near-green, enabling it on PRs or nightly is worth discussing; the flakes + MCP version-sensitivity above are the remaining blockers.

## Verification

- Each fixed spec verified green in isolation; full suite run: 197 passed / 3 failed (the 3 documented above) / 2 skipped / 3 did not run
- The 6 original failures were first reproduced identically on bare `origin/main` (clean-worktree baseline) to rule out interference from other branches
- `pnpm run check` passes

Part of this: #5447 (#5391) 
