### PR TITLE
Fixes dropped webview telemetry in GlWebviewApp-based webviews

### DIFF
--- a/src/webviews/apps/shared/appBase.ts
+++ b/src/webviews/apps/shared/appBase.ts
@@ -141,6 +141,12 @@ export abstract class GlWebviewApp extends GlElement {
 			this._ipc,
 			(this._promos = new PromosContext(this._ipc)),
 			(this._telemetry = new TelemetryContext(this._ipc)),
+			// Forward `emitTelemetrySentEvent` DOM events to the host over IPC. Without this bridge
+			// (present in the legacy `App` base below, but previously missing here) every
+			// `gl-telemetry-fired` event from a `GlWebviewApp`-based webview was silently dropped.
+			DOM.on(window, telemetryEventName, e => {
+				this._telemetry.sendEvent(e.detail);
+			}),
 		);
 
 		// Focus tracking (sends debounced focus state to host for context keys)


### PR DESCRIPTION
## Summary

`GlWebviewApp.connectedCallback` creates the `TelemetryContext` (and provides it via context), but never registered the `window` listener that forwards `gl-telemetry-fired` DOM events — the events dispatched by `emitTelemetrySentEvent` — to the host over IPC. That bridge exists only in the legacy `App` base class. As a result, **every `emitTelemetrySentEvent`-emitted event from a modern (Lit/RPC) webview was silently dropped**; only events sent directly through `TelemetryContext.sendEvent` arrived.

**Affected webviews** (everything on `GlWebviewApp`/`GlAppHost`/`SignalWatcherWebviewApp`): Graph — including all of the #5356 sidebar panel telemetry (`graph/{panel}/shown`, `*Action`, `filtered`, `layoutToggled`, …) and the Visualizations/Kanban/Timeline events — plus Home, Commit Details, Timeline, Settings, Welcome, Rebase, and Composer. Only `patchDetails` (still on legacy `App`) was forwarding.

**Since when:** the bridge-less `GlWebviewApp` was introduced 2026-03-16 in the Supertalk RPC infrastructure (`2b7c1c708`); each webview has been affected from the commit that migrated it onto the new base (e.g. Home in `ff68fa180`, the Lit Graph app in `265e3a155`). Events instrumented via `emitTelemetrySentEvent` in those apps have not been reaching analytics since.

## The fix

Registers the same forwarding listener the legacy `App` class has — `DOM.on(window, telemetryEventName, e => this._telemetry.sendEvent(e.detail))` — in `GlWebviewApp.connectedCallback`, disposed with the app's other disposables. 6 lines, no behavior change beyond restoring the forwarding; no double-send is possible (the legacy class is a separate hierarchy, and direct `TelemetryContext.sendEvent` callers don't dispatch DOM events).

## How it was found & verified

Discovered during the live validation sweep for #5477: the graph webview emitted `graph/branches/branchAction {location:'inline'}` as a DOM event, but a spy on the host telemetry seams received nothing; a source sweep confirmed exactly one `telemetryEventName` listener in the entire apps tree, in the legacy class. After the fix (verified live in a real instance): the event arrives exactly once, and the sidebar panel `shown`/`action` events flow end-to-end from DOM emit → IPC → `WebviewController.sendTelemetryEvent`.

## Test plan

- [x] Live-verified: graph sidebar inline action → exactly one event at the host telemetry service; panel `shown` events arrive on panel switches
- [x] `pnpm run check` clean; webviews build compiles
- [ ] Post-merge: confirm `graph/*`, `home/*` event volumes recover in analytics

🤖 Generated with [Claude Code](https://claude.com/claude-code)
