### PR TITLE
Fixes self-managed cloud token requests using the domain as a token id (#5497)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,10 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/) and this p
 
 - Removes the _Pro_ feature badge from the _Commit Graph_ header &mdash; the _Start New_ menu now occupies that area ([#5447](https://github.com/gitkraken/vscode-gitlens/issues/5447))
 
+### Fixed
+
+- Fixes self-managed cloud integrations (e.g. GitHub Enterprise, GitLab Self-Hosted) repeatedly issuing a token request that the server rejects on every session refresh, and legacy connections getting stuck reported as connected with no usable token &mdash; the per-connection token fetch no longer uses the host domain as the token id, and a connection whose token can no longer be fetched is now cleanly disconnected instead of left token-less ([#5497](https://github.com/gitkraken/vscode-gitlens/issues/5497))
+
 ## [18.3.0] - 2026-07-09
 
 ### Added

--- a/packages/plus/integrations/src/__tests__/configuredIntegrationService.test.ts
+++ b/packages/plus/integrations/src/__tests__/configuredIntegrationService.test.ts
@@ -85,6 +85,103 @@ suite('ConfiguredIntegrationService — multi-account (#5430)', () => {
 		assert.equal(session.accessToken, 'ent');
 	});
 
+	test('getConfiguredConnectionId returns undefined for a legacy self-managed connection keyed by domain', async () => {
+		const runtime = createFakeRuntime();
+		// Legacy/migrated single connection: hydration backfills the descriptor id from the domain, so
+		// `id === domain` (see ConfiguredIntegrationDescriptor.id). That is NOT a real backend token id, and
+		// returning it would target `v1/provider-tokens/tokens/{domain}` (rejected by the backend as a non-uuid).
+		await runtime.storage.store('integrations:configured', {
+			'cloud-github-enterprise': [
+				{ cloud: true, integrationId: 'cloud-github-enterprise', domain: 'gh.example.com', scopes: 'repo' },
+			],
+		});
+
+		const service = new ConfiguredIntegrationService(runtime);
+
+		assert.equal(
+			service.getConfiguredConnectionId(
+				GitSelfManagedHostIntegrationId.CloudGitHubEnterprise,
+				'gh.example.com',
+				true,
+			),
+			undefined,
+			'a domain-keyed legacy id must not be returned as a token id',
+		);
+	});
+
+	test('getConfiguredConnectionId returns the token id for a real multi-account self-managed connection', async () => {
+		const runtime = createFakeRuntime();
+		await runtime.storage.store('integrations:configured', {
+			'cloud-github-enterprise': [
+				{
+					id: 'ghe-a1',
+					cloud: true,
+					integrationId: 'cloud-github-enterprise',
+					domain: 'ghe-a.example.com',
+					scopes: 'repo',
+					primary: true,
+				},
+			],
+		});
+
+		const service = new ConfiguredIntegrationService(runtime);
+
+		assert.equal(
+			service.getConfiguredConnectionId(
+				GitSelfManagedHostIntegrationId.CloudGitHubEnterprise,
+				'ghe-a.example.com',
+				true,
+			),
+			'ghe-a1',
+		);
+	});
+
+	test('getConfiguredConnectionId returns undefined for a legacy cloud connection keyed by the canonical domain', async () => {
+		const runtime = createFakeRuntime();
+		// Legacy cloud descriptor: hydration backfills the id from the canonical domain (`github.com`) while
+		// the descriptor has no domain, so `id !== domain` alone would return `github.com` as a token id.
+		await runtime.storage.store('integrations:configured', {
+			github: [{ cloud: true, integrationId: 'github', scopes: 'repo' }],
+		});
+
+		const service = new ConfiguredIntegrationService(runtime);
+
+		assert.equal(
+			service.getConfiguredConnectionId(GitCloudHostIntegrationId.GitHub, undefined, true),
+			undefined,
+			'a canonical-domain-keyed legacy id must not be returned as a token id',
+		);
+	});
+
+	test('getConfiguredConnectionId returns undefined when only a local (PAT) connection matches the cloud scope', async () => {
+		const runtime = createFakeRuntime();
+		// Only a local (PAT) descriptor (id !== domain) matches this host. scopeConnectionCandidates falls back
+		// to the non-cloud set, so `id !== domain` alone would return the local id as a cloud token id.
+		await runtime.storage.store('integrations:configured', {
+			'cloud-github-enterprise': [
+				{
+					id: 'ghe-x',
+					cloud: false,
+					integrationId: 'cloud-github-enterprise',
+					domain: 'gh.example.com',
+					scopes: 'repo',
+				},
+			],
+		});
+
+		const service = new ConfiguredIntegrationService(runtime);
+
+		assert.equal(
+			service.getConfiguredConnectionId(
+				GitSelfManagedHostIntegrationId.CloudGitHubEnterprise,
+				'gh.example.com',
+				true,
+			),
+			undefined,
+			'a local (PAT) connection id must not be returned as a cloud token id',
+		);
+	});
+
 	test('two accounts on the same provider coexist; first is primary', async () => {
 		const runtime = createFakeRuntime();
 		const service = new ConfiguredIntegrationService(runtime);

--- a/packages/plus/integrations/src/__tests__/reconcileConnections.test.ts
+++ b/packages/plus/integrations/src/__tests__/reconcileConnections.test.ts
@@ -910,6 +910,37 @@ suite('cloud sync — multi-account reconcile (#5430)', () => {
 		manager.dispose();
 	});
 
+	test('a failed forced re-sync drops the connection instead of leaving it token-less (#5497)', async () => {
+		// The backend still lists the connection (state = 'connected'), but every token fetch fails (500). A
+		// forced re-sync deletes the cloud secret up front while preserving the descriptor; the replacement
+		// fetch then fails. The descriptor (and its secret) must not be left behind reported as connected.
+		const { runtime, manager } = createManager({
+			connections: [{ tokenId: 'p1', provider: 'github', type: 'oauth', domain: 'github.com' }],
+			token: () => null, // every token fetch fails
+		});
+		await runtime.storage.store('integrations:configured', {
+			github: [{ id: 'p1', cloud: true, integrationId: 'github', scopes: 'repo', primary: true }],
+		});
+		await runtime.storage.storeSecret(
+			'integration.auth.cloud:github|p1',
+			JSON.stringify({ id: 'p1', accessToken: 'old-p1', scopes: ['repo'], cloud: true, type: 'oauth' }),
+		);
+
+		await manager.refreshConnections();
+
+		assert.deepEqual(
+			manager.getConfigured(GitCloudHostIntegrationId.GitHub),
+			[],
+			'the token-less descriptor is removed after the failed forced re-sync',
+		);
+		assert.ok(
+			(await runtime.storage.getSecret('integration.auth.cloud:github|p1')) == null,
+			'the deleted cloud secret is not restored',
+		);
+
+		manager.dispose();
+	});
+
 	test('a non-forced check-in does not re-fetch tokens for already-stored, non-expired connections', async () => {
 		const { runtime, manager, paths } = createManager({
 			connections: [

--- a/packages/plus/integrations/src/authentication/configuredIntegrationService.ts
+++ b/packages/plus/integrations/src/authentication/configuredIntegrationService.ts
@@ -483,14 +483,29 @@ export class ConfiguredIntegrationService implements Disposable {
 	/**
 	 * Returns the id of the configured connection an unscoped descriptor resolves to (the primary for the
 	 * descriptor's domain, matching {@link resolveConnectionId}'s selection), or `undefined` when nothing is
-	 * configured for it. Unlike {@link resolveConnectionId} this never falls back to the domain, so callers
-	 * can safely use the result as a real per-connection token id (e.g. to scope a cloud token fetch to one
-	 * host of a multi-host self-managed provider instead of the provider-global primary).
+	 * configured for it. Unlike {@link resolveConnectionId} this only returns a genuine per-connection cloud
+	 * token id (never a local/PAT or domain-derived legacy id), so callers can safely use it to scope a cloud
+	 * token fetch to one host of a multi-host self-managed provider, or fall through to the provider-global
+	 * primary endpoint on `undefined`.
 	 */
 	getConfiguredConnectionId(id: IntegrationIds, domain: string | undefined, cloud?: boolean): string | undefined {
 		const scoped = isGitSelfManagedHostIntegrationId(id) ? domain : undefined;
 		const candidates = this.scopeConnectionCandidates(id, scoped, cloud);
-		return (candidates?.find(c => c.primary) ?? candidates?.[0])?.id;
+		const connection = candidates?.find(c => c.primary) ?? candidates?.[0];
+		if (connection == null) return undefined;
+
+		// Only return a real per-connection cloud token id. Reject a local (PAT) descriptor (surfaced by
+		// scopeConnectionCandidates' non-cloud fallback) and a domain-derived legacy id (the descriptor's own
+		// domain or the provider's canonical domain — see ConfiguredIntegrationDescriptor.id), either of which
+		// would target `v1/provider-tokens/tokens/{domain}` (rejected as a non-uuid). Callers then fall through
+		// to the provider-scoped primary endpoint.
+		if (!connection.cloud) return undefined;
+
+		const canonicalDomain = providersMetadata[id]?.domain;
+		if (connection.id === connection.domain || (canonicalDomain && connection.id === canonicalDomain)) {
+			return undefined;
+		}
+		return connection.id;
 	}
 
 	/**

--- a/packages/plus/integrations/src/authentication/integrationAuthenticationProvider.ts
+++ b/packages/plus/integrations/src/authentication/integrationAuthenticationProvider.ts
@@ -38,12 +38,16 @@ export interface IntegrationAuthenticationSessionDescriptor {
 export interface IntegrationAuthenticationProvider extends Disposable {
 	/**
 	 * Clears the stored secret for one connection only (never the whole provider). Unlike
-	 * {@link deleteAllSessions}, this deliberately leaves the descriptor in `integrations:configured` — its
-	 * only caller today is a forced re-sync, which needs `getConfigured()` to keep reporting the connection
+	 * {@link deleteAllSessions}, this by default leaves the descriptor in `integrations:configured` — its
+	 * primary caller is a forced re-sync, which needs `getConfigured()` to keep reporting the connection
 	 * while a fresh session is fetched to replace the deleted secret. Implementers should not treat this as
-	 * a full disconnect.
+	 * a full disconnect. Pass `preserveConfigured: false` to also drop the descriptor (e.g. when the
+	 * re-sync's replacement fetch failed and the connection should no longer be reported as connected).
 	 */
-	deleteSession(descriptor: IntegrationAuthenticationSessionDescriptor): Promise<void>;
+	deleteSession(
+		descriptor: IntegrationAuthenticationSessionDescriptor,
+		options?: { preserveConfigured?: boolean },
+	): Promise<void>;
 	deleteAllSessions(descriptor?: IntegrationAuthenticationSessionDescriptor): Promise<void>;
 	getSession(
 		descriptor: IntegrationAuthenticationSessionDescriptor,
@@ -76,7 +80,10 @@ abstract class IntegrationAuthenticationProviderBase<
 	protected abstract get authProviderId(): ID;
 
 	@trace()
-	async deleteSession(descriptor: IntegrationAuthenticationSessionDescriptor): Promise<void> {
+	async deleteSession(
+		descriptor: IntegrationAuthenticationSessionDescriptor,
+		options?: { preserveConfigured?: boolean },
+	): Promise<void> {
 		const domain = isGitSelfManagedHostIntegrationId(this.authProviderId) ? descriptor?.domain : undefined;
 		const configured = this.configuredIntegrationService.getConfigured(this.authProviderId, {
 			domain: domain,
@@ -89,7 +96,7 @@ abstract class IntegrationAuthenticationProviderBase<
 			this.authProviderId,
 			{ ...descriptor, cloud: true },
 			true,
-			{ preserveConfigured: true },
+			{ preserveConfigured: options?.preserveConfigured ?? true },
 		);
 
 		if (configured?.length) {

--- a/packages/plus/integrations/src/models/integration.ts
+++ b/packages/plus/integrations/src/models/integration.ts
@@ -349,6 +349,7 @@ export abstract class IntegrationBase<
 		switch (state) {
 			case 'connected': {
 				const oldSession = this._session;
+				let resyncing = false;
 				if (forceSync) {
 					// Reset our stored session so that we get a new one from the cloud
 					const authProvider = await this.authenticationService.get(this.authProvider.id);
@@ -356,6 +357,7 @@ export abstract class IntegrationBase<
 					// Reset the session and clear our "stay disconnected" flag
 					this._session = undefined;
 					await this.ctx.storage.deleteWorkspace(this.connectedKey);
+					resyncing = true;
 				} else {
 					// Only sync if we're not connected and not disabled and don't have pending errors
 					if (
@@ -375,6 +377,15 @@ export abstract class IntegrationBase<
 
 				if (oldSession && newSession && newSession.accessToken !== oldSession.accessToken) {
 					this.resetRequestExceptionCount('all');
+				}
+
+				// The forced re-sync above deleted the cloud secret but preserved the descriptor to avoid UI
+				// churn while a fresh token is fetched. If that fetch failed, drop the now token-less descriptor
+				// so the connection isn't reported connected without a backing token (matches the pre-multi-account
+				// clean-disconnect-on-failure behavior). The success path leaves the descriptor untouched.
+				if (resyncing && newSession == null) {
+					const authProvider = await this.authenticationService.get(this.authProvider.id);
+					await authProvider.deleteSession(this.authProviderDescriptor, { preserveConfigured: false });
 				}
 
 				break;


### PR DESCRIPTION
Fixes #5497.

## Problem

Self-managed cloud integrations (e.g. GitHub Enterprise, GitLab Self-Hosted) were requesting `v1/provider-tokens/tokens/<domain>` instead of `/tokens/<uuid>`, which the backend rejects as a non-uuid — repeated on every session refresh.

`getConfiguredConnectionId` returned a legacy/migrated connection's descriptor id, which for self-managed hosts is backfilled from the *domain* (see `ConfiguredIntegrationDescriptor.id`). Using that as a per-connection token id produced the bad request.

A related failure mode: a forced re-sync deletes the cloud secret up front but preserves the descriptor so the connection keeps reporting connected while a fresh token is fetched. If that refetch failed, the connection was left reported as connected with **no backing token** — permanent for self-managed legacy connections, since reconcile can't restore an id-less connection.

## Fix

- **`getConfiguredConnectionId`** now only returns an id that is a real per-connection token id (`id !== domain`); legacy connections fall through to the provider-scoped primary endpoint instead of targeting `/tokens/<domain>`.
- **`deleteSession`** gains a `preserveConfigured` option, and `syncCloudConnection` drops the orphaned descriptor when a forced re-sync's replacement fetch returns nothing — a clean disconnect on failure instead of a token-less "connected" state (matches pre-multi-account behavior).

## Testing

- Added `configuredIntegrationService` unit tests: `getConfiguredConnectionId` returns `undefined` for a legacy domain-keyed connection, and the real token id for a genuine multi-account connection.
- Added a `reconcileConnections` test: a failed forced re-sync drops the connection (descriptor + secret) instead of leaving it token-less.
- Both new tests were confirmed to fail without the corresponding source change.
- `pnpm run build` (type-check + lint) passes; all 147 integrations package tests pass.