### PR TITLE
Asks which layout is preferred on first entry to the Commit Graph view

### DIFF
--- a/contributions.json
+++ b/contributions.json
@@ -4329,6 +4329,10 @@
 				]
 			}
 		},
+		"gitlens.graph.simulate.mainView": {
+			"label": "Simulate Graph as Main View (Debugging)",
+			"commandPalette": "gitlens:enabled && (gitlens:debugging || gitlens:prerelease)"
+		},
 		"gitlens.graph.soloBranch": {
 			"label": "Solo Branch",
 			"commandPalette": "gitlens:enabled",

--- a/docs/telemetry-events.md
+++ b/docs/telemetry-events.md
@@ -3054,6 +3054,44 @@ background-upgraded the extension while the host kept running the old build
 }
 ```
 
+### graph/layoutPrompt/choice
+
+> Sent when the user answers (or closes) the one-time layout-choice prompt
+
+```typescript
+{
+  // `dismissed` = closed the prompt without choosing (keeps the current layout, never re-asks)
+  'choice': 'panel' | 'sidebar' | 'dismissed',
+  'context.repository.closed': boolean,
+  'context.repository.folder.scheme': string,
+  'context.repository.id': string,
+  'context.repository.provider.id': string,
+  'context.repository.scheme': string,
+  'context.webview.host': 'editor' | 'view' | 'panel',
+  'context.webview.id': string,
+  'context.webview.instanceId': string,
+  'context.webview.type': string
+}
+```
+
+### graph/layoutPrompt/shown
+
+> Sent when the one-time layout-choice prompt is shown on first entry to the Graph view
+
+```typescript
+{
+  'context.repository.closed': boolean,
+  'context.repository.folder.scheme': string,
+  'context.repository.id': string,
+  'context.repository.provider.id': string,
+  'context.repository.scheme': string,
+  'context.webview.host': 'editor' | 'view' | 'panel',
+  'context.webview.id': string,
+  'context.webview.instanceId': string,
+  'context.webview.type': string
+}
+```
+
 ### graph/minimap/day/selected
 
 > Sent when the user selects (clicks on) a day on the minimap on the Commit Graph

--- a/package.json
+++ b/package.json
@@ -8309,6 +8309,11 @@
 				"title": "Share as Cloud Patch..."
 			},
 			{
+				"command": "gitlens.graph.simulate.mainView",
+				"title": "Simulate Graph as Main View (Debugging)",
+				"category": "GitLens"
+			},
+			{
 				"command": "gitlens.graph.soloBranch",
 				"title": "Solo Branch",
 				"category": "GitLens"
@@ -14009,6 +14014,10 @@
 				{
 					"command": "gitlens.graph.shareAsCloudPatch",
 					"when": "false"
+				},
+				{
+					"command": "gitlens.graph.simulate.mainView",
+					"when": "gitlens:enabled && (gitlens:debugging || gitlens:prerelease)"
 				},
 				{
 					"command": "gitlens.graph.soloBranch",

--- a/src/constants.commands.generated.ts
+++ b/src/constants.commands.generated.ts
@@ -1027,6 +1027,7 @@ export type ContributedPaletteCommands =
 	| 'gitlens.git.worktree.open'
 	| 'gitlens.gitCommands'
 	| 'gitlens.gk.switchOrganization'
+	| 'gitlens.graph.simulate.mainView'
 	| 'gitlens.graph.soloBranch'
 	| 'gitlens.graph.soloBranch:views'
 	| 'gitlens.graph.soloTag'

--- a/src/constants.onboarding.ts
+++ b/src/constants.onboarding.ts
@@ -30,6 +30,9 @@ export const onboardingDefinitions = {
 	// Graph Kanban Toggle (first-interaction callout)
 	'graph:kanban:buttonCallout': { schema: '18.2.0', scope: 'global' },
 
+	// Graph Layout Prompt (one-time layout choice on first entry to the Graph view)
+	'graph:layoutPrompt': { schema: '18.4.0', scope: 'global' },
+
 	// Graph Walkthrough Banner
 	'graph-walkthrough:banner': {
 		schema: '18.0.0',

--- a/src/constants.telemetry.ts
+++ b/src/constants.telemetry.ts
@@ -408,6 +408,11 @@ export interface TelemetryEvents extends WebviewShowAbortedEvents, WebviewShownE
 	/** Sent when the user types in the filter box in the sidebar tags panel */
 	'graph/tags/filtered': GraphSidebarTagsFilteredEvent;
 
+	/** Sent when the one-time layout-choice prompt is shown on first entry to the Graph view */
+	'graph/layoutPrompt/shown': GraphLayoutPromptShownEvent;
+	/** Sent when the user answers (or closes) the one-time layout-choice prompt */
+	'graph/layoutPrompt/choice': GraphLayoutPromptChoiceEvent;
+
 	/** Sent when the user switches the active visualization via the switcher, or when a virtual repo forces a fallback from the Commits Treemap to the Files Treemap */
 	'graph/visualizations/modeChanged': GraphVisualizationsModeChangedEvent;
 	/** Sent when the Graph leaves Visualizations display mode (close button, sidebar rail, external search request, etc.) */
@@ -2135,6 +2140,14 @@ interface GraphSidebarTagsFilteredEvent extends GraphContextEventData {
  *  (visualizationMode × treemapMode) state so one field names the active visualization,
  *  matching the switcher's tab model. */
 export type GraphVisualizationKey = 'timeline' | 'treemap-files' | 'treemap-commits' | 'treemap-activity';
+
+/** No dimensions beyond the shared graph context */
+type GraphLayoutPromptShownEvent = GraphContextEventData;
+
+interface GraphLayoutPromptChoiceEvent extends GraphContextEventData {
+	/** `dismissed` = closed the prompt without choosing (keeps the current layout, never re-asks) */
+	choice: 'sidebar' | 'panel' | 'dismissed';
+}
 
 interface GraphVisualizationsModeChangedEvent extends GraphContextEventData {
 	'mode.old': GraphVisualizationKey;

--- a/src/webviews/apps/plus/graph/components/gl-graph-layout-prompt.ts
+++ b/src/webviews/apps/plus/graph/components/gl-graph-layout-prompt.ts
@@ -1,0 +1,435 @@
+import { css, html, LitElement, svg } from 'lit';
+import { customElement, state } from 'lit/decorators.js';
+import type { GlDialog } from '../../../shared/components/overlays/dialog.js';
+import '../../../shared/components/button.js';
+import '../../../shared/components/code-icon.js';
+import { srOnlyStyles } from '../../../shared/components/styles/lit/a11y.css.js';
+import { emitTelemetrySentEvent } from '../../../shared/telemetry.js';
+import '../../../shared/components/overlays/dialog.js';
+import '../../../shared/components/overlays/tooltip.js';
+
+export type GraphLayoutPromptChoice = 'sidebar' | 'panel' | 'dismissed';
+
+const promptTitle = 'How would you like to use the Commit Graph?';
+const promptCaption =
+	"The Commit Graph is now the main GitLens view — it's your command center for managing agents, worktrees, commits, and reviews. Pick where it should live; you can always drag it elsewhere later.";
+const sidebarCaption = 'Compact, alongside your editor';
+const panelCaption = 'Full width, below your editor';
+
+/** The compact variants hide the per-option captions — keep in sync with the media queries in the styles */
+const captionsHiddenMediaQuery = '(max-width: 479px), (max-height: 419px)';
+
+export interface GraphLayoutPromptChoiceEventDetail {
+	choice: GraphLayoutPromptChoice;
+}
+
+/**
+ * One-time prompt shown on first entry to the Graph *view*, asking which layout the user
+ * prefers: the Graph in the side bar, or full-width in the bottom panel (#5412).
+ * Options are illustrated abstractly (VS Code customize-layout icon style) rather than
+ * text-only. Any outcome — a choice or closing the dialog — dismisses the prompt for good;
+ * the host (`ChooseGraphLayoutCommand`) owns moving the view and storing the dismissal.
+ */
+@customElement('gl-graph-layout-prompt')
+export class GlGraphLayoutPrompt extends LitElement {
+	static override styles = css`
+		.layout-prompt {
+			position: relative;
+			display: flex;
+			flex-direction: column;
+			gap: var(--gl-space-16);
+		}
+
+		/* The dialog surface (editorWidget background) matches the tooltip surface (hover
+		   background) in many themes; the tooltip BODY still reads via its border and shadow,
+		   but the pointer arrow has neither and vanishes. Shift the tooltip surface slightly
+		   toward the foreground so the arrow (which follows this variable) stays visible. */
+		gl-tooltip {
+			--wa-tooltip-background-color: color-mix(
+				in srgb,
+				var(--color-hover-background) 88%,
+				var(--color-hover-foreground)
+			);
+		}
+
+		.layout-prompt__title {
+			margin: 0;
+			/* Clear the absolutely-positioned close button in the top-right corner */
+			padding-right: 2.8rem;
+			font-size: 1.6rem;
+			font-weight: 600;
+			line-height: 1.2;
+		}
+
+		.layout-prompt__caption {
+			margin: 0;
+			color: var(--vscode-descriptionForeground);
+		}
+
+		/* Stand-in for the main caption when a compact variant visually hides it (see below) */
+		.layout-prompt__title-info {
+			display: none;
+			margin-left: 0.4rem;
+			color: var(--vscode-descriptionForeground);
+			/* Match the title's font size and center on its text line ('middle' lands the icon
+			   box on the line-box midpoint here; the short variant's smaller title needs an
+			   extra optical nudge — see below) */
+			--code-icon-size: 1em;
+			--code-icon-v-align: middle;
+		}
+
+		.layout-prompt__options {
+			display: flex;
+			gap: var(--gl-space-12);
+			justify-content: center;
+		}
+
+		.layout-prompt__option {
+			display: flex;
+			flex-direction: column;
+			align-items: center;
+			gap: var(--gl-space-8);
+			padding: var(--gl-space-12);
+			background: none;
+			color: inherit;
+			font-family: inherit;
+			font-size: inherit;
+			border: 1px solid var(--vscode-widget-border);
+			border-radius: var(--gl-radius-sm);
+			cursor: pointer;
+		}
+
+		.layout-prompt__option:hover,
+		.layout-prompt__option:focus-visible {
+			background-color: var(--vscode-list-hoverBackground);
+			border-color: var(--vscode-focusBorder);
+			outline: none;
+		}
+
+		.layout-prompt__option-label {
+			font-weight: 600;
+		}
+
+		.layout-prompt__option-caption {
+			color: var(--vscode-descriptionForeground);
+			font-size: 1.1rem;
+			/* Keep the description on one line — the dialog is min-content sized, so without this
+			   the caption wraps at the illustration's width */
+			white-space: nowrap;
+		}
+
+		.layout-prompt__illustration .frame {
+			fill: var(--vscode-editorWidget-background);
+			stroke: var(--vscode-descriptionForeground);
+			opacity: 0.9;
+		}
+
+		.layout-prompt__illustration .region {
+			fill: var(--vscode-focusBorder);
+			opacity: 0.2;
+			stroke: var(--vscode-focusBorder);
+			stroke-opacity: 0.9;
+		}
+
+		.layout-prompt__illustration .lane {
+			stroke: var(--vscode-focusBorder);
+			fill: none;
+		}
+
+		.layout-prompt__illustration .dot {
+			fill: var(--vscode-focusBorder);
+		}
+
+		.layout-prompt__illustration .muted {
+			stroke: var(--vscode-descriptionForeground);
+			opacity: 0.35;
+		}
+
+		.layout-prompt__footer {
+			display: flex;
+			justify-content: center;
+		}
+
+		.layout-prompt__skip {
+			background: none;
+			border: none;
+			padding: 0;
+			color: var(--vscode-textLink-foreground);
+			font-family: inherit;
+			font-size: inherit;
+			cursor: pointer;
+		}
+
+		.layout-prompt__skip:hover,
+		.layout-prompt__skip:focus-visible {
+			text-decoration: underline;
+			outline: none;
+		}
+
+		.layout-prompt__close {
+			position: absolute;
+			top: -0.4rem;
+			right: -0.4rem;
+		}
+
+		.layout-prompt__option-text {
+			display: flex;
+			flex-direction: column;
+			align-items: center;
+			gap: var(--gl-space-4);
+		}
+
+		.layout-prompt__illustration {
+			display: block;
+			width: 13.2rem;
+			height: auto;
+		}
+
+		/* Keep the dialog inside small webview hosts (side bar ≈300px wide, bottom panel can be
+		   short); gl-dialog's own min-width (40rem) would otherwise overflow the side bar */
+		gl-dialog::part(base) {
+			box-sizing: border-box;
+			min-width: min(40rem, calc(100vw - 2.4rem));
+			max-width: min(56rem, calc(100vw - 2.4rem));
+			max-height: calc(100vh - 2.4rem);
+			overflow: auto;
+
+			/* Brand-gradient border, matching the graph's feature gate (feature-gate.css.ts):
+			   border-image ignores border-radius, so use a transparent real border, a solid fill
+			   clipped to padding-box, and the brand gradient clipped to border-box so it only
+			   shows through the border ring. */
+			background:
+				linear-gradient(var(--vscode-editorWidget-background), var(--vscode-editorWidget-background))
+					padding-box,
+				var(--gl-gradient-brand) border-box;
+			border: 0.2rem solid transparent;
+			border-radius: var(--gl-radius-xl);
+			box-shadow: 0 0 0 1px var(--vscode-editorWidget-border);
+		}
+
+		/* Background-painted borders are dropped in forced-colors mode — restore a solid border. */
+		@media (forced-colors: active) {
+			gl-dialog::part(base) {
+				border-color: var(--vscode-editorWidget-border);
+			}
+		}
+
+		/* Horizontally narrow (e.g. the Graph in the side bar): stack the option cards — each
+		   keeps the normal column layout (title below the picture, like the short variant) —
+		   and drop the captions so the dialog stays short enough; the hidden text surfaces
+		   via hover tooltips (option cards + the title's info icon) instead */
+		@media (max-width: 479px) {
+			.layout-prompt__options {
+				flex-direction: column;
+				/* Cards hug their content (like the short variant) instead of stretching to the
+				   dialog's width, which read as flexible side padding */
+				align-items: center;
+			}
+
+			.layout-prompt__option {
+				padding: var(--gl-space-8);
+			}
+
+			/* Visually hidden but kept in the accessibility tree — sighted users get the same
+			   text from the title's info-icon tooltip instead */
+			.layout-prompt__caption {
+				${srOnlyStyles}
+			}
+
+			.layout-prompt__title-info {
+				display: inline-block;
+			}
+
+			.layout-prompt__option-caption {
+				display: none;
+			}
+
+			.layout-prompt__illustration {
+				width: 9.6rem;
+			}
+		}
+
+		/* Vertically narrow (e.g. the Graph in a short bottom panel): compress — smaller
+		   illustrations, drop the secondary captions, tighter spacing */
+		@media (max-height: 419px) {
+			.layout-prompt {
+				gap: var(--gl-space-8);
+			}
+
+			.layout-prompt__title {
+				font-size: 1.3rem;
+			}
+
+			.layout-prompt__caption,
+			.layout-prompt__option-caption {
+				display: none;
+			}
+
+			.layout-prompt__option {
+				padding: var(--gl-space-8);
+			}
+
+			.layout-prompt__illustration {
+				width: 9.6rem;
+			}
+		}
+	`;
+
+	private _answered = false;
+
+	/** When a compact variant hides the per-option captions, surface them as hover tooltips instead */
+	@state()
+	private _optionCaptionsHidden = false;
+
+	private _captionsHiddenMedia?: MediaQueryList;
+	private readonly onCaptionsHiddenMediaChange = (e: MediaQueryListEvent): void => {
+		this._optionCaptionsHidden = e.matches;
+	};
+
+	override connectedCallback(): void {
+		super.connectedCallback?.();
+
+		this._captionsHiddenMedia = window.matchMedia(captionsHiddenMediaQuery);
+		this._captionsHiddenMedia.addEventListener('change', this.onCaptionsHiddenMediaChange);
+		this._optionCaptionsHidden = this._captionsHiddenMedia.matches;
+	}
+
+	override disconnectedCallback(): void {
+		this._captionsHiddenMedia?.removeEventListener('change', this.onCaptionsHiddenMediaChange);
+		this._captionsHiddenMedia = undefined;
+
+		super.disconnectedCallback?.();
+	}
+
+	override render(): unknown {
+		return html`<gl-dialog
+			modal
+			open
+			autofocus-self
+			closedby="any"
+			label=${promptTitle}
+			@gl-dialog-close=${this.onDialogClose}
+		>
+			<div class="layout-prompt">
+				<h2 class="layout-prompt__title">
+					${promptTitle}<gl-tooltip content=${promptCaption}
+						><code-icon class="layout-prompt__title-info" icon="info" aria-hidden="true"></code-icon
+					></gl-tooltip>
+				</h2>
+				<p class="layout-prompt__caption">${promptCaption}</p>
+				<div class="layout-prompt__options">
+					<gl-tooltip content=${sidebarCaption} ?disabled=${!this._optionCaptionsHidden}>
+						<button type="button" class="layout-prompt__option" @click=${() => this.choose('sidebar')}>
+							${this.renderSidebarIllustration()}
+							<span class="layout-prompt__option-text">
+								<span class="layout-prompt__option-label">Side Bar</span>
+								<span class="layout-prompt__option-caption">${sidebarCaption}</span>
+							</span>
+						</button>
+					</gl-tooltip>
+					<gl-tooltip content=${panelCaption} ?disabled=${!this._optionCaptionsHidden}>
+						<button type="button" class="layout-prompt__option" @click=${() => this.choose('panel')}>
+							${this.renderPanelIllustration()}
+							<span class="layout-prompt__option-text">
+								<span class="layout-prompt__option-label">Bottom Panel</span>
+								<span class="layout-prompt__option-caption">${panelCaption}</span>
+							</span>
+						</button>
+					</gl-tooltip>
+				</div>
+				<div class="layout-prompt__footer">
+					<gl-tooltip content="Close and keep my current layout">
+						<button type="button" class="layout-prompt__skip" @click=${() => this.choose('dismissed')}>
+							Keep my current layout
+						</button>
+					</gl-tooltip>
+				</div>
+				<!-- Last in the DOM so it's the last tab stop (the option cards and skip link come
+				     first for keyboard users); positioned visually at the top-right corner. -->
+				<gl-button
+					class="layout-prompt__close"
+					appearance="toolbar"
+					density="compact"
+					tooltip="Close and keep my current layout"
+					aria-label="Close and keep my current layout"
+					@click=${() => this.choose('dismissed')}
+					><code-icon icon="close"></code-icon
+				></gl-button>
+			</div>
+		</gl-dialog>`;
+	}
+
+	/** Abstract window mock: highlighted side bar hosting a vertical commit graph */
+	private renderSidebarIllustration() {
+		return svg`<svg class="layout-prompt__illustration" width="132" height="88" viewBox="0 0 132 88" aria-hidden="true">
+			<rect class="frame" x="1" y="1" width="130" height="86" rx="4" />
+			<rect class="region" x="2" y="2" width="55" height="84" />
+			<line class="lane" x1="20" y1="16" x2="20" y2="72" />
+			<path class="lane" d="M20 26 C 20 34, 36 32, 36 40 L 36 52 C 36 60, 20 58, 20 66" fill="none" />
+			<circle class="dot" cx="20" cy="16" r="3.5" />
+			<circle class="dot" cx="20" cy="40" r="3.5" />
+			<circle class="dot" cx="36" cy="46" r="3.5" />
+			<circle class="dot" cx="20" cy="72" r="3.5" />
+			<line class="muted" x1="66" y1="18" x2="120" y2="18" />
+			<line class="muted" x1="66" y1="32" x2="112" y2="32" />
+			<line class="muted" x1="66" y1="46" x2="120" y2="46" />
+			<line class="muted" x1="66" y1="60" x2="104" y2="60" />
+		</svg>`;
+	}
+
+	/** Abstract window mock: highlighted bottom panel hosting the commit graph — the graph
+	 * still flows top→bottom there (same list, wider), so the mini-graph is NOT rotated */
+	private renderPanelIllustration() {
+		return svg`<svg class="layout-prompt__illustration" width="132" height="88" viewBox="0 0 132 88" aria-hidden="true">
+			<rect class="frame" x="1" y="1" width="130" height="86" rx="4" />
+			<line class="muted" x1="14" y1="2" x2="14" y2="50" />
+			<rect class="region" x="2" y="51" width="128" height="35" />
+			<line class="lane" x1="24" y1="56" x2="24" y2="81" />
+			<path class="lane" d="M24 59 C 24 65, 35 63, 35 69 L 35 77" fill="none" />
+			<circle class="dot" cx="24" cy="56" r="3" />
+			<circle class="dot" cx="35" cy="77" r="3" />
+			<circle class="dot" cx="24" cy="81" r="3" />
+			<line class="muted" x1="48" y1="56" x2="120" y2="56" />
+			<line class="muted" x1="48" y1="68" x2="104" y2="68" />
+			<line class="muted" x1="48" y1="81" x2="112" y2="81" />
+			<line class="muted" x1="26" y1="14" x2="120" y2="14" />
+			<line class="muted" x1="26" y1="26" x2="108" y2="26" />
+			<line class="muted" x1="26" y1="38" x2="120" y2="38" />
+		</svg>`;
+	}
+
+	private choose(choice: GraphLayoutPromptChoice): void {
+		if (this._answered) return;
+
+		this._answered = true;
+		// Close the native dialog before the host unmounts us, so the browser restores focus to
+		// the previously-focused element (unmounting an open dialog skips that). The resulting
+		// `gl-dialog-close` echo is absorbed by the `_answered` guard above.
+		this.shadowRoot?.querySelector<GlDialog>('gl-dialog')?.close();
+
+		emitTelemetrySentEvent<'graph/layoutPrompt/choice'>(this, {
+			name: 'graph/layoutPrompt/choice',
+			data: { choice: choice },
+		});
+		this.dispatchEvent(
+			new CustomEvent<GraphLayoutPromptChoiceEventDetail>('gl-graph-layout-choice', {
+				detail: { choice: choice },
+				bubbles: true,
+				composed: true,
+			}),
+		);
+	}
+
+	// Esc/backdrop closes the native dialog without a click — count it as a dismissal (the
+	// prompt is one-shot either way). A choice click also closes the dialog; `_answered`
+	// keeps that from double-reporting.
+	private onDialogClose = (): void => {
+		this.choose('dismissed');
+	};
+}
+
+declare global {
+	interface HTMLElementTagNameMap {
+		'gl-graph-layout-prompt': GlGraphLayoutPrompt;
+	}
+}

--- a/src/webviews/apps/plus/graph/components/gl-graph-layout-prompt.ts
+++ b/src/webviews/apps/plus/graph/components/gl-graph-layout-prompt.ts
@@ -80,7 +80,7 @@ export class GlGraphLayoutPrompt extends LitElement {
 
 		.layout-prompt__options {
 			display: flex;
-			gap: var(--gl-space-12);
+			gap: var(--gl-space-16);
 			justify-content: center;
 		}
 
@@ -89,7 +89,7 @@ export class GlGraphLayoutPrompt extends LitElement {
 			flex-direction: column;
 			align-items: center;
 			gap: var(--gl-space-8);
-			padding: var(--gl-space-12);
+			padding: var(--gl-space-16);
 			background: none;
 			color: inherit;
 			font-family: inherit;
@@ -118,31 +118,27 @@ export class GlGraphLayoutPrompt extends LitElement {
 			white-space: nowrap;
 		}
 
-		.layout-prompt__illustration .frame {
-			fill: var(--vscode-editorWidget-background);
-			stroke: var(--vscode-descriptionForeground);
-			opacity: 0.9;
+		/* Designed illustrations ship as dark/light exports differing only in these colors — one
+		   markup, themed via custom properties (host body carries the vscode-* theme class) */
+		:host {
+			--lp-frame-bg: #121212;
+			--lp-frame-stroke: #363636;
+			--lp-shell-bg: #2a2a2c;
+			--lp-dot-fill: #d9d9d9;
+			--lp-row: #808080;
+			--lp-purple: #aa5bf5;
+			--lp-green: #00a02e;
 		}
 
-		.layout-prompt__illustration .region {
-			fill: var(--vscode-focusBorder);
-			opacity: 0.2;
-			stroke: var(--vscode-focusBorder);
-			stroke-opacity: 0.9;
-		}
-
-		.layout-prompt__illustration .lane {
-			stroke: var(--vscode-focusBorder);
-			fill: none;
-		}
-
-		.layout-prompt__illustration .dot {
-			fill: var(--vscode-focusBorder);
-		}
-
-		.layout-prompt__illustration .muted {
-			stroke: var(--vscode-descriptionForeground);
-			opacity: 0.35;
+		:host-context(.vscode-light),
+		:host-context(.vscode-high-contrast-light) {
+			--lp-frame-bg: #fefefe;
+			--lp-frame-stroke: #dddddd;
+			--lp-shell-bg: #e3e3e3;
+			--lp-dot-fill: #9c9c9c;
+			--lp-row: #b4b4b4;
+			--lp-purple: #c180ff;
+			--lp-green: #37d865;
 		}
 
 		.layout-prompt__footer {
@@ -181,7 +177,8 @@ export class GlGraphLayoutPrompt extends LitElement {
 
 		.layout-prompt__illustration {
 			display: block;
-			width: 13.2rem;
+			/* 1.25× the illustrations' native 13.8rem */
+			width: 17.25rem;
 			height: auto;
 		}
 
@@ -189,8 +186,8 @@ export class GlGraphLayoutPrompt extends LitElement {
 		   short); gl-dialog's own min-width (40rem) would otherwise overflow the side bar */
 		gl-dialog::part(base) {
 			box-sizing: border-box;
-			min-width: min(40rem, calc(100vw - 2.4rem));
-			max-width: min(56rem, calc(100vw - 2.4rem));
+			min-width: min(44rem, calc(100vw - 2.4rem));
+			max-width: min(60rem, calc(100vw - 2.4rem));
 			max-height: calc(100vh - 2.4rem);
 			overflow: auto;
 
@@ -260,7 +257,18 @@ export class GlGraphLayoutPrompt extends LitElement {
 				font-size: 1.3rem;
 			}
 
-			.layout-prompt__caption,
+			/* Visually hidden but kept in the accessibility tree — sighted users get the same
+			   text from the title's info-icon tooltip instead */
+			.layout-prompt__caption {
+				${srOnlyStyles}
+			}
+
+			.layout-prompt__title-info {
+				display: inline-block;
+				/* The smaller title leaves the icon sitting low — nudge it up optically */
+				translate: 0 -0.06em;
+			}
+
 			.layout-prompt__option-caption {
 				display: none;
 			}
@@ -359,42 +367,82 @@ export class GlGraphLayoutPrompt extends LitElement {
 		</gl-dialog>`;
 	}
 
-	/** Abstract window mock: highlighted side bar hosting a vertical commit graph */
+	/** Designed window mock: highlighted side bar hosting a vertical commit graph */
 	private renderSidebarIllustration() {
-		return svg`<svg class="layout-prompt__illustration" width="132" height="88" viewBox="0 0 132 88" aria-hidden="true">
-			<rect class="frame" x="1" y="1" width="130" height="86" rx="4" />
-			<rect class="region" x="2" y="2" width="55" height="84" />
-			<line class="lane" x1="20" y1="16" x2="20" y2="72" />
-			<path class="lane" d="M20 26 C 20 34, 36 32, 36 40 L 36 52 C 36 60, 20 58, 20 66" fill="none" />
-			<circle class="dot" cx="20" cy="16" r="3.5" />
-			<circle class="dot" cx="20" cy="40" r="3.5" />
-			<circle class="dot" cx="36" cy="46" r="3.5" />
-			<circle class="dot" cx="20" cy="72" r="3.5" />
-			<line class="muted" x1="66" y1="18" x2="120" y2="18" />
-			<line class="muted" x1="66" y1="32" x2="112" y2="32" />
-			<line class="muted" x1="66" y1="46" x2="120" y2="46" />
-			<line class="muted" x1="66" y1="60" x2="104" y2="60" />
+		return svg`<svg class="layout-prompt__illustration" width="138" height="75" viewBox="0 0 138 75" fill="none" aria-hidden="true">
+			<rect x="0.336586" y="0.336586" width="137.327" height="74.0488" rx="1.00976" fill="var(--lp-frame-bg)" stroke="var(--lp-frame-stroke)" stroke-width="0.673171"/>
+			<path d="M0.5 0.999999C0.5 0.447715 0.947715 0 1.5 0H37.5V74H1.5C0.947715 74 0.5 73.5523 0.5 73V0.999999Z" fill="var(--lp-shell-bg)"/>
+			<rect x="114.837" y="5.33659" width="18.3268" height="10.3268" rx="1.00976" stroke="var(--lp-frame-stroke)" stroke-width="0.673171"/>
+			<rect x="101.837" y="21.3366" width="22.3268" height="33.3268" rx="1.00976" stroke="var(--lp-frame-stroke)" stroke-width="0.673171"/>
+			<rect x="101.837" y="59.3366" width="31.3268" height="10.3268" rx="1.00976" stroke="var(--lp-frame-stroke)" stroke-width="0.673171"/>
+			<rect x="127.566" y="63.6147" width="3.36585" height="3.36585" rx="1.68293" fill="var(--lp-dot-fill)" stroke="#D9D9D9" stroke-width="0.673171"/>
+			<path d="M37.4707 0L37.4707 74.722" stroke="var(--lp-frame-stroke)" stroke-width="0.673171"/>
+			<path d="M96.1536 0L96.1536 74.722" stroke="var(--lp-frame-stroke)" stroke-width="0.673171"/>
+			<path d="M9.11255 74.4023L9.11255 62.0884" stroke="var(--lp-purple)" stroke-width="0.812499"/>
+			<path d="M9.11255 45.2381L9.11255 10.8887" stroke="var(--lp-purple)" stroke-width="0.812499"/>
+			<path d="M9.11255 51.7189L9.11255 49.1265" stroke="var(--lp-purple)" stroke-width="0.812499"/>
+			<path d="M9.11255 58.1998L9.11255 55.6074" stroke="var(--lp-purple)" stroke-width="0.812499"/>
+			<path d="M15.5935 74.4025L15.5935 42.6455" stroke="var(--lp-green)" stroke-width="0.812499"/>
+			<path d="M15.5935 38.4579L15.5935 17.0706" stroke="var(--lp-green)" stroke-width="0.812499"/>
+			<path d="M22.0745 74.4026L22.0745 23.8506" stroke="#40AAA3" stroke-width="0.812499"/>
+			<path d="M28.5557 74.4023L28.5557 30.3313" stroke="#8A743A" stroke-width="0.812499"/>
+			<circle cx="28.5556" cy="28.3874" r="1.94431" stroke="#8A743A" stroke-width="0.812499"/>
+			<circle cx="22.0747" cy="21.9062" r="1.94431" stroke="#40AAA3" stroke-width="0.812499"/>
+			<circle cx="15.5937" cy="15.4253" r="1.94431" stroke="var(--lp-green)" stroke-width="0.812499"/>
+			<circle cx="15.5937" cy="40.7014" r="1.94431" stroke="var(--lp-green)" stroke-width="0.812499"/>
+			<circle cx="9.11276" cy="8.94431" r="1.94431" stroke="var(--lp-purple)" stroke-width="0.812499"/>
+			<circle cx="9.11276" cy="60.1443" r="1.94431" stroke="var(--lp-purple)" stroke-width="0.812499"/>
+			<circle cx="9.11276" cy="53.6633" r="1.94431" stroke="var(--lp-purple)" stroke-width="0.812499"/>
+			<circle cx="9.11276" cy="47.1823" r="1.94431" stroke="var(--lp-purple)" stroke-width="0.812499"/>
+			<path d="M37.3506 8.94385L11.0569 8.94385" stroke="#AA5BF5" stroke-opacity="0.3" stroke-width="2.75444"/>
+			<path d="M37.3506 47.1821H11.0569" stroke="#AA5BF5" stroke-opacity="0.3" stroke-width="2.75444"/>
+			<path d="M37.3506 53.6631H11.0569" stroke="#AA5BF5" stroke-opacity="0.3" stroke-width="2.75444"/>
+			<path d="M37.3506 15.4248L17.5379 15.4248" stroke="#00A02E" stroke-opacity="0.3" stroke-width="2.75444"/>
+			<path d="M37.3506 40.7012H17.5379" stroke="#00A02E" stroke-opacity="0.3" stroke-width="2.75444"/>
+			<path d="M37.3506 21.906H24.0189" stroke="#309FC7" stroke-opacity="0.3" stroke-width="2.75444"/>
+			<path d="M37.3506 28.3872H30.4999" stroke="#C7B830" stroke-opacity="0.3" stroke-width="2.75444"/>
+			<path d="M37.3506 60.7925H11.0569" stroke="#C7308B" stroke-opacity="0.3" stroke-width="2.75444"/>
 		</svg>`;
 	}
 
-	/** Abstract window mock: highlighted bottom panel hosting the commit graph — the graph
-	 * still flows top→bottom there (same list, wider), so the mini-graph is NOT rotated */
+	/** Designed window mock: highlighted bottom panel hosting the commit graph */
 	private renderPanelIllustration() {
-		return svg`<svg class="layout-prompt__illustration" width="132" height="88" viewBox="0 0 132 88" aria-hidden="true">
-			<rect class="frame" x="1" y="1" width="130" height="86" rx="4" />
-			<line class="muted" x1="14" y1="2" x2="14" y2="50" />
-			<rect class="region" x="2" y="51" width="128" height="35" />
-			<line class="lane" x1="24" y1="56" x2="24" y2="81" />
-			<path class="lane" d="M24 59 C 24 65, 35 63, 35 69 L 35 77" fill="none" />
-			<circle class="dot" cx="24" cy="56" r="3" />
-			<circle class="dot" cx="35" cy="77" r="3" />
-			<circle class="dot" cx="24" cy="81" r="3" />
-			<line class="muted" x1="48" y1="56" x2="120" y2="56" />
-			<line class="muted" x1="48" y1="68" x2="104" y2="68" />
-			<line class="muted" x1="48" y1="81" x2="112" y2="81" />
-			<line class="muted" x1="26" y1="14" x2="120" y2="14" />
-			<line class="muted" x1="26" y1="26" x2="108" y2="26" />
-			<line class="muted" x1="26" y1="38" x2="120" y2="38" />
+		return svg`<svg class="layout-prompt__illustration" width="138" height="75" viewBox="0 0 138 75" fill="none" aria-hidden="true">
+			<rect x="0.336586" y="0.336586" width="137.327" height="74.0488" rx="1.00976" fill="var(--lp-frame-bg)" stroke="var(--lp-frame-stroke)" stroke-width="0.673171"/>
+			<path d="M1.5 75C0.947712 75 0.5 74.5523 0.5 74L0.499998 40L102.5 40L102.5 74C102.5 74.5523 102.052 75 101.5 75L1.5 75Z" fill="var(--lp-shell-bg)"/>
+			<rect x="118.815" y="5.04899" width="14.8098" height="10.7707" rx="1.00976" stroke="var(--lp-frame-stroke)" stroke-width="0.673171"/>
+			<rect x="106.697" y="21.205" width="14.8098" height="33.6586" rx="1.00976" stroke="var(--lp-frame-stroke)" stroke-width="0.673171"/>
+			<rect x="106.697" y="58.9025" width="26.9268" height="10.7707" rx="1.00976" stroke="var(--lp-frame-stroke)" stroke-width="0.673171"/>
+			<rect x="127.566" y="63.6149" width="3.36585" height="3.36585" rx="1.68293" fill="var(--lp-dot-fill)" stroke="#D9D9D9" stroke-width="0.673171"/>
+			<path d="M102.5 40L0.499999 40" stroke="var(--lp-frame-stroke)" stroke-width="0.673171"/>
+			<path d="M102.154 0L102.154 74.722" stroke="var(--lp-frame-stroke)" stroke-width="0.673171"/>
+			<path d="M37.3188 63.404L37.3188 63.2017" stroke="var(--lp-purple)" stroke-width="0.673171"/>
+			<g clip-path="url(#lp-panel-clip)">
+				<path d="M12.3188 76.2404L12.3188 47.7812" stroke="var(--lp-purple)" stroke-width="0.673171"/>
+				<path d="M60 46.1702H13.9299" stroke="#AA5BF5" stroke-opacity="0.3" stroke-width="2.2821"/>
+				<path d="M60 51.5398H19.2996" stroke="#00A02E" stroke-opacity="0.3" stroke-width="2.2821"/>
+				<path d="M60 72.4817H19.2996" stroke="#00A02E" stroke-opacity="0.3" stroke-width="2.2821"/>
+				<path d="M60 56.9094H24.6692" stroke="#309FC7" stroke-opacity="0.3" stroke-width="2.2821"/>
+				<path d="M60 62.2793H30.0389" stroke="#C7B830" stroke-opacity="0.3" stroke-width="2.2821"/>
+				<path d="M17.6885 70.6232L17.6885 52.9033" stroke="var(--lp-green)" stroke-width="0.673171"/>
+				<path d="M23.0581 100.404L23.0581 58.5205" stroke="#40AAA3" stroke-width="0.673171"/>
+				<path d="M28.4282 100.404L28.4282 63.8901" stroke="#8A743A" stroke-width="0.673171"/>
+				<circle cx="28.4278" cy="62.2794" r="1.6109" stroke="#8A743A" stroke-width="0.673171"/>
+				<circle cx="23.0582" cy="56.9097" r="1.6109" stroke="#40AAA3" stroke-width="0.673171"/>
+				<circle cx="17.6885" cy="51.5401" r="1.6109" stroke="var(--lp-green)" stroke-width="0.673171"/>
+				<circle cx="17.6885" cy="72.4817" r="1.6109" stroke="var(--lp-green)" stroke-width="0.673171"/>
+				<circle cx="12.3189" cy="46.1705" r="1.6109" stroke="var(--lp-purple)" stroke-width="0.673171"/>
+			</g>
+			<path d="M88.8481 47.1704H65.7586" stroke="var(--lp-row)" stroke-width="0.673171"/>
+			<path d="M80.7939 52.54H65.7589" stroke="var(--lp-row)" stroke-width="0.673171"/>
+			<path d="M88.8481 57.9097H65.7586" stroke="var(--lp-row)" stroke-width="0.673171"/>
+			<path d="M80.7939 63.2793H65.7589" stroke="var(--lp-row)" stroke-width="0.673171"/>
+			<path d="M88.8481 68.6489H65.7586" stroke="var(--lp-row)" stroke-width="0.673171"/>
+			<defs>
+				<clipPath id="lp-panel-clip">
+					<rect width="51" height="30" fill="white" transform="translate(9.5 44)"/>
+				</clipPath>
+			</defs>
 		</svg>`;
 	}
 

--- a/src/webviews/apps/plus/graph/components/gl-graph-layout-prompt.ts
+++ b/src/webviews/apps/plus/graph/components/gl-graph-layout-prompt.ts
@@ -78,6 +78,12 @@ export class GlGraphLayoutPrompt extends LitElement {
 			--code-icon-v-align: middle;
 		}
 
+		.layout-prompt__title-info:focus-visible {
+			outline: 1px solid var(--vscode-focusBorder);
+			outline-offset: 0.2rem;
+			border-radius: var(--gl-radius-sm);
+		}
+
 		.layout-prompt__options {
 			display: flex;
 			gap: var(--gl-space-16);
@@ -320,8 +326,18 @@ export class GlGraphLayoutPrompt extends LitElement {
 		>
 			<div class="layout-prompt">
 				<h2 class="layout-prompt__title">
+					<!-- Focusable (not aria-hidden) so sighted keyboard-only users can reach the
+					     caption in the compact variants, where hovering this icon is otherwise the
+					     only way to see it; gl-tooltip opens on focus. display: none in the normal
+					     layout keeps it out of the tab order there. -->
 					${promptTitle}<gl-tooltip content=${promptCaption}
-						><code-icon class="layout-prompt__title-info" icon="info" aria-hidden="true"></code-icon
+						><code-icon
+							class="layout-prompt__title-info"
+							icon="info"
+							role="img"
+							tabindex="0"
+							aria-label="More information"
+						></code-icon
 					></gl-tooltip>
 				</h2>
 				<p class="layout-prompt__caption">${promptCaption}</p>

--- a/src/webviews/apps/plus/graph/graph-app.ts
+++ b/src/webviews/apps/plus/graph/graph-app.ts
@@ -31,6 +31,7 @@ import type {
 	VisualizationMode,
 } from '../../../plus/graph/protocol.js';
 import {
+	ChooseGraphLayoutCommand,
 	createSecondaryWipSha,
 	createWipSha,
 	EnableChangesColumnCommand,
@@ -67,6 +68,7 @@ import '../shared/components/account-bar.js';
 import { emitTelemetrySentEvent } from '../../shared/telemetry.js';
 import type { GlGraphDetailsPanel } from './components/gl-graph-details-panel.js';
 import type { GlGraphKeyboardShortcuts } from './components/gl-graph-keyboard-shortcuts.js';
+import type { GraphLayoutPromptChoiceEventDetail } from './components/gl-graph-layout-prompt.js';
 import type {
 	GlGraphTimelineCommitSelectDetail,
 	GlGraphTimelineConfigChangeDetail,
@@ -113,6 +115,7 @@ import '../../shared/components/overlays/drag-shift-overlay.js';
 import './components/gl-graph-details-panel.js';
 import './components/gl-graph-kanban.js';
 import './components/gl-graph-keyboard-shortcuts.js';
+import './components/gl-graph-layout-prompt.js';
 import './components/gl-graph-wip-bar.js';
 import './components/gl-graph-timeline.js';
 import './components/gl-graph-visualizations.js';
@@ -1497,6 +1500,11 @@ export class GraphApp extends SignalWatcher(LitElement) {
 		// fire again after sign-in.
 		this.ensureGraphObserved();
 
+		if (this.shouldShowLayoutPrompt && !this._layoutPromptShownReported) {
+			this._layoutPromptShownReported = true;
+			emitTelemetrySentEvent<'graph/layoutPrompt/shown'>(this, { name: 'graph/layoutPrompt/shown', data: {} });
+		}
+
 		// Start the Launchpad pipeline once `services` first resolves. `services` is a `@consume`d
 		// context value (not a reactive property), so it won't appear in `changedProperties` — guard
 		// with a one-shot flag instead.
@@ -1899,6 +1907,17 @@ export class GraphApp extends SignalWatcher(LitElement) {
 				${displayMode === 'kanban'
 					? html`<div class="graph__graph-content">${this.renderKanbanMain()}</div>`
 					: nothing}
+				${when(
+					this.shouldShowLayoutPrompt,
+					// Living inside the graph subtree means the no-repo empty state skips the prompt —
+					// deliberate: asking where the Graph should live is noise without a repo to show,
+					// and the prompt is one-shot on ANSWER (not on show), so it simply defers until a
+					// repository is open.
+					() =>
+						html`<gl-graph-layout-prompt
+							@gl-graph-layout-choice=${this.handleLayoutPromptChoice}
+						></gl-graph-layout-prompt>`,
+				)}
 			</div>
 		`;
 	}
@@ -2625,6 +2644,34 @@ export class GraphApp extends SignalWatcher(LitElement) {
 		// `renderGraphPaneContent` short-circuits the sidebar split when `displayMode !== 'graph'`, so
 		// the user's `sidebarVisible` setting is preserved automatically and restored on return.
 		this.persistState();
+	};
+
+	/** One-shot guard: `shown` telemetry per webview session, not per mount — the `when()` gate
+	 *  can unmount/remount the prompt (e.g. an onboarding reset re-shows the walkthrough banner
+	 *  mid-prompt), and a remount must not mint a second impression. */
+	private _layoutPromptShownReported = false;
+
+	private get shouldShowLayoutPrompt(): boolean {
+		return (
+			(this.graphState.layoutPromptNeeded ?? false) &&
+			// Don't compete with the graph walkthrough popover on first entry — hold the layout
+			// prompt until that banner is dismissed, completed, or STARTED ("See what's new" tracks
+			// started without dismissing the banner, and the header only force-opens the popover
+			// while not started — so a started walkthrough isn't visually competing). Re-renders
+			// reactively as the walkthrough notifications land.
+			((this.graphState.graphWalkthroughBannerCollapsed ?? true) ||
+				(this.graphState.graphWalkthroughComplete ?? false) ||
+				(this.graphState.graphWalkthroughStarted ?? false))
+		);
+	}
+
+	private handleLayoutPromptChoice = (e: CustomEvent<GraphLayoutPromptChoiceEventDetail>): void => {
+		// Optimistic unmount — the prompt has already closed its native dialog, but without this
+		// it would stay mounted until the host echoes `DidChangeLayoutPromptNotification`.
+		// `layoutPromptNeeded` is a plain (non-signal) property, so trigger the re-render manually.
+		this.graphState.layoutPromptNeeded = false;
+		this.requestUpdate();
+		this._ipc.sendCommand(ChooseGraphLayoutCommand, { choice: e.detail.choice });
 	};
 
 	private handleTimelineCommitSelect = (e: CustomEvent<GlGraphTimelineCommitSelectDetail>): void => {

--- a/src/webviews/apps/plus/graph/graph-app.ts
+++ b/src/webviews/apps/plus/graph/graph-app.ts
@@ -2655,9 +2655,11 @@ export class GraphApp extends SignalWatcher(LitElement) {
 		return (
 			(this.graphState.layoutPromptNeeded ?? false) &&
 			// The prompt lives inside the graph subtree, which the no-repository empty state
-			// doesn't render — mirror that condition here so the `shown` telemetry in `updated()`
-			// can't fire (and burn its one-shot guard) without a real impression.
-			this.graphState.repositories?.length !== 0 &&
+			// doesn't render — require repositories to be RESOLVED and non-empty (stricter than
+			// the subtree's own `?.length === 0` check, which renders during the initial load
+			// window) so the prompt can't flash and the `shown` telemetry in `updated()` can't
+			// fire (burning its one-shot guard) before a no-repo profile lands on the empty state.
+			(this.graphState.repositories?.length ?? 0) > 0 &&
 			// Don't compete with the graph walkthrough popover on first entry — hold the layout
 			// prompt until that banner is dismissed, completed, or STARTED ("See what's new" tracks
 			// started without dismissing the banner, and the header only force-opens the popover

--- a/src/webviews/apps/plus/graph/graph-app.ts
+++ b/src/webviews/apps/plus/graph/graph-app.ts
@@ -2654,6 +2654,10 @@ export class GraphApp extends SignalWatcher(LitElement) {
 	private get shouldShowLayoutPrompt(): boolean {
 		return (
 			(this.graphState.layoutPromptNeeded ?? false) &&
+			// The prompt lives inside the graph subtree, which the no-repository empty state
+			// doesn't render — mirror that condition here so the `shown` telemetry in `updated()`
+			// can't fire (and burn its one-shot guard) without a real impression.
+			this.graphState.repositories?.length !== 0 &&
 			// Don't compete with the graph walkthrough popover on first entry — hold the layout
 			// prompt until that banner is dismissed, completed, or STARTED ("See what's new" tracks
 			// started without dismissing the banner, and the header only force-opens the popover

--- a/src/webviews/apps/plus/graph/stateProvider.ts
+++ b/src/webviews/apps/plus/graph/stateProvider.ts
@@ -35,6 +35,7 @@ import {
 	DidChangeGraphWalkthroughComplete,
 	DidChangeGraphWalkthroughStarted,
 	DidChangeHooksBanner,
+	DidChangeLayoutPromptNotification,
 	DidChangeMcpBanner,
 	DidChangeNotification,
 	DidChangeOrgSettings,
@@ -546,6 +547,7 @@ export class GraphStateProvider extends StateProviderBase<State['webviewId'], Ap
 	graphWalkthroughBannerCollapsed?: boolean | undefined;
 	graphWalkthroughComplete?: boolean | undefined;
 	graphWalkthroughStarted?: boolean | undefined;
+	layoutPromptNeeded?: boolean | undefined;
 
 	constructor(
 		host: ReactiveElementHost,
@@ -1595,6 +1597,10 @@ export class GraphStateProvider extends StateProviderBase<State['webviewId'], Ap
 
 			case DidChangeGraphWalkthroughStarted.is(msg):
 				this.updateState({ graphWalkthroughStarted: msg.params });
+				break;
+
+			case DidChangeLayoutPromptNotification.is(msg):
+				this.updateState({ layoutPromptNeeded: msg.params });
 				break;
 
 			case DidChangeWorkingTreeNotification.is(msg): {

--- a/src/webviews/apps/shared/components/overlays/dialog.ts
+++ b/src/webviews/apps/shared/components/overlays/dialog.ts
@@ -47,6 +47,17 @@ export class GlDialog extends LitElement {
 	@property()
 	closedby?: 'any' | 'closerequest' | 'none';
 
+	/** Accessible name for the dialog. Slotted headings can't be referenced across the shadow
+	 *  boundary via `aria-labelledby`, so consumers should pass their title text here. */
+	@property()
+	label?: string;
+
+	/** Focus the dialog itself on open instead of its first focusable control (native
+	 *  `showModal()` behavior). Keyboard users still Tab into the controls; nothing renders
+	 *  pre-focused. Per the dialog focusing steps, `autofocus` on the dialog element wins. */
+	@property({ type: Boolean, attribute: 'autofocus-self' })
+	autofocusSelf = false;
+
 	@query('dialog')
 	dialog!: HTMLDialogElement;
 
@@ -60,7 +71,13 @@ export class GlDialog extends LitElement {
 
 	override render() {
 		return html`
-			<dialog part="base" closedby=${ifDefined(this.closedby)} @close=${this.onDialogClose}>
+			<dialog
+				part="base"
+				aria-label=${ifDefined(this.label)}
+				?autofocus=${this.autofocusSelf}
+				closedby=${ifDefined(this.closedby)}
+				@close=${this.onDialogClose}
+			>
 				<slot></slot>
 			</dialog>
 		`;
@@ -86,6 +103,12 @@ export class GlDialog extends LitElement {
 			} else {
 				this.dialog.show();
 			}
+
+			// Chromium doesn't honor `autofocus` on a shadow-hosted dialog element itself (it still
+			// focuses the first focusable descendant), so retarget explicitly.
+			if (this.autofocusSelf) {
+				this.dialog.focus();
+			}
 		} else if (this.dialog.open) {
 			this.dialog.close();
 		}
@@ -93,6 +116,12 @@ export class GlDialog extends LitElement {
 
 	close() {
 		this.open = false;
+		// Close the native dialog synchronously too — the reactive update lands a microtask
+		// later, which is too late for consumers that unmount right after calling close():
+		// native focus restoration only runs if the dialog closes while still connected.
+		if (this.dialog?.open) {
+			this.dialog.close();
+		}
 	}
 
 	show() {

--- a/src/webviews/plus/graph/graphWebview.ts
+++ b/src/webviews/plus/graph/graphWebview.ts
@@ -57,6 +57,7 @@ import type {
 	GraphTelemetryContext,
 	WebviewTelemetryEvents,
 } from '../../../constants.telemetry.js';
+import { viewIdsByDefaultContainerId } from '../../../constants.views.js';
 import type { Container } from '../../../container.js';
 import type { FeaturePreview } from '../../../features.js';
 import { getFeaturePreviewStatus } from '../../../features.js';
@@ -164,6 +165,7 @@ import type { GraphWipServiceContext } from './graphWipService.js';
 import { GraphWipService } from './graphWipService.js';
 import type {
 	BranchState,
+	ChooseGraphLayoutParams,
 	CloseGraphWalkthroughBannerParams,
 	DidGetSidebarDataParams,
 	DidRequestOpenTimelineScopeParams,
@@ -204,6 +206,7 @@ import {
 	ChooseAuthorRequest,
 	ChooseComparisonRequest,
 	ChooseFileRequest,
+	ChooseGraphLayoutCommand,
 	ChooseRefRequest,
 	ChooseRepositoryCommand,
 	CloseGraphWalkthroughBannerCommand,
@@ -218,6 +221,7 @@ import {
 	DidChangeGraphWalkthroughComplete,
 	DidChangeGraphWalkthroughStarted,
 	DidChangeHooksBanner,
+	DidChangeLayoutPromptNotification,
 	DidChangeMcpBanner,
 	DidChangeNotification,
 	DidChangeOrgSettings,
@@ -1998,6 +2002,8 @@ export class GraphWebviewProvider implements WebviewProvider<State, State, Graph
 			this.onHooksBannerChanged();
 		} else if (e.key === 'graph-walkthrough:banner') {
 			this.onGraphWalkthroughBannerChanged();
+		} else if (e.key === 'graph:layoutPrompt') {
+			this.onLayoutPromptChanged();
 		}
 	}
 
@@ -2070,6 +2076,52 @@ export class GraphWebviewProvider implements WebviewProvider<State, State, Graph
 		if (!this.host.visible) return;
 
 		void this.host.notify(DidChangeGraphWalkthroughBanner, this.getGraphWalkthroughBannerState());
+	}
+
+	/** The prompt only applies to the Graph *view* (side bar/panel host) — the editor tab has no
+	 *  side-vs-bottom placement to choose. It arms only once the Graph's DEFAULT container is the
+	 *  GitLens side bar — i.e. when the Graph has replaced Home as the panel's main view (#5391).
+	 *  Until that consolidation lands this is always false for users; devs/pre-release can preview
+	 *  via the `gitlens.graph.simulate.mainView` command, which mutates the same mapping. */
+	private getLayoutPromptNeeded(): boolean {
+		const graphIsMainView =
+			viewIdsByDefaultContainerId.get('workbench.view.extension.gitlens')?.includes('graph') ?? false;
+
+		return graphIsMainView && this.host.is('view') && !this.container.onboarding.isDismissed('graph:layoutPrompt');
+	}
+
+	private onLayoutPromptChanged() {
+		if (!this.host.visible) return;
+
+		void this.host.notify(DidChangeLayoutPromptNotification, this.getLayoutPromptNeeded());
+	}
+
+	@ipcCommand(ChooseGraphLayoutCommand)
+	private async onChooseGraphLayout(params: ChooseGraphLayoutParams) {
+		// One-shot prompt: any answer — including closing without choosing — dismisses it for good
+		void this.container.onboarding.dismiss('graph:layoutPrompt').catch(() => {});
+
+		if (params.choice === 'dismissed') return;
+
+		// Move this view to the chosen container; VS Code persists view locations itself, so the
+		// choice sticks across reloads without any setting of our own
+		const destinationId =
+			params.choice === 'sidebar' ? 'workbench.view.extension.gitlens' : 'workbench.view.extension.gitlensPanel';
+		// Guarded like `resetViewsLayout`: the prompt is already consumed (dismissed above), so a
+		// rejected move must not also skip the container reset / re-reveal below
+		try {
+			await executeCoreCommand('vscode.moveViews', { viewIds: [this.host.id], destinationId: destinationId });
+		} catch {}
+		// The destination container itself may have been dragged elsewhere — dragging a container's
+		// only view relocates the whole container (e.g. the Graph in the secondary side bar means
+		// `gitlensPanel` IS the secondary side bar), which makes the move above a no-op. Send the
+		// container back to its declared home too — mirrors `resetViewsLayout`.
+		try {
+			await executeCoreCommand(`${destinationId}.resetViewContainerLocation`);
+		} catch {}
+		// Re-reveal — the move leaves the view collapsed/unfocused. The prompt only exists on the
+		// view host (see getLayoutPromptNeeded), so the view id is the right target here.
+		void executeCoreCommand('gitlens.views.graph.focus');
 	}
 
 	private onGraphWalkthroughProgressChanged() {
@@ -4344,6 +4396,7 @@ export class GraphWebviewProvider implements WebviewProvider<State, State, Graph
 			graphWalkthroughBannerCollapsed: graphWalkthroughBanner.dismissed,
 			graphWalkthroughComplete: this.getGraphWalkthroughComplete(),
 			graphWalkthroughStarted: this.getGraphWalkthroughStarted(),
+			layoutPromptNeeded: this.getLayoutPromptNeeded(),
 			searchRequest: searchRequest,
 			details: {
 				...storedPanels?.details,

--- a/src/webviews/plus/graph/protocol.ts
+++ b/src/webviews/plus/graph/protocol.ts
@@ -459,6 +459,8 @@ export interface State extends WebviewState<'gitlens.graph' | 'gitlens.views.gra
 	graphWalkthroughBannerCollapsed?: boolean;
 	graphWalkthroughComplete?: boolean;
 	graphWalkthroughStarted?: boolean;
+	/** Show the one-time layout-choice prompt (view host only, until `graph:layoutPrompt` is dismissed) */
+	layoutPromptNeeded?: boolean;
 
 	// Persisted UI state (from `graph:state` workspace memento)
 	displayMode?: GraphDisplayMode;
@@ -1429,6 +1431,16 @@ export const DidChangeGraphWalkthroughStarted = new IpcNotification<boolean>(
 	scope,
 	'graphWalkthrough/started/didChange',
 );
+
+/** The user's answer to the one-time layout prompt: move the Graph view to the side bar
+ *  (vertical), keep/move it to the bottom panel (full width), or close without choosing. */
+export interface ChooseGraphLayoutParams {
+	choice: 'sidebar' | 'panel' | 'dismissed';
+}
+export const ChooseGraphLayoutCommand = new IpcCommand<ChooseGraphLayoutParams>(scope, 'layoutPrompt/choose');
+
+/** Pushed when the `graph:layoutPrompt` onboarding state changes (e.g. dismissed in another window) */
+export const DidChangeLayoutPromptNotification = new IpcNotification<boolean>(scope, 'layoutPrompt/didChange');
 
 export interface DidRequestActiveSidebarPanelParams {
 	panel: GraphSidebarPanel;

--- a/src/webviews/plus/graph/registration.ts
+++ b/src/webviews/plus/graph/registration.ts
@@ -4,6 +4,7 @@ import type { GitReference } from '@gitlens/git/models/reference.js';
 import type { SearchQuery } from '@gitlens/git/models/search.js';
 import { isUri } from '@gitlens/utils/uri.js';
 import type { Source } from '../../../constants.telemetry.js';
+import { viewIdsByDefaultContainerId } from '../../../constants.views.js';
 import type { Container } from '../../../container.js';
 import { GitUri } from '../../../git/gitUri.js';
 import type { GlRepository } from '../../../git/models/repository.js';
@@ -242,6 +243,36 @@ export function registerGraphWebviewCommands<T>(
 				await executeCoreCommand('gitlens.views.graph.resetViewLocation');
 				void executeCommand('gitlens.showGraphView');
 			});
+		}),
+		registerCommand('gitlens.graph.simulate.mainView', () => {
+			// Dev/pre-release only (see contributions gating): simulates the #5391 end state where
+			// the Graph has replaced Home as the GitLens side bar's main view, by mutating the same
+			// default-container mapping the real consolidation will change. Arms the one-time layout
+			// prompt (graphWebview.getLayoutPromptNeeded reads this mapping) and — coherently — makes
+			// "Reset Views Layout" send the Graph to the side bar while the simulation is on.
+			// In-memory only; a window reload restores the real defaults.
+			const sidebar = viewIdsByDefaultContainerId.get('workbench.view.extension.gitlens');
+			const panel = viewIdsByDefaultContainerId.get('workbench.view.extension.gitlensPanel');
+			if (sidebar == null || panel == null) return;
+
+			const simulated = sidebar.includes('graph');
+			const [from, to] = simulated ? [sidebar, panel] : [panel, sidebar];
+			// Guard the index — splice(-1, 1) would silently remove the LAST entry and corrupt the
+			// mapping (which Reset Views Layout also depends on) if 'graph' ever isn't where this
+			// toggle expects it (e.g. after the #5391 consolidation changes the defaults)
+			const index = from.indexOf('graph');
+			if (index !== -1) {
+				from.splice(index, 1);
+			}
+			if (!to.includes('graph')) {
+				to.push('graph');
+			}
+
+			void window.showInformationMessage(
+				`Graph-as-main-view simulation: ${simulated ? 'OFF' : 'ON (layout prompt armed)'}`,
+			);
+			// Rebuild the view's bootstrap so the prompt gate re-evaluates (no-op if not yet resolved)
+			void executeCommand('gitlens.views.graph.refresh');
 		}),
 		registerCommand('gitlens.toggleGraph', (...args: any[]) => {
 			if (getContext('gitlens:webviewView:graph:visible')) {


### PR DESCRIPTION
# Description

Closes #5412 — asks the user on first entry to the _Commit Graph_ view which layout they prefer, with an abstract illustrated preview of each option ("Sidebar › ask on entry" item of #5391).

## Screenshot


<img width="400" alt="Image" src="https://github.com/user-attachments/assets/58919474-31a8-4734-b58d-0fc25de363be" /> <img width="250" alt="Image" src="https://github.com/user-attachments/assets/065c5228-90c9-4465-90c2-7c772d309342" /> <img width="400" alt="Image" src="https://github.com/user-attachments/assets/276e570c-fd74-4b83-87f5-9889bf906a19" />


Tooltips:

- <img width="400" alt="image" src="https://github.com/user-attachments/assets/075ceabf-62a5-4edb-aa5e-3bf74aba0d1a" />

- <img width="400" alt="image" src="https://github.com/user-attachments/assets/39e6fa8b-7d93-40f8-bd40-a39f97dd7171" />



## What it does

A one-time modal (`gl-graph-layout-prompt`, hosted in the Graph webview) explaining that the Graph now takes the place of the Home view, and offering two illustrated choices:

- **Side Bar** — vertical, alongside the editor
- **Bottom Panel** — horizontal, below the editor

Choosing moves the view via `vscode.moveViews` + `<container>.resetViewContainerLocation` (both guarded, mirroring _Reset Views Layout_) to the GitLens side bar container or the bottom `gitlensPanel` container and re-reveals it. The container reset matters: dragging a container's only view relocates the whole container, so e.g. a Graph sitting in the **secondary side bar** means `gitlensPanel` _is_ the secondary side bar — without the reset, "Bottom Panel" would be a no-op. VS Code persists placement itself, so there's no new setting.

The ✕ button, the "Keep my current layout" link, Esc, and backdrop-click all keep the current layout. Any outcome dismisses the prompt for good (new `graph:layoutPrompt` onboarding key, so `gitlens.advanced.skipOnboarding` and _GitLens: Reset → Onboarding_ work as expected).

## ⚠️ Dark-shipped — users will NOT see this yet

The prompt only arms when the Graph's **default** container is the GitLens side bar:

```ts
viewIdsByDefaultContainerId.get('workbench.view.extension.gitlens')?.includes('graph')
```

Today the Graph's default container is the bottom panel, so this is inert for everyone. When the #5391 consolidation makes the Graph the panel's main view, that PR must update this same mapping anyway (otherwise _Reset Views Layout_ would send the Graph back to the bottom panel) — so the prompt arms automatically, with zero coordination. Deliberately no experimental setting.

**Deferred to that future PR** (noted in code comments): re-adding the CHANGELOG entry (removed here — no announcing an invisible feature), bumping the onboarding `schema` stamp if the merge slips past 18.4.0, and an E2E spec.

## Dev/pre-release preview

- **`GitLens: Simulate Graph as Main View (Debugging)`** — new command, palette-visible only with `gitlens:debugging || gitlens:prerelease`. Toggles `graph` between the panel/side-bar entries of `viewIdsByDefaultContainerId` in-memory (window reload restores) and refreshes the view. While on, _Reset Views Layout_ coherently treats the side bar as the Graph's home.
- Re-run the flow anytime: _GitLens: Reset…_ → _Onboarding…_ → refresh the Graph view.

## Behavior details

- **View host only** (`gitlens.views.graph`) — the editor-tab graph has no side-vs-bottom placement to choose.
- **Sequenced after the graph walkthrough popover** — on a truly fresh profile both fire on first entry; the prompt holds until the walkthrough banner is dismissed, completed, **or started** ("See what's new" tracks started without dismissing the banner, and the header only force-opens the popover while not started — without the `started` case, CTA-clickers would never see the prompt).
- **Design**: reuses the graph feature gate's brand-gradient border recipe (`--gl-gradient-brand`, `--gl-radius-xl`, forced-colors fallback) so the two first-run surfaces read as one family.
- **Keyboard & a11y**: the dialog self-focuses on open (nothing pre-selected; new opt-in `autofocus-self` on `gl-dialog`, with an explicit focus fallback since Chromium ignores `autofocus` on a shadow-hosted dialog); Tab order is Side Bar → Bottom Panel → skip link → ✕ (the ✕ is last in the DOM, positioned top-right visually); the dialog closes before unmount so native focus restoration runs; `gl-dialog` also gained a `label` property → `aria-label` (slotted headings can't cross the shadow boundary).
- **Responsive**: side-by-side cards normally (captions kept to one line); stacked row-cards under 480px width (side-bar host); compressed variant (captions dropped, smaller illustrations) under 420px height (short bottom panel). Includes a `box-sizing` fix for `gl-dialog::part(base)` so the dialog can't overflow a ~300px side-bar webview.
- **Telemetry**: `graph/layoutPrompt/shown` (once per webview session, remount-safe) and `graph/layoutPrompt/choice` (`sidebar`/`panel`/`dismissed`).

## Verification

Live-exercised against a real instance (fresh profiles): gate inert by default; simulate command arms/disarms at runtime without reload; both move destinations actually relocate the view; all four dismissal paths dismiss without moving; dismissal survives refresh/recreation; both responsive variants fit their real host dimensions; dialog self-focus verified via activeElement probing; `pnpm run check` clean. Later rounds (error-path guards, `started` cohort, focus restore) are verified by code-trace and types.

# Checklist

- [x] I have followed the guidelines in the Contributing document
- [x] My changes follow the coding style of this project
- [x] My changes build without any errors or warnings
- [x] My changes have been formatted and linted
- [x] My changes include any required corresponding changes to the documentation (CHANGELOG entry intentionally deferred — see above)
- [x] My changes have been rebased and squashed to the minimal number (typically 1) of relevant commits
- [x] My changes have a descriptive commit message with a short title

🤖 Generated with [Claude Code](https://claude.com/claude-code)
