### PR TITLE
Adds an empty state to the Commit Graph when no repository is open

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,10 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/) and this p
 
 ## [Unreleased]
 
+### Added
+
+- Adds an empty state to the _Commit Graph_ when no repository is open &mdash; offers _Open a Folder_, _Clone a Repository_, and _Start a New Project_ actions to get started; in web/virtual environments (e.g. vscode.dev) clone and new-project are replaced by an _Open Remote Repository_ action ([#5408](https://github.com/gitkraken/vscode-gitlens/issues/5408))
+
 ### Changed
 
 - Changes the default _Commit Graph_ lane colors for dark and high-contrast themes to a new vibrant, perceptually-uniform palette &mdash; every lane shares the same perceived brightness so no lane visually dominates; light themes keep the previous colors, and any `gitlens.graphLane1Color`&ndash;`gitlens.graphLane10Color` customizations in `workbench.colorCustomizations` are still honored

--- a/contributions.json
+++ b/contributions.json
@@ -6545,7 +6545,7 @@
 		"gitlens.showGraph": {
 			"label": "Show Commit Graph",
 			"icon": "$(gitlens-graph)",
-			"commandPalette": "gitlens:enabled",
+			"commandPalette": true,
 			"menus": {
 				"gitlens/scm/title": [
 					{
@@ -6619,12 +6619,12 @@
 		"gitlens.showGraphPage": {
 			"label": "Show Commit Graph in Editor",
 			"icon": "$(gitlens-graph)",
-			"commandPalette": "gitlens:enabled"
+			"commandPalette": true
 		},
 		"gitlens.showGraphView": {
 			"label": "Show Commit Graph View",
 			"icon": "$(gitlens-graph)",
-			"commandPalette": "gitlens:enabled"
+			"commandPalette": true
 		},
 		"gitlens.showHomeView": {
 			"label": "Show Home View",
@@ -20924,7 +20924,7 @@
 		"gitlens.views.graph": {
 			"type": "webview",
 			"name": "Graph",
-			"when": "!gitlens:disabled && (!gitlens:plus:disabled || gitlens:plus:disabled:view:overrides =~ /(?:^|\\|)gitlens\\.views\\.graph(?:\\||$)/)",
+			"when": "!gitlens:plus:disabled || gitlens:plus:disabled:view:overrides =~ /(?:^|\\|)gitlens\\.views\\.graph(?:\\||$)/",
 			"contextualTitle": "GitLens",
 			"icon": "$(gitlens-graph)",
 			"initialSize": 4,

--- a/package.json
+++ b/package.json
@@ -14568,18 +14568,6 @@
 					"when": "gitlens:enabled"
 				},
 				{
-					"command": "gitlens.showGraph",
-					"when": "gitlens:enabled"
-				},
-				{
-					"command": "gitlens.showGraphPage",
-					"when": "gitlens:enabled"
-				},
-				{
-					"command": "gitlens.showGraphView",
-					"when": "gitlens:enabled"
-				},
-				{
 					"command": "gitlens.showInCommitGraph",
 					"when": "false"
 				},
@@ -29283,7 +29271,7 @@
 					"type": "webview",
 					"id": "gitlens.views.graph",
 					"name": "Graph",
-					"when": "!gitlens:disabled && (!gitlens:plus:disabled || gitlens:plus:disabled:view:overrides =~ /(?:^|\\|)gitlens\\.views\\.graph(?:\\||$)/)",
+					"when": "!gitlens:plus:disabled || gitlens:plus:disabled:view:overrides =~ /(?:^|\\|)gitlens\\.views\\.graph(?:\\||$)/",
 					"contextualTitle": "GitLens",
 					"icon": "$(gitlens-graph)",
 					"initialSize": 4,

--- a/src/commands/showView.ts
+++ b/src/commands/showView.ts
@@ -88,7 +88,10 @@ export class ShowViewCommand extends GlCommandBase {
 				await this.waitForRepo();
 				return this.container.views.showView('fileHistory');
 			case 'gitlens.showGraphView':
-				await this.waitForRepoOrNotify('the Commit Graph');
+				// The Commit Graph shows its own in-view empty state (Open a Folder / Clone / Start a New
+				// Project) when there's no repo, so skip the redundant "No repository detected" notification —
+				// just wait for discovery so we don't flash the empty state before repos are known.
+				await this.waitForRepo();
 				return this.container.views.graph.show(undefined, ...(args as GraphWebviewShowingArgs));
 			case 'gitlens.showHomeView':
 				return this.container.views.home.show(undefined, ...(args as HomeWebviewShowingArgs));

--- a/src/webviews/apps/plus/graph/empty-state.ts
+++ b/src/webviews/apps/plus/graph/empty-state.ts
@@ -1,0 +1,109 @@
+import { SignalWatcher } from '@lit-labs/signals';
+import { consume } from '@lit/context';
+import { css, html, LitElement } from 'lit';
+import { customElement } from 'lit/decorators.js';
+import { when } from 'lit/directives/when.js';
+import { graphStateContext } from './context.js';
+import '../../shared/components/button.js';
+import '../../shared/components/code-icon.js';
+
+@customElement('gl-graph-empty-state')
+export class GlGraphEmptyState extends SignalWatcher(LitElement) {
+	static override styles = css`
+		:host {
+			position: absolute;
+			inset: 0;
+			z-index: var(--gl-z-cover);
+			display: flex;
+			align-items: center;
+			justify-content: center;
+			padding: var(--gl-space-24);
+			background: var(--vscode-editor-background);
+			overflow: auto;
+		}
+
+		.container {
+			display: flex;
+			flex-direction: column;
+			align-items: center;
+			gap: var(--gl-space-16);
+			width: 100%;
+			max-width: 36rem;
+			text-align: center;
+		}
+
+		.icon {
+			color: var(--vscode-descriptionForeground);
+		}
+
+		.icon code-icon {
+			font-size: 4rem;
+		}
+
+		.title {
+			margin: 0;
+			font-size: var(--gl-font-lg);
+			font-weight: 600;
+		}
+
+		.description {
+			margin: 0;
+			font-size: var(--gl-font-base);
+			color: var(--vscode-descriptionForeground);
+		}
+
+		.actions {
+			display: flex;
+			flex-direction: column;
+			gap: var(--gl-space-8);
+			width: 100%;
+			margin-top: var(--gl-space-8);
+		}
+	`;
+
+	@consume({ context: graphStateContext, subscribe: true })
+	graphState!: typeof graphStateContext.__context__;
+
+	override render(): unknown {
+		return html`
+			<div class="container" role="group" aria-label="No repository open">
+				<div class="icon"><code-icon icon="source-control"></code-icon></div>
+				<h2 class="title">No repository open</h2>
+				<p class="description">
+					Open a folder or repository to visualize its history, branches, and commits in the Commit Graph.
+				</p>
+				<div class="actions">
+					<gl-button full href="command:workbench.action.files.openFolder">
+						<code-icon slot="prefix" icon="folder-opened"></code-icon>
+						Open a Folder
+					</gl-button>
+					${when(
+						this.graphState.isWeb,
+						() => html`
+							<gl-button appearance="secondary" full href="command:remoteHub.openRepository">
+								<code-icon slot="prefix" icon="globe"></code-icon>
+								Open Remote Repository
+							</gl-button>
+						`,
+						() => html`
+							<gl-button appearance="secondary" full href="command:git.clone">
+								<code-icon slot="prefix" icon="repo-clone"></code-icon>
+								Clone a Repository
+							</gl-button>
+							<gl-button appearance="secondary" full href="command:git.init">
+								<code-icon slot="prefix" icon="new-folder"></code-icon>
+								Start a New Project
+							</gl-button>
+						`,
+					)}
+				</div>
+			</div>
+		`;
+	}
+}
+
+declare global {
+	interface HTMLElementTagNameMap {
+		'gl-graph-empty-state': GlGraphEmptyState;
+	}
+}

--- a/src/webviews/apps/plus/graph/graph-app.ts
+++ b/src/webviews/apps/plus/graph/graph-app.ts
@@ -99,6 +99,7 @@ import { getSelectedRepoPath } from './utils/repository.utils.js';
 import { getCommitDateFromRow } from './utils/row.utils.js';
 import { serializeWipContext } from './utils/rowContext.utils.js';
 import { shouldShowPrimaryWipRow } from './utils/wip.utils.js';
+import './empty-state.js';
 import './gate.js';
 import './graph-header.js';
 import './graph-wrapper/graph-wrapper.js';
@@ -1620,6 +1621,10 @@ export class GraphApp extends SignalWatcher(LitElement) {
 				></gl-graph-header>
 				<div class="graph__workspace">
 					${when(!this.graphState.allowed, () => html`<gl-graph-gate class="graph__gate"></gl-graph-gate>`)}
+					${when(
+						this.graphState.repositories?.length === 0,
+						() => html`<gl-graph-empty-state class="graph__empty-state"></gl-graph-empty-state>`,
+					)}
 					<gl-graph-hover id="commit-hover" .distance=${0} .skidding=${15}></gl-graph-hover>
 					<gl-drag-shift-overlay label="to Resume Dragging"></gl-drag-shift-overlay>
 					<main id="main" class="graph__panes">${this.renderDetailsPanel()}</main>

--- a/src/webviews/apps/plus/graph/stateProvider.ts
+++ b/src/webviews/apps/plus/graph/stateProvider.ts
@@ -382,6 +382,9 @@ export class GraphStateProvider extends StateProviderBase<State['webviewId'], Ap
 	accessor webroot: string | undefined;
 
 	@signalState()
+	accessor isWeb: State['isWeb'] = false;
+
+	@signalState()
 	accessor repositories: State['repositories'];
 
 	@signalState()

--- a/src/webviews/plus/graph/graphWebview.ts
+++ b/src/webviews/plus/graph/graphWebview.ts
@@ -1,5 +1,6 @@
 import type { CancellationToken, ColorTheme, ConfigurationChangeEvent, TextDocumentShowOptions } from 'vscode';
 import { CancellationTokenSource, commands, Disposable, Uri, ViewColumn, window, workspace } from 'vscode';
+import { isWeb } from '@env/platform.js';
 import type { GitBranch } from '@gitlens/git/models/branch.js';
 import { GitCommit } from '@gitlens/git/models/commit.js';
 import type { GitGraph, GitGraphRow, GitGraphRowType } from '@gitlens/git/models/graph.js';
@@ -3680,14 +3681,14 @@ export class GraphWebviewProvider implements WebviewProvider<State, State, Graph
 
 		if (this.container.git.repositoryCount === 0) {
 			this._wip.updateWorkingTreeBadge(undefined);
-			return { ...this.host.baseWebviewState, allowed: true, repositories: [] };
+			return { ...this.host.baseWebviewState, allowed: true, repositories: [], isWeb: isWeb };
 		}
 
 		if (this.repository == null) {
 			this.repository = this.container.git.getBestRepositoryOrFirst();
 			if (this.repository == null) {
 				this._wip.updateWorkingTreeBadge(undefined);
-				return { ...this.host.baseWebviewState, allowed: true, repositories: [] };
+				return { ...this.host.baseWebviewState, allowed: true, repositories: [], isWeb: isWeb };
 			}
 		}
 

--- a/src/webviews/plus/graph/protocol.ts
+++ b/src/webviews/plus/graph/protocol.ts
@@ -378,6 +378,9 @@ export interface GraphScope {
 export interface State extends WebviewState<'gitlens.graph' | 'gitlens.views.graph'> {
 	windowFocused?: boolean;
 	webroot?: string;
+	/** True when running in a web/virtual environment (e.g. vscode.dev), where the no-repo empty state
+	 *  offers "Open Remote Repository" instead of clone/init. Sourced from `isWeb` (`@env/platform`). */
+	isWeb?: boolean;
 	repositories?: GraphRepository[];
 	/** Absolute fsPaths of every worktree in the current repo's family (the main checkout plus
 	 *  every secondary worktree), sourced from the loaded graph. A reusable registry for any


### PR DESCRIPTION
# Description

Adds an empty state to the _Commit Graph_ shown when no repository is open, guiding users to get started. Closes #5408.

- **Empty-state overlay** with a primary **Open a Folder** action and secondary **Clone a Repository** / **Start a New Project** actions. In web/virtual workspaces (e.g. vscode.dev), clone and new-project are replaced by a single **Open Remote Repository** action (driven by an `isWeb` flag surfaced from the host).
- **Reachability when no repo:** GitLens marks itself `gitlens:disabled` when there are zero repositories, which previously hid the graph view and filtered the _Show Commit Graph_ commands out of the Command Palette. The graph view now stays available with no repo, and the `Show Commit Graph` / `…in Editor` / `…View` commands are surfaced in the palette (matching `Show Home View`), so the empty state is reachable via both the editor page and the bottom panel.
- **Removes the redundant** "No repository detected" notification when opening the graph — the in-view empty state now provides the guidance.

<img width="1240" height="1566" alt="image" src="https://github.com/user-attachments/assets/ee8620fe-a09e-4361-951d-f6c106218cf5" />



## Testing

Verified live in the Extension Development Host with no repository open:

- Empty state renders in both the editor page and the bottom-panel view; desktop shows the three actions, `isWeb` shows Open a Folder + Open Remote Repository.
- Buttons execute their commands end-to-end (e.g. Clone → `git.clone` quick input); reactive transition works (opening a repo hides the overlay and renders the graph, closing it restores the empty state).
- All _Show Commit Graph_ commands appear in the Command Palette with no repo, and no "No repository detected" toast is shown.