### PR TITLE
Fixes #5137 - Improve active editor change handling for virtual and non-virtual URIs

### DIFF
--- a/src/views/nodes/fileHistoryTrackerNode.ts
+++ b/src/views/nodes/fileHistoryTrackerNode.ts
@@ -143,10 +143,10 @@ export class FileHistoryTrackerNode extends SubscribeableViewNode<'file-history-
 	private _triggerChangeDebounced: Deferrable<() => Promise<void>> | undefined;
 	@trace({ args: false })
 	private onActiveEditorChanged(editor: TextEditor | undefined) {
-		// If we are losing the active editor, give more time before assuming its really gone
-		// For virtual repositories the active editor event takes a while to fire
-		// Ultimately we need to be using the upcoming Tabs api to avoid this
-		if (editor == null && isVirtualUri(this._uri)) {
+		// If we are losing the active editor, give more time before assuming its really gone.
+		// This can happen on initial activation before the editor is fully established,
+		// including for non-virtual URIs. Ultimately we need to be using the upcoming Tabs api to avoid this.
+		if (editor == null && (this.hasUri || isVirtualUri(this._uri))) {
 			this._triggerChangeDebounced ??= debounce(() => this.triggerChange(), 1500);
 			void this._triggerChangeDebounced();
 			return;


### PR DESCRIPTION
# Description

Fixes #5137

This pull request makes a targeted improvement to the logic for handling active editor changes in the `FileHistoryTrackerNode`. The main change is to broaden the debounce behavior to cover more scenarios, ensuring smoother handling when the active editor is lost, not just for virtual URIs.

Editor change handling improvement:

* Updated the condition in `onActiveEditorChanged` to debounce the change trigger when there is no active editor and either `hasUri` is true or the URI is virtual, rather than only when the URI is virtual. This should make the UI more robust during initial activation and other edge cases.




# Checklist

<!-- Please check off the following -->

- [x] I have followed the guidelines in the Contributing document
- [x] My changes follow the coding style of this project
- [x] My changes build without any errors or warnings
- [x] My changes have been formatted and linted
- [x] My changes include any required corresponding changes to the documentation (including CHANGELOG.md and README.md)
- [x] My changes have been rebased and squashed to the minimal number (typically 1) of relevant commits
- [x] My changes have a descriptive commit message with a short title, including a `Fixes $XXX -` or `Closes #XXX -` prefix to auto-close the issue that your PR addresses