### PR TITLE
Fixes live updating of subscription and organization state in webviews

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,7 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/) and this p
 
 ### Fixed
 
+- Fixes the _Commit Graph_ header's account/subscription state never updating after the view loads &mdash; sign-in/sign-out, organization switches, and plan changes (including the subscription simulator) now update the header live instead of requiring a reload; the same underlying fix also keeps account and organization state live in _Commit Details_ and organization AI/drafts settings live in the _Home_ view ([#5513](https://github.com/gitkraken/vscode-gitlens/issues/5513))
 - Fixes the _Commit Graph_ working changes (WIP) details continuing to show files after they were committed or discarded outside of VS Code (e.g. from a terminal)
 - Fixes the _Commit Graph_ view's progress indicator repeatedly flashing while nothing appears to change (most noticeable after the VS Code window regains focus) &mdash; last-fetched updates now coalesce into a single pending update instead of queuing one per `FETCH_HEAD` change
 

--- a/src/webviews/apps/commitDetails/events.ts
+++ b/src/webviews/apps/commitDetails/events.ts
@@ -60,8 +60,8 @@ export function setupSubscriptions(
 				handleRepositoryChanged(state, event, actions),
 			),
 		() => services.config.onConfigChanged(() => handleConfigChanged(actions)),
-		// Note: onSubscriptionChanged removed — hasAccount signal bridged from host
-		// Note: onOrgSettingsChanged removed — orgSettings signal bridged from host
+		// Note: onSubscriptionChanged/onOrgSettingsChanged removed — the bridged hasAccount and
+		// orgSettings signals are kept fresh by SubscriptionService's eager listeners (#5513)
 		() =>
 			services.integrations.onIntegrationsChanged(data => handleIntegrationsChanged(state, data.hasAnyConnected)),
 		() => services.ai.onModelChanged(model => state.aiModel.set(model)),

--- a/src/webviews/apps/home/events.ts
+++ b/src/webviews/apps/home/events.ts
@@ -131,7 +131,9 @@ export function setupSubscriptions(
 		// Generic events — from WebviewEventsService
 		// ============================================================
 
-		// Subscription changed — state handled by signal bridges, keep side effects only
+		// Subscription changed — state flows via the bridged signals, whose freshness is
+		// guaranteed by SubscriptionService's eager listeners (#5513); this subscription
+		// exists solely for its side effects and is safe to remove if they go away
 		() =>
 			services.subscription.onSubscriptionChanged(() => {
 				actions.onSubscriptionChanged();
@@ -145,7 +147,8 @@ export function setupSubscriptions(
 				actions.refreshOverview();
 			}),
 
-		// Note: onOrgSettingsChanged removed — orgSettings signal bridged from host
+		// Note: onOrgSettingsChanged removed — the bridged orgSettings signal is kept fresh
+		// by SubscriptionService's eager listeners (#5513)
 
 		// Repository discovery completed
 		() =>

--- a/src/webviews/rpc/__tests__/servicesProxy.test.ts
+++ b/src/webviews/rpc/__tests__/servicesProxy.test.ts
@@ -1,0 +1,52 @@
+/**
+ * Covers the service disposal mechanism introduced for #5513 (eager signal-freshness
+ * listeners in `SubscriptionService` must be released at webview teardown).
+ *
+ * `SubscriptionService` itself cannot be imported here: it runtime-imports
+ * `system/-webview/context.ts` → `command.ts` → `container.ts`, a chain that cannot
+ * initialize in the self-contained test bundle (circular-init on `@command` registration).
+ * Its eager-freshness behavior is exercised against the live extension instead.
+ */
+
+import * as assert from 'assert';
+import * as sinon from 'sinon';
+import { disposeServices, proxyServices } from '../services/proxy.js';
+
+suite('RPC services proxy/disposal Test Suite', () => {
+	test('disposes collected disposable services exactly once and skips the rest', () => {
+		const dispose = sinon.spy();
+		const services = proxyServices({
+			disposable: { dispose: dispose, other: () => {} },
+			plain: { other: () => {} },
+			fn: () => {},
+			nothing: undefined,
+		});
+
+		disposeServices(services);
+		assert.strictEqual(dispose.callCount, 1);
+	});
+
+	test('is idempotent — disposing twice does not re-dispose services', () => {
+		const dispose = sinon.spy();
+		const services = proxyServices({ disposable: { dispose: dispose } });
+
+		disposeServices(services);
+		disposeServices(services);
+		assert.strictEqual(dispose.callCount, 1);
+	});
+
+	test('collected disposables are not exposed as an enumerable property', () => {
+		const services = proxyServices({ disposable: { dispose: () => {} } });
+		assert.deepStrictEqual(Object.keys(services), ['disposable']);
+		assert.strictEqual(Object.getOwnPropertySymbols(services).length, 1);
+		assert.strictEqual(
+			Object.entries(services).every(([, value]) => value != null),
+			true,
+		);
+	});
+
+	test('is a safe no-op for objects without collected disposables', () => {
+		assert.doesNotThrow(() => disposeServices({}));
+		assert.doesNotThrow(() => disposeServices(undefined));
+	});
+});

--- a/src/webviews/rpc/eventVisibilityBuffer.ts
+++ b/src/webviews/rpc/eventVisibilityBuffer.ts
@@ -206,6 +206,11 @@ export function createRpcEvent<T>(key: string, mode: 'save-last' | 'signal', sig
  * Standard pattern for the common case: Container event emitter → buffered handler → cleanup.
  * The `subscribe` function receives the already-buffered handler and returns a `Disposable`.
  *
+ * The `subscribe` callback runs LAZILY — only when a client registers a handler, and once per
+ * registration. It must never be the sole updater of a bridged `Signal.State`: a webview that
+ * reads the signal without subscribing gets a permanently frozen value (#5513). Keep signals
+ * fresh with an eagerly-registered listener instead — see `SubscriptionService`'s constructor.
+ *
  * For custom patterns (aggregation, handler maps, replay-on-subscribe), use `bufferEventHandler` directly.
  *
  * @param buffer - Optional visibility buffer (undefined = no buffering)

--- a/src/webviews/rpc/services/common.ts
+++ b/src/webviews/rpc/services/common.ts
@@ -7,7 +7,6 @@
  *
  */
 
-import { proxy } from '@eamodio/supertalk';
 import type { Container } from '../../../container.js';
 import type { EventVisibilityBuffer, SubscriptionTracker } from '../eventVisibilityBuffer.js';
 import { AIService } from './ai.js';
@@ -98,17 +97,4 @@ export function createSharedServices(
 	};
 }
 
-/**
- * Wraps all object-valued properties with Supertalk's `proxy()` marker.
- *
- * Call this on the final services object returned from `getRpcServices()`.
- * Sub-service objects and class instances become remote proxies;
- * functions and primitives pass through unchanged.
- */
-export function proxyServices<T extends Record<string, unknown>>(services: T): T {
-	const result: Record<string, unknown> = {};
-	for (const [key, value] of Object.entries(services)) {
-		result[key] = value != null && typeof value === 'object' ? proxy(value) : value;
-	}
-	return result as T;
-}
+export { disposeServices, proxyServices } from './proxy.js';

--- a/src/webviews/rpc/services/proxy.ts
+++ b/src/webviews/rpc/services/proxy.ts
@@ -1,0 +1,60 @@
+/**
+ * Service proxying and disposal for the webview RPC layer.
+ *
+ * Kept free of service-class imports so it can be unit-tested — the service
+ * classes transitively reach `system/-webview/command.ts` (and through it the
+ * whole extension), which cannot initialize in the test bundle.
+ */
+
+import { proxy } from '@eamodio/supertalk';
+import type { Disposable } from 'vscode';
+
+const servicesDisposables = Symbol('rpcServicesDisposables');
+
+/**
+ * Wraps all object-valued properties with Supertalk's `proxy()` marker.
+ *
+ * Call this on the final services object returned from `getRpcServices()`.
+ * Sub-service objects and class instances become remote proxies;
+ * functions and primitives pass through unchanged.
+ *
+ * Services that implement `dispose()` are collected behind a non-enumerable symbol
+ * (invisible to the RPC layer) so the webview controller can release them at teardown
+ * via {@link disposeServices}. This is the disposal path for service resources that
+ * must outlive `SubscriptionTracker.reset()` (RPC reconnection), e.g. the eager
+ * signal-freshness listeners in `SubscriptionService`.
+ *
+ * Only TOP-LEVEL properties are scanned — a disposable service nested inside a
+ * sub-object won't be collected; hoist it to the top level instead.
+ */
+export function proxyServices<T extends Record<string, unknown>>(services: T): T {
+	const result: Record<string, unknown> = {};
+	const disposables: Disposable[] = [];
+	for (const [key, value] of Object.entries(services)) {
+		if (value != null && typeof value === 'object') {
+			if (typeof (value as Partial<Disposable>).dispose === 'function') {
+				disposables.push(value as Disposable);
+			}
+			result[key] = proxy(value);
+		} else {
+			result[key] = value;
+		}
+	}
+	Object.defineProperty(result, servicesDisposables, { value: disposables, enumerable: false });
+	return result as T;
+}
+
+/**
+ * Disposes the disposable services collected by {@link proxyServices}.
+ * Safe to call with any object — a no-op when none were collected — and idempotent.
+ */
+export function disposeServices(services: object | undefined): void {
+	if (services == null) return;
+
+	const disposables = (services as { [servicesDisposables]?: Disposable[] })[servicesDisposables];
+	if (disposables == null) return;
+
+	for (const disposable of disposables.splice(0)) {
+		disposable.dispose();
+	}
+}

--- a/src/webviews/rpc/services/subscription.ts
+++ b/src/webviews/rpc/services/subscription.ts
@@ -5,9 +5,15 @@
  * `Signal.State` properties (for reactive bridging via Supertalk's SignalHandler).
  * The signals are the canonical host-side mirrors of Container state — portable
  * across all webviews that use this shared service.
+ *
+ * Signal freshness is guaranteed by listeners registered eagerly in the constructor —
+ * it must never depend on a client subscribing to the RPC change events, because
+ * webviews are entitled to read the bridged signals without subscribing (#5513).
+ * The service must be disposed (via `disposeServices`) to release those listeners.
  */
 
 import { Signal } from 'signal-polyfill';
+import { Disposable } from 'vscode';
 import { getAvatarUriFromGravatarEmail } from '../../../avatars.js';
 import type { Container } from '../../../container.js';
 import type { Subscription } from '../../../plus/gk/models/subscription.js';
@@ -17,8 +23,9 @@ import type { EventVisibilityBuffer, SubscriptionTracker } from '../eventVisibil
 import { createRpcEventSubscription } from '../eventVisibilityBuffer.js';
 import type { OrgSettings, RpcEventSubscription } from './types.js';
 
-export class SubscriptionService {
+export class SubscriptionService implements Disposable {
 	readonly #container: Container;
+	readonly #disposable: Disposable;
 
 	// ── Reactive signals (auto-synced to webview via SignalHandler) ──
 
@@ -76,8 +83,34 @@ export class SubscriptionService {
 			drafts: getContext('gitlens:gk:organization:drafts:enabled', false),
 		});
 
-		// Initialize subscription asynchronously — resolves before webview connects
+		// Keep the signals fresh eagerly — NOT inside the lazy RPC-event subscriptions below,
+		// which only register their Container listeners when a client subscribes a handler.
+		// Clients (e.g. the Graph header) read the bridged signals without ever subscribing (#5513).
+		// Registered before the async seed below so no change can slip between them.
+		// These listeners outlive `tracker.reset()` (RPC reconnection) by design; they are
+		// released by `dispose()` at webview teardown.
+		this.#disposable = Disposable.from(
+			container.subscription.onDidChange(e => {
+				const serialized = serialize(e.current);
+				this.subscriptionState.set(serialized);
+				this.#updateDerivedState(serialized);
+			}),
+			onDidChangeContext(key => {
+				if (key === 'gitlens:gk:organization:ai:enabled' || key === 'gitlens:gk:organization:drafts:enabled') {
+					this.orgSettingsState.set({
+						ai: getContext('gitlens:gk:organization:ai:enabled', false),
+						drafts: getContext('gitlens:gk:organization:drafts:enabled', false),
+					});
+				}
+			}),
+		);
+
+		// Initialize subscription asynchronously — resolves before webview connects.
+		// If a change event has already populated the signal by then, keep it — the event's
+		// state is at least as fresh as this snapshot, which was requested earlier.
 		void container.subscription.getSubscription().then(sub => {
+			if (this.subscriptionState.get() !== undefined) return;
+
 			const serialized = serialize(sub);
 			this.subscriptionState.set(serialized);
 			this.#updateDerivedState(serialized);
@@ -87,13 +120,7 @@ export class SubscriptionService {
 			buffer,
 			'subscriptionChanged',
 			'save-last',
-			buffered =>
-				container.subscription.onDidChange(e => {
-					const serialized = serialize(e.current);
-					this.subscriptionState.set(serialized);
-					this.#updateDerivedState(serialized);
-					buffered(serialized);
-				}),
+			buffered => container.subscription.onDidChange(e => buffered(serialize(e.current))),
 			undefined,
 			tracker,
 		);
@@ -108,17 +135,19 @@ export class SubscriptionService {
 						key === 'gitlens:gk:organization:ai:enabled' ||
 						key === 'gitlens:gk:organization:drafts:enabled'
 					) {
-						const settings: OrgSettings = {
+						buffered({
 							ai: getContext('gitlens:gk:organization:ai:enabled', false),
 							drafts: getContext('gitlens:gk:organization:drafts:enabled', false),
-						};
-						this.orgSettingsState.set(settings);
-						buffered(settings);
+						});
 					}
 				}),
 			undefined,
 			tracker,
 		);
+	}
+
+	dispose(): void {
+		this.#disposable.dispose();
 	}
 
 	/**

--- a/src/webviews/webviewController.ts
+++ b/src/webviews/webviewController.ts
@@ -64,6 +64,7 @@ import {
 import { isRpcMessage } from './rpc/constants.js';
 import { EventVisibilityBuffer, SubscriptionTracker } from './rpc/eventVisibilityBuffer.js';
 import { RpcHost } from './rpc/rpcHost.js';
+import { disposeServices } from './rpc/services/proxy.js';
 import type { WebviewCommandCallback, WebviewCommandRegistrar } from './webviewCommandRegistrar.js';
 import type { CustomEditorDescriptor, WebviewPanelDescriptor, WebviewViewDescriptor } from './webviewDescriptors.js';
 import type { WebviewHost, WebviewProvider, WebviewShowingArgs } from './webviewProvider.js';
@@ -318,6 +319,9 @@ export class WebviewController<
 				...(this.provider.registerCommands?.() ?? []),
 				this.provider,
 				...(this._rpcHost != null ? [this._rpcHost] : []),
+				// Service resources that must survive tracker.reset() (reconnection) are released
+				// only here, at controller teardown — see proxyServices/disposeServices
+				{ dispose: () => disposeServices(rpcServices) },
 			);
 		});
 	}


### PR DESCRIPTION
# Description

Closes #5513

The account/subscription header at the top of the Commit Graph populated its state on webview load and never updated afterwards — sign-in/sign-out, organization switches, plan/trial changes, and the Subscription Simulator were all ignored until a full webview reload.

**Root cause**: the per-webview `SubscriptionService`'s reactive signals were only updated inside the `container.subscription.onDidChange` handler, which `createRpcEventSubscription` registers lazily — only when a client subscribes a handler to the RPC change event. The Graph app never subscribes (it reads the bridged signals directly), so its service instance's signals stayed frozen at construction-time values. The Home view stayed live only because it subscribes to `onSubscriptionChanged` for an unrelated side effect (`refreshPromo`), incidentally arming the listener.

## Changes

- Registers the `container.subscription.onDidChange` and `onDidChangeContext` listeners eagerly in the `SubscriptionService` constructor, decoupling signal freshness from RPC-event subscription; the lazy RPC-event subscriptions now only forward buffered events
- Makes `SubscriptionService` disposable; `proxyServices` (moved to a new dependency-free `rpc/services/proxy.ts` module) collects disposable services behind a non-enumerable symbol, and the webview controller releases them at teardown via the new `disposeServices` — deliberately outside `SubscriptionTracker`, whose `reset()` on RPC reconnection would otherwise orphan the eager listeners
- Also fixes, via the same change: frozen account state in Commit Details (same latent bug — it removed its `onSubscriptionChanged` call trusting signals were self-fresh), and frozen organization AI/drafts settings (`orgSettingsState`) in every webview (`onOrgSettingsChanged` has no callers anywhere)
- Corrects the misleading "state handled by signal bridges" comments in `home/events.ts` and `commitDetails/events.ts` to point at where the freshness guarantee actually lives

## Testing

- `pnpm run check`: clean
- `pnpm run test`: 1290 passing, including 3 new tests for the service disposal mechanism (`servicesProxy.test.ts`)
- Live-verified in a dev instance with `gitlens.graph.experimental.homeHeader.enabled`: `gitlens.plus.simulate.subscription` flipped the Graph account chip Community → Pro → Pro Trial live with no reload, including simulator re-runs (the case called out in the issue)
- Note: `SubscriptionService` itself is not unit-testable today — importing it pulls the `context.ts → command.ts → container.ts` chain, which cannot initialize in the self-contained test bundle (pre-existing circular-init limitation); the test file documents this

# Checklist

- [x] I have followed the guidelines in the Contributing document
- [x] My changes follow the coding style of this project
- [x] My changes build without any errors or warnings
- [x] My changes have been formatted and linted
- [x] My changes include any required corresponding changes to the documentation (including CHANGELOG.md and README.md)
- [x] My changes have been rebased and squashed to the minimal number (typically 1) of relevant commits
- [x] My changes have a descriptive commit message with a short title, including a `Fixes $XXX -` or `Closes #XXX -` prefix to auto-close the issue that your PR addresses
