### PR TITLE
Adapt the Commit Graph feature-gate to constrained areas

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,7 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/) and this p
 
 - Changes the default _Commit Graph_ lane colors for dark and high-contrast themes to a new vibrant, perceptually-uniform palette &mdash; every lane shares the same perceived brightness so no lane visually dominates; light themes keep the previous colors, and any `gitlens.graphLane1Color`&ndash;`gitlens.graphLane10Color` customizations in `workbench.colorCustomizations` are still honored
 - Changes the _Commit Graph_ sidebar to be unpinned by default &mdash; the sidebar now floats over the graph and auto-collapses when it loses focus; pin it (or set `gitlens.graph.sidebar.pinned` to `true`) to restore the previous shared-space layout ([#5447](https://github.com/gitkraken/vscode-gitlens/issues/5447))
+- Changes the Pro feature gate to adapt to constrained spaces &mdash; in narrow placements (e.g. the side bar) the feature list collapses to a single column, and in short placements (e.g. the bottom panel) the header, messaging, and spacing compact so the pitch and _Upgrade_ action stay legible without hiding any content; full-size placements are unchanged ([#5519](https://github.com/gitkraken/vscode-gitlens/issues/5519))
 
 ### Fixed
 

--- a/src/webviews/apps/plus/graph/gate.ts
+++ b/src/webviews/apps/plus/graph/gate.ts
@@ -20,7 +20,10 @@ export class GlGraphGate extends SignalWatcher(LitElement) {
 		featureGateContentStyles,
 		css`
 			gl-feature-gate::part(section) {
-				width: 90vw;
+				/* Container units (not vw): size against the gate overlay's own box (the
+				   feature-gate host) rather than the webview viewport, so the card keeps tracking
+				   the gated area even if the gate is ever hosted in a sub-region of the view. */
+				width: calc(100cqi - var(--gl-space-16));
 				max-width: 90rem;
 			}
 		`,

--- a/src/webviews/apps/plus/shared/components/feature-gate-plus-state.ts
+++ b/src/webviews/apps/plus/shared/components/feature-gate-plus-state.ts
@@ -59,7 +59,10 @@ export class GlFeatureGatePlusState extends LitElement {
 				max-width: 300px;
 			}
 
-			@container (max-width: 600px) {
+			/* Collapses the CTA to a block, centered button in narrow default-appearance gates.
+			   A deliberate literal — this threshold is independent of the compact threshold shared
+			   via featureGateCompactThreshold (and of the alert dialog's same-valued width cap). */
+			@container (max-width: 60rem) {
 				:host([appearance='default']) gl-button:not(.inline) {
 					display: block;
 					margin-right: auto;
@@ -123,7 +126,7 @@ export class GlFeatureGatePlusState extends LitElement {
 	];
 
 	@query('gl-button')
-	private readonly button!: GlButton;
+	private readonly button?: GlButton;
 
 	@property()
 	appearance?: 'alert' | 'default';
@@ -152,10 +155,21 @@ export class GlFeatureGatePlusState extends LitElement {
 	@property()
 	webroot?: string;
 
-	protected override firstUpdated(): void {
-		if (this.appearance === 'alert') {
-			queueMicrotask(() => this.button.focus());
-		}
+	private _ctaPrimed = false;
+
+	protected override updated(): void {
+		// Prime the CTA for Enter — once, on the first update that actually renders a button
+		// (`state` can arrive after the first render, which emits nothing until then). Don't
+		// scroll it into view: in constrained placements the button sits far below the fold and
+		// scrolling to it hides the gate's title/context. The latch keeps later reactive updates
+		// (e.g. a subscription refresh) from stealing focus the user has since moved.
+		if (this._ctaPrimed || this.appearance !== 'alert') return;
+
+		const button = this.button;
+		if (button == null) return;
+
+		this._ctaPrimed = true;
+		queueMicrotask(() => button.focus({ preventScroll: true }));
 	}
 
 	override render(): unknown {

--- a/src/webviews/apps/plus/shared/components/feature-gate-plus-state.ts
+++ b/src/webviews/apps/plus/shared/components/feature-gate-plus-state.ts
@@ -15,6 +15,7 @@ import { getFeaturePreviewStatus } from '../../../../../features.js';
 import type { SubscriptionUpgradeCommandArgs } from '../../../../../plus/gk/models/subscription.js';
 import { createCommandLink } from '../../../../../system/commands.js';
 import type { GlButton } from '../../../shared/components/button.js';
+import { featureGateCompactThreshold } from '../../../shared/components/feature-gate.css.js';
 import type { PromosContext } from '../../../shared/contexts/promos.js';
 import { promosContext } from '../../../shared/contexts/promos.js';
 import { linkStyles } from './vscode.css.js';
@@ -76,16 +77,48 @@ export class GlFeatureGatePlusState extends LitElement {
 				margin-left: auto;
 			}
 
-			:host-context([appearance='alert']) p:first-child {
+			/* .trial's first paragraph is excluded: wrapping the trailing paragraphs made it a
+			   :first-child, which would newly zero its top margin at every size — full-size
+			   spacing must stay as it was before the wrapper existed. */
+			:host([appearance='alert']) p:first-child:not(.trial p) {
 				margin-top: 0;
 			}
 
-			:host-context([appearance='alert']) p:last-child {
+			:host([appearance='alert']) p:last-child {
 				margin-bottom: 0;
 			}
 
 			.centered {
 				text-align: center;
+			}
+
+			/* Centering lives on the wrapper (not the paragraphs) because the compact mode below
+			   turns the paragraphs inline — text-align only aligns content of block containers. */
+			.trial {
+				text-align: center;
+			}
+
+			/* Vertically constrained alert gates (e.g. the bottom panel): compact the action zone so
+			   it costs less height — tighter paragraph/rule rhythm, and the trial message + promo
+			   collapse onto a single line. The normal-height dialog keeps its default spacing.
+			   Only the TrialExpired branch has a .trial wrapper: it's the sole state that renders
+			   two trailing paragraphs — every other state ends with a single one, so there's
+			   nothing to collapse. */
+			@container (max-height: ${featureGateCompactThreshold}) {
+				:host([appearance='alert']) p,
+				:host([appearance='alert']) hr {
+					margin-block: var(--gl-space-6);
+				}
+
+				:host([appearance='alert']) .trial p {
+					display: inline;
+				}
+
+				:host([appearance='alert']) .trial gl-promo,
+				:host([appearance='alert']) .trial gl-promo::part(text) {
+					display: inline;
+					margin: 0;
+				}
 			}
 
 			.preview-image {
@@ -247,11 +280,13 @@ export class GlFeatureGatePlusState extends LitElement {
 						>
 					</p>
 					<hr />
-					<p class="centered">
-						Your trial has ended — upgrade to keep ${this.featureWithArticleIfNeeded ?? 'all Pro features'}
-						unlocked.
-					</p>
-					<p class="centered">${this.renderPromo()}</p>`;
+					<div class="trial">
+						<p>
+							Your trial has ended — upgrade to keep
+							${this.featureWithArticleIfNeeded ?? 'all Pro features'} unlocked.
+						</p>
+						<p>${this.renderPromo()}</p>
+					</div>`;
 
 			case SubscriptionState.TrialReactivationEligible:
 				return html`<slot name="feature"></slot>

--- a/src/webviews/apps/shared/components/feature-gate.css.ts
+++ b/src/webviews/apps/shared/components/feature-gate.css.ts
@@ -1,4 +1,9 @@
-import { css } from 'lit';
+import { css, unsafeCSS } from 'lit';
+
+/* The single threshold (both axes) below which the gate switches to its compact look. Shared as a
+   constant because the width- and height-compact rules span this file and
+   feature-gate-plus-state.ts, and @container conditions can't read custom properties. */
+export const featureGateCompactThreshold = unsafeCSS('45rem');
 
 export const featureGateBaseStyles = css`
 	:host {
@@ -10,6 +15,11 @@ export const featureGateBaseStyles = css`
 		position: absolute;
 		inset: 0;
 		box-sizing: border-box;
+
+		/* Size container for the gate's narrow-width adaptations. Safe because the host is an
+		   inset-0 overlay, so its inline size never depends on its contents. The top-layer dialog
+		   still resolves against this container via its flat-tree ancestry. */
+		container-type: inline-size;
 	}
 
 	::slotted(p) {
@@ -76,6 +86,12 @@ export const featureGateBaseStyles = css`
 		overflow: auto;
 	}
 
+	@container (max-width: ${featureGateCompactThreshold}) {
+		.content {
+			padding-inline: var(--gl-space-12);
+		}
+	}
+
 	:host-context(body[data-placement='editor']) dialog,
 	:host([appearance='alert']) dialog {
 		--link-decoration-default: underline;
@@ -88,7 +104,7 @@ export const featureGateBaseStyles = css`
 
 		inset: 0;
 		width: max-content;
-		max-width: 600px;
+		max-width: 60rem;
 		height: max-content;
 		max-height: calc(100% - 0.4rem);
 		margin: auto;
@@ -170,6 +186,12 @@ export const featureGateContentStyles = css`
 		color: var(--color-foreground);
 	}
 
+	@container (max-width: ${featureGateCompactThreshold}) {
+		.feature__title {
+			font-size: var(--gl-font-lg);
+		}
+	}
+
 	.feature__title gl-feature-badge {
 		margin: 0;
 		transform: translateY(-0.4rem);
@@ -186,7 +208,9 @@ export const featureGateContentStyles = css`
 
 	.list {
 		display: grid;
-		grid-template-columns: repeat(2, 1fr);
+		/* Intrinsic column collapse: two columns when the content area is wide enough for two
+		   32rem tracks, a single column in narrow placements (side bar, panel splits). */
+		grid-template-columns: repeat(auto-fit, minmax(min(32rem, 100%), 1fr));
 		gap: var(--gl-space-16);
 		padding-inline-start: 0;
 		margin-block: var(--gl-space-6);

--- a/src/webviews/apps/shared/components/feature-gate.css.ts
+++ b/src/webviews/apps/shared/components/feature-gate.css.ts
@@ -16,10 +16,10 @@ export const featureGateBaseStyles = css`
 		inset: 0;
 		box-sizing: border-box;
 
-		/* Size container for the gate's narrow-width adaptations. Safe because the host is an
-		   inset-0 overlay, so its inline size never depends on its contents. The top-layer dialog
-		   still resolves against this container via its flat-tree ancestry. */
-		container-type: inline-size;
+		/* Size container for the gate's narrow-width and short-height adaptations. Safe because the
+		   host is an inset-0 overlay, so its size never depends on its contents. The top-layer
+		   dialog still resolves against this container via its flat-tree ancestry. */
+		container-type: size;
 	}
 
 	::slotted(p) {
@@ -167,6 +167,17 @@ export const featureGateContentStyles = css`
 		align-items: flex-start;
 	}
 
+	/* Vertically constrained placements (e.g. the bottom panel): title and lede share one line
+	   (wrapping when also narrow) to shorten the header. The normal-height dialog is untouched. */
+	@container (max-height: ${featureGateCompactThreshold}) {
+		.feature__header hgroup {
+			display: flex;
+			flex-wrap: wrap;
+			column-gap: var(--gl-space-8);
+			align-items: baseline;
+		}
+	}
+
 	.feature__feature-icon {
 		/* Fixed light glyph: the brand gradient is dark in every theme, so a theme-driven foreground
 		   (near-black on light themes) would fail contrast against it. */
@@ -234,6 +245,36 @@ export const featureGateContentStyles = css`
 		strong {
 			font-size: var(--gl-font-md);
 			color: var(--color-foreground);
+		}
+	}
+
+	/* Vertically constrained placements: tighten the feature list. Halve the between-column gap,
+	   and float each item's icon so its copy flows around and under it instead of sitting in a
+	   rigid second column — reclaiming the indent for text. Placed after the base .list/.list__item
+	   rules so the height-scoped overrides win the cascade (the base .list gap shorthand would
+	   otherwise reset column-gap, and the base .list__item/.list__copy flex would defeat the float). */
+	@container (max-height: ${featureGateCompactThreshold}) {
+		.list {
+			column-gap: var(--gl-space-8);
+		}
+
+		.list__item {
+			display: block;
+		}
+
+		.list__item .icon-cube {
+			float: inline-start;
+			margin-inline-end: var(--gl-space-6);
+		}
+
+		.list__copy {
+			display: block;
+		}
+
+		/* The title runs in on the same line as the body, so match its size to the body — the
+		   larger heading size reads as inconsistent mid-sentence. Weight/color keep it distinct. */
+		.list__copy strong {
+			font-size: var(--gl-font-sm);
 		}
 	}
 `;


### PR DESCRIPTION
Closes #5519 (part of #5391)

## Summary

Makes the Commit Graph's Pro feature-gate (`gl-graph-gate`) degrade gracefully when the Graph is docked in a constrained area — a narrow side bar or the short bottom panel — consistent with the other Graph-in-constrained-space work (#5449, #5500, #5513). Previously the gate was sized in viewport units, used a fixed two-column feature list, and — because the CTA is focused on open — scrolled the user to a mid-content position where neither the heading nor the Upgrade button was reliably visible.

**The full-height dialog (full-height editor tab, maximized panel) is unchanged.** Compaction keys off actual available height rather than placement, so a short split-editor pane (below ~450px) intentionally compacts as well. Every adaptation is scoped behind a container query, and no feature items are ever hidden — constrained layouts compact and scroll instead.


- Normal view:

    <img width="500" alt="Image" src="https://github.com/user-attachments/assets/4ef0b2ff-1955-4ba5-a673-fcfc872bc4af" />

- Horizontally narrow view: one column

    <img width="200" alt="Image" src="https://github.com/user-attachments/assets/064d6c94-02db-42fa-b5b8-e466fb83ca7e" />

- Vertically narrow view: collapsing titles to one line witht the text, floating around icons, smaller intervals

    <img width="500" alt="Image" src="https://github.com/user-attachments/assets/ed683441-b065-4343-b0eb-c01e1c985e5a" />

- <img width="500" alt="Image" src="https://github.com/user-attachments/assets/187f83b5-bfe3-482f-8b65-b7156c9b2b27" />

- Both: smaller gaps, floating texts, one column

    <img width="200" alt="Image" src="https://github.com/user-attachments/assets/3ae6487a-c3f1-4b1a-8617-dda539444100" />

- https://github.com/user-attachments/assets/d10e4b5a-8d41-40a4-8db7-4ee7aa89841c

## What changes

**Narrow width (side bar)**
- Feature list collapses two columns → one intrinsically (`repeat(auto-fit, minmax(min(32rem, 100%), 1fr))`).
- Card tracks the gated view's width via container units (`100cqi`) instead of `90vw` (the window's width — wrong basis inside a dock).
- Tighter content padding and title size.

**Short height (bottom panel)**
- Header collapses to one line (title + lede).
- Trial message + promo collapse to one line; footer paragraph/rule rhythm tightens.
- Feature-list horizontal gaps halve.
- Each item's icon floats (`float: inline-start`) so its copy flows around and under it instead of sitting in a rigid second column; the run-in title is sized to match the body.

**Both**
- The CTA focus no longer scrolls the gate (`focus({ preventScroll: true })`), so it opens at the top with the heading and context visible.

## Mechanism

`gl-feature-gate`'s `:host` becomes a `container-type: size` query container (safe — it's an `inset: 0` overlay, so its size is content-independent in both axes; the top-layer `<dialog>` resolves the container via its flat-tree ancestry, verified live). Adaptations live behind `@container (max-width: 45rem)` and `@container (max-height: 45rem)`. This matches the container-query pattern already used by `gl-details-header`, `gl-wip-tree-pane`, and the graph minimap — not viewport media queries.

Timeline also imports `featureGateContentStyles` and mounts the wrapper, so it **shares** these adaptations in its constrained Visual File History view — verified live to render correctly (one-line header, compacted title/padding; the `.list` float/gap rules are inert as timeline has no feature list). The rebase conflict-indicator and merge-target-status mount the wrapper but render their own content and don't import the content styles, so only `.content` padding / plus-state rhythm can reach them.

## Validation

- Reproduced live via `gitlens.plus.simulate.subscription` (trial-expired) + simulated private-repo visibility, across editor / side-bar / bottom-panel placements.
- Verified computed layout at each breakpoint: normal dialog identical to before (two-column flex list, full-size header); panel/side-bar compact as intended; no feature items hidden.
- Verified timeline (the other consumer of the content styles) shares the adaptation and renders correctly in its constrained Visual File History view; the rebase conflict-indicator and merge-target-status don't import the content styles and render their own content.
- `pnpm run check` clean.

## Out of scope

`gl-graph-access-account` (the account-less "Get Started" screen) has the same constrained-space problem but is a separate component — candidate follow-up.
