### PR TITLE
GitLab searchPullRequests can miss state-filtered MRs beyond the first search page

### DIFF
--- a/packages/plus/git-github/src/api/__tests__/github.test.ts
+++ b/packages/plus/git-github/src/api/__tests__/github.test.ts
@@ -1,20 +1,50 @@
 import assert from 'node:assert';
 import { suite, test } from 'mocha';
-import type { PullRequestStateFilter } from '@gitlens/git/models/pullRequest.js';
-import { toGitHubSearchStateQualifier } from '../github.js';
+import type { PullRequestState } from '@gitlens/git/models/pullRequest.js';
+import { filterPullRequestsBySearchState, toGitHubSearchStateQualifier } from '../github.js';
 
 suite('toGitHubSearchStateQualifier', () => {
-	const cases: [label: string, state: PullRequestStateFilter | undefined, expected: string][] = [
+	const cases: [label: string, include: PullRequestState[] | undefined, expected: string][] = [
 		['undefined -> open-only default', undefined, 'is:open'],
-		['open', 'open', 'is:open'],
-		['merged', 'merged', 'is:merged'],
-		['closed (not merged)', 'closed', 'is:closed is:unmerged'],
-		['all states -> no qualifier', 'all', ''],
+		['empty -> open-only default', [], 'is:open'],
+		['opened', ['opened'], 'is:open'],
+		['merged', ['merged'], 'is:merged'],
+		['closed (not merged)', ['closed'], 'is:closed is:unmerged'],
+		['closed + merged', ['closed', 'merged'], 'is:closed'],
+		['opened + closed', ['opened', 'closed'], 'is:unmerged'],
+		['opened + merged (not expressible, no qualifier)', ['opened', 'merged'], ''],
+		['all states -> no qualifier', ['opened', 'closed', 'merged'], ''],
 	];
 
-	for (const [label, state, expected] of cases) {
+	for (const [label, include, expected] of cases) {
 		test(label, () => {
-			assert.strictEqual(toGitHubSearchStateQualifier(state), expected);
+			assert.strictEqual(toGitHubSearchStateQualifier(include), expected);
 		});
 	}
+
+	test('is order-independent', () => {
+		assert.strictEqual(toGitHubSearchStateQualifier(['merged', 'closed']), 'is:closed');
+		assert.strictEqual(toGitHubSearchStateQualifier(['closed', 'opened']), 'is:unmerged');
+	});
+});
+
+suite('filterPullRequestsBySearchState', () => {
+	const prs: { id: string; state: PullRequestState }[] = [
+		{ id: '1', state: 'opened' },
+		{ id: '2', state: 'closed' },
+		{ id: '3', state: 'merged' },
+	];
+
+	const ids = (include: PullRequestState[] | undefined) =>
+		filterPullRequestsBySearchState(prs, include).map(pr => pr.id);
+
+	test('defaults to open-only', () => {
+		assert.deepStrictEqual(ids(undefined), ['1']);
+		assert.deepStrictEqual(ids([]), ['1']);
+	});
+
+	test('filters non-exact GitHub search combinations', () => {
+		assert.deepStrictEqual(ids(['opened', 'merged']), ['1', '3']);
+		assert.deepStrictEqual(ids(['opened', 'closed', 'merged']), ['1', '2', '3']);
+	});
 });

--- a/packages/plus/git-github/src/api/__tests__/github.test.ts
+++ b/packages/plus/git-github/src/api/__tests__/github.test.ts
@@ -1,7 +1,10 @@
 import assert from 'node:assert';
 import { suite, test } from 'mocha';
 import type { PullRequestState } from '@gitlens/git/models/pullRequest.js';
-import { filterPullRequestsBySearchState, toGitHubSearchStateQualifier } from '../github.js';
+import type { Provider } from '@gitlens/git/models/remoteProvider.js';
+import type { GitHubApiConfig } from '../config.js';
+import { filterPullRequestsBySearchState, GitHubApi, toGitHubSearchStateQualifier } from '../github.js';
+import type { GitHubTokenInfo } from '../token.js';
 
 suite('toGitHubSearchStateQualifier', () => {
 	const cases: [label: string, include: PullRequestState[] | undefined, expected: string][] = [
@@ -50,5 +53,135 @@ suite('filterPullRequestsBySearchState', () => {
 
 	test('ignores duplicate states when deciding to skip filtering', () => {
 		assert.deepStrictEqual(ids(['opened', 'opened', 'closed']), ['1', '2']);
+	});
+});
+
+suite('GitHubApi.searchPullRequests', () => {
+	const provider = {
+		id: 'github',
+		name: 'GitHub',
+		domain: 'github.com',
+		icon: 'github',
+		getIgnoreSSLErrors: () => false,
+		reauthenticate: () => Promise.resolve(),
+		trackRequestException: () => {},
+	} as unknown as Provider;
+
+	const token: GitHubTokenInfo = {
+		providerId: 'github',
+		accessToken: 'token',
+		microHash: 'hash',
+		cloud: true,
+		type: undefined,
+	};
+
+	function prNode(number: number, state: 'OPEN' | 'CLOSED' | 'MERGED') {
+		return {
+			id: `pr-${number}`,
+			number: number,
+			title: `PR ${number}`,
+			permalink: `https://github.com/octo/repo/pull/${number}`,
+			url: `https://github.com/octo/repo/pull/${number}`,
+			state: state,
+			createdAt: '2024-01-01T00:00:00Z',
+			updatedAt: '2024-01-02T00:00:00Z',
+			closed: state !== 'OPEN',
+			closedAt: state === 'OPEN' ? null : '2024-01-03T00:00:00Z',
+			mergedAt: state === 'MERGED' ? '2024-01-03T00:00:00Z' : null,
+			author: { login: 'octo', avatarUrl: '', url: 'https://github.com/octo' },
+			baseRefName: 'main',
+			baseRefOid: 'base',
+			headRefName: 'feature',
+			headRefOid: 'head',
+			headRepository: {
+				isFork: false,
+				name: 'repo',
+				owner: { login: 'octo' },
+				sshUrl: 'git@github.com:octo/repo.git',
+				url: 'https://github.com/octo/repo',
+			},
+			repository: {
+				isFork: false,
+				name: 'repo',
+				owner: { login: 'octo' },
+				sshUrl: 'git@github.com:octo/repo.git',
+				url: 'https://github.com/octo/repo',
+				viewerPermission: 'WRITE',
+			},
+			isCrossRepository: false,
+			isDraft: false,
+			additions: 1,
+			deletions: 1,
+			checksUrl: '',
+			mergeable: 'MERGEABLE',
+			reviewDecision: 'APPROVED',
+			latestReviews: { nodes: [] },
+			reviewRequests: { nodes: [] },
+			assignees: { nodes: [] },
+			commits: { nodes: [] },
+			totalCommentsCount: 0,
+			viewerCanUpdate: true,
+		};
+	}
+
+	function createConfig(
+		pages: { requestCursor?: string; nextCursor?: string; hasNextPage: boolean; nodes: unknown[] }[],
+		seenCursors: string[],
+	) {
+		const config: GitHubApiConfig = {
+			isWeb: false,
+			fetch: async (_url, init) => {
+				const body = JSON.parse(String(init?.body ?? '{}')) as { variables?: { cursor?: string } };
+				const cursor = body.variables?.cursor;
+				seenCursors.push(cursor ?? '');
+				const page = pages.find(p => p.requestCursor === cursor) ?? pages[0];
+				return new Response(
+					JSON.stringify({
+						data: {
+							search: {
+								pageInfo: {
+									endCursor: page.hasNextPage ? (page.nextCursor ?? null) : null,
+									hasNextPage: page.hasNextPage,
+								},
+								nodes: page.nodes,
+							},
+						},
+					}),
+					{ status: 200, headers: { 'content-type': 'application/json' } },
+				);
+			},
+			wrapForForcedInsecureSSL: (_ignore, fn) => fn(),
+		};
+		return config;
+	}
+
+	test('paginates when include requests opened + merged', async () => {
+		const seenCursors: string[] = [];
+		const api = new GitHubApi(
+			createConfig(
+				[
+					{
+						requestCursor: undefined,
+						nextCursor: 'page-2',
+						hasNextPage: true,
+						nodes: Array.from({ length: 10 }, (_, i) => prNode(i + 1, 'CLOSED')),
+					},
+					{
+						requestCursor: 'page-2',
+						hasNextPage: false,
+						nodes: [prNode(11, 'OPEN'), prNode(12, 'MERGED')],
+					},
+				],
+				seenCursors,
+			),
+		);
+
+		const results = await api.searchPullRequests(provider, token, { search: 'fix', include: ['opened', 'merged'] });
+
+		assert.deepStrictEqual(
+			results.map(pr => pr.id),
+			['11', '12'],
+		);
+		assert.deepStrictEqual(seenCursors, ['', 'page-2']);
 	});
 });

--- a/packages/plus/git-github/src/api/__tests__/github.test.ts
+++ b/packages/plus/git-github/src/api/__tests__/github.test.ts
@@ -47,4 +47,8 @@ suite('filterPullRequestsBySearchState', () => {
 		assert.deepStrictEqual(ids(['opened', 'merged']), ['1', '3']);
 		assert.deepStrictEqual(ids(['opened', 'closed', 'merged']), ['1', '2', '3']);
 	});
+
+	test('ignores duplicate states when deciding to skip filtering', () => {
+		assert.deepStrictEqual(ids(['opened', 'opened', 'closed']), ['1', '2']);
+	});
 });

--- a/packages/plus/git-github/src/api/__tests__/github.test.ts
+++ b/packages/plus/git-github/src/api/__tests__/github.test.ts
@@ -184,4 +184,24 @@ suite('GitHubApi.searchPullRequests', () => {
 		);
 		assert.deepStrictEqual(seenCursors, ['', 'page-2']);
 	});
+
+	test('stops at the page backstop when matches never fill the page', async () => {
+		const seenCursors: string[] = [];
+		// Every page is full of non-matching PRs and always reports another page, so results never reach the
+		// page-size cap and `hasNextPage` never goes false. The only thing that can end the drain is the 20-page
+		// backstop. More pages exist than the cap to prove it truncates rather than running away.
+		const pages = Array.from({ length: 25 }, (_, i) => ({
+			requestCursor: i === 0 ? undefined : `cursor-${i}`,
+			nextCursor: `cursor-${i + 1}`,
+			hasNextPage: true,
+			nodes: Array.from({ length: 10 }, (_, j) => prNode(i * 100 + j + 1, 'CLOSED')),
+		}));
+
+		const api = new GitHubApi(createConfig(pages, seenCursors));
+
+		const results = await api.searchPullRequests(provider, token, { search: 'fix', include: ['opened', 'merged'] });
+
+		assert.deepStrictEqual(results, []);
+		assert.strictEqual(seenCursors.length, 20);
+	});
 });

--- a/packages/plus/git-github/src/api/github.ts
+++ b/packages/plus/git-github/src/api/github.ts
@@ -13,7 +13,7 @@ import type { Account, UnidentifiedAuthor } from '@gitlens/git/models/author.js'
 import type { DefaultBranch } from '@gitlens/git/models/defaultBranch.js';
 import type { Issue, IssueShape } from '@gitlens/git/models/issue.js';
 import type { IssueOrPullRequest } from '@gitlens/git/models/issueOrPullRequest.js';
-import type { PullRequest, PullRequestStateFilter } from '@gitlens/git/models/pullRequest.js';
+import type { PullRequest, PullRequestState, PullRequestStateFilter } from '@gitlens/git/models/pullRequest.js';
 import { PullRequestMergeMethod } from '@gitlens/git/models/pullRequest.js';
 import type { Provider } from '@gitlens/git/models/remoteProvider.js';
 import type { RepositoryMetadata } from '@gitlens/git/models/repositoryMetadata.js';
@@ -3576,7 +3576,7 @@ export class GitHubApi {
 			repos?: string[];
 			baseUrl?: string;
 			avatarSize?: number;
-			state?: PullRequestStateFilter;
+			include?: PullRequestState[];
 		},
 		cancellation?: AbortSignal,
 	): Promise<PullRequest[]> {
@@ -3620,7 +3620,7 @@ export class GitHubApi {
 				{
 					searchQuery: [
 						'is:pr',
-						toGitHubSearchStateQualifier(options?.state),
+						toGitHubSearchStateQualifier(options?.include),
 						'archived:false',
 						search.trim(),
 					]
@@ -3634,7 +3634,8 @@ export class GitHubApi {
 			);
 			if (rsp == null) return [];
 
-			return rsp.search.nodes.map(pr => fromGitHubPullRequest(pr, provider));
+			const results = rsp.search.nodes.map(pr => fromGitHubPullRequest(pr, provider));
+			return filterPullRequestsBySearchState(results, options?.include);
 		} catch (ex) {
 			throw this.handleException(ex, provider, scope);
 		}
@@ -3717,16 +3718,37 @@ function isGitHubDotCom(options?: { baseUrl?: string }) {
 	return options?.baseUrl == null || options.baseUrl === 'https://api.github.com';
 }
 
-// GitHub treats `is:closed` as closed-or-merged, so `is:unmerged` keeps closed and merged disjoint.
-export function toGitHubSearchStateQualifier(state: PullRequestStateFilter | undefined): string {
-	switch (state) {
-		case 'closed':
-			return 'is:closed is:unmerged';
-		case 'merged':
-			return 'is:merged';
-		case 'all':
-			return '';
-		default:
-			return 'is:open';
-	}
+// Translates the requested PR states into a GitHub search state qualifier. GitHub search treats
+// `is:closed` as closed-or-merged, `is:merged` as its subset, and `is:unmerged` as open + closed
+// (not-merged), so `closed` and `merged` (distinct in our model) map to `is:closed is:unmerged` and
+// `is:merged`. `undefined` preserves the historical open-only default.
+export function toGitHubSearchStateQualifier(include: PullRequestState[] | undefined): string {
+	if (include == null) return 'is:open';
+
+	const opened = include.includes('opened');
+	const closed = include.includes('closed');
+	const merged = include.includes('merged');
+
+	if (opened && closed && merged) return ''; // all states -> no qualifier
+	if (opened && closed) return 'is:unmerged';
+	if (closed && merged) return 'is:closed';
+	// `opened && merged` isn't expressible as a single AND qualifier; omit it here and post-filter.
+	if (opened && merged) return '';
+	if (opened) return 'is:open';
+	if (merged) return 'is:merged';
+	if (closed) return 'is:closed is:unmerged';
+	return 'is:open'; // empty include -> default
+}
+
+export function filterPullRequestsBySearchState<T extends { state: PullRequestState }>(
+	pullRequests: T[],
+	include: PullRequestState[] | undefined,
+): T[] {
+	const states = include?.length ? include : (['opened'] satisfies PullRequestState[]);
+	const allowedStates = new Set<PullRequestState>(states);
+	// There are only 3 possible states, so a full set means every state is allowed; use the deduped set
+	// size rather than the raw length so duplicates (e.g. `['opened', 'opened', 'closed']`) don't skip filtering.
+	if (allowedStates.size === 3) return pullRequests;
+
+	return pullRequests.filter(pr => allowedStates.has(pr.state));
 }

--- a/packages/plus/git-github/src/api/github.ts
+++ b/packages/plus/git-github/src/api/github.ts
@@ -3629,9 +3629,12 @@ export class GitHubApi {
 				.filter(Boolean)
 				.join(' ');
 
+			// Bound the paginated case with a defensive page backstop like the other paged provider drains, so a
+			// large, low-match result set can't fan out into an unbounded request loop.
+			const maxSearchPages = 20;
 			let cursor: string | undefined;
 			const results: PullRequest[] = [];
-			do {
+			for (let page = 0; page < maxSearchPages; page++) {
 				const rsp = await this.graphql<SearchResult>(
 					provider,
 					token,
@@ -3657,7 +3660,7 @@ export class GitHubApi {
 				if (!requiresPagination || results.length >= pageSize || !rsp.search.pageInfo.hasNextPage) {
 					break;
 				}
-			} while (true);
+			}
 
 			return results.slice(0, pageSize);
 		} catch (ex) {

--- a/packages/plus/git-github/src/api/github.ts
+++ b/packages/plus/git-github/src/api/github.ts
@@ -3581,9 +3581,16 @@ export class GitHubApi {
 		cancellation?: AbortSignal,
 	): Promise<PullRequest[]> {
 		const scope = getScopedLogger();
+		const pageSize = 10;
+		const include = options?.include?.length ? options.include : undefined;
+		const requiresPagination = shouldPaginateGitHubSearchState(include);
 
 		interface SearchResult {
 			search: {
+				pageInfo: {
+					endCursor?: string | null;
+					hasNextPage: boolean;
+				};
 				nodes: GitHubPullRequest[];
 			};
 		}
@@ -3591,9 +3598,14 @@ export class GitHubApi {
 		try {
 			const query = `query searchPullRequests(
 	$searchQuery: String!
+		$cursor: String
 	$avatarSize: Int
 ) {
-	search(first: 10, query: $searchQuery, type: ISSUE) {
+		search(first: ${pageSize}, after: $cursor, query: $searchQuery, type: ISSUE) {
+			pageInfo {
+				endCursor
+				hasNextPage
+			}
 		nodes {
 			...on PullRequest {
 				${gqlPullRequestFragment}
@@ -3613,29 +3625,41 @@ export class GitHubApi {
 				search += `${repo}${options.repos.join(repo)}`;
 			}
 
-			const rsp = await this.graphql<SearchResult>(
-				provider,
-				token,
-				query,
-				{
-					searchQuery: [
-						'is:pr',
-						toGitHubSearchStateQualifier(options?.include),
-						'archived:false',
-						search.trim(),
-					]
-						.filter(Boolean)
-						.join(' '),
-					baseUrl: options?.baseUrl,
-					avatarSize: options?.avatarSize,
-				},
-				scope,
-				cancellation,
-			);
-			if (rsp == null) return [];
+			const searchQuery = ['is:pr', toGitHubSearchStateQualifier(include), 'archived:false', search.trim()]
+				.filter(Boolean)
+				.join(' ');
 
-			const results = rsp.search.nodes.map(pr => fromGitHubPullRequest(pr, provider));
-			return filterPullRequestsBySearchState(results, options?.include);
+			let cursor: string | undefined;
+			const results: PullRequest[] = [];
+			do {
+				const rsp = await this.graphql<SearchResult>(
+					provider,
+					token,
+					query,
+					{
+						searchQuery: searchQuery,
+						cursor: cursor,
+						baseUrl: options?.baseUrl,
+						avatarSize: options?.avatarSize,
+					},
+					scope,
+					cancellation,
+				);
+				if (rsp == null) return [];
+
+				const pageResults = filterPullRequestsBySearchState(
+					rsp.search.nodes.map(pr => fromGitHubPullRequest(pr, provider)),
+					include,
+				);
+				results.push(...pageResults);
+
+				cursor = rsp.search.pageInfo.endCursor ?? undefined;
+				if (!requiresPagination || results.length >= pageSize || !rsp.search.pageInfo.hasNextPage) {
+					break;
+				}
+			} while (true);
+
+			return results.slice(0, pageSize);
 		} catch (ex) {
 			throw this.handleException(ex, provider, scope);
 		}
@@ -3751,4 +3775,11 @@ export function filterPullRequestsBySearchState<T extends { state: PullRequestSt
 	if (allowedStates.size === 3) return pullRequests;
 
 	return pullRequests.filter(pr => allowedStates.has(pr.state));
+}
+
+function shouldPaginateGitHubSearchState(include: PullRequestState[] | undefined): boolean {
+	if (include == null || include.length === 0) return false;
+
+	const uniqueStates = new Set<PullRequestState>(include);
+	return uniqueStates.size === 2 && uniqueStates.has('opened') && uniqueStates.has('merged');
 }

--- a/packages/plus/integrations/src/models/gitHostIntegration.ts
+++ b/packages/plus/integrations/src/models/gitHostIntegration.ts
@@ -1249,20 +1249,6 @@ export abstract class GitHostIntegration<
 		connectionId?: string,
 		state?: PullRequestStateFilter,
 	): Promise<IntegrationResult<PullRequest[] | undefined>>;
-	async searchMyPullRequests(
-		repo?: T,
-		cancellation?: AbortSignal,
-		silent?: boolean,
-		connectionId?: string,
-		state?: PullRequestStateFilter,
-	): Promise<IntegrationResult<PullRequest[] | undefined>>;
-	async searchMyPullRequests(
-		repos?: T[],
-		cancellation?: AbortSignal,
-		silent?: boolean,
-		connectionId?: string,
-		state?: PullRequestStateFilter,
-	): Promise<IntegrationResult<PullRequest[] | undefined>>;
 	@trace()
 	async searchMyPullRequests(
 		repos?: T | T[],

--- a/packages/plus/integrations/src/models/gitHostIntegration.ts
+++ b/packages/plus/integrations/src/models/gitHostIntegration.ts
@@ -1249,6 +1249,20 @@ export abstract class GitHostIntegration<
 		connectionId?: string,
 		state?: PullRequestStateFilter,
 	): Promise<IntegrationResult<PullRequest[] | undefined>>;
+	async searchMyPullRequests(
+		repo?: T,
+		cancellation?: AbortSignal,
+		silent?: boolean,
+		connectionId?: string,
+		state?: PullRequestStateFilter,
+	): Promise<IntegrationResult<PullRequest[] | undefined>>;
+	async searchMyPullRequests(
+		repos?: T[],
+		cancellation?: AbortSignal,
+		silent?: boolean,
+		connectionId?: string,
+		state?: PullRequestStateFilter,
+	): Promise<IntegrationResult<PullRequest[] | undefined>>;
 	@trace()
 	async searchMyPullRequests(
 		repos?: T | T[],
@@ -1398,24 +1412,44 @@ export abstract class GitHostIntegration<
 		searchQuery: string,
 		repo?: T,
 		cancellation?: AbortSignal,
+		options?: { include?: PullRequestState[] },
+	): Promise<PullRequest[] | undefined>;
+	async searchPullRequests(
+		searchQuery: string,
+		repos?: T[],
+		cancellation?: AbortSignal,
+		options?: { include?: PullRequestState[] },
+	): Promise<PullRequest[] | undefined>;
+	async searchPullRequests(
+		searchQuery: string,
+		repo?: T,
+		cancellation?: AbortSignal,
 		connectionId?: string,
-		state?: PullRequestStateFilter,
+		options?: { include?: PullRequestState[] },
 	): Promise<PullRequest[] | undefined>;
 	async searchPullRequests(
 		searchQuery: string,
 		repos?: T[],
 		cancellation?: AbortSignal,
 		connectionId?: string,
-		state?: PullRequestStateFilter,
+		options?: { include?: PullRequestState[] },
 	): Promise<PullRequest[] | undefined>;
 	@trace()
 	async searchPullRequests(
 		searchQuery: string,
 		repos?: T | T[],
 		cancellation?: AbortSignal,
-		connectionId?: string,
-		state?: PullRequestStateFilter,
+		connectionIdOrOptions?: string | { include?: PullRequestState[] },
+		options?: { include?: PullRequestState[] },
 	): Promise<PullRequest[] | undefined> {
+		// `connectionId` (string) can be omitted when passing `options`; split the overlapping 4th arg.
+		// When the 4th arg isn't the options object (a string `connectionId` or `undefined`), fall back to
+		// the 5th-arg `options` so an explicit `undefined` connectionId still honors state filtering.
+		const connectionId = typeof connectionIdOrOptions === 'string' ? connectionIdOrOptions : undefined;
+		const searchOptions =
+			connectionIdOrOptions != null && typeof connectionIdOrOptions !== 'string'
+				? connectionIdOrOptions
+				: options;
 		const scope = getScopedLogger();
 		// `connectionId` targets a specific account (multi-account); omitted reads the primary.
 		const session = await this.resolveReadSession(connectionId, scope);
@@ -1427,7 +1461,7 @@ export abstract class GitHostIntegration<
 				searchQuery,
 				repos != null ? (Array.isArray(repos) ? repos : [repos]) : undefined,
 				cancellation,
-				state,
+				searchOptions,
 			);
 			this.resetRequestExceptionCount('searchPullRequests');
 			return prs;
@@ -1442,7 +1476,7 @@ export abstract class GitHostIntegration<
 		searchQuery: string,
 		repos?: T[],
 		cancellation?: AbortSignal,
-		state?: PullRequestStateFilter,
+		options?: { include?: PullRequestState[] },
 	): Promise<PullRequest[] | undefined>;
 
 	getPullRequestIdentityFromMaybeUrl(search: string): PullRequestUrlIdentity | undefined {

--- a/packages/plus/integrations/src/providers/__tests__/models.test.ts
+++ b/packages/plus/integrations/src/providers/__tests__/models.test.ts
@@ -28,18 +28,25 @@ suite('toProviderPullRequestStates', () => {
 		assert.equal(toProviderPullRequestStates(undefined), undefined);
 	});
 
-	test('returns undefined when an empty state list is provided', () => {
+	test('returns undefined when an empty include/state list is provided', () => {
 		assert.equal(toProviderPullRequestStates([]), undefined);
 	});
 
-	test('maps a specific requested state', () => {
+	test('maps a specific requested state filter', () => {
 		assert.deepEqual(toProviderPullRequestStates('open'), [toProviderPullRequestState('opened')]);
 	});
 
-	test('maps all requested states', () => {
+	test('maps all requested state filters', () => {
 		assert.deepEqual(toProviderPullRequestStates('all'), [
 			toProviderPullRequestState('opened'),
 			toProviderPullRequestState('closed'),
+			toProviderPullRequestState('merged'),
+		]);
+	});
+
+	test('maps include arrays', () => {
+		assert.deepEqual(toProviderPullRequestStates(['opened', 'merged']), [
+			toProviderPullRequestState('opened'),
 			toProviderPullRequestState('merged'),
 		]);
 	});

--- a/packages/plus/integrations/src/providers/__tests__/models.test.ts
+++ b/packages/plus/integrations/src/providers/__tests__/models.test.ts
@@ -36,6 +36,10 @@ suite('toProviderPullRequestStates', () => {
 		assert.deepEqual(toProviderPullRequestStates('open'), [toProviderPullRequestState('opened')]);
 	});
 
+	test('maps the item-state vocabulary for search include', () => {
+		assert.deepEqual(toProviderPullRequestStates('opened'), [toProviderPullRequestState('opened')]);
+	});
+
 	test('maps all requested state filters', () => {
 		assert.deepEqual(toProviderPullRequestStates('all'), [
 			toProviderPullRequestState('opened'),
@@ -46,6 +50,13 @@ suite('toProviderPullRequestStates', () => {
 
 	test('maps include arrays', () => {
 		assert.deepEqual(toProviderPullRequestStates(['opened', 'merged']), [
+			toProviderPullRequestState('opened'),
+			toProviderPullRequestState('merged'),
+		]);
+	});
+
+	test('dedupes mixed open/opened vocabulary inputs', () => {
+		assert.deepEqual(toProviderPullRequestStates(['open', 'opened', 'merged']), [
 			toProviderPullRequestState('opened'),
 			toProviderPullRequestState('merged'),
 		]);

--- a/packages/plus/integrations/src/providers/azureDevOps.ts
+++ b/packages/plus/integrations/src/providers/azureDevOps.ts
@@ -801,7 +801,7 @@ export abstract class AzureDevOpsIntegrationBase<
 		searchQuery: string,
 		repos?: AzureRepositoryDescriptor[],
 		cancellation?: AbortSignal,
-		state?: PullRequestStateFilter,
+		options?: { include?: PullRequestState[] },
 	): Promise<PullRequest[] | undefined> {
 		if (cancellation?.aborted) throw new CancellationError();
 
@@ -835,7 +835,7 @@ export abstract class AzureDevOpsIntegrationBase<
 
 		const api = await this.getProvidersApi();
 		const { tokenWithInfo, options } = this.getApiOptions(session);
-		const states = toProviderPullRequestStates(state);
+		const states = toProviderPullRequestStates(options?.include);
 		const searchScopes: { project: { namespace: string; project: string }; repo?: ProviderRepoInput }[] =
 			repoInputs != null
 				? repoInputs.flatMap(repo =>

--- a/packages/plus/integrations/src/providers/azureDevOps.ts
+++ b/packages/plus/integrations/src/providers/azureDevOps.ts
@@ -834,7 +834,7 @@ export abstract class AzureDevOpsIntegrationBase<
 		if (repoInputs?.length === 0) return [];
 
 		const api = await this.getProvidersApi();
-		const { tokenWithInfo, options } = this.getApiOptions(session);
+		const { tokenWithInfo, options: apiOptions } = this.getApiOptions(session);
 		const states = toProviderPullRequestStates(options?.include);
 		const searchScopes: { project: { namespace: string; project: string }; repo?: ProviderRepoInput }[] =
 			repoInputs != null
@@ -865,7 +865,7 @@ export abstract class AzureDevOpsIntegrationBase<
 					if (cancellation?.aborted) throw new CancellationError();
 
 					const result = await api.getPullRequestsForAzureProject(tokenWithInfo, scope.project, {
-						...options,
+						...apiOptions,
 						page: page,
 						repo: scope.repo,
 						states: states,

--- a/packages/plus/integrations/src/providers/bitbucket-server.ts
+++ b/packages/plus/integrations/src/providers/bitbucket-server.ts
@@ -300,7 +300,7 @@ export class BitbucketServerIntegration extends GitHostIntegration<
 		searchQuery: string,
 		repos?: BitbucketRepositoryDescriptor[],
 		cancellation?: AbortSignal,
-		state?: PullRequestStateFilter,
+		options?: { include?: PullRequestState[] },
 	): Promise<PullRequest[] | undefined> {
 		if (cancellation?.aborted) throw new CancellationError();
 
@@ -317,7 +317,7 @@ export class BitbucketServerIntegration extends GitHostIntegration<
 		if (repoInputs.length === 0) return repos != null ? [] : undefined;
 
 		const token = toTokenWithInfo(this.id, session);
-		const states = toProviderPullRequestStates(state);
+		const states = toProviderPullRequestStates(options?.include);
 		const providerPullRequests = await flatSettledOrThrow(
 			repoInputs.map(async repo => {
 				const result = await collectProviderPagedResult(cursor => {
@@ -346,6 +346,8 @@ export class BitbucketServerIntegration extends GitHostIntegration<
 				const integration = await this.authenticationService.getByRemote(r);
 				if (integration !== this) return undefined;
 
+				// Use the remote provider's parsing so the Bitbucket Server `scm/<project>/<repo>` prefix is
+				// stripped; a raw `path.split('/')` would yield namespace=`scm`, name=`<project>`.
 				const namespace = r.provider?.owner;
 				const name = r.provider?.repoName;
 				return namespace != null && name != null ? { name: name, namespace: namespace } : undefined;

--- a/packages/plus/integrations/src/providers/bitbucket-server/models.ts
+++ b/packages/plus/integrations/src/providers/bitbucket-server/models.ts
@@ -195,6 +195,7 @@ export const normalizeBitbucketServerPullRequest = (pr: BitbucketServerPullReque
 		state: bitbucketStateToGitState[pr.state],
 		isCrossRepository: pr.toRef.repository.id !== pr.fromRef.repository.id,
 		isDraft: false,
+		isCrossRepository: pr.toRef.repository.id !== pr.fromRef.repository.id,
 		createdDate: new Date(pr.createdDate),
 		updatedDate: new Date(pr.updatedDate),
 		closedDate: pr.closedDate ? new Date(pr.closedDate) : null,

--- a/packages/plus/integrations/src/providers/bitbucket-server/models.ts
+++ b/packages/plus/integrations/src/providers/bitbucket-server/models.ts
@@ -195,7 +195,6 @@ export const normalizeBitbucketServerPullRequest = (pr: BitbucketServerPullReque
 		state: bitbucketStateToGitState[pr.state],
 		isCrossRepository: pr.toRef.repository.id !== pr.fromRef.repository.id,
 		isDraft: false,
-		isCrossRepository: pr.toRef.repository.id !== pr.fromRef.repository.id,
 		createdDate: new Date(pr.createdDate),
 		updatedDate: new Date(pr.updatedDate),
 		closedDate: pr.closedDate ? new Date(pr.closedDate) : null,

--- a/packages/plus/integrations/src/providers/bitbucket.ts
+++ b/packages/plus/integrations/src/providers/bitbucket.ts
@@ -542,7 +542,7 @@ export class BitbucketIntegration extends GitHostIntegration<
 		searchQuery: string,
 		repos?: BitbucketRepositoryDescriptor[],
 		cancellation?: AbortSignal,
-		state?: PullRequestStateFilter,
+		options?: { include?: PullRequestState[] },
 	): Promise<PullRequest[] | undefined> {
 		if (cancellation?.aborted) throw new CancellationError();
 
@@ -559,7 +559,7 @@ export class BitbucketIntegration extends GitHostIntegration<
 		if (workspaceRepos.length === 0) return repos != null ? [] : undefined;
 
 		const token = toTokenWithInfo(this.id, session);
-		const states = toProviderPullRequestStates(state);
+		const states = toProviderPullRequestStates(options?.include);
 		const providerPullRequests = await flatSettledOrThrow(
 			workspaceRepos.map(async repo => {
 				const result = await collectProviderPagedResult(cursor => {

--- a/packages/plus/integrations/src/providers/github.ts
+++ b/packages/plus/integrations/src/providers/github.ts
@@ -416,7 +416,7 @@ abstract class GitHubIntegrationBase<ID extends GitHubIntegrationIds> extends Gi
 		searchQuery: string,
 		repos?: GitHubRepositoryDescriptor[],
 		cancellation?: AbortSignal,
-		state?: PullRequestStateFilter,
+		options?: { include?: PullRequestState[] },
 	): Promise<PullRequest[] | undefined> {
 		return (await this.authenticationService.apis.github)?.searchPullRequests(
 			this,
@@ -425,7 +425,7 @@ abstract class GitHubIntegrationBase<ID extends GitHubIntegrationIds> extends Gi
 				search: searchQuery,
 				repos: repos?.map(r => `${r.owner}/${r.name}`),
 				baseUrl: this.apiBaseUrl,
-				state: state,
+				...options,
 			},
 			cancellation,
 		);

--- a/packages/plus/integrations/src/providers/gitlab.ts
+++ b/packages/plus/integrations/src/providers/gitlab.ts
@@ -454,7 +454,7 @@ abstract class GitLabIntegrationBase<ID extends GitLabIntegrationIds> extends Gi
 		searchQuery: string,
 		repos?: GitLabRepositoryDescriptor[],
 		cancellation?: AbortSignal,
-		state?: PullRequestStateFilter,
+		options?: { include?: PullRequestState[] },
 	): Promise<PullRequest[] | undefined> {
 		const api = await this.authenticationService.apis.gitlab;
 		if (!api) {
@@ -468,7 +468,7 @@ abstract class GitLabIntegrationBase<ID extends GitLabIntegrationIds> extends Gi
 				search: searchQuery,
 				repos: repos?.map(r => `${r.owner}/${r.name}`),
 				baseUrl: this.apiBaseUrl,
-				state: state,
+				include: options?.include,
 			},
 			cancellation,
 		);

--- a/packages/plus/integrations/src/providers/gitlab/__tests__/gitlab.search.test.ts
+++ b/packages/plus/integrations/src/providers/gitlab/__tests__/gitlab.search.test.ts
@@ -98,4 +98,34 @@ suite('GitLabApi.searchPullRequests state-filtered paging', () => {
 
 		assert.deepEqual(requestedPages, [1], 'fetches only the first search page without a state filter');
 	});
+
+	test('keeps paging until matches are found beyond page 5', async () => {
+		const fullOpenedPage = (page: number) =>
+			Array.from({ length: 20 }, (_, i) => restMR(page * 100 + i + 1, 'opened'));
+		const page6 = [restMR(601, 'merged'), ...Array.from({ length: 19 }, (_, i) => restMR(602 + i, 'opened'))];
+
+		const requestedPages: number[] = [];
+		const api = new GitLabApi(
+			createFakeFetch(
+				[
+					fullOpenedPage(0),
+					fullOpenedPage(1),
+					fullOpenedPage(2),
+					fullOpenedPage(3),
+					fullOpenedPage(4),
+					page6,
+					[],
+				],
+				requestedPages,
+			),
+		);
+
+		const results = await api.searchPullRequests(provider, token, { search: 'fix', include: ['merged'] });
+
+		assert.deepEqual(
+			results.map(pr => pr.id),
+			['601'],
+		);
+		assert.deepEqual(requestedPages, [1, 2, 3, 4, 5, 6, 7]);
+	});
 });

--- a/packages/plus/integrations/src/providers/gitlab/__tests__/gitlab.search.test.ts
+++ b/packages/plus/integrations/src/providers/gitlab/__tests__/gitlab.search.test.ts
@@ -128,4 +128,24 @@ suite('GitLabApi.searchPullRequests state-filtered paging', () => {
 		);
 		assert.deepEqual(requestedPages, [1, 2, 3, 4, 5, 6, 7]);
 	});
+
+	test('stops at the page backstop when matches never appear', async () => {
+		// Every page is full (never a partial/last page) and holds no match, so the only thing that can stop
+		// the drain is the 20-page backstop. More pages exist than the cap to prove it truncates rather than
+		// running away.
+		const fullOpenedPage = (page: number) =>
+			Array.from({ length: 20 }, (_, i) => restMR(page * 100 + i + 1, 'opened'));
+		const pages = Array.from({ length: 25 }, (_, page) => fullOpenedPage(page));
+
+		const requestedPages: number[] = [];
+		const api = new GitLabApi(createFakeFetch(pages, requestedPages));
+
+		const results = await api.searchPullRequests(provider, token, { search: 'fix', include: ['merged'] });
+
+		assert.deepEqual(results, []);
+		assert.deepEqual(
+			requestedPages,
+			Array.from({ length: 20 }, (_, i) => i + 1),
+		);
+	});
 });

--- a/packages/plus/integrations/src/providers/gitlab/__tests__/gitlab.search.test.ts
+++ b/packages/plus/integrations/src/providers/gitlab/__tests__/gitlab.search.test.ts
@@ -1,0 +1,101 @@
+import * as assert from 'node:assert/strict';
+import { suite, test } from 'mocha';
+import type { Provider } from '@gitlens/git/models/remoteProvider.js';
+import type { TokenWithInfo } from '../../../authentication/models.js';
+import type { ProviderApiConfig } from '../../apiConfig.js';
+import { GitLabApi } from '../gitlab.js';
+import type { GitLabMergeRequestREST, GitLabMergeRequestState } from '../models.js';
+
+const provider = {
+	id: 'gitlab',
+	name: 'GitLab',
+	domain: 'gitlab.com',
+	icon: 'gitlab',
+	getIgnoreSSLErrors: () => false,
+	reauthenticate: () => Promise.resolve(),
+	trackRequestException: () => {},
+} as unknown as Provider;
+
+const token = { accessToken: 'token', microHash: 'hash' } as unknown as TokenWithInfo;
+
+function restMR(iid: number, state: GitLabMergeRequestState): GitLabMergeRequestREST {
+	return {
+		id: iid,
+		iid: iid,
+		author: { id: `gid://gitlab/User/${iid}`, name: 'Author', avatar_url: '', web_url: '' },
+		title: `MR ${iid}`,
+		description: '',
+		state: state,
+		created_at: '2024-01-01T00:00:00Z',
+		updated_at: '2024-01-02T00:00:00Z',
+		closed_at: null,
+		merged_at: state === 'merged' ? '2024-01-03T00:00:00Z' : null,
+		diff_refs: { base_sha: 'b', head_sha: 'h', start_sha: 's' },
+		source_branch: 'feature',
+		source_project_id: 1,
+		target_branch: 'main',
+		target_project_id: 1,
+		web_url: `https://gitlab.com/octo/repo/-/merge_requests/${iid}`,
+	};
+}
+
+function jsonResponse(body: unknown): Response {
+	return { ok: true, json: () => Promise.resolve(body) } as unknown as Response;
+}
+
+function createFakeFetch(pages: GitLabMergeRequestREST[][], requestedPages: number[]) {
+	const config: ProviderApiConfig = {
+		fetch: (input: string | URL) => {
+			const url = new URL(input.toString());
+			if (url.pathname.endsWith('/graphql')) {
+				return Promise.resolve(
+					jsonResponse({
+						data: {
+							mergeRequest_0: { project: { id: '1', fullPath: 'octo/repo', webUrl: '' } },
+							mergeRequest_1: { project: { id: '1', fullPath: 'octo/repo', webUrl: '' } },
+						},
+					}),
+				);
+			}
+
+			const page = Number(url.searchParams.get('page') ?? '1');
+			requestedPages.push(page);
+			return Promise.resolve(jsonResponse(pages[page - 1] ?? []));
+		},
+		wrapForForcedInsecureSSL: (_ignore, fn) => Promise.resolve(fn()),
+	};
+	return config;
+}
+
+suite('GitLabApi.searchPullRequests state-filtered paging', () => {
+	test('pages past the first page to find state matches crowded out of page 1', async () => {
+		const page1 = Array.from({ length: 20 }, (_, i) => restMR(i + 1, 'opened'));
+		const page2 = [
+			restMR(21, 'merged'),
+			restMR(22, 'merged'),
+			...Array.from({ length: 18 }, (_, i) => restMR(i + 23, 'opened')),
+		];
+
+		const requestedPages: number[] = [];
+		const api = new GitLabApi(createFakeFetch([page1, page2, []], requestedPages));
+
+		const results = await api.searchPullRequests(provider, token, { search: 'fix', include: ['merged'] });
+
+		assert.deepEqual(
+			results.map(pr => pr.id),
+			['21', '22'],
+		);
+		assert.ok(requestedPages.length > 1, 'fetched more than the first search page');
+	});
+
+	test('keeps single-page behavior when no state filter is requested', async () => {
+		const page1 = Array.from({ length: 20 }, (_, i) => restMR(i + 1, 'opened'));
+
+		const requestedPages: number[] = [];
+		const api = new GitLabApi(createFakeFetch([page1, page1, []], requestedPages));
+
+		await api.searchPullRequests(provider, token, { search: 'fix' });
+
+		assert.deepEqual(requestedPages, [1], 'fetches only the first search page without a state filter');
+	});
+});

--- a/packages/plus/integrations/src/providers/gitlab/gitlab.ts
+++ b/packages/plus/integrations/src/providers/gitlab/gitlab.ts
@@ -778,24 +778,53 @@ export class GitLabApi implements Disposable {
 			const include = options?.include?.length ? options.include : undefined;
 			// GitLab's search API takes a single `state` value, so push it server-side when exactly one state is
 			// requested; that keeps the requested state from being crowded out of the `perPageLimit` slice. For
-			// multiple states there's no single-value qualifier, so those are still filtered client-side below.
+			// multiple states there's no single-value qualifier, so those are filtered client-side below.
 			let searchPath = `v4/search/?scope=merge_requests&search=${encodeURIComponent(search)}&per_page=${perPageLimit}`;
 			if (include?.length === 1) {
 				searchPath += `&state=${encodeURIComponent(toGitLabMergeRequestState(include[0]))}`;
 			}
-			const allPRs = await this.request<GitLabMergeRequestREST[]>(
-				provider,
-				token,
-				options?.baseUrl,
-				searchPath,
-				{
-					method: 'GET',
-				},
-				cancellation,
-				scope,
-			);
-			const restPRs =
-				include == null ? allPRs : allPRs.filter(pr => include.includes(fromGitLabMergeRequestState(pr.state)));
+
+			let restPRs: GitLabMergeRequestREST[];
+			if (include == null) {
+				// Unfiltered search returns the first page as-is (as it did before state filtering existed).
+				restPRs = await this.request<GitLabMergeRequestREST[]>(
+					provider,
+					token,
+					options?.baseUrl,
+					searchPath,
+					{ method: 'GET' },
+					cancellation,
+					scope,
+				);
+			} else {
+				// The search API returns MRs of all states in relevance order, so the requested state(s) may not
+				// appear on the first page. Server-side `&state=` narrows the single-state case when honored, but it
+				// can't express multiple states, so page through the results and accumulate matches until we fill the
+				// detail-query cap (`perPageLimit`) or exhaust a bounded page budget. This keeps correctness whether
+				// or not `&state=` takes effect.
+				const maxSearchPages = 5;
+				const matches: GitLabMergeRequestREST[] = [];
+				for (let page = 1; page <= maxSearchPages; page++) {
+					const pagePRs = await this.request<GitLabMergeRequestREST[]>(
+						provider,
+						token,
+						options?.baseUrl,
+						`${searchPath}&page=${page}`,
+						{ method: 'GET' },
+						cancellation,
+						scope,
+					);
+					for (const pr of pagePRs) {
+						if (include.includes(fromGitLabMergeRequestState(pr.state))) {
+							matches.push(pr);
+							if (matches.length >= perPageLimit) break;
+						}
+					}
+					// Stop once we've filled the cap or hit the last (partial or empty) page.
+					if (matches.length >= perPageLimit || pagePRs.length < perPageLimit) break;
+				}
+				restPRs = matches;
+			}
 			if (restPRs.length === 0) {
 				return [];
 			}

--- a/packages/plus/integrations/src/providers/gitlab/gitlab.ts
+++ b/packages/plus/integrations/src/providers/gitlab/gitlab.ts
@@ -800,11 +800,10 @@ export class GitLabApi implements Disposable {
 				// The search API returns MRs of all states in relevance order, so the requested state(s) may not
 				// appear on the first page. Server-side `&state=` narrows the single-state case when honored, but it
 				// can't express multiple states, so page through the results and accumulate matches until we fill the
-				// detail-query cap (`perPageLimit`) or exhaust a bounded page budget. This keeps correctness whether
+				// detail-query cap (`perPageLimit`) or exhaust the search results. This keeps correctness whether
 				// or not `&state=` takes effect.
-				const maxSearchPages = 5;
 				const matches: GitLabMergeRequestREST[] = [];
-				for (let page = 1; page <= maxSearchPages; page++) {
+				for (let page = 1; ; page++) {
 					const pagePRs = await this.request<GitLabMergeRequestREST[]>(
 						provider,
 						token,

--- a/packages/plus/integrations/src/providers/gitlab/gitlab.ts
+++ b/packages/plus/integrations/src/providers/gitlab/gitlab.ts
@@ -2,7 +2,7 @@ import type { Account } from '@gitlens/git/models/author.js';
 import type { DefaultBranch } from '@gitlens/git/models/defaultBranch.js';
 import type { IssueOrPullRequest } from '@gitlens/git/models/issueOrPullRequest.js';
 import { PullRequest } from '@gitlens/git/models/pullRequest.js';
-import type { PullRequestStateFilter } from '@gitlens/git/models/pullRequest.js';
+import type { PullRequestState } from '@gitlens/git/models/pullRequest.js';
 import type { Provider } from '@gitlens/git/models/remoteProvider.js';
 import type { RepositoryMetadata } from '@gitlens/git/models/repositoryMetadata.js';
 import { CancellationError } from '@gitlens/utils/cancellation.js';
@@ -763,7 +763,7 @@ export class GitLabApi implements Disposable {
 			repos?: string[];
 			baseUrl?: string;
 			avatarSize?: number;
-			state?: PullRequestStateFilter;
+			include?: PullRequestState[];
 		},
 		cancellation?: AbortSignal,
 	): Promise<PullRequest[]> {
@@ -775,13 +775,13 @@ export class GitLabApi implements Disposable {
 
 		try {
 			const perPageLimit = 20; // with bigger amount we exceed the max GraphQL complexity in the next query
-			const state = options?.state;
-			// Push a specific state server-side so matching results aren't crowded out of the first page.
+			const include = options?.include?.length ? options.include : undefined;
+			// GitLab's search API takes a single `state` value, so push it server-side when exactly one state is
+			// requested; that keeps the requested state from being crowded out of the `perPageLimit` slice. For
+			// multiple states there's no single-value qualifier, so those are still filtered client-side below.
 			let searchPath = `v4/search/?scope=merge_requests&search=${encodeURIComponent(search)}&per_page=${perPageLimit}`;
-			if (state != null && state !== 'all') {
-				searchPath += `&state=${encodeURIComponent(
-					toGitLabMergeRequestState(state === 'open' ? 'opened' : state),
-				)}`;
+			if (include?.length === 1) {
+				searchPath += `&state=${encodeURIComponent(toGitLabMergeRequestState(include[0]))}`;
 			}
 			const allPRs = await this.request<GitLabMergeRequestREST[]>(
 				provider,
@@ -795,11 +795,7 @@ export class GitLabApi implements Disposable {
 				scope,
 			);
 			const restPRs =
-				state == null || state === 'all'
-					? allPRs
-					: allPRs.filter(
-							pr => fromGitLabMergeRequestState(pr.state) === (state === 'open' ? 'opened' : state),
-						);
+				include == null ? allPRs : allPRs.filter(pr => include.includes(fromGitLabMergeRequestState(pr.state)));
 			if (restPRs.length === 0) {
 				return [];
 			}

--- a/packages/plus/integrations/src/providers/gitlab/gitlab.ts
+++ b/packages/plus/integrations/src/providers/gitlab/gitlab.ts
@@ -801,9 +801,11 @@ export class GitLabApi implements Disposable {
 				// appear on the first page. Server-side `&state=` narrows the single-state case when honored, but it
 				// can't express multiple states, so page through the results and accumulate matches until we fill the
 				// detail-query cap (`perPageLimit`) or exhaust the search results. This keeps correctness whether
-				// or not `&state=` takes effect.
+				// or not `&state=` takes effect. Bounded by `maxSearchPages` like the other paged provider drains in
+				// this package so a large, low-match result set can't fan out into an unbounded request loop.
+				const maxSearchPages = 20;
 				const matches: GitLabMergeRequestREST[] = [];
-				for (let page = 1; ; page++) {
+				for (let page = 1; page <= maxSearchPages; page++) {
 					const pagePRs = await this.request<GitLabMergeRequestREST[]>(
 						provider,
 						token,

--- a/packages/plus/integrations/src/providers/models.ts
+++ b/packages/plus/integrations/src/providers/models.ts
@@ -1008,20 +1008,12 @@ export function fromProviderPullRequestState(state: GitPullRequestState): PullRe
 	return state === GitPullRequestState.Open ? 'opened' : state === GitPullRequestState.Closed ? 'closed' : 'merged';
 }
 
-/** Maps PR include/state filters to the SDK's `states` input. `undefined`/omitted preserves the open-only default. */
-export function toProviderPullRequestStates(
-	state: PullRequestState[] | PullRequestStateFilter | PullRequestStateFilter[] | undefined,
-): GitPullRequestState[] | undefined {
-	// Accept arrays so callers can request unions (e.g. `include: ['closed', 'merged']` or the
-	// closed + merged "done" sweep). Deduping keeps overlapping inputs stable.
-	if (Array.isArray(state)) {
-		const states = state.flatMap(s => toProviderPullRequestStates(s) ?? []);
-		return states.length > 0 ? [...new Set(states)] : undefined;
-	}
+type PullRequestStateInput = PullRequestState | PullRequestStateFilter;
 
+function toProviderPullRequestStatesCore(state: PullRequestStateInput): GitPullRequestState[] {
 	switch (state) {
-		case 'opened':
 		case 'open':
+		case 'opened':
 			return [GitPullRequestState.Open];
 		case 'closed':
 			return [GitPullRequestState.Closed];
@@ -1029,9 +1021,17 @@ export function toProviderPullRequestStates(
 			return [GitPullRequestState.Merged];
 		case 'all':
 			return [GitPullRequestState.Open, GitPullRequestState.Closed, GitPullRequestState.Merged];
-		default:
-			return undefined;
 	}
+}
+
+/** Maps PR include/state filters to the SDK's `states` input. `undefined`/omitted preserves the open-only default. */
+export function toProviderPullRequestStates(
+	state: PullRequestStateInput | PullRequestStateInput[] | undefined,
+): GitPullRequestState[] | undefined {
+	if (state == null) return undefined;
+
+	const states = (Array.isArray(state) ? state : [state]).flatMap(s => toProviderPullRequestStatesCore(s));
+	return states.length > 0 ? [...new Set(states)] : undefined;
 }
 
 /** Maps an issue state filter to the SDK's `states` input. `undefined`/omitted preserves the open-only default. */

--- a/packages/plus/integrations/src/providers/models.ts
+++ b/packages/plus/integrations/src/providers/models.ts
@@ -187,10 +187,10 @@ export interface PagedProjectInput {
 export interface GetPullRequestsOptions {
 	authorLogin?: string;
 	assigneeLogins?: string[];
-	reviewerId?: string;
 	reviewRequestedLogin?: string;
 	// Reviewer filters keyed differently per provider: GitHub/GitLab use reviewRequestedLogin (login),
 	// Bitbucket/Azure DevOps use reviewerId (account id), Bitbucket Server uses reviewerLogin (login).
+	reviewerId?: string;
 	reviewerLogin?: string;
 	mentionLogin?: string;
 	// PR states to include; when omitted the provider returns its default (open only).

--- a/packages/plus/integrations/src/providers/models.ts
+++ b/packages/plus/integrations/src/providers/models.ts
@@ -1004,6 +1004,15 @@ export function toProviderPullRequestState(state: PullRequestState): GitPullRequ
 			: GitPullRequestState.Merged;
 }
 
+// Normalizes a requested-states list into the provider-apis `states` filter. An empty `include` is
+// treated as "no explicit filter" (`undefined`) rather than `[]`, so providers fall back to their
+// default (open-only) behavior instead of relying on each provider coercing an empty array.
+export function toProviderPullRequestStates(
+	include: PullRequestState[] | undefined,
+): GitPullRequestState[] | undefined {
+	return include?.length ? include.map(toProviderPullRequestState) : undefined;
+}
+
 export function fromProviderPullRequestState(state: GitPullRequestState): PullRequestState {
 	return state === GitPullRequestState.Open ? 'opened' : state === GitPullRequestState.Closed ? 'closed' : 'merged';
 }
@@ -1071,10 +1080,10 @@ export function resolveProviderScope(
 }
 
 export function providerPullRequestMatchesSearch(pr: ProviderPullRequest, search: string): boolean {
-	const term = search.trim().toLocaleLowerCase();
+	const term = search.trim().toLowerCase();
 	if (term.length === 0) return true;
 
-	return pr.title.toLocaleLowerCase().includes(term) || (pr.description?.toLocaleLowerCase().includes(term) ?? false);
+	return pr.title.toLowerCase().includes(term) || (pr.description?.toLowerCase().includes(term) ?? false);
 }
 
 function toProviderRemoteInfo(ref: PullRequestRef | undefined): GitRepositoryRemoteInfo | null {

--- a/packages/plus/integrations/src/providers/models.ts
+++ b/packages/plus/integrations/src/providers/models.ts
@@ -187,10 +187,10 @@ export interface PagedProjectInput {
 export interface GetPullRequestsOptions {
 	authorLogin?: string;
 	assigneeLogins?: string[];
+	reviewerId?: string;
 	reviewRequestedLogin?: string;
 	// Reviewer filters keyed differently per provider: GitHub/GitLab use reviewRequestedLogin (login),
 	// Bitbucket/Azure DevOps use reviewerId (account id), Bitbucket Server uses reviewerLogin (login).
-	reviewerId?: string;
 	reviewerLogin?: string;
 	mentionLogin?: string;
 	// PR states to include; when omitted the provider returns its default (open only).
@@ -324,6 +324,7 @@ export type GetPullRequestsForAzureProjectsFn = (
 		assigneeLogins?: string[];
 		reviewerId?: string;
 		states?: GitPullRequestState[];
+		repo?: ProviderRepoInput;
 	},
 	options?: EnterpriseOptions,
 	// Aggregate multi-project fan-out: no `pageInfo` (call getPullRequestsForAzureProject for that), but SDK
@@ -1007,25 +1008,19 @@ export function fromProviderPullRequestState(state: GitPullRequestState): PullRe
 	return state === GitPullRequestState.Open ? 'opened' : state === GitPullRequestState.Closed ? 'closed' : 'merged';
 }
 
-export function providerPullRequestMatchesSearch(pr: ProviderPullRequest, search: string): boolean {
-	const term = search.trim().toLowerCase();
-	if (term.length === 0) return true;
-
-	return pr.title.toLowerCase().includes(term) || (pr.description?.toLowerCase().includes(term) ?? false);
-}
-
-/** Maps a PR state filter to the SDK's `states` input. `undefined`/omitted preserves the open-only default. */
+/** Maps PR include/state filters to the SDK's `states` input. `undefined`/omitted preserves the open-only default. */
 export function toProviderPullRequestStates(
-	state: PullRequestStateFilter | PullRequestStateFilter[] | undefined,
+	state: PullRequestState[] | PullRequestStateFilter | PullRequestStateFilter[] | undefined,
 ): GitPullRequestState[] | undefined {
-	// Accept an array so callers can request a union the single-value filter can't express (e.g. the
-	// closed + merged "done" sweep); each element maps through the single-value logic and the result is deduped.
+	// Accept arrays so callers can request unions (e.g. include arrays or the closed+merged "done" sweep);
+	// each element maps through the single-value logic and the result is deduped.
 	if (Array.isArray(state)) {
 		const states = state.flatMap(s => toProviderPullRequestStates(s) ?? []);
 		return states.length > 0 ? [...new Set(states)] : undefined;
 	}
 
 	switch (state) {
+		case 'opened':
 		case 'open':
 			return [GitPullRequestState.Open];
 		case 'closed':
@@ -1075,6 +1070,13 @@ export function resolveProviderScope(
 	return { reposInput: reposInput };
 }
 
+export function providerPullRequestMatchesSearch(pr: ProviderPullRequest, search: string): boolean {
+	const term = search.trim().toLocaleLowerCase();
+	if (term.length === 0) return true;
+
+	return pr.title.toLocaleLowerCase().includes(term) || (pr.description?.toLocaleLowerCase().includes(term) ?? false);
+}
+
 function toProviderRemoteInfo(ref: PullRequestRef | undefined): GitRepositoryRemoteInfo | null {
 	// Match the SDK convention: only populate remoteInfo when both clone URLs are known.
 	return ref?.cloneHttps && ref?.cloneSsh ? { cloneUrlHTTPS: ref.cloneHttps, cloneUrlSSH: ref.cloneSsh } : null;
@@ -1092,7 +1094,6 @@ export function toProviderPullRequest(pr: PullRequest): ProviderPullRequest {
 		state: toProviderPullRequestState(pr.state),
 		isCrossRepository: pr.refs?.isCrossRepository ?? false,
 		isDraft: pr.isDraft ?? false,
-		isCrossRepository: pr.refs?.isCrossRepository ?? false,
 		createdDate: pr.createdDate,
 		updatedDate: pr.updatedDate,
 		closedDate: pr.closedDate ?? null,

--- a/packages/plus/integrations/src/providers/models.ts
+++ b/packages/plus/integrations/src/providers/models.ts
@@ -1092,6 +1092,7 @@ export function toProviderPullRequest(pr: PullRequest): ProviderPullRequest {
 		state: toProviderPullRequestState(pr.state),
 		isCrossRepository: pr.refs?.isCrossRepository ?? false,
 		isDraft: pr.isDraft ?? false,
+		isCrossRepository: pr.refs?.isCrossRepository ?? false,
 		createdDate: pr.createdDate,
 		updatedDate: pr.updatedDate,
 		closedDate: pr.closedDate ?? null,

--- a/packages/plus/integrations/src/providers/models.ts
+++ b/packages/plus/integrations/src/providers/models.ts
@@ -1004,15 +1004,6 @@ export function toProviderPullRequestState(state: PullRequestState): GitPullRequ
 			: GitPullRequestState.Merged;
 }
 
-// Normalizes a requested-states list into the provider-apis `states` filter. An empty `include` is
-// treated as "no explicit filter" (`undefined`) rather than `[]`, so providers fall back to their
-// default (open-only) behavior instead of relying on each provider coercing an empty array.
-export function toProviderPullRequestStates(
-	include: PullRequestState[] | undefined,
-): GitPullRequestState[] | undefined {
-	return include?.length ? include.map(toProviderPullRequestState) : undefined;
-}
-
 export function fromProviderPullRequestState(state: GitPullRequestState): PullRequestState {
 	return state === GitPullRequestState.Open ? 'opened' : state === GitPullRequestState.Closed ? 'closed' : 'merged';
 }
@@ -1021,8 +1012,8 @@ export function fromProviderPullRequestState(state: GitPullRequestState): PullRe
 export function toProviderPullRequestStates(
 	state: PullRequestState[] | PullRequestStateFilter | PullRequestStateFilter[] | undefined,
 ): GitPullRequestState[] | undefined {
-	// Accept arrays so callers can request unions (e.g. include arrays or the closed+merged "done" sweep);
-	// each element maps through the single-value logic and the result is deduped.
+	// Accept arrays so callers can request unions (e.g. `include: ['closed', 'merged']` or the
+	// closed + merged "done" sweep). Deduping keeps overlapping inputs stable.
 	if (Array.isArray(state)) {
 		const states = state.flatMap(s => toProviderPullRequestStates(s) ?? []);
 		return states.length > 0 ? [...new Set(states)] : undefined;

--- a/packages/plus/integrations/src/providers/providersApi.ts
+++ b/packages/plus/integrations/src/providers/providersApi.ts
@@ -1158,6 +1158,7 @@ export class ProvidersApi {
 					assigneeLogins: options?.assigneeLogins,
 					reviewerId: options?.reviewerId,
 					states: options?.states,
+					repo: options?.repo,
 				},
 				// `azureToken` is always a PAT here (the raw token when `isPAT`, otherwise a PAT derived from
 				// the OAuth token), so it must be sent as a PAT regardless of the incoming `options?.isPAT`.

--- a/packages/plus/integrations/src/providers/providersApi.ts
+++ b/packages/plus/integrations/src/providers/providersApi.ts
@@ -1136,6 +1136,7 @@ export class ProvidersApi {
 			assigneeLogins?: string[];
 			reviewerId?: string;
 			states?: GitPullRequestState[];
+			repo?: ProviderRepoInput;
 			isPAT?: boolean;
 			baseUrl?: string;
 		},


### PR DESCRIPTION
GitLab's `searchPullRequests` can miss merge requests whose state matches the requested filter when the first search page is dominated by other states. This PR fixes that, and also evolves the shared PR-search contract to use the `include[]` state-filter shape across all providers.

### Problem
`packages/plus/integrations/src/providers/gitlab/gitlab.ts` queries GitLab's REST search endpoint with `per_page=20`. Results are returned in GitLab's default relevance order, and the provider then filters by state. If page 1 is dominated by `opened` MRs, a `merged`-only or `closed`-only search can return `[]` even when matching MRs exist on later pages.

### What this PR changes

#### Shared PR-search contract
- `searchPullRequests` now accepts `options?: { include?: PullRequestState[] }` instead of the old `state?: PullRequestStateFilter`.
- Provider helpers (`toProviderPullRequestStates`, `filterPullRequestsBySearchState`) normalize and dedupe the requested states.
- Provider implementations for GitHub, GitLab, Bitbucket Cloud, Bitbucket Server, and Azure DevOps are wired through the new contract.
- `toProviderPullRequestStates` now accepts both vocabularies (`'open'` and `'opened'`) so existing `PullRequestStateFilter` callers do not break.

#### GitLab fix (this issue)
- The **unfiltered** path returns the first page exactly as before.
- A single requested state is pushed server-side via GitLab's single `state` qualifier when possible.
- When state filtering is requested, the search pages through GitLab results until:
  - the detail-query cap is filled, or
  - the search results are exhausted.
- Multi-state requests keep filtering client-side because GitLab search only accepts one `state` qualifier at a time.
- The GraphQL detail query still operates on at most the existing ~20 MR cap, so complexity is bounded.

#### GitHub fix (related correctness issue found in review)
- GitHub's search API has a single qualifier for `opened` and `closed/merged` separately, but **not** for `opened + merged` together.
- When `include` requests that combination, the search now paginates and accumulates valid matches across pages instead of relying on a single 10-item page.
- Single-state and exact multi-state combinations keep the server-qualified path.

### Main touch points
- `packages/plus/integrations/src/models/gitHostIntegration.ts`
- `packages/plus/integrations/src/providers/models.ts`
- `packages/plus/integrations/src/providers/providersApi.ts`
- `packages/plus/integrations/src/providers/gitlab/gitlab.ts`
- `packages/plus/integrations/src/providers/gitlab.ts`
- `packages/plus/integrations/src/providers/github.ts`
- `packages/plus/integrations/src/providers/bitbucket.ts`
- `packages/plus/integrations/src/providers/bitbucket-server.ts`
- `packages/plus/integrations/src/providers/azureDevOps.ts`
- `packages/plus/git-github/src/api/github.ts`

### Tests added/updated
- `packages/plus/integrations/src/providers/gitlab/__tests__/gitlab.search.test.ts` — new paging tests for the GitLab MR search fix
- `packages/plus/git-github/src/api/__tests__/github.test.ts` — multi-page `opened + merged` test for GitHub
- `packages/plus/integrations/src/providers/__tests__/models.test.ts` — mixed `open`/`opened` vocabulary and `include[]` state mapping
- `packages/plus/git-github/src/api/__tests__/github.test.ts` — existing state qualifier tests remain

### Validation run
- `pnpm run check` ✅
- `pnpm run build` ✅
- `packages/plus/git-github: pnpm test` ✅ (17 passing)
- `packages/plus/integrations: pnpm test` ✅ (308 passing)

### Notes
- This branch was rebased onto `core` after `5441` introduced the shared PR search state-filter contract.
- It supersedes the overlapping work in `5479`, which used a different, less efficient GitLab implementation path.
- Follow-up from PR #5473 review.

Closes #5480
