### PR TITLE
Fix GitHub per-state PR cursors

### DIFF
--- a/packages/plus/integrations/src/__tests__/providerBackendSurface.test.ts
+++ b/packages/plus/integrations/src/__tests__/providerBackendSurface.test.ts
@@ -292,6 +292,207 @@ suite('ProviderBackend surface facade (#5438)', () => {
 		manager.dispose();
 	});
 
+	test('listPullRequestsPage preserves GitHub account-wide per-state cursors', async () => {
+		const runtime = createFakeRuntime();
+		const manager = createIntegrationManager(runtime);
+		const gh = await manager.get(GitCloudHostIntegrationId.GitHub);
+		assert.ok(gh);
+		(gh as unknown as { _session: ProviderAuthenticationSession })._session = primarySession('t');
+		const githubApi = await (
+			gh as unknown as {
+				authenticationService: {
+					apis: { github: Promise<Record<string, unknown> | undefined> };
+				};
+			}
+		).authenticationService.apis.github;
+		assert.ok(githubApi);
+
+		const seen: { state?: string; cursor?: string }[] = [];
+		githubApi.searchMyPullRequestsPage = async (
+			_provider: unknown,
+			_token: unknown,
+			options?: { state?: string; cursor?: string },
+		) => {
+			seen.push({ state: options?.state, cursor: options?.cursor });
+			if (options?.state === 'closed' && options.cursor == null) {
+				return { values: [searchPullRequest('1', 'closed')], hasMore: true, cursor: 'closed-next' };
+			}
+
+			return {
+				values: [
+					options?.state === 'closed' ? searchPullRequest('3', 'closed') : searchPullRequest('2', 'merged'),
+				],
+				hasMore: false,
+			};
+		};
+
+		const first = await manager.listPullRequestsPage({
+			providerId: GitCloudHostIntegrationId.GitHub,
+			states: ['closed', 'merged'],
+		});
+
+		assert.equal(first.hasMore, true);
+		assert.equal(typeof first.cursor, 'string');
+		assert.deepEqual(JSON.parse(first.cursor ?? '{}'), { type: 'cursor', cursors: { closed: 'closed-next' } });
+
+		const second = await manager.listPullRequestsPage({
+			providerId: GitCloudHostIntegrationId.GitHub,
+			states: ['closed', 'merged'],
+			cursor: first.cursor,
+		});
+
+		// The continuation page must only re-query the states still carrying a cursor. `merged` was exhausted
+		// on the first page (no cursor in the bundle), so re-querying it would refetch PR '2' and duplicate it
+		// in the sweep, which appends across pages without deduping.
+		assert.deepEqual(seen, [
+			{ state: 'closed', cursor: undefined },
+			{ state: 'merged', cursor: undefined },
+			{ state: 'closed', cursor: 'closed-next' },
+		]);
+		assert.deepEqual(
+			second.items.map(pr => pr.id),
+			['3'],
+			'the continuation page returns only the closed PR, not the already-drained merged PR',
+		);
+
+		manager.dispose();
+	});
+
+	test('a malformed GitHub per-state cursor degrades to the first page instead of returning empty', async () => {
+		const runtime = createFakeRuntime();
+		const manager = createIntegrationManager(runtime);
+		const gh = await manager.get(GitCloudHostIntegrationId.GitHub);
+		assert.ok(gh);
+		(gh as unknown as { _session: ProviderAuthenticationSession })._session = primarySession('t');
+		const githubApi = await (
+			gh as unknown as {
+				authenticationService: {
+					apis: { github: Promise<Record<string, unknown> | undefined> };
+				};
+			}
+		).authenticationService.apis.github;
+		assert.ok(githubApi);
+
+		const seen: { state?: string; cursor?: string }[] = [];
+		githubApi.searchMyPullRequestsPage = async (
+			_provider: unknown,
+			_token: unknown,
+			options?: { state?: string; cursor?: string },
+		) => {
+			seen.push({ state: options?.state, cursor: options?.cursor });
+			const state = options?.state === 'closed' ? 'closed' : 'merged';
+			return {
+				values: [searchPullRequest(state === 'closed' ? '1' : '2', state)],
+				hasMore: false,
+			};
+		};
+
+		const result = await manager.listPullRequestsPage({
+			providerId: GitCloudHostIntegrationId.GitHub,
+			states: ['closed', 'merged'],
+			cursor: JSON.stringify({ type: 'cursor', cursors: 'not-an-object' }),
+		});
+
+		assert.deepEqual(seen, [
+			{ state: 'closed', cursor: undefined },
+			{ state: 'merged', cursor: undefined },
+		]);
+		assert.deepEqual(
+			result.items.map(pr => pr.id),
+			['1', '2'],
+			'the malformed continuation falls back to the first page rather than short-circuiting empty',
+		);
+
+		manager.dispose();
+	});
+
+	test('a mismatched GitHub per-state cursor degrades to the first page instead of returning empty', async () => {
+		const runtime = createFakeRuntime();
+		const manager = createIntegrationManager(runtime);
+		const gh = await manager.get(GitCloudHostIntegrationId.GitHub);
+		assert.ok(gh);
+		(gh as unknown as { _session: ProviderAuthenticationSession })._session = primarySession('t');
+		const githubApi = await (
+			gh as unknown as {
+				authenticationService: {
+					apis: { github: Promise<Record<string, unknown> | undefined> };
+				};
+			}
+		).authenticationService.apis.github;
+		assert.ok(githubApi);
+
+		const seen: { state?: string; cursor?: string }[] = [];
+		githubApi.searchMyPullRequestsPage = async (
+			_provider: unknown,
+			_token: unknown,
+			options?: { state?: string; cursor?: string },
+		) => {
+			seen.push({ state: options?.state, cursor: options?.cursor });
+			return {
+				values: [searchPullRequest('1', options?.state === 'open' ? 'open' : 'closed')],
+				hasMore: false,
+			};
+		};
+
+		const result = await manager.listPullRequestsPage({
+			providerId: GitCloudHostIntegrationId.GitHub,
+			states: ['open'],
+			cursor: JSON.stringify({ type: 'cursor', cursors: { closed: 'closed-next' } }),
+		});
+
+		assert.deepEqual(seen, [{ state: 'open', cursor: undefined }]);
+		assert.deepEqual(
+			result.items.map(pr => pr.id),
+			['1'],
+			'the mismatched continuation falls back to the first page rather than short-circuiting empty',
+		);
+
+		manager.dispose();
+	});
+
+	test('an empty-string GitHub per-state cursor degrades to the first page instead of being forwarded', async () => {
+		const runtime = createFakeRuntime();
+		const manager = createIntegrationManager(runtime);
+		const gh = await manager.get(GitCloudHostIntegrationId.GitHub);
+		assert.ok(gh);
+		(gh as unknown as { _session: ProviderAuthenticationSession })._session = primarySession('t');
+		const githubApi = await (
+			gh as unknown as {
+				authenticationService: {
+					apis: { github: Promise<Record<string, unknown> | undefined> };
+				};
+			}
+		).authenticationService.apis.github;
+		assert.ok(githubApi);
+
+		const seen: { state?: string; cursor?: string }[] = [];
+		githubApi.searchMyPullRequestsPage = async (
+			_provider: unknown,
+			_token: unknown,
+			options?: { state?: string; cursor?: string },
+		) => {
+			seen.push({ state: options?.state, cursor: options?.cursor });
+			return {
+				values: [searchPullRequest('1', 'closed')],
+				hasMore: false,
+			};
+		};
+
+		const result = await manager.listPullRequestsPage({
+			providerId: GitCloudHostIntegrationId.GitHub,
+			states: ['closed'],
+			cursor: JSON.stringify({ type: 'cursor', cursors: { closed: '' } }),
+		});
+
+		assert.deepEqual(seen, [{ state: 'closed', cursor: undefined }]);
+		assert.deepEqual(
+			result.items.map(pr => pr.id),
+			['1'],
+		);
+
+		manager.dispose();
+	});
+
 	test('listPullRequestsPage derives the self-managed GitHub Enterprise baseUrl for repo reads', async () => {
 		const runtime = createFakeRuntime();
 		const manager = createIntegrationManager(runtime);

--- a/packages/plus/integrations/src/providers/github.ts
+++ b/packages/plus/integrations/src/providers/github.ts
@@ -34,18 +34,33 @@ import type { ProvidersApi } from './providersApi.js';
 
 type GitHubPullRequestStateCursor = Partial<Record<PullRequestStateFilter, string>>;
 
+function isPullRequestStateFilter(key: string): key is PullRequestStateFilter {
+	return key === 'open' || key === 'closed' || key === 'merged' || key === 'all';
+}
+
+function toPullRequestStateCursor(value: unknown): GitHubPullRequestStateCursor {
+	if (value == null || typeof value !== 'object' || Array.isArray(value)) return {};
+
+	return Object.fromEntries(
+		Object.entries(value).filter(
+			([key, cursor]) => isPullRequestStateFilter(key) && typeof cursor === 'string' && cursor.length !== 0,
+		),
+	);
+}
+
 function parsePullRequestStateCursor(cursor: string | undefined): GitHubPullRequestStateCursor {
 	if (!cursor) return {};
 
 	try {
-		const parsed = JSON.parse(cursor) as Record<string, unknown>;
-		return Object.fromEntries(
-			Object.entries(parsed).filter(
-				([key, value]) =>
-					(key === 'open' || key === 'closed' || key === 'merged' || key === 'all') &&
-					typeof value === 'string',
-			),
-		);
+		const parsed = JSON.parse(cursor) as unknown;
+		if (parsed != null && typeof parsed === 'object' && !Array.isArray(parsed) && 'cursors' in parsed) {
+			const wrapped = parsed as { type?: unknown; cursors?: unknown };
+			if (wrapped.type === 'cursor') {
+				return toPullRequestStateCursor(wrapped.cursors);
+			}
+		}
+
+		return toPullRequestStateCursor(parsed);
 	} catch {
 		return {};
 	}
@@ -319,8 +334,20 @@ abstract class GitHubIntegrationBase<ID extends GitHubIntegrationIds> extends Gi
 
 			const requestedStates = [...new Set(options.state)];
 			const cursors = parsePullRequestStateCursor(options.cursor);
+			const hasResumableStateCursor = Object.keys(cursors).length !== 0;
+			const statesWithCursor = requestedStates.filter(state => cursors[state] != null);
+			// The first call has no cursor, so query every requested state. A continuation only happens after a
+			// prior page reported `more:true`, whose bundle carries a cursor for each state still in flight;
+			// states absent from the bundle are exhausted, so re-querying them from scratch would refetch the
+			// same PRs (duplicated by the dedup-free sweep) and waste an API call per page. Query only the
+			// states that still have a cursor, but degrade a malformed/empty cursor bundle, or one that doesn't
+			// apply to the current requested states, to the first page rather than returning an empty page.
+			const statesToQuery =
+				options.cursor != null && hasResumableStateCursor && statesWithCursor.length !== 0
+					? statesWithCursor
+					: requestedStates;
 			const results = await Promise.all(
-				requestedStates.map(async state => ({
+				statesToQuery.map(async state => ({
 					state: state,
 					result: await github.searchMyPullRequestsPage(this, toTokenWithInfo(this.id, session), {
 						baseUrl: this.apiBaseUrl,
@@ -351,7 +378,7 @@ abstract class GitHubIntegrationBase<ID extends GitHubIntegrationIds> extends Gi
 				values: [...values.values()],
 				paging: {
 					more: hasMore,
-					cursor: JSON.stringify(nextCursors),
+					cursor: hasMore ? JSON.stringify({ type: 'cursor', cursors: nextCursors }) : '{}',
 					truncated: truncated || undefined,
 				},
 			};


### PR DESCRIPTION
## Summary
- Wrap GitHub account-wide per-state PR cursors in the retained opaque cursor shape
- Keep parsing legacy flat per-state cursor payloads for compatibility
- Add ProviderBackend coverage for closed/merged paging continuation

## Root Cause
GitHub account-wide state-filtered PR paging returned `hasMore: true` with a plain state cursor map. The ProviderBackend page normalization drops cursor payloads that are not tagged as a cursor/page or a known cursor bundle, so callers saw `hasMore: true` without a cursor to continue paging.

## Validation
- `pnpm run check`
- `pnpm --filter @gitlens/integrations test -- --grep "GitHub account-wide per-state cursors|GitHub account-wide closed/merged"`
- Review-fix pass: no findings