### PR TITLE
Fixes incoherent isPAT flag on Azure PAT-converted token requests (#5529)

### DIFF
--- a/packages/plus/integrations/src/providers/__tests__/azurePullRequestAuth.test.ts
+++ b/packages/plus/integrations/src/providers/__tests__/azurePullRequestAuth.test.ts
@@ -1,0 +1,64 @@
+import * as assert from 'node:assert/strict';
+import { suite, test } from 'mocha';
+import { base64 } from '@gitlens/utils/base64.js';
+import { createFakeRuntime } from '../../__tests__/fakeRuntime.js';
+import type { TokenWithInfo } from '../../authentication/models.js';
+import { GitCloudHostIntegrationId } from '../../constants.js';
+import { createIntegrationManager } from '../../index.js';
+
+type CapturedAzureOptions = {
+	token?: string;
+	isPAT?: boolean;
+	baseUrl?: string;
+};
+
+suite('Azure pull request auth (#5529)', () => {
+	test('sends the PAT-converted OAuth token as PAT for single-project PR reads', async () => {
+		const runtime = createFakeRuntime();
+		const manager = createIntegrationManager(runtime);
+		const ado = await manager.get(GitCloudHostIntegrationId.AzureDevOps);
+
+		const api = await (
+			ado as unknown as { getProvidersApi(): Promise<{ providers: Record<string, Record<string, unknown>> }> }
+		).getProvidersApi();
+
+		let capturedOptions: CapturedAzureOptions | undefined;
+		(
+			api.providers[GitCloudHostIntegrationId.AzureDevOps] as {
+				getPullRequestsForAzureProjectFn: (
+					input: unknown,
+					options?: CapturedAzureOptions,
+				) => Promise<{ data: unknown[]; pageInfo: { hasNextPage: boolean; nextPage: number | null } }>;
+			}
+		).getPullRequestsForAzureProjectFn = (_input, options) => {
+			capturedOptions = options;
+			return Promise.resolve({ data: [], pageInfo: { hasNextPage: false, nextPage: null } });
+		};
+
+		await (
+			api as unknown as {
+				getPullRequestsForAzureProject: (
+					token: TokenWithInfo<GitCloudHostIntegrationId.AzureDevOps>,
+					project: { namespace: string; project: string },
+					options: { isPAT: boolean },
+				) => Promise<unknown>;
+			}
+		).getPullRequestsForAzureProject(
+			{
+				providerId: GitCloudHostIntegrationId.AzureDevOps,
+				accessToken: 'oauth-token',
+				microHash: undefined,
+				cloud: true,
+				type: 'oauth',
+				scopes: [],
+			},
+			{ namespace: 'org', project: 'project' },
+			{ isPAT: false },
+		);
+
+		assert.equal(capturedOptions?.token, base64('PAT:oauth-token'));
+		assert.equal(capturedOptions?.isPAT, true);
+
+		manager.dispose();
+	});
+});

--- a/packages/plus/integrations/src/providers/providersApi.ts
+++ b/packages/plus/integrations/src/providers/providersApi.ts
@@ -1214,7 +1214,9 @@ export class ProvidersApi {
 					repo: options?.repo,
 					page: options?.page,
 				},
-				{ token: azureToken, isPAT: options?.isPAT, baseUrl: options?.baseUrl },
+				// `azureToken` is always a PAT here (already PAT-formatted when `isPAT`, otherwise derived from
+				// the OAuth token), so it must be sent as a PAT regardless of the incoming `options?.isPAT`.
+				{ token: azureToken, isPAT: true, baseUrl: options?.baseUrl },
 			);
 			if (result == null) return undefined;
 			return { data: result.data, hasMore: result.pageInfo.hasNextPage, nextPage: result.pageInfo.nextPage };


### PR DESCRIPTION
Closes #5529

## Problem

`getPullRequestsForAzureProject` converts an OAuth token into an Azure PAT-formatted credential:

```ts
const azureToken = options?.isPAT ? token : this.getAzurePATForOAuthToken(token);
```

But it forwarded the caller's original `options?.isPAT` to `@gitkraken/provider-apis`. When an OAuth caller passed `isPAT: false`, the SDK would build a Bearer request with a PAT-formatted token and Azure would reject it.

The plural `getPullRequestsForAzureProjects` already treats the converted token consistently with `isPAT: true`.

## Fix

Force `isPAT: true` for the single-project Azure PR SDK call after `azureToken` has been normalized to PAT format.

## Verification

- Added a focused regression test covering the OAuth-to-PAT path for `getPullRequestsForAzureProject`.
- `pnpm --filter @gitlens/integrations test`
- `pnpm run check`
