### PR TITLE
Makes Bitbucket reviewer PR slice opt-in for parity (#5530)

### DIFF
--- a/packages/plus/integrations/src/index.ts
+++ b/packages/plus/integrations/src/index.ts
@@ -88,6 +88,7 @@ export type { ApiClients } from './providers/apiClients.js';
 export type { Source } from './telemetry.js';
 export type { IntegrationIds, SupportedCloudIntegrationIds } from './constants.js';
 export type { ConnectionStateChangeEvent, IntegrationConnectionChangeEvent } from './integrationService.js';
+export type { SearchMyPullRequestsOptions } from './models/gitHostIntegration.js';
 export type { ConfiguredIntegrationsChangeEvent } from './authentication/configuredIntegrationService.js';
 
 // Authentication contract — what `IntegrationServiceHooks.createAuthenticationProvider`

--- a/packages/plus/integrations/src/integrationService.ts
+++ b/packages/plus/integrations/src/integrationService.ts
@@ -45,7 +45,7 @@ import {
 } from './constants.js';
 import type { AuthenticationSessionsChangeEvent, IntegrationServiceContext } from './context.js';
 import { RequestNotFoundError } from './errors.js';
-import type { GitHostIntegration } from './models/gitHostIntegration.js';
+import type { GitHostIntegration, SearchMyPullRequestsOptions } from './models/gitHostIntegration.js';
 import type {
 	Integration,
 	IntegrationBase,
@@ -675,6 +675,7 @@ export class IntegrationService implements Disposable {
 		integrationIds?: (GitCloudHostIntegrationId | CloudGitSelfManagedHostIntegrationIds)[],
 		cancellation?: AbortSignal,
 		silent?: boolean,
+		options?: SearchMyPullRequestsOptions,
 	): Promise<IntegrationResult<PullRequest[] | undefined>> {
 		const integrations: Map<GitHostIntegration, ResourceDescriptor[] | undefined> = new Map();
 		for (const integrationId of integrationIds?.length
@@ -690,13 +691,14 @@ export class IntegrationService implements Disposable {
 		}
 		if (integrations.size === 0) return undefined;
 
-		return this.getMyPullRequestsCore(integrations, cancellation, silent);
+		return this.getMyPullRequestsCore(integrations, cancellation, silent, options);
 	}
 
 	private async getMyPullRequestsCore(
 		integrations: Map<GitHostIntegration, ResourceDescriptor[] | undefined>,
 		cancellation?: AbortSignal,
 		silent?: boolean,
+		options?: SearchMyPullRequestsOptions,
 	): Promise<IntegrationResult<PullRequest[] | undefined>> {
 		const start = performance.now();
 
@@ -704,7 +706,7 @@ export class IntegrationService implements Disposable {
 		for (const [integration, repos] of integrations) {
 			if (integration == null) continue;
 
-			promises.push(integration.searchMyPullRequests(repos, cancellation, silent));
+			promises.push(integration.searchMyPullRequests(repos, cancellation, silent, undefined, undefined, options));
 		}
 
 		const results = await Promise.allSettled(promises);

--- a/packages/plus/integrations/src/models/gitHostIntegration.ts
+++ b/packages/plus/integrations/src/models/gitHostIntegration.ts
@@ -108,6 +108,10 @@ function getSelfManagedApiBaseUrl(
 	}
 }
 
+export type SearchMyPullRequestsOptions = {
+	includeReviewRequested?: boolean;
+};
+
 export abstract class GitHostIntegration<
 	ID extends IntegrationIds = IntegrationIds,
 	T extends ResourceDescriptor = ResourceDescriptor,
@@ -1241,6 +1245,7 @@ export abstract class GitHostIntegration<
 		silent?: boolean,
 		connectionId?: string,
 		state?: PullRequestStateFilter,
+		options?: SearchMyPullRequestsOptions,
 	): Promise<IntegrationResult<PullRequest[] | undefined>>;
 	async searchMyPullRequests(
 		repos?: T[],
@@ -1248,6 +1253,7 @@ export abstract class GitHostIntegration<
 		silent?: boolean,
 		connectionId?: string,
 		state?: PullRequestStateFilter,
+		options?: SearchMyPullRequestsOptions,
 	): Promise<IntegrationResult<PullRequest[] | undefined>>;
 	@trace()
 	async searchMyPullRequests(
@@ -1256,6 +1262,7 @@ export abstract class GitHostIntegration<
 		silent?: boolean,
 		connectionId?: string,
 		state?: PullRequestStateFilter,
+		options?: SearchMyPullRequestsOptions,
 	): Promise<IntegrationResult<PullRequest[] | undefined>> {
 		const scope = getScopedLogger();
 		// `connectionId` targets a specific account (multi-account); omitted reads the primary.
@@ -1284,6 +1291,7 @@ export abstract class GitHostIntegration<
 						cancellation,
 						silent,
 						state,
+						options,
 					),
 				};
 			}
@@ -1376,6 +1384,7 @@ export abstract class GitHostIntegration<
 		cancellation?: AbortSignal,
 		silent?: boolean,
 		state?: PullRequestStateFilter,
+		options?: SearchMyPullRequestsOptions,
 	): Promise<PullRequest[] | undefined>;
 
 	/**

--- a/packages/plus/integrations/src/models/gitHostIntegration.ts
+++ b/packages/plus/integrations/src/models/gitHostIntegration.ts
@@ -1282,6 +1282,7 @@ export abstract class GitHostIntegration<
 					cancellation,
 					silent,
 					state,
+					options,
 				);
 			} else {
 				result = {
@@ -1401,6 +1402,7 @@ export abstract class GitHostIntegration<
 		cancellation?: AbortSignal,
 		silent?: boolean,
 		state?: PullRequestStateFilter,
+		options?: SearchMyPullRequestsOptions,
 	): Promise<IntegrationResult<PullRequest[] | undefined>>;
 
 	async searchPullRequests(

--- a/packages/plus/integrations/src/providers/__tests__/bitbucketMyPullRequests.test.ts
+++ b/packages/plus/integrations/src/providers/__tests__/bitbucketMyPullRequests.test.ts
@@ -1,0 +1,115 @@
+import * as assert from 'node:assert/strict';
+import { suite, test } from 'mocha';
+import type { GitRemote } from '@gitlens/git/models/remote.js';
+import { createFakeRuntime } from '../../__tests__/fakeRuntime.js';
+import { GitCloudHostIntegrationId } from '../../constants.js';
+import { createIntegrationManager } from '../../index.js';
+
+async function seedBitbucketPrimaryConnection(runtime: ReturnType<typeof createFakeRuntime>) {
+	await runtime.storage.store('integrations:configured', {
+		bitbucket: [
+			{ id: 'bb-primary', cloud: true, integrationId: 'bitbucket', scopes: 'pullrequest:read', primary: true },
+		],
+	});
+	await runtime.storage.storeSecret(
+		'integration.auth.cloud:bitbucket|bb-primary',
+		JSON.stringify({
+			id: 'bb-primary',
+			accessToken: 'token-primary',
+			scopes: ['pullrequest:read'],
+			cloud: true,
+			type: 'oauth',
+			domain: 'bitbucket.org',
+		}),
+	);
+}
+
+type CapturingProvider = Record<string, (input: unknown, options?: { token?: string }) => Promise<unknown>>;
+
+suite('Bitbucket my pull requests search (#5530)', () => {
+	test('default sweep returns authored PRs only and skips the reviewer fan-out', async () => {
+		const runtime = createFakeRuntime();
+		await seedBitbucketPrimaryConnection(runtime);
+
+		let openRemotesCalls = 0;
+		runtime.repositories.getOpenRemotes = async () => {
+			openRemotesCalls++;
+			return [{ path: 'octo/repo', provider: { owner: 'octo', repoName: 'repo' } } as unknown as GitRemote];
+		};
+
+		const manager = createIntegrationManager(runtime);
+		const bb = await manager.get(GitCloudHostIntegrationId.Bitbucket);
+		(
+			bb as unknown as { authenticationService: { getByRemote: (remote: GitRemote) => Promise<unknown> } }
+		).authenticationService.getByRemote = async () => bb;
+
+		const api = await (
+			bb as unknown as { getProvidersApi(): Promise<{ providers: Record<string, unknown> }> }
+		).getProvidersApi();
+		const provider = api.providers.bitbucket as CapturingProvider;
+
+		let authoredCalls = 0;
+		let reviewerCalls = 0;
+		provider.getCurrentUserFn = () => Promise.resolve({ data: { id: 'acc-uuid', username: 'octo' } });
+		provider.getBitbucketResourcesForCurrentUserFn = () => Promise.resolve({ data: [{ slug: 'workspace' }] });
+		provider.getBitbucketPullRequestsAuthoredByUserForWorkspaceFn = () => {
+			authoredCalls++;
+			return Promise.resolve({ data: [], pageInfo: { hasNextPage: false, nextPage: null } });
+		};
+		provider.getPullRequestsForReposFn = () => {
+			reviewerCalls++;
+			return Promise.resolve({ data: [], pageInfo: undefined });
+		};
+
+		const result = await manager.getMyPullRequests([GitCloudHostIntegrationId.Bitbucket]);
+
+		assert.deepEqual(result?.value, [], 'empty authored results still resolve cleanly');
+		assert.equal(authoredCalls, 1, 'authored workspace read still runs');
+		assert.equal(reviewerCalls, 0, 'reviewer repo fan-out is skipped by default');
+		assert.equal(openRemotesCalls, 0, 'default sweep avoids enumerating open remotes');
+
+		manager.dispose();
+	});
+
+	test('opt-in reviewer sweep fans out across open remotes with the reviewer BBQL clause', async () => {
+		const runtime = createFakeRuntime();
+		await seedBitbucketPrimaryConnection(runtime);
+
+		let openRemotesCalls = 0;
+		runtime.repositories.getOpenRemotes = async () => {
+			openRemotesCalls++;
+			return [{ path: 'octo/repo', provider: { owner: 'octo', repoName: 'repo' } } as unknown as GitRemote];
+		};
+
+		const manager = createIntegrationManager(runtime);
+		const bb = await manager.get(GitCloudHostIntegrationId.Bitbucket);
+		(
+			bb as unknown as { authenticationService: { getByRemote: (remote: GitRemote) => Promise<unknown> } }
+		).authenticationService.getByRemote = async () => bb;
+
+		const api = await (
+			bb as unknown as { getProvidersApi(): Promise<{ providers: Record<string, unknown> }> }
+		).getProvidersApi();
+		const provider = api.providers.bitbucket as CapturingProvider;
+
+		let reviewerInput: Record<string, unknown> | undefined;
+		provider.getCurrentUserFn = () => Promise.resolve({ data: { id: 'acc-uuid', username: 'octo' } });
+		provider.getBitbucketResourcesForCurrentUserFn = () => Promise.resolve({ data: [{ slug: 'workspace' }] });
+		provider.getBitbucketPullRequestsAuthoredByUserForWorkspaceFn = () =>
+			Promise.resolve({ data: [], pageInfo: { hasNextPage: false, nextPage: null } });
+		provider.getPullRequestsForReposFn = input => {
+			reviewerInput = input as Record<string, unknown>;
+			return Promise.resolve({ data: [], pageInfo: undefined });
+		};
+
+		await manager.getMyPullRequests([GitCloudHostIntegrationId.Bitbucket], undefined, undefined, {
+			includeReviewRequested: true,
+		});
+
+		assert.equal(openRemotesCalls, 1, 'opt-in reviewer sweep enumerates open remotes once');
+		assert.deepEqual(reviewerInput?.repos, [{ namespace: 'octo', name: 'repo' }]);
+		assert.equal(reviewerInput?.query, 'state="OPEN" AND reviewers.uuid="acc-uuid"');
+
+		manager.dispose();
+	});
+});

--- a/packages/plus/integrations/src/providers/azureDevOps.ts
+++ b/packages/plus/integrations/src/providers/azureDevOps.ts
@@ -25,6 +25,7 @@ import { toTokenWithInfo } from '../authentication/models.js';
 import { GitCloudHostIntegrationId, GitSelfManagedHostIntegrationId } from '../constants.js';
 import type { IntegrationServiceContext } from '../context.js';
 import type { IntegrationConnectionChangeEvent } from '../integrationService.js';
+import type { SearchMyPullRequestsOptions } from '../models/gitHostIntegration.js';
 import { GitHostIntegration } from '../models/gitHostIntegration.js';
 import type { AccountWideIssuesResult, IntegrationKey } from '../models/integration.js';
 import { toCollectionScopeFailure } from '../results.js';
@@ -617,6 +618,7 @@ export abstract class AzureDevOpsIntegrationBase<
 		_cancellation?: AbortSignal,
 		_silent?: boolean,
 		state?: PullRequestStateFilter,
+		_options?: SearchMyPullRequestsOptions,
 	): Promise<PullRequest[] | undefined> {
 		const api = await this.getProvidersApi();
 		if (repos != null) {

--- a/packages/plus/integrations/src/providers/bitbucket-server.ts
+++ b/packages/plus/integrations/src/providers/bitbucket-server.ts
@@ -25,6 +25,7 @@ import { toTokenWithInfo } from '../authentication/models.js';
 import { GitSelfManagedHostIntegrationId } from '../constants.js';
 import type { IntegrationServiceContext } from '../context.js';
 import type { IntegrationConnectionChangeEvent } from '../integrationService.js';
+import type { SearchMyPullRequestsOptions } from '../models/gitHostIntegration.js';
 import { GitHostIntegration } from '../models/gitHostIntegration.js';
 import type { IntegrationKey } from '../models/integration.js';
 import type { BitbucketRepositoryDescriptor } from './bitbucket/models.js';
@@ -250,6 +251,7 @@ export class BitbucketServerIntegration extends GitHostIntegration<
 		_cancellation?: AbortSignal,
 		_silent?: boolean,
 		state?: PullRequestStateFilter,
+		_options?: SearchMyPullRequestsOptions,
 	): Promise<PullRequest[] | undefined> {
 		if (repos != null) {
 			// TODO: implement repos version

--- a/packages/plus/integrations/src/providers/bitbucket.ts
+++ b/packages/plus/integrations/src/providers/bitbucket.ts
@@ -22,6 +22,7 @@ import type {
 } from '../authentication/models.js';
 import { toTokenWithInfo } from '../authentication/models.js';
 import { GitCloudHostIntegrationId } from '../constants.js';
+import type { SearchMyPullRequestsOptions } from '../models/gitHostIntegration.js';
 import { GitHostIntegration } from '../models/gitHostIntegration.js';
 import { toCollectionScopeFailure } from '../results.js';
 import type { BitbucketRepositoryDescriptor, BitbucketWorkspaceDescriptor } from './bitbucket/models.js';
@@ -304,6 +305,7 @@ export class BitbucketIntegration extends GitHostIntegration<
 		_cancellation?: AbortSignal,
 		_silent?: boolean,
 		state?: PullRequestStateFilter,
+		options?: SearchMyPullRequestsOptions,
 	): Promise<PullRequest[] | undefined> {
 		if (repos != null) {
 			// TODO: implement repos version
@@ -311,22 +313,11 @@ export class BitbucketIntegration extends GitHostIntegration<
 		}
 
 		const states = toProviderPullRequestStates(state);
-		// Bitbucket's reviewing PRs use a raw BBQL query; map the requested state to its state clause.
-		const stateClause =
-			state === 'closed'
-				? '(state="DECLINED" OR state="SUPERSEDED")'
-				: state === 'merged'
-					? 'state="MERGED"'
-					: state === 'all'
-						? undefined
-						: 'state="OPEN"';
 
 		const api = await this.getProvidersApi();
 		if (!api) {
 			return undefined;
 		}
-
-		const workspaceRepos = await this.getWorkspaceRepoInputs();
 
 		const user = await this.getProviderCurrentAccount(session);
 		if (user?.username == null) return undefined;
@@ -346,6 +337,38 @@ export class BitbucketIntegration extends GitHostIntegration<
 			);
 			return prs?.data.map(pr => fromProviderPullRequest(pr, this));
 		});
+
+		if (!options?.includeReviewRequested) {
+			return [
+				...uniqueBy(
+					await flatSettled(authoredPrs),
+					pr => pr.url,
+					(orig, _cur) => orig,
+				),
+			];
+		}
+
+		// Bitbucket's reviewing PRs require a repo-scoped BBQL query; keep that sweep opt-in so the default
+		// "my pull requests" feed stays aligned with backends that only expose authored PRs.
+		const stateClause =
+			state === 'closed'
+				? '(state="DECLINED" OR state="SUPERSEDED")'
+				: state === 'merged'
+					? 'state="MERGED"'
+					: state === 'all'
+						? undefined
+						: 'state="OPEN"';
+
+		const workspaceRepos = await this.getWorkspaceRepoInputs();
+		if (workspaceRepos.length === 0) {
+			return [
+				...uniqueBy(
+					await flatSettled(authoredPrs),
+					pr => pr.url,
+					(orig, _cur) => orig,
+				),
+			];
+		}
 
 		const reviewerClause = `reviewers.uuid="${user.id}"`;
 		const reviewingPrs = api

--- a/packages/plus/integrations/src/providers/bitbucket.ts
+++ b/packages/plus/integrations/src/providers/bitbucket.ts
@@ -320,7 +320,9 @@ export class BitbucketIntegration extends GitHostIntegration<
 		}
 
 		const user = await this.getProviderCurrentAccount(session);
-		if (user?.username == null) return undefined;
+		// `user.id` feeds both the authored workspace reads and the reviewer BBQL clause; guard on it so we
+		// never issue requests/queries with an undefined uuid. `username` isn't used here, so don't gate on it.
+		if (user?.id == null) return undefined;
 
 		const workspacesResult = await this.getProviderResourcesForCurrentUser(session);
 		if (workspacesResult == null) return undefined;

--- a/packages/plus/integrations/src/providers/github.ts
+++ b/packages/plus/integrations/src/providers/github.ts
@@ -20,6 +20,7 @@ import { toTokenWithInfo } from '../authentication/models.js';
 import { GitCloudHostIntegrationId, GitSelfManagedHostIntegrationId } from '../constants.js';
 import type { IntegrationServiceContext } from '../context.js';
 import type { IntegrationConnectionChangeEvent } from '../integrationService.js';
+import type { SearchMyPullRequestsOptions } from '../models/gitHostIntegration.js';
 import { GitHostIntegration } from '../models/gitHostIntegration.js';
 import type { GitHubIntegrationIds } from './github/github.utils.js';
 import { getGitHubPullRequestIdentityFromMaybeUrl } from './github/github.utils.js';
@@ -293,6 +294,7 @@ abstract class GitHubIntegrationBase<ID extends GitHubIntegrationIds> extends Gi
 		cancellation?: AbortSignal,
 		silent?: boolean,
 		state?: PullRequestStateFilter,
+		_options?: SearchMyPullRequestsOptions,
 	): Promise<PullRequest[] | undefined> {
 		return (await this.authenticationService.apis.github)?.searchMyPullRequests(
 			this,

--- a/packages/plus/integrations/src/providers/gitlab.ts
+++ b/packages/plus/integrations/src/providers/gitlab.ts
@@ -21,6 +21,7 @@ import { toTokenWithInfo } from '../authentication/models.js';
 import { GitCloudHostIntegrationId, GitSelfManagedHostIntegrationId } from '../constants.js';
 import type { IntegrationServiceContext } from '../context.js';
 import type { IntegrationConnectionChangeEvent } from '../integrationService.js';
+import type { SearchMyPullRequestsOptions } from '../models/gitHostIntegration.js';
 import { GitHostIntegration } from '../models/gitHostIntegration.js';
 import type { GitLabIntegrationIds } from './gitlab/gitlab.utils.js';
 import { getGitLabPullRequestIdentityFromMaybeUrl, matchesGitLabOrgNamespace } from './gitlab/gitlab.utils.js';
@@ -313,6 +314,7 @@ abstract class GitLabIntegrationBase<ID extends GitLabIntegrationIds> extends Gi
 		_cancellation?: AbortSignal,
 		_silent?: boolean,
 		state?: PullRequestStateFilter,
+		_options?: SearchMyPullRequestsOptions,
 	): Promise<PullRequest[] | undefined> {
 		const api = await this.getProvidersApi();
 		// Resolve the username from THIS session's token (multi-account: `session` may be a non-primary


### PR DESCRIPTION
Closes #5530.

Bitbucket's account-wide "my pull requests" path was fanning out to every open remote to also fetch review-requested PRs, making it a superset of the gkcli baseline and other backends that only expose authored PRs. This change makes that reviewer sweep opt-in via `includeReviewRequested?: boolean` on `SearchMyPullRequestsOptions` so the default feed stays aligned across providers.

- Adds `SearchMyPullRequestsOptions` with `includeReviewRequested`.
- Threads the option through `IntegrationService.getMyPullRequests` and `GitHostIntegration.searchMyPullRequests`.
- Bitbucket Cloud now only runs the repo-scoped reviewer BBQL sweep when the flag is explicitly `true`; authored PRs are still always returned.
- Keeps `getMyPullRequestsForRemotes` unchanged (it does not expose the new flag) because the repo-scoped Bitbucket path is not yet implemented there.
- Adds `bitbucketMyPullRequests.test.ts` covering default (author-only) and opt-in reviewer behavior.

### Verification
- `pnpm --filter @gitlens/integrations build` passes.
- `pnpm --filter @gitlens/integrations test` passes (311 passing).
