### PR TITLE
Fixes per-connection git-host identity reads (#5531)

### DIFF
--- a/packages/plus/integrations/scripts/test.mjs
+++ b/packages/plus/integrations/scripts/test.mjs
@@ -51,3 +51,7 @@ execFileSync(pnpm, ['--filter', '@gitlens/integrations-consumer-fixture', 'test'
 	stdio: 'inherit',
 	cwd: workspaceRoot,
 });
+
+// Smoke-test the published ESM facade directly under Node too. Bundled tests/fixtures can mask CommonJS named
+// export regressions in transitive deps, but direct consumers of the package import the built entrypoint.
+await import(new URL('../dist/lite.js', import.meta.url));

--- a/packages/plus/integrations/scripts/test.mjs
+++ b/packages/plus/integrations/scripts/test.mjs
@@ -52,6 +52,13 @@ execFileSync(pnpm, ['--filter', '@gitlens/integrations-consumer-fixture', 'test'
 	cwd: workspaceRoot,
 });
 
+// Build the package before importing the published facade so the smoke test validates the current sources,
+// not a stale or missing dist/ directory from a prior run.
+execFileSync(pnpm, ['build'], {
+	stdio: 'inherit',
+	cwd: packageRoot,
+});
+
 // Smoke-test the published ESM facade directly under Node too. Bundled tests/fixtures can mask CommonJS named
 // export regressions in transitive deps, but direct consumers of the package import the built entrypoint.
 await import(new URL('../dist/lite.js', import.meta.url));

--- a/packages/plus/integrations/src/__tests__/fakeRuntime.ts
+++ b/packages/plus/integrations/src/__tests__/fakeRuntime.ts
@@ -126,9 +126,8 @@ export function createFakeRuntime(): FakeRuntime {
 		getIssueOrPullRequest: undefined as never,
 		getIssue: (id, resource, integration, cacheable) => {
 			const key = `${integration?.id ?? 'none'}:${integration?.domain ?? 'none'}:${id}:${JSON.stringify(resource)}`;
-			const cached = issueCache.get(key);
-			if (cached != null) {
-				return cached as ReturnType<typeof cacheable>['value'];
+			if (issueCache.has(key)) {
+				return issueCache.get(key) as ReturnType<typeof cacheable>['value'];
 			}
 
 			const entry = cacheable({ invalidate: () => issueCache.delete(key) } as never).value;

--- a/packages/plus/integrations/src/__tests__/fakeRuntime.ts
+++ b/packages/plus/integrations/src/__tests__/fakeRuntime.ts
@@ -52,6 +52,7 @@ export function createFakeRuntime(): FakeRuntime {
 	const storage = new Map<string, unknown>();
 	const workspaceStorage = new Map<string, unknown>();
 	const secrets = new Map<string, string>();
+	const issueCache = new Map<string, unknown>();
 	const currentAccountCache = new Map<string, { etag: string | undefined; value: unknown }>();
 
 	const storageProvider: IntegrationStorageProvider = {
@@ -123,14 +124,24 @@ export function createFakeRuntime(): FakeRuntime {
 			throw new Error('FakeRuntime.cache.getPullRequest: not implemented in test');
 		},
 		getIssueOrPullRequest: undefined as never,
-		getIssue: () => {
-			throw new Error('FakeRuntime.cache.getIssue: not implemented in test');
+		getIssue: (id, resource, integration, cacheable) => {
+			const key = `${integration?.id ?? 'none'}:${integration?.domain ?? 'none'}:${id}:${JSON.stringify(resource)}`;
+			const cached = issueCache.get(key);
+			if (cached != null) {
+				return cached as ReturnType<typeof cacheable>['value'];
+			}
+
+			const entry = cacheable({ invalidate: () => issueCache.delete(key) } as never).value;
+			issueCache.set(key, entry);
+			void Promise.resolve(entry).catch(() => issueCache.delete(key));
+			return entry;
 		},
 		getCurrentAccount: (integration, cacheable, options) => {
 			const key = `${integration.id}:${integration.domain}:${options?.connectionId ?? ''}`;
 			const cached = currentAccountCache.get(key);
-			if (cached != null && cached.etag === options?.etag)
+			if (cached != null && cached.etag === options?.etag) {
 				return cached.value as ReturnType<typeof cacheable>['value'];
+			}
 
 			const entry = cacheable({ invalidate: () => currentAccountCache.delete(key) } as never).value;
 			currentAccountCache.set(key, { etag: options?.etag, value: entry });

--- a/packages/plus/integrations/src/__tests__/fakeRuntime.ts
+++ b/packages/plus/integrations/src/__tests__/fakeRuntime.ts
@@ -52,6 +52,7 @@ export function createFakeRuntime(): FakeRuntime {
 	const storage = new Map<string, unknown>();
 	const workspaceStorage = new Map<string, unknown>();
 	const secrets = new Map<string, string>();
+	const currentAccountCache = new Map<string, { etag: string | undefined; value: unknown }>();
 
 	const storageProvider: IntegrationStorageProvider = {
 		get: <T>(key: string) => storage.get(key) as T | undefined,
@@ -125,8 +126,16 @@ export function createFakeRuntime(): FakeRuntime {
 		getIssue: () => {
 			throw new Error('FakeRuntime.cache.getIssue: not implemented in test');
 		},
-		getCurrentAccount: () => {
-			throw new Error('FakeRuntime.cache.getCurrentAccount: not implemented in test');
+		getCurrentAccount: (integration, cacheable, options) => {
+			const key = `${integration.id}:${integration.domain}:${options?.connectionId ?? ''}`;
+			const cached = currentAccountCache.get(key);
+			if (cached != null && cached.etag === options?.etag)
+				return cached.value as ReturnType<typeof cacheable>['value'];
+
+			const entry = cacheable({ invalidate: () => currentAccountCache.delete(key) } as never).value;
+			currentAccountCache.set(key, { etag: options?.etag, value: entry });
+			void Promise.resolve(entry).catch(() => currentAccountCache.delete(key));
+			return entry;
 		},
 	};
 

--- a/packages/plus/integrations/src/__tests__/perConnectionReads.test.ts
+++ b/packages/plus/integrations/src/__tests__/perConnectionReads.test.ts
@@ -4,7 +4,7 @@ import type { Account } from '@gitlens/git/models/author.js';
 import type { IssueShape } from '@gitlens/git/models/issue.js';
 import type { PullRequest } from '@gitlens/git/models/pullRequest.js';
 import type { ProviderAuthenticationSession } from '../authentication/models.js';
-import { GitCloudHostIntegrationId } from '../constants.js';
+import { GitCloudHostIntegrationId, GitSelfManagedHostIntegrationId } from '../constants.js';
 import { createIntegrationManager } from '../index.js';
 import { createFakeRuntime } from './fakeRuntime.js';
 
@@ -27,7 +27,190 @@ async function seedConnectionSecret(runtime: ReturnType<typeof createFakeRuntime
 	);
 }
 
+async function seedPrimaryConnection(runtime: ReturnType<typeof createFakeRuntime>, tokenId: string, token: string) {
+	await runtime.storage.store('integrations:configured', {
+		github: [{ id: tokenId, cloud: true, integrationId: 'github', scopes: 'repo', primary: true }],
+	});
+	await seedConnectionSecret(runtime, tokenId, token);
+}
+
 suite('per-connection reads (#5430)', () => {
+	test('getCurrentAccount reads with the specified connection token and caches per connection', async () => {
+		const runtime = createFakeRuntime();
+		await seedPrimaryConnection(runtime, 'primary-tok', 'token-primary');
+		await seedConnectionSecret(runtime, 'sec-tok', 'token-secondary');
+		const manager = createIntegrationManager(runtime);
+		const gh = await manager.get(GitCloudHostIntegrationId.GitHub);
+
+		const lookups: string[] = [];
+		(
+			gh as unknown as {
+				getProviderCurrentAccount: (session: ProviderAuthenticationSession) => Promise<Account | undefined>;
+			}
+		).getProviderCurrentAccount = session => {
+			lookups.push(session.accessToken);
+			return Promise.resolve({ id: session.accessToken, username: session.accessToken } as Account);
+		};
+
+		const primary = await gh.getCurrentAccount();
+		const secondary = await gh.getCurrentAccount({ connectionId: 'sec-tok' });
+		const primaryAgain = await gh.getCurrentAccount();
+
+		assert.equal(primary?.username, 'token-primary', 'primary lookup uses the primary session');
+		assert.equal(secondary?.username, 'token-secondary', 'secondary lookup uses the specified connection');
+		assert.equal(primaryAgain?.username, 'token-primary', 'primary cache remains distinct after a secondary read');
+		assert.deepEqual(
+			lookups,
+			['token-primary', 'token-secondary'],
+			'provider lookups are cached separately for the primary and requested connection',
+		);
+
+		manager.dispose();
+	});
+
+	test('getCurrentAccount invalidates a cached secondary identity when that connection token changes', async () => {
+		const runtime = createFakeRuntime();
+		await seedConnectionSecret(runtime, 'sec-tok', 'token-secondary-1');
+		const manager = createIntegrationManager(runtime);
+		const gh = await manager.get(GitCloudHostIntegrationId.GitHub);
+
+		const lookups: string[] = [];
+		(
+			gh as unknown as {
+				getProviderCurrentAccount: (session: ProviderAuthenticationSession) => Promise<Account | undefined>;
+			}
+		).getProviderCurrentAccount = session => {
+			lookups.push(session.accessToken);
+			return Promise.resolve({ id: session.accessToken, username: session.accessToken } as Account);
+		};
+
+		const first = await gh.getCurrentAccount({ connectionId: 'sec-tok' });
+		await seedConnectionSecret(runtime, 'sec-tok', 'token-secondary-2');
+		const second = await gh.getCurrentAccount({ connectionId: 'sec-tok' });
+
+		assert.equal(first?.username, 'token-secondary-1');
+		assert.equal(second?.username, 'token-secondary-2');
+		assert.deepEqual(
+			lookups,
+			['token-secondary-1', 'token-secondary-2'],
+			'the same connection id refetches after its session token changes',
+		);
+
+		manager.dispose();
+	});
+
+	test('getMyCurrentAccounts threads connectionId to the account lookup', async () => {
+		const runtime = createFakeRuntime();
+		await seedConnectionSecret(runtime, 'sec-tok', 'token-secondary');
+		const manager = createIntegrationManager(runtime);
+		const gh = await manager.get(GitCloudHostIntegrationId.GitHub);
+
+		let capturedToken: string | undefined;
+		(
+			gh as unknown as {
+				getProviderCurrentAccount: (session: ProviderAuthenticationSession) => Promise<Account | undefined>;
+			}
+		).getProviderCurrentAccount = session => {
+			capturedToken = session.accessToken;
+			return Promise.resolve({ id: 'me', username: 'secondary-user' } as Account);
+		};
+
+		const accounts = await manager.getMyCurrentAccounts([GitCloudHostIntegrationId.GitHub], 'sec-tok');
+
+		assert.equal(
+			capturedToken,
+			'token-secondary',
+			'service routed the account lookup through the requested connection',
+		);
+		assert.equal(
+			accounts.get(GitCloudHostIntegrationId.GitHub)?.username,
+			'secondary-user',
+			'service returns the requested connection account',
+		);
+
+		manager.dispose();
+	});
+
+	test('getMyCurrentAccounts resolves the self-managed host for the requested connection', async () => {
+		const runtime = createFakeRuntime();
+		await runtime.storage.store('integrations:configured', {
+			[GitSelfManagedHostIntegrationId.CloudGitHubEnterprise]: [
+				{
+					id: 'ghe-a1',
+					cloud: true,
+					integrationId: GitSelfManagedHostIntegrationId.CloudGitHubEnterprise,
+					domain: 'ghe-a.example.com',
+					scopes: 'repo',
+					primary: true,
+				},
+				{
+					id: 'ghe-b1',
+					cloud: true,
+					integrationId: GitSelfManagedHostIntegrationId.CloudGitHubEnterprise,
+					domain: 'ghe-b.example.com',
+					scopes: 'repo',
+					primary: true,
+				},
+			],
+		});
+		await runtime.storage.storeSecret(
+			'integration.auth.cloud:cloud-github-enterprise|ghe-a1',
+			JSON.stringify({
+				id: 'ghe-a1',
+				accessToken: 'token-a',
+				scopes: ['repo'],
+				cloud: true,
+				type: 'oauth',
+				domain: 'ghe-a.example.com',
+			}),
+		);
+		await runtime.storage.storeSecret(
+			'integration.auth.cloud:cloud-github-enterprise|ghe-b1',
+			JSON.stringify({
+				id: 'ghe-b1',
+				accessToken: 'token-b',
+				scopes: ['repo'],
+				cloud: true,
+				type: 'oauth',
+				domain: 'ghe-b.example.com',
+			}),
+		);
+
+		const manager = createIntegrationManager(runtime);
+		const gheA = await manager.get(GitSelfManagedHostIntegrationId.CloudGitHubEnterprise, 'ghe-a.example.com');
+		const gheB = await manager.get(GitSelfManagedHostIntegrationId.CloudGitHubEnterprise, 'ghe-b.example.com');
+
+		const lookups: Array<{ domain: string; token: string }> = [];
+		for (const integration of [gheA, gheB]) {
+			(
+				integration as unknown as {
+					domain: string;
+					getProviderCurrentAccount: (session: ProviderAuthenticationSession) => Promise<Account | undefined>;
+				}
+			).getProviderCurrentAccount = session => {
+				lookups.push({
+					domain: (integration as unknown as { domain: string }).domain,
+					token: session.accessToken,
+				});
+				return Promise.resolve({ id: session.accessToken, username: session.accessToken } as Account);
+			};
+		}
+
+		const accounts = await manager.getMyCurrentAccounts(
+			[GitSelfManagedHostIntegrationId.CloudGitHubEnterprise],
+			'ghe-b1',
+		);
+
+		assert.deepEqual(lookups, [{ domain: 'ghe-b.example.com', token: 'token-b' }]);
+		assert.equal(
+			accounts.get(GitSelfManagedHostIntegrationId.CloudGitHubEnterprise)?.username,
+			'token-b',
+			'the requested self-managed connection account is returned',
+		);
+
+		manager.dispose();
+	});
+
 	test('searchMyIssues reads with the specified connection token, not the primary', async () => {
 		const runtime = createFakeRuntime();
 		await seedConnectionSecret(runtime, 'sec-tok', 'token-secondary');

--- a/packages/plus/integrations/src/__tests__/trello.test.ts
+++ b/packages/plus/integrations/src/__tests__/trello.test.ts
@@ -151,6 +151,43 @@ suite('Trello integration (#5438)', () => {
 		manager.dispose();
 	});
 
+	test('branch-associated Trello issues resolve through the real integration read', async () => {
+		const manager = createIntegrationManager(createFakeRuntime());
+		const trello = await manager.get(IssuesCloudHostIntegrationId.Trello);
+		(trello as unknown as { _session: ProviderAuthenticationSession })._session = trelloSession('my-app-key');
+
+		let boardReads = 0;
+		stubApi(trello, {
+			getTrelloListsForBoard: () => Promise.resolve([{ id: 'l1', name: 'To Do' }]),
+			getTrelloIssuesForBoard: () => {
+				boardReads++;
+				return Promise.resolve({ values: [fakeIssue()], metadata: { completeness: 'complete' } });
+			},
+		});
+
+		const issue = (await trello.getIssuesForProject({ key: 'b1', id: 'b1', name: 'Board 1' }))?.[0];
+		assert.ok(issue != null, 'a Trello issue was mapped');
+		if (issue == null) throw new Error('Expected a Trello issue');
+
+		const owner = getIssueOwner(issue);
+		assert.ok(owner != null, 'a Trello board owner descriptor can be derived');
+		if (owner == null) throw new Error('Expected a Trello owner descriptor');
+
+		const identifier = encodeIssueOrPullRequestForGitConfig({ ...issue, type: 'issue' } satisfies Issue, owner);
+		const resolved = await getIssueFromGitConfigEntityIdentifier(id => manager.get(id), identifier);
+
+		assert.equal(boardReads, 2, 'the identifier resolution performs a real board read on cache miss');
+		assert.equal(resolved?.id, '1');
+		assert.deepEqual(resolved?.project, {
+			id: 'b1',
+			name: 'Board 1',
+			resourceId: 'b1',
+			resourceName: 'Board 1',
+		});
+
+		manager.dispose();
+	});
+
 	test('a complete board result reports no truncation (#5438)', async () => {
 		const manager = createIntegrationManager(createFakeRuntime());
 		const trello = await manager.get(IssuesCloudHostIntegrationId.Trello);

--- a/packages/plus/integrations/src/__tests__/trello.test.ts
+++ b/packages/plus/integrations/src/__tests__/trello.test.ts
@@ -1,10 +1,16 @@
 import * as assert from 'node:assert/strict';
 import { suite, test } from 'mocha';
+import type { Issue } from '@gitlens/git/models/issue.js';
 import type { ProviderAuthenticationSession } from '../authentication/models.js';
 import { IssuesCloudHostIntegrationId } from '../constants.js';
 import { createIntegrationManager } from '../index.js';
 import type { IssuesIntegration } from '../models/issuesIntegration.js';
 import type { ProviderIssue } from '../providers/models.js';
+import {
+	encodeIssueOrPullRequestForGitConfig,
+	getIssueFromGitConfigEntityIdentifier,
+	getIssueOwner,
+} from '../providers/utils.js';
 import { createFakeRuntime } from './fakeRuntime.js';
 
 /**
@@ -88,6 +94,59 @@ suite('Trello integration (#5438)', () => {
 		assert.equal(issues?.length, 1, 'the board issues are mapped to issue shapes');
 		assert.equal(capturedBoardId, 'b1');
 		assert.equal(capturedAppKey, 'my-app-key');
+		assert.deepEqual(issues?.[0]?.project, {
+			id: 'b1',
+			name: 'Board 1',
+			resourceId: 'b1',
+			resourceName: 'Board 1',
+		});
+
+		manager.dispose();
+	});
+
+	test('Trello issues round-trip through branch association metadata', async () => {
+		const manager = createIntegrationManager(createFakeRuntime());
+		const trello = await manager.get(IssuesCloudHostIntegrationId.Trello);
+		(trello as unknown as { _session: ProviderAuthenticationSession })._session = trelloSession('my-app-key');
+
+		stubApi(trello, {
+			getTrelloListsForBoard: () => Promise.resolve([{ id: 'l1', name: 'To Do' }]),
+			getTrelloIssuesForBoard: () =>
+				Promise.resolve({ values: [fakeIssue()], metadata: { completeness: 'complete' } }),
+		});
+
+		const issue = (await trello.getIssuesForProject({ key: 'b1', id: 'b1', name: 'Board 1' }))?.[0];
+		assert.ok(issue != null, 'a Trello issue was mapped');
+		if (issue == null) throw new Error('Expected a Trello issue');
+
+		const owner = getIssueOwner(issue);
+		assert.ok(owner != null, 'a Trello board owner descriptor can be derived');
+		if (owner == null) throw new Error('Expected a Trello owner descriptor');
+
+		const issueWithType = { ...issue, type: 'issue' } satisfies Issue;
+
+		const identifier = encodeIssueOrPullRequestForGitConfig(issueWithType, owner);
+		let captured: { resource: { id?: string; key: string; owner?: string; name?: string }; id: string } | undefined;
+
+		const resolved = await getIssueFromGitConfigEntityIdentifier(
+			async () => ({
+				getIssue: async (resource, id) => {
+					captured = {
+						resource: resource as { id?: string; key: string; owner?: string; name?: string },
+						id: id,
+					};
+					return issueWithType;
+				},
+			}),
+			identifier,
+		);
+
+		assert.equal(identifier.provider, 'trello');
+		assert.deepEqual(captured, {
+			resource: { id: 'b1', key: 'b1', owner: undefined, name: 'Board 1' },
+			id: '1',
+		});
+		assert.equal(resolved?.id, '1');
 
 		manager.dispose();
 	});

--- a/packages/plus/integrations/src/context.ts
+++ b/packages/plus/integrations/src/context.ts
@@ -155,7 +155,7 @@ export interface IntegrationCacheProvider {
 	getCurrentAccount(
 		integration: IntegrationBase,
 		cacheable: Cacheable<Account>,
-		options?: CacheExpiryOptions,
+		options?: CacheExpiryOptions & { connectionId?: string; etag?: string },
 	): CacheResult<Account>;
 }
 

--- a/packages/plus/integrations/src/integrationService.ts
+++ b/packages/plus/integrations/src/integrationService.ts
@@ -648,18 +648,22 @@ export class IntegrationService implements Disposable {
 	}
 
 	@debug({
-		args: integrationIds => ({ integrationIds: integrationIds?.length ? integrationIds.join(',') : '<undefined>' }),
+		args: (integrationIds, connectionId) => ({
+			integrationIds: integrationIds?.length ? integrationIds.join(',') : '<undefined>',
+			connectionId: connectionId ?? '<primary>',
+		}),
 	})
 	async getMyCurrentAccounts(
 		integrationIds: (GitCloudHostIntegrationId | CloudGitSelfManagedHostIntegrationIds)[],
+		connectionId?: string,
 	): Promise<Map<GitCloudHostIntegrationId | CloudGitSelfManagedHostIntegrationIds, Account>> {
 		const accounts = new Map<GitCloudHostIntegrationId | CloudGitSelfManagedHostIntegrationIds, Account>();
 		await Promise.allSettled(
 			integrationIds.map(async integrationId => {
-				const integration = await this.get(integrationId);
+				const integration = await this.getIntegrationForRead(integrationId, connectionId);
 				if (integration == null) return;
 
-				const account = await integration.getCurrentAccount();
+				const account = await integration.getCurrentAccount({ connectionId: connectionId });
 				if (account) {
 					accounts.set(integrationId, account);
 				}

--- a/packages/plus/integrations/src/models/integration.ts
+++ b/packages/plus/integrations/src/models/integration.ts
@@ -146,9 +146,13 @@ export abstract class IntegrationBase<
 		if (this._session == null) return undefined;
 
 		if (this._sessionFingerprint?.session !== this._session) {
-			this._sessionFingerprint = { session: this._session, hash: fnv1aHash64(this._session.accessToken) };
+			this._sessionFingerprint = { session: this._session, hash: this.getSessionFingerprint(this._session) };
 		}
 		return this._sessionFingerprint.hash;
+	}
+
+	protected getSessionFingerprint(session: ProviderAuthenticationSession): string {
+		return fnv1aHash64(session.accessToken);
 	}
 
 	get connectionExpired(): boolean | undefined {
@@ -740,16 +744,16 @@ export abstract class IntegrationBase<
 
 	async getCurrentAccount(options?: {
 		avatarSize?: number;
+		connectionId?: string;
 		expiryOverride?: boolean | number;
 	}): Promise<Account | undefined> {
 		const scope = getScopedLogger();
+		const { connectionId: requestedConnectionId, expiryOverride, ...opts } = options ?? {};
+		const connectionId = requestedConnectionId || undefined;
+		const session = await this.resolveReadSession(connectionId, scope);
+		if (session == null) return undefined;
 
-		const connected = this.maybeConnected ?? (await this.isConnected());
-		if (!connected) return undefined;
-
-		await this.refreshSessionIfExpired(scope);
-
-		const { expiryOverride, ...opts } = options ?? {};
+		const sessionFingerprint = this.getSessionFingerprint(session);
 
 		const currentAccount = await this.ctx.cache.getCurrentAccount(
 			this,
@@ -757,7 +761,7 @@ export abstract class IntegrationBase<
 			(cacheable: any) => ({
 				value: (async () => {
 					try {
-						const account = await this.getProviderCurrentAccount?.(this._session!, opts);
+						const account = await this.getProviderCurrentAccount?.(session, opts);
 						this.resetRequestExceptionCount('getCurrentAccount');
 						return account;
 					} catch (ex) {
@@ -778,7 +782,12 @@ export abstract class IntegrationBase<
 					}
 				})(),
 			}),
-			{ expiryOverride: expiryOverride, expireOnError: false },
+			{
+				connectionId: connectionId,
+				expiryOverride: expiryOverride,
+				expireOnError: false,
+				etag: `${this.id}:${this.maybeConnected ?? false}:${sessionFingerprint}`,
+			},
 		);
 		return currentAccount;
 	}

--- a/packages/plus/integrations/src/providers/bitbucket-server/models.ts
+++ b/packages/plus/integrations/src/providers/bitbucket-server/models.ts
@@ -1,5 +1,30 @@
-import { GitPullRequestMergeableState, GitPullRequestReviewState, GitPullRequestState } from '@gitkraken/provider-apis';
+import type {
+	GitPullRequestMergeableState as GitPullRequestMergeableStateType,
+	GitPullRequestReviewState as GitPullRequestReviewStateType,
+	GitPullRequestState as GitPullRequestStateType,
+} from '@gitkraken/provider-apis';
 import type { ProviderAccount, ProviderPullRequest } from '../models.js';
+
+type GitPullRequestMergeableState = GitPullRequestMergeableStateType;
+type GitPullRequestReviewState = GitPullRequestReviewStateType;
+type GitPullRequestState = GitPullRequestStateType;
+
+const GitPullRequestState = {
+	Open: 'OPEN' as GitPullRequestState,
+	Closed: 'CLOSED' as GitPullRequestState,
+	Merged: 'MERGED' as GitPullRequestState,
+} as const;
+
+const GitPullRequestReviewState = {
+	Approved: 'APPROVED' as GitPullRequestReviewState,
+	ChangesRequested: 'CHANGES_REQUESTED' as GitPullRequestReviewState,
+	Commented: 'COMMENTED' as GitPullRequestReviewState,
+	ReviewRequested: 'REVIEW_REQUESTED' as GitPullRequestReviewState,
+} as const;
+
+const GitPullRequestMergeableState = {
+	Unknown: 'UNKNOWN' as GitPullRequestMergeableState,
+} as const;
 
 export interface BitbucketServerLink {
 	href: string;

--- a/packages/plus/integrations/src/providers/models.ts
+++ b/packages/plus/integrations/src/providers/models.ts
@@ -13,11 +13,16 @@ import type {
 	CursorPageInput,
 	EnterpriseOptions,
 	GetRepoInput,
+	GitBuildStatusState as GitBuildStatusStateType,
 	GitHub,
+	GitIssueState as GitIssueStateType,
 	GitLab,
 	GitLabGroup,
 	GitMergeStrategy,
 	GitPullRequest,
+	GitPullRequestMergeableState as GitPullRequestMergeableStateType,
+	GitPullRequestReviewState as GitPullRequestReviewStateType,
+	GitPullRequestState as GitPullRequestStateType,
 	GitRepository,
 	GitRepositoryRemoteInfo,
 	Jira,
@@ -36,15 +41,8 @@ import type {
 	SetPullRequestInput,
 	Trello,
 } from '@gitkraken/provider-apis';
-import {
-	GitBuildStatusState,
-	GitIssueState,
-	GitPullRequestMergeableState,
-	GitPullRequestReviewState,
-	GitPullRequestState,
-} from '@gitkraken/provider-apis';
-import { EntityIdentifierUtils } from '@gitkraken/provider-apis/entity-identifiers';
-import { GitProviderUtils } from '@gitkraken/provider-apis/provider-utils';
+import entityIdentifiersModule from '@gitkraken/provider-apis/entity-identifiers';
+import providerUtilsModule from '@gitkraken/provider-apis/provider-utils';
 import type { Account as UserAccount } from '@gitlens/git/models/author.js';
 import type { IssueMember, IssueProject, IssueShape, IssueStateFilter } from '@gitlens/git/models/issue.js';
 import { Issue, RepositoryAccessLevel } from '@gitlens/git/models/issue.js';
@@ -77,6 +75,57 @@ import {
 } from '../constants.js';
 import type { Integration, IntegrationType } from '../models/integration.js';
 import { getEntityIdentifierInput } from './utils.js';
+
+type GitBuildStatusState = GitBuildStatusStateType;
+type GitIssueState = GitIssueStateType;
+type GitPullRequestMergeableState = GitPullRequestMergeableStateType;
+type GitPullRequestReviewState = GitPullRequestReviewStateType;
+type GitPullRequestState = GitPullRequestStateType;
+
+const { EntityIdentifierUtils } = entityIdentifiersModule;
+const { GitProviderUtils } = providerUtilsModule;
+
+const GitBuildStatusState = {
+	ActionRequired: 'ACTION_REQUIRED' as GitBuildStatusState,
+	Cancelled: 'CANCELLED' as GitBuildStatusState,
+	Error: 'ERROR' as GitBuildStatusState,
+	Failed: 'FAILED' as GitBuildStatusState,
+	Pending: 'PENDING' as GitBuildStatusState,
+	Running: 'RUNNING' as GitBuildStatusState,
+	Skipped: 'SKIPPED' as GitBuildStatusState,
+	Success: 'SUCCESS' as GitBuildStatusState,
+	Warning: 'WARNING' as GitBuildStatusState,
+	OptionalActionRequired: 'OPTIONAL_ACTION_REQUIRED' as GitBuildStatusState,
+} as const;
+
+const GitIssueState = {
+	Open: 'OPEN' as GitIssueState,
+	Closed: 'CLOSED' as GitIssueState,
+} as const;
+
+const GitPullRequestState = {
+	Open: 'OPEN' as GitPullRequestState,
+	Closed: 'CLOSED' as GitPullRequestState,
+	Merged: 'MERGED' as GitPullRequestState,
+} as const;
+
+const GitPullRequestReviewState = {
+	Approved: 'APPROVED' as GitPullRequestReviewState,
+	ChangesRequested: 'CHANGES_REQUESTED' as GitPullRequestReviewState,
+	Commented: 'COMMENTED' as GitPullRequestReviewState,
+	ReviewRequested: 'REVIEW_REQUESTED' as GitPullRequestReviewState,
+} as const;
+
+const GitPullRequestMergeableState = {
+	Behind: 'BEHIND' as GitPullRequestMergeableState,
+	Blocked: 'BLOCKED' as GitPullRequestMergeableState,
+	Conflicts: 'CONFLICTS' as GitPullRequestMergeableState,
+	FailingChecks: 'FAILING_CHECKS' as GitPullRequestMergeableState,
+	Mergeable: 'MERGEABLE' as GitPullRequestMergeableState,
+	Unknown: 'UNKNOWN' as GitPullRequestMergeableState,
+	UnknownAndBlocked: 'UNKNOWN_AND_BLOCKED' as GitPullRequestMergeableState,
+	Unstable: 'UNSTABLE' as GitPullRequestMergeableState,
+} as const;
 
 /**
  * Forward-only host type — the package only sets `EnrichablePullRequest.enrichable`

--- a/packages/plus/integrations/src/providers/trello.ts
+++ b/packages/plus/integrations/src/providers/trello.ts
@@ -118,15 +118,22 @@ export class TrelloIntegration extends IssuesIntegration<IssuesCloudHostIntegrat
 			acc[list.id] = { name: list.name };
 			return acc;
 		}, {});
+		const boardProject = {
+			id: project.id,
+			name: project.name,
+			resourceId: project.id,
+			resourceName: project.name,
+		};
 
 		const result = await api.getTrelloIssuesForBoard(tokenWithInfo, appKey, project.id, {
 			assigneeLogins: options?.user != null ? [options.user] : undefined,
 			trelloBoardListsById: trelloBoardListsById,
 		});
 
-		const values = result.values
-			.map(issue => toIssueShape(issue, this))
-			.filter((issue): issue is IssueShape => issue != null);
+		const values = result.values.flatMap(issue => {
+			const mapped = toIssueShape(issue, this);
+			return mapped == null ? [] : [{ ...mapped, project: boardProject } satisfies IssueShape];
+		});
 
 		// Trello's search caps results and reports the cap through `metadata.completeness` (partial/unknown),
 		// never a cursor. Surface that as terminal truncation; there is no next page to fetch, so retrying the

--- a/packages/plus/integrations/src/providers/trello.ts
+++ b/packages/plus/integrations/src/providers/trello.ts
@@ -10,7 +10,7 @@ import { IssuesCloudHostIntegrationId } from '../constants.js';
 import { IntegrationReadUnavailableError } from '../errors.js';
 import { IssuesIntegration } from '../models/issuesIntegration.js';
 import type { IssueFilter } from './models.js';
-import { providersMetadata, toIssueShape } from './models.js';
+import { fromProviderIssue, providersMetadata, toIssueShape } from './models.js';
 
 const metadata = providersMetadata[IssuesCloudHostIntegrationId.Trello];
 const authProvider = Object.freeze({ id: metadata.id, scopes: metadata.scopes });
@@ -161,11 +161,36 @@ export class TrelloIntegration extends IssuesIntegration<IssuesCloudHostIntegrat
 		return Promise.resolve(undefined);
 	}
 
-	protected override getProviderIssue(
-		_session: ProviderAuthenticationSession,
-		_resource: ResourceDescriptor,
-		_id: string,
+	protected override async getProviderIssue(
+		session: ProviderAuthenticationSession,
+		resource: ResourceDescriptor,
+		id: string,
 	): Promise<Issue | undefined> {
-		return Promise.resolve(undefined);
+		if (!isIssueResourceDescriptor(resource)) return undefined;
+
+		const appKey = this.requireAppKey(session);
+		const api = await this.getProvidersApi();
+		const tokenWithInfo = toTokenWithInfo(this.id, session);
+		const lists = await api.getTrelloListsForBoard(tokenWithInfo, appKey, resource.id);
+		const trelloBoardListsById = lists?.reduce<Record<string, { name: string }>>((acc, list) => {
+			acc[list.id] = { name: list.name };
+			return acc;
+		}, {});
+		const issue = (
+			await api.getTrelloIssuesForBoard(tokenWithInfo, appKey, resource.id, {
+				trelloBoardListsById: trelloBoardListsById,
+			})
+		)?.values.find(issue => issue.number === id || issue.id === id);
+
+		return issue != null
+			? fromProviderIssue(issue, this, {
+					project: {
+						id: resource.id,
+						name: resource.name,
+						resourceId: resource.id,
+						resourceName: resource.name,
+					},
+				})
+			: undefined;
 	}
 }

--- a/packages/plus/integrations/src/providers/utils.ts
+++ b/packages/plus/integrations/src/providers/utils.ts
@@ -1,5 +1,4 @@
 import type { AnyEntityIdentifierInput, EntityIdentifier } from '@gitkraken/provider-apis';
-import { EntityIdentifierProviderType, EntityType, EntityVersion } from '@gitkraken/provider-apis';
 import type { Issue, IssueShape } from '@gitlens/git/models/issue.js';
 import type { IssueOrPullRequest } from '@gitlens/git/models/issueOrPullRequest.js';
 import type { PullRequest } from '@gitlens/git/models/pullRequest.js';
@@ -20,6 +19,30 @@ import { isCloudGitSelfManagedHostIntegrationId } from '../utils/integration.uti
 import type { AzureProjectInputDescriptor } from './azure/models.js';
 import type { GitConfigEntityIdentifier } from './models.js';
 import { isGitHubDotCom, isGitLabDotCom } from './models.js';
+
+const EntityIdentifierProviderType = {
+	Azure: 'azure',
+	AzureDevOpsServer: 'azureDevOpsServer',
+	Github: 'github',
+	GithubEnterprise: 'githubEnterprise',
+	Gitlab: 'gitlab',
+	GitlabSelfHosted: 'gitlabSelfHosted',
+	Bitbucket: 'bitbucket',
+	BitbucketServer: 'bitbucketServer',
+	Jira: 'jira',
+	JiraServer: 'jiraServer',
+	Linear: 'linear',
+	Trello: 'trello',
+} as const;
+
+const EntityType = {
+	PullRequest: 'pr',
+	Issue: 'issue',
+} as const;
+
+const EntityVersion = {
+	One: '1',
+} as const;
 
 /**
  * Forward-compatible structural shape of the host's `LaunchpadItem`. The package
@@ -48,7 +71,7 @@ function isIssue(item: IssueOrPullRequest | LaunchpadItem): item is Issue {
 }
 
 export function getEntityIdentifierInput(entity: Issue | PullRequest | LaunchpadItem): AnyEntityIdentifierInput {
-	let entityType = EntityType.Issue;
+	let entityType: (typeof EntityType)[keyof typeof EntityType] = EntityType.Issue;
 	if (entity.type === 'pullrequest') {
 		entityType = EntityType.PullRequest;
 	}
@@ -69,6 +92,7 @@ export function getEntityIdentifierInput(entity: Issue | PullRequest | Launchpad
 
 	let projectId = null;
 	let resourceId = null;
+	let accountOrOrgId = null;
 	let organizationName = null;
 	let repoId = null;
 	if (provider === EntityIdentifierProviderType.Jira) {
@@ -93,6 +117,15 @@ export function getEntityIdentifierInput(entity: Issue | PullRequest | Launchpad
 		if (entityType === EntityType.PullRequest && repoId == null) {
 			throw new Error('Azure PRs must have a repository ID to be encoded');
 		}
+	} else if (provider === EntityIdentifierProviderType.Trello) {
+		if (!isIssue(entity) || entity.project == null) {
+			throw new Error('Trello issues must have a board project to be encoded');
+		}
+
+		projectId = entity.project.id;
+		// Trello currently exposes the board but not a separate workspace/org id here. Reuse the board id in
+		// both serialization slots so branch associations remain round-trippable until the upstream shape grows.
+		accountOrOrgId = entity.project.resourceId || entity.project.id;
 	} else if (
 		provider === EntityIdentifierProviderType.Bitbucket ||
 		provider === EntityIdentifierProviderType.BitbucketServer
@@ -115,9 +148,9 @@ export function getEntityIdentifierInput(entity: Issue | PullRequest | Launchpad
 	// structurally narrowed to any single variant. The 2-step cast through
 	// `unknown` is the documented escape for this discriminated-union pattern.
 	return {
-		accountOrOrgId: null, // needed for Trello issues, once supported
+		accountOrOrgId: accountOrOrgId,
 		organizationName: organizationName, // needed for Azure issues and PRs, once supported
-		projectId: projectId, // needed for Jira issues, Trello issues, and Azure issues and PRs, once supported
+		projectId: projectId,
 		repoId: repoId ?? null, // needed for Azure and BitBucket PRs, once supported
 		resourceId: resourceId, // needed for Jira issues
 		provider: provider,
@@ -144,6 +177,8 @@ export function getProviderIdFromEntityIdentifier(
 			return IssuesCloudHostIntegrationId.Jira;
 		case EntityIdentifierProviderType.Linear:
 			return IssuesCloudHostIntegrationId.Linear;
+		case EntityIdentifierProviderType.Trello:
+			return IssuesCloudHostIntegrationId.Trello;
 		case EntityIdentifierProviderType.Azure:
 			return GitCloudHostIntegrationId.AzureDevOps;
 		case EntityIdentifierProviderType.AzureDevOpsServer:
@@ -159,7 +194,9 @@ export function getProviderIdFromEntityIdentifier(
 	}
 }
 
-function fromStringToEntityIdentifierProviderType(str: string): EntityIdentifierProviderType {
+function fromStringToEntityIdentifierProviderType(
+	str: string,
+): (typeof EntityIdentifierProviderType)[keyof typeof EntityIdentifierProviderType] {
 	switch (str) {
 		case 'github':
 			return EntityIdentifierProviderType.Github;
@@ -173,6 +210,8 @@ function fromStringToEntityIdentifierProviderType(str: string): EntityIdentifier
 			return EntityIdentifierProviderType.Jira;
 		case 'linear':
 			return EntityIdentifierProviderType.Linear;
+		case 'trello':
+			return EntityIdentifierProviderType.Trello;
 		case 'azure':
 		case 'azureDevOps':
 		case 'azure-devops':
@@ -304,7 +343,8 @@ export async function getIssueFromGitConfigEntityIdentifier(
 		identifier.provider !== EntityIdentifierProviderType.Bitbucket &&
 		identifier.provider !== EntityIdentifierProviderType.BitbucketServer &&
 		identifier.provider !== EntityIdentifierProviderType.AzureDevOpsServer &&
-		identifier.provider !== EntityIdentifierProviderType.Azure
+		identifier.provider !== EntityIdentifierProviderType.Azure &&
+		identifier.provider !== EntityIdentifierProviderType.Trello
 	) {
 		return undefined;
 	}

--- a/src/__tests__/cacheProvider.test.ts
+++ b/src/__tests__/cacheProvider.test.ts
@@ -1,0 +1,50 @@
+import * as assert from 'assert';
+import type { Account } from '@gitlens/git/models/author.js';
+import type { IntegrationBase } from '@gitlens/integrations/models/integration.js';
+import { CacheProvider } from '../cache.js';
+
+function createIntegration(domain: string): IntegrationBase {
+	const integration = {
+		id: 'cloud-github-enterprise',
+		domain: domain,
+		maybeConnected: true,
+		sessionFingerprint: 'shared-session',
+	};
+	return integration as IntegrationBase;
+}
+
+suite('CacheProvider', () => {
+	test('getCurrentAccount keys self-managed integrations by domain', async () => {
+		const cache = new CacheProvider({} as never);
+		const lookups: string[] = [];
+
+		const accountA1 = await cache.getCurrentAccount(createIntegration('ghe-a.example.com'), () => ({
+			value: Promise.resolve({
+				id: 'acct-a',
+				name: 'Account A',
+				username: 'acct-a',
+			} satisfies Partial<Account> as Account),
+		}));
+		lookups.push(accountA1?.id ?? '');
+
+		const accountB = await cache.getCurrentAccount(createIntegration('ghe-b.example.com'), () => ({
+			value: Promise.resolve({
+				id: 'acct-b',
+				name: 'Account B',
+				username: 'acct-b',
+			} satisfies Partial<Account> as Account),
+		}));
+		lookups.push(accountB?.id ?? '');
+
+		const accountA2 = await cache.getCurrentAccount(createIntegration('ghe-a.example.com'), () => ({
+			value: Promise.resolve({
+				id: 'acct-a-refetched',
+				name: 'Account A',
+				username: 'acct-a-refetched',
+			} satisfies Partial<Account> as Account),
+		}));
+
+		assert.deepStrictEqual(lookups, ['acct-a', 'acct-b']);
+		assert.strictEqual(accountA2?.id, 'acct-a', 'the first domain keeps its own cached account entry');
+	});
+});

--- a/src/cache.ts
+++ b/src/cache.ts
@@ -112,10 +112,12 @@ export class CacheProvider implements Disposable {
 	getCurrentAccount(
 		integration: IntegrationBase,
 		cacheable: Cacheable<Account>,
-		options?: ExpiryOptions,
+		options?: ExpiryOptions & { connectionId?: string; etag?: string },
 	): CacheResult<Account> {
+		const { connectionId, etag: etagOverride, ...cacheOptions } = options ?? {};
 		const { key, etag } = this.getIntegrationKeyAndEtag(integration);
-		return this.get('currentAccount', `id:${key}`, etag, cacheable, options);
+		const connectionKey = connectionId ? `:${connectionId}` : '';
+		return this.get('currentAccount', `id:${key}${connectionKey}`, etagOverride ?? etag, cacheable, cacheOptions);
 	}
 
 	// getEnrichedAutolinks(

--- a/src/cache.ts
+++ b/src/cache.ts
@@ -355,9 +355,10 @@ export class CacheProvider implements Disposable {
 	}
 
 	private getIntegrationKeyAndEtag(integration: IntegrationBase) {
+		const key = this.getIntegrationCacheKey(integration);
 		return {
-			key: integration.id,
-			etag: `${integration.id}:${integration.maybeConnected ?? false}:${integration.sessionFingerprint ?? ''}`,
+			key: key,
+			etag: `${key}:${integration.maybeConnected ?? false}:${integration.sessionFingerprint ?? ''}`,
 		};
 	}
 
@@ -365,13 +366,17 @@ export class CacheProvider implements Disposable {
 	private getResourceKeyAndEtag(resource: ResourceDescriptor, integration?: GitHostIntegration | IntegrationBase) {
 		let fingerprint = '';
 		if (integration != null) {
-			fingerprint =
-				this.peek('currentAccount', `id:${integration.id}`)?.id ?? integration.sessionFingerprint ?? '';
+			const { key } = this.getIntegrationKeyAndEtag(integration);
+			fingerprint = this.peek('currentAccount', `id:${key}`)?.id ?? integration.sessionFingerprint ?? '';
 		}
 		return {
 			key: resource.key,
 			etag: `${resource.key}:${integration?.maybeConnected ?? false}:${fingerprint}`,
 		};
+	}
+
+	private getIntegrationCacheKey(integration: IntegrationBase): string {
+		return `${integration.id}:${integration.domain}`;
 	}
 }
 

--- a/src/webviews/plus/graph/graphWebview.utils.ts
+++ b/src/webviews/plus/graph/graphWebview.utils.ts
@@ -226,6 +226,8 @@ export function toGraphIssueTrackerType(id: string): GraphIssueTrackerType | und
 			return 'jiraCloud';
 		case IssuesCloudHostIntegrationId.Linear:
 			return 'linear';
+		case IssuesCloudHostIntegrationId.Trello:
+			return 'trello';
 
 		// case IssueIntegrationId.JiraServer:
 		// 	return 'jiraServer';


### PR DESCRIPTION
## Summary
- Fixes #5531
- thread `connectionId` all the way through git-host current-account reads
- fix follow-up regressions found on the branch review before opening the PR
- add targeted coverage plus an ESM smoke check for the built integrations entrypoint

## What changed
- route `Integration.getCurrentAccount()` through a connection-specific session fingerprint so `currentAccount` cache entries invalidate when a secondary token changes
- make `IntegrationService.getMyCurrentAccounts()` use `getIntegrationForRead()` so self-managed reads resolve against the correct configured host/domain
- remove runtime named-enum imports from `@gitkraken/provider-apis` and its helper subpaths in the built integrations package, avoiding Node ESM interop failures
- wire Trello into graph issue-tracker mapping and branch-association metadata helpers
- enrich Trello issue project metadata so branch-associated Trello issues round-trip through git-config identifiers
- add regression tests for secondary-token cache invalidation, self-managed `getMyCurrentAccounts()`, and Trello branch-association round-tripping
- smoke-test `packages/plus/integrations/dist/lite.js` directly under Node from the package test script

## Validation
- `pnpm --filter @gitlens/integrations build`
- `pnpm --filter @gitlens/integrations test`
- `pnpm run build:packages && pnpm run test:packages`
- `pnpm run check`
