### PR TITLE
ProviderBackend surface: dedupe listOrgs warnings, Jira reasons, issue id contract, resolveRepository protocol (#5532)

### DIFF
--- a/packages/git/src/remotes/__tests__/matcher.test.ts
+++ b/packages/git/src/remotes/__tests__/matcher.test.ts
@@ -143,6 +143,23 @@ suite('createRemoteProviderMatcher Test Suite', () => {
 			assert.strictEqual(provider.id, 'gitlab');
 		});
 
+		test("a config's protocol override wins over the URL scheme", () => {
+			// The config declares plain `http` for a self-managed host; the matcher must honor that override on
+			// the built provider rather than the `https` scheme carried by the URL. resolveRepository relies on
+			// this when it forwards a config-derived protocol on its synthetic exact-domain entry.
+			const configs: RemoteProviderConfig[] = [{ domain: 'git.mycorp.com', type: 'github', protocol: 'http' }];
+			const matcher = createRemoteProviderMatcher(configs);
+			const provider = matcher(
+				'https://git.mycorp.com/owner/repo.git',
+				'git.mycorp.com',
+				'owner/repo.git',
+				'https',
+			);
+			assert.ok(provider);
+			assert.strictEqual(provider.id, 'github');
+			assert.strictEqual(provider.protocol, 'http');
+		});
+
 		test('custom configs take priority over built-in providers', () => {
 			const configs: RemoteProviderConfig[] = [{ domain: 'github.com', type: 'gitlab' }];
 			const matcher = createRemoteProviderMatcher(configs);

--- a/packages/plus/integrations/src/__tests__/jira.test.ts
+++ b/packages/plus/integrations/src/__tests__/jira.test.ts
@@ -167,6 +167,42 @@ suite('Jira issue scoping (#5438)', () => {
 
 		manager.dispose();
 	});
+
+	test('when every filter branch rejects, propagates the first reason unwrapped (not an AggregateError)', async () => {
+		const manager = createIntegrationManager(createFakeRuntime());
+		const jira = await manager.get(IssuesCloudHostIntegrationId.Jira);
+		(jira as unknown as { _session: ProviderAuthenticationSession })._session = jiraSession();
+
+		// Two filter branches, both rejecting with distinct errors. The first reason must be re-thrown as-is so
+		// the facade can still classify it by type (auth/rate-limit); wrapping every reason in an AggregateError
+		// would collapse the classification to a generic 'other'. The remaining reason is logged, not surfaced.
+		const first = new Error('assignee branch failed');
+		stubApi(jira, {
+			getIssuesForProjectPaged: (
+				_t: unknown,
+				_name: string,
+				_resourceId: string,
+				options?: { authorLogin?: string; assigneeLogins?: string[] },
+			) =>
+				options?.authorLogin != null
+					? Promise.reject(new Error('author branch failed'))
+					: Promise.reject(first),
+		});
+
+		const result = await jira.getIssuesForProjectWithTruncationResult(project, {
+			user: 'me',
+			filters: [IssueFilter.Assignee, IssueFilter.Author],
+		});
+
+		assert.equal(result?.value, undefined, 'an all-rejected read is a hard error, not a partial success');
+		assert.equal(result?.error, first, 'the first reason is propagated verbatim, not wrapped');
+		assert.ok(
+			!(result?.error instanceof AggregateError),
+			'the reasons are not collapsed into an AggregateError (which would lose type-based classification)',
+		);
+
+		manager.dispose();
+	});
 });
 
 /**

--- a/packages/plus/integrations/src/integrationService.ts
+++ b/packages/plus/integrations/src/integrationService.ts
@@ -2829,7 +2829,27 @@ export class IntegrationService implements Disposable {
 			const type = this.remoteProviderTypeForIntegration(options.providerId);
 			const domain = options.host ?? parsedDomain;
 			if (type != null && domain) {
-				configs.unshift({ type: type, domain: domain });
+				// The synthetic exact-domain entry is unshifted to the front, so it wins the match over the
+				// user's own config for the same host. Carry that config's protocol override across (matched by
+				// domain or regex, mirroring `ignoreSSLErrors`) so a self-managed host configured for a custom
+				// protocol — e.g. plain `http` — isn't silently downgraded to the provider default here.
+				const lowerDomain = domain.toLowerCase();
+				const protocol = configs.find(c => {
+					if (c.type !== type) return false;
+					if (c.domain != null) return c.domain.toLowerCase() === lowerDomain;
+
+					// Truthy (not just non-null): an empty regex would compile to a match-everything pattern.
+					if (c.regex) {
+						try {
+							return new RegExp(c.regex, 'i').test(lowerDomain);
+						} catch {
+							return false;
+						}
+					}
+
+					return false;
+				})?.protocol;
+				configs.unshift({ type: type, domain: domain, protocol: protocol });
 			}
 		}
 

--- a/packages/plus/integrations/src/integrationService.ts
+++ b/packages/plus/integrations/src/integrationService.ts
@@ -1225,7 +1225,11 @@ export class IntegrationService implements Disposable {
 			}
 
 			items.push(...result.items);
-			warnings.push(...result.warnings);
+			// Dedupe across the multi-provider fan-out (matches listProjects): a warning that repeats verbatim
+			// across scopes — e.g. the same account surfaced under two ids — shouldn't be reported twice.
+			for (const w of result.warnings) {
+				appendDedupedWarning(warnings, w);
+			}
 			if (result.fetchFailed) {
 				fetchFailed = true;
 			}

--- a/packages/plus/integrations/src/providers/jira.ts
+++ b/packages/plus/integrations/src/providers/jira.ts
@@ -308,8 +308,20 @@ export class JiraIntegration extends IssuesIntegration<IssuesCloudHostIntegratio
 
 			// If every filter branch rejected, the read failed outright — propagate the first rejection instead
 			// of returning an empty list, which the facade (getIssuesForProjectResult → runCaptured) would
-			// otherwise surface as a successful "no issues" rather than a warning + fetchFailed.
+			// otherwise surface as a successful "no issues" rather than a warning + fetchFailed. The first
+			// reason is re-thrown as-is (not wrapped in an AggregateError) so the facade can still classify it
+			// by type (auth/rate-limit) — wrapping would collapse every failure to a generic 'other'. The
+			// remaining reasons would otherwise be discarded, so log them here to keep them diagnosable.
 			if (settled.every(r => r.status === 'rejected')) {
+				for (let i = 1; i < settled.length; i++) {
+					const outcome = settled[i];
+					if (outcome.status === 'rejected') {
+						Logger.error(
+							outcome.reason,
+							`getProviderIssuesForProjectWithTruncation: filter '${filters[i]}' failed`,
+						);
+					}
+				}
 				throw settled[0].status === 'rejected' ? settled[0].reason : new Error('Jira issue read failed');
 			}
 

--- a/packages/plus/integrations/src/providers/models.ts
+++ b/packages/plus/integrations/src/providers/models.ts
@@ -815,6 +815,11 @@ export function toIssueShape(issue: ProviderIssue, provider: ProviderReference):
 	return {
 		type: 'issue',
 		provider: provider,
+		// `id` is the provider's display number/key (GitHub number, Jira/Linear key, Trello idShort), NOT a
+		// globally-unique id: it's rendered to users as `#{id}`, used to build branch names, and passed back
+		// to the provider as the `getIssue`/cache lookup key, all of which expect the number. It is only unique
+		// within its container (repo/board/project), so consumers correlating issues across containers must key
+		// off `nodeId` (the stable global id), never `id`.
 		id: issue.number,
 		nodeId: issue.graphQLId ?? issue.id,
 		title: issue.title,


### PR DESCRIPTION
Addresses the four minor consistency/robustness observations from #5532 on the `core` branch's ProviderBackend surface. Each is small and self-contained; one commit per finding.

### 1. `listOrgs` now dedupes warnings across the fan-out
`listOrgs` pushed each provider result's warnings verbatim, while the sibling `listProjects` routes them through `appendDedupedWarning`. Aligned the two. This is consistency/robustness only: warning keys already include `providerId`, so the common multi-provider path doesn't collide today; the change hardens the seam to match `listProjects`.

### 2. Jira all-rejected read logs the other filters' reasons
In `getProviderIssuesForProjectWithTruncation`, when every filter branch rejected, only `settled[0].reason` was thrown and the sibling reasons were dropped. Now the remaining reasons are logged before re-throwing.

I deliberately did **not** wrap them in an `AggregateError`: the facade (`toProviderWarning`) classifies failures by error type (`AuthenticationError` → `auth`, `RequestRateLimitError` → `rate-limit`), and a wrapper would collapse every failure to a generic `other`, losing that signal. Re-throwing the first reason as-is preserves classification; logging the rest keeps them diagnosable.

### 3. `toIssueShape` id-vs-nodeId contract documented
`toIssueShape` stores the provider's display number/key in `IssueShape.id` (GitHub number, Jira/Linear key, Trello `idShort`), which is only unique within its container, not globally.

I checked the consumers before touching this, and it's intentional, not a bug: `id` is rendered to users as `#{id}`, feeds `createBranchNameFromIssue`, and is the `integration.getIssue`/cache lookup key, all of which expect the number (GitHub does `Number(id)`; Jira/Linear pass it as `number`). Global uniqueness already lives on `nodeId` (`graphQLId ?? id`), which is what `getEntityIdentifierInput` and branch↔issue association key off. Switching `id` to a global value would break the common path, so this commit documents the invariant instead of changing behavior, so consumers correlating issues across containers key off `nodeId`.

### 4. `resolveRepository` preserves the config's protocol override
When given an explicit `providerId`, `resolveRepository` unshifts a synthetic exact-domain config to the front so a custom domain maps to the right provider. That entry dropped the protocol override, so a matching user config's custom protocol (e.g. plain `http` on a self-managed host) was silently downgraded to the provider default. Now the protocol is carried across from the matching config (by domain or regex, mirroring `ignoreSSLErrors`). Limited impact today since `getRepoInfo` derives the `baseUrl` from the session, but it keeps the matched provider faithful to the user's config.

### Tests
- `jira.test.ts`: an all-rejected multi-filter read propagates the first reason verbatim and is not collapsed into an `AggregateError`.
- `matcher.test.ts`: a config's protocol override wins over the URL scheme (the contract finding #4 relies on).
- Findings #1 and #3 are consistency/documentation changes with no behavior delta to assert against beyond the existing `listOrgs`/`toIssueShape` coverage.

`pnpm run check` is clean and the integrations + git suites pass (310 passing).

> Note: this PR targets `core`, not `main`, so the `Closes` keyword below won't auto-close on merge; linking for traceability.

Closes #5532
