### PR TITLE
Normalize PR/repo types on the ProviderBackend surface (#5533)

### DIFF
--- a/packages/core/CHANGELOG.md
+++ b/packages/core/CHANGELOG.md
@@ -20,6 +20,7 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/) and this p
 
 ### Changed
 
+- Normalizes the pull-request and repository item types on the ProviderBackend surface so consumers no longer depend on `@gitkraken/provider-apis` types (matching how issues already surface `IssueShape`): `IntegrationService.listPullRequestsPage`/`sweepPullRequests`/`sweepClosedPullRequests` now return the GitLens-owned `PullRequestShape` and `listRepos` returns the new GitLens-owned `ProviderRepositoryShape`; the raw provider-apis PR/repo/account/issue types are no longer re-exported from the `@gitlens/integrations` facade ([#5533](https://github.com/gitkraken/vscode-gitlens/issues/5533)) (plus/integrations)
 - Decouples the `GitLabApi`, `BitbucketApi`, and `AzureDevOpsApi` clients from `IntegrationServiceContext`, taking a narrow `ProviderApiConfig` instead (mirroring `GitHubApiConfig`); the manager wires them via new `createGitLabApi`/`createBitbucketApi`/`createAzureDevOpsApi` factories (plus/integrations)
 
 ## [0.4.0] - 2026-06-30

--- a/packages/plus/integrations/src/__tests__/providerBackendSurface.test.ts
+++ b/packages/plus/integrations/src/__tests__/providerBackendSurface.test.ts
@@ -1,4 +1,5 @@
 import * as assert from 'node:assert/strict';
+import { GitPullRequestMergeableState, GitPullRequestState } from '@gitkraken/provider-apis';
 import { suite, test } from 'mocha';
 import type { IssueShape } from '@gitlens/git/models/issue.js';
 import type { PullRequest } from '@gitlens/git/models/pullRequest.js';
@@ -44,6 +45,55 @@ function primarySession(token: string): ProviderAuthenticationSession {
 
 function stubApi(gh: GitHostIntegration, api: Record<string, unknown>): void {
 	(gh as unknown as { getProvidersApi: () => Promise<unknown> }).getProvidersApi = () => Promise.resolve(api);
+}
+
+function providerPr(id: string): ProviderPullRequest {
+	return {
+		id: id,
+		number: Number(id),
+		title: `PR ${id}`,
+		description: null,
+		url: `https://example.com/pull/${id}`,
+		state: GitPullRequestState.Open,
+		isCrossRepository: false,
+		isDraft: false,
+		createdDate: new Date(0),
+		updatedDate: new Date(0),
+		closedDate: null,
+		mergedDate: null,
+		baseRef: null,
+		headRef: null,
+		commentCount: null,
+		upvoteCount: null,
+		commitCount: null,
+		fileCount: null,
+		additions: null,
+		deletions: null,
+		author: null,
+		assignees: null,
+		reviews: null,
+		reviewDecision: null,
+		repository: { id: `repo-${id}`, name: 'hello', owner: { login: 'octocat' }, remoteInfo: null },
+		headRepository: null,
+		headCommit: null,
+		mergeableState: GitPullRequestMergeableState.Unknown,
+		permissions: null,
+	};
+}
+
+function providerIssue(id: string): ProviderIssue {
+	return {
+		id: id,
+		number: id,
+		title: `Issue ${id}`,
+		url: `https://github.com/o/r/issues/${id}`,
+		createdDate: new Date(0),
+		updatedDate: new Date(0),
+		closedDate: null,
+		author: { id: 'a', name: 'A', avatarUrl: null, url: null },
+		assignees: [],
+		labels: [],
+	} as unknown as ProviderIssue;
 }
 
 function searchPullRequest(id: string, state: 'open' | 'closed' | 'merged'): PullRequest {
@@ -93,7 +143,8 @@ suite('ProviderBackend surface facade (#5438)', () => {
 		const gh = await manager.get(GitCloudHostIntegrationId.GitHub);
 		(gh as unknown as { _session: ProviderAuthenticationSession })._session = primarySession('t');
 
-		const pr = { id: '1' } as unknown as ProviderPullRequest;
+		const firstPagePr = providerPr('1');
+		const secondPagePrs = [providerPr('2'), providerPr('3')];
 		let capturedCursor: string | undefined;
 		let page = 0;
 		stubApi(gh, {
@@ -104,7 +155,7 @@ suite('ProviderBackend surface facade (#5438)', () => {
 				page += 1;
 				// Second page has no more data; the opaque cursor from the first page is threaded to advance.
 				return Promise.resolve({
-					values: [pr],
+					values: page === 1 ? [firstPagePr] : secondPagePrs,
 					paging: {
 						more: page === 1,
 						cursor: page === 1 ? JSON.stringify({ value: 'NEXT', type: 'cursor' }) : '{}',
@@ -124,8 +175,13 @@ suite('ProviderBackend surface facade (#5438)', () => {
 			JSON.stringify({ value: 'NEXT', type: 'cursor' }),
 			'page 2 advanced via the opaque cursor from page 1',
 		);
-		assert.equal(result.items.length, 2, 'prefix from page 1 preserved and page 2 items appended');
+		assert.deepEqual(
+			result.items.map(pr => pr.id),
+			['2', '3'],
+			'only the requested page is returned after draining',
+		);
 		assert.equal(result.page.currentPage, 2, 'currentPage reflects the requested page after draining');
+		assert.equal(result.page.itemsPerPage, 2, 'itemsPerPage reflects the returned page after draining');
 		assert.equal(result.hasMore, false, 'hasMore reflects the final page');
 		assert.equal(result.warnings.length, 0);
 
@@ -215,7 +271,7 @@ suite('ProviderBackend surface facade (#5438)', () => {
 		const gh = await manager.get(GitCloudHostIntegrationId.GitHub);
 		(gh as unknown as { _session: ProviderAuthenticationSession })._session = primarySession('t');
 
-		const pr = { id: '1' } as unknown as ProviderPullRequest;
+		const pr = providerPr('1');
 		stubApi(gh, {
 			isRepoIdsInput: () => false,
 			getProviderPullRequestsPagingMode: () => PagingMode.Repos,
@@ -237,7 +293,8 @@ suite('ProviderBackend surface facade (#5438)', () => {
 			repos: repos,
 		});
 
-		assert.deepEqual(result.items, [pr], 'the successful sibling PR survives the failed repo');
+		assert.equal(result.items.length, 1, 'the successful sibling PR survives the failed repo');
+		assert.equal(result.items[0].id, '1', 'the surviving PR is normalized to the GitLens shape');
 		assert.equal(result.fetchFailed, true, 'a structured failure means the collection is incomplete');
 		assert.equal(result.page.truncated, true, 'partial completeness sets terminal truncation');
 		assert.equal(result.warnings.length, 1, 'one scope-aware warning, no duplicate generic truncation warning');
@@ -360,7 +417,7 @@ suite('ProviderBackend surface facade (#5438)', () => {
 		const gh = await manager.get(GitCloudHostIntegrationId.GitHub);
 		(gh as unknown as { _session: ProviderAuthenticationSession })._session = primarySession('t');
 
-		const pr = { id: '1' } as unknown as ProviderPullRequest;
+		const pr = providerPr('1');
 		stubApi(gh, {
 			isRepoIdsInput: () => false,
 			getProviderPullRequestsPagingMode: () => PagingMode.Repos,
@@ -377,7 +434,8 @@ suite('ProviderBackend surface facade (#5438)', () => {
 			repos: repos,
 		});
 
-		assert.deepEqual(result.items, [pr]);
+		assert.equal(result.items.length, 1);
+		assert.equal(result.items[0].id, '1');
 		assert.equal(result.fetchFailed, undefined, 'unknown without a failure is not a fetch failure');
 		assert.equal(result.page.truncated, true, 'unknown completeness still cannot claim a complete read');
 		assert.equal(result.warnings.length, 1, 'a single generic incompleteness warning');
@@ -392,7 +450,7 @@ suite('ProviderBackend surface facade (#5438)', () => {
 		const gh = await manager.get(GitCloudHostIntegrationId.GitHub);
 		(gh as unknown as { _session: ProviderAuthenticationSession })._session = primarySession('t');
 
-		const pr = { id: '1' } as unknown as ProviderPullRequest;
+		const pr = providerPr('1');
 		stubApi(gh, {
 			isRepoIdsInput: () => false,
 			getProviderPullRequestsPagingMode: () => PagingMode.Repos,
@@ -409,9 +467,58 @@ suite('ProviderBackend surface facade (#5438)', () => {
 			repos: repos,
 		});
 
-		assert.deepEqual(result.items, [pr]);
+		assert.equal(result.items.length, 1);
+		assert.equal(result.items[0].id, '1');
 		assert.equal(result.fetchFailed, undefined);
 		assert.equal(result.page.truncated, undefined, 'complete adds no truncation');
+		assert.equal(result.warnings.length, 0);
+
+		manager.dispose();
+	});
+
+	test('listIssuesPage drains cursor-only hosts to the requested page', async () => {
+		const runtime = createFakeRuntime();
+		const manager = createIntegrationManager(runtime);
+		const gh = await manager.get(GitCloudHostIntegrationId.GitHub);
+		(gh as unknown as { _session: ProviderAuthenticationSession })._session = primarySession('t');
+
+		let capturedCursor: string | undefined;
+		let page = 0;
+		stubApi(gh, {
+			isRepoIdsInput: () => false,
+			getProviderIssuesPagingMode: () => PagingMode.Repos,
+			getIssuesForRepos: (_t: unknown, _r: unknown, opts: { cursor?: string }) => {
+				capturedCursor = opts.cursor;
+				page += 1;
+				return Promise.resolve({
+					values: page === 1 ? [providerIssue('7')] : [providerIssue('8'), providerIssue('9')],
+					paging: {
+						more: page === 1,
+						cursor: page === 1 ? JSON.stringify({ value: 'NEXT', type: 'cursor' }) : '{}',
+					},
+				} satisfies PagedResult<ProviderIssue>);
+			},
+		});
+
+		const result = await manager.listIssuesPage({
+			providerId: GitCloudHostIntegrationId.GitHub,
+			repos: repos,
+			page: 2,
+		});
+
+		assert.equal(
+			capturedCursor,
+			JSON.stringify({ value: 'NEXT', type: 'cursor' }),
+			'page 2 advanced via the opaque cursor from page 1',
+		);
+		assert.deepEqual(
+			result.items.map(issue => issue.id),
+			['8', '9'],
+			'only the requested page is returned after draining',
+		);
+		assert.equal(result.page.currentPage, 2, 'currentPage reflects the requested page after draining');
+		assert.equal(result.page.itemsPerPage, 2, 'itemsPerPage reflects the returned page after draining');
+		assert.equal(result.hasMore, false, 'hasMore reflects the final page');
 		assert.equal(result.warnings.length, 0);
 
 		manager.dispose();
@@ -423,20 +530,7 @@ suite('ProviderBackend surface facade (#5438)', () => {
 		const gh = await manager.get(GitCloudHostIntegrationId.GitHub);
 		(gh as unknown as { _session: ProviderAuthenticationSession })._session = primarySession('t');
 
-		// A raw provider issue with the fields toIssueShape requires (updatedDate + url), since listIssuesPage
-		// now normalizes repo-scoped results to IssueShape.
-		const issue = {
-			id: '7',
-			number: '7',
-			title: 'Issue 7',
-			url: 'https://github.com/o/r/issues/7',
-			createdDate: new Date(0),
-			updatedDate: new Date(0),
-			closedDate: null,
-			author: { id: 'a', name: 'A', avatarUrl: null, url: null },
-			assignees: [],
-			labels: [],
-		} as unknown as ProviderIssue;
+		const issue = providerIssue('7');
 		let capturedCursor: string | undefined;
 		stubApi(gh, {
 			isRepoIdsInput: () => false,
@@ -470,18 +564,7 @@ suite('ProviderBackend surface facade (#5438)', () => {
 		const gh = await manager.get(GitCloudHostIntegrationId.GitHub);
 		(gh as unknown as { _session: ProviderAuthenticationSession })._session = primarySession('t');
 
-		const issue = {
-			id: '7',
-			number: '7',
-			title: 'Issue 7',
-			url: 'https://github.com/o/r/issues/7',
-			createdDate: new Date(0),
-			updatedDate: new Date(0),
-			closedDate: null,
-			author: { id: 'a', name: 'A', avatarUrl: null, url: null },
-			assignees: [],
-			labels: [],
-		} as unknown as ProviderIssue;
+		const issue = providerIssue('7');
 		// A single-page repo-scoped read that can't confirm completeness sets `paging.truncated`. The facade
 		// must surface it via the shared truncation-warning helper, which is also used by PR reads: the message
 		// has to name the issue read, not mislabel it as a pull request read.

--- a/packages/plus/integrations/src/__tests__/sweepAndBroaden.test.ts
+++ b/packages/plus/integrations/src/__tests__/sweepAndBroaden.test.ts
@@ -1,4 +1,5 @@
 import * as assert from 'node:assert/strict';
+import { GitPullRequestMergeableState, GitPullRequestState } from '@gitkraken/provider-apis';
 import type { CollectionMetadata } from '@gitkraken/provider-apis';
 import { suite, test } from 'mocha';
 import type { PagedResult } from '@gitlens/utils/paging.js';
@@ -39,6 +40,41 @@ function stubApi(gh: GitHostIntegration, api: Record<string, unknown>): void {
 	(gh as unknown as { getProvidersApi: () => Promise<unknown> }).getProvidersApi = () => Promise.resolve(api);
 }
 
+function providerPr(id: string, overrides?: Partial<ProviderPullRequest>): ProviderPullRequest {
+	return {
+		id: id,
+		number: Number.parseInt(id.split('-').at(-1) ?? id, 10) || 1,
+		title: `PR ${id}`,
+		description: null,
+		url: `https://example.com/pull/${id}`,
+		state: GitPullRequestState.Open,
+		isCrossRepository: false,
+		isDraft: false,
+		createdDate: new Date(0),
+		updatedDate: new Date(0),
+		closedDate: null,
+		mergedDate: null,
+		baseRef: null,
+		headRef: null,
+		commentCount: null,
+		upvoteCount: null,
+		commitCount: null,
+		fileCount: null,
+		additions: null,
+		deletions: null,
+		author: null,
+		assignees: null,
+		reviews: null,
+		reviewDecision: null,
+		repository: { id: `repo-${id}`, name: 'hello', owner: { login: 'octocat' }, remoteInfo: null },
+		headRepository: null,
+		headCommit: null,
+		mergeableState: GitPullRequestMergeableState.Unknown,
+		permissions: null,
+		...overrides,
+	};
+}
+
 async function connectedGitHub(runtime: ReturnType<typeof createFakeRuntime>) {
 	const manager = createIntegrationManager(runtime);
 	const gh = await manager.get(GitCloudHostIntegrationId.GitHub);
@@ -58,7 +94,7 @@ suite('sweep + broaden (#5438)', () => {
 			getPullRequestsForRepos: () => {
 				calls++;
 				return Promise.resolve({
-					values: [{ id: `pr-${calls}` } as unknown as ProviderPullRequest],
+					values: [providerPr(`pr-${calls}`)],
 					paging: { more: true, cursor: JSON.stringify({ value: calls + 1, type: 'page' }) },
 				} satisfies PagedResult<ProviderPullRequest>);
 			},
@@ -94,7 +130,7 @@ suite('sweep + broaden (#5438)', () => {
 			getPullRequestsForRepos: () => {
 				calls++;
 				return Promise.resolve({
-					values: [{ id: `pr-${calls}` } as unknown as ProviderPullRequest],
+					values: [providerPr(`pr-${calls}`)],
 					paging: {
 						more: calls < 2,
 						cursor: calls < 2 ? JSON.stringify({ value: calls + 1, type: 'page' }) : '{}',
@@ -129,7 +165,7 @@ suite('sweep + broaden (#5438)', () => {
 				calls++;
 				if (calls === 1) {
 					return Promise.resolve({
-						values: [{ id: 'pr-1' } as unknown as ProviderPullRequest],
+						values: [providerPr('pr-1')],
 						paging: { more: true, cursor: JSON.stringify({ value: 2, type: 'page' }) },
 					} satisfies PagedResult<ProviderPullRequest>);
 				}
@@ -161,7 +197,7 @@ suite('sweep + broaden (#5438)', () => {
 			// PR must survive, but the sweep cannot claim it read every page.
 			getPullRequestsForRepos: () =>
 				Promise.resolve({
-					values: [{ id: 'pr-good' } as unknown as ProviderPullRequest],
+					values: [providerPr('pr-good')],
 					paging: { more: false, cursor: '{}' },
 					metadata: {
 						completeness: 'partial',
@@ -644,7 +680,7 @@ suite('sweep + broaden (#5438)', () => {
 			accountWideStates = o?.state;
 			return Promise.resolve({
 				value: {
-					values: [{ id: 'mine' } as unknown as ProviderPullRequest],
+					values: [providerPr('mine')],
 					paging: { more: false, cursor: '{}' },
 				},
 			});
@@ -652,7 +688,8 @@ suite('sweep + broaden (#5438)', () => {
 
 		const result = await manager.sweepClosedPullRequests({ providerIds: [GitCloudHostIntegrationId.GitHub] });
 		assert.equal(reposCalled, false, 'no repos → the repo-scoped core is not called');
-		assert.deepEqual(result.items, [{ id: 'mine' }], 'account-wide user PRs are returned');
+		assert.equal(result.items.length, 1, 'account-wide user PRs are returned');
+		assert.equal(result.items[0].id, 'mine', 'the account-wide PR is normalized to the GitLens shape');
 		assert.deepEqual(
 			accountWideStates,
 			['closed', 'merged'],
@@ -675,7 +712,7 @@ suite('sweep + broaden (#5438)', () => {
 		).getMyPullRequestsForUserResult = () =>
 			Promise.resolve({
 				value: {
-					values: [{ id: 'pr' } as unknown as ProviderPullRequest],
+					values: [providerPr('pr')],
 					paging: { more: false, cursor: '{}', truncated: true },
 				},
 			});
@@ -939,7 +976,12 @@ suite('sweep + broaden (#5438)', () => {
 					);
 				}
 				return Promise.resolve({
-					values: [{ id: 'good-pr', url: 'u/good' } as unknown as ProviderPullRequest],
+					values: [
+						providerPr('good-pr', {
+							url: 'u/good',
+							repository: { id: 'r1', name: 'good', owner: { login: 'ws' }, remoteInfo: null },
+						}),
+					],
 					paging: { more: false, cursor: '{}' },
 				});
 			},

--- a/packages/plus/integrations/src/index.ts
+++ b/packages/plus/integrations/src/index.ts
@@ -141,15 +141,13 @@ export type {
 	RepositoryResolutionStatus,
 	ResolveRepositoryResult,
 } from './results.js';
-// Item shapes surfaced by the read methods. `ProviderOrganization` is a local interface; the rest are
-// re-aliases of `@gitkraken/provider-apis` types that resolve for consumers via the transitive install.
-export type {
-	ProviderAccount,
-	ProviderIssue,
-	ProviderOrganization,
-	ProviderPullRequest,
-	ProviderRepository,
-} from './providers/models.js';
+// GitLens-owned item shapes surfaced by the org/repo discovery read methods (`listOrgs`/`listProjects`/
+// `listRepos`). These carry no `@gitkraken/provider-apis` types, so consumers depend only on
+// `@gitkraken/core-gitlens`. PR/issue reads surface `PullRequestShape`/`IssueShape` from
+// `@gitlens/git/models` (reached via the `@gitkraken/core-gitlens/git/models/*` subpath), mirroring how
+// issues are already exposed; the raw provider-apis PR/repo/account/issue types are intentionally not
+// re-exported here.
+export type { ProviderOrganization, ProviderRepositoryShape } from './providers/models.js';
 // Runtime enums — re-exported as values (not `export type`) so consumers can read their members.
 export { IssueFilter, PullRequestFilter } from './providers/models.js';
 // Cross-provider PR/issue state filters (string unions in the git models).

--- a/packages/plus/integrations/src/integrationService.ts
+++ b/packages/plus/integrations/src/integrationService.ts
@@ -1,7 +1,7 @@
 import type { CollectionMetadata } from '@gitkraken/provider-apis';
 import type { Account } from '@gitlens/git/models/author.js';
 import type { IssueShape } from '@gitlens/git/models/issue.js';
-import type { PullRequest, PullRequestStateFilter } from '@gitlens/git/models/pullRequest.js';
+import type { PullRequest, PullRequestShape, PullRequestStateFilter } from '@gitlens/git/models/pullRequest.js';
 import type { GitRemote } from '@gitlens/git/models/remote.js';
 import type { RemoteProviderId } from '@gitlens/git/models/remoteProvider.js';
 import type { IssueResourceDescriptor, ResourceDescriptor } from '@gitlens/git/models/resourceDescriptor.js';
@@ -63,9 +63,15 @@ import type {
 	ProviderPullRequest,
 	ProviderReposInput,
 	ProviderRepository,
+	ProviderRepositoryShape,
 	PullRequestFilter,
 } from './providers/models.js';
-import { IssueFilter, providersMetadata } from './providers/models.js';
+import {
+	fromProviderPullRequest,
+	IssueFilter,
+	providersMetadata,
+	toProviderRepositoryShape,
+} from './providers/models.js';
 import type { ProvidersApi } from './providers/providersApi.js';
 import { mergeCollectionMetadata, parsePageCursor, toPageCursor } from './providers/utils/providerPaging.js';
 import type {
@@ -1387,7 +1393,7 @@ export class IntegrationService implements Disposable {
 		cursor?: string;
 		itemsPerPage?: number;
 		connectionId?: string;
-	}): Promise<ProviderPagedResult<ProviderRepository>> {
+	}): Promise<ProviderPagedResult<ProviderRepositoryShape>> {
 		const page = Math.max(1, options.page ?? 1);
 		const integration = await this.getIntegrationForRead(options.providerId, options.connectionId);
 		if (integration == null || isIssuesIntegration(integration)) {
@@ -1470,7 +1476,8 @@ export class IntegrationService implements Disposable {
 		// gave no cursor, synthesize the next page so the caller has something resumable to advance with.
 		const cursorOut = paged.cursor ?? (paged.hasMore ? this.pageToCursor(currentPage + 1) : undefined);
 		return {
-			items: items,
+			// Normalize the raw provider-apis repos to the GitLens-owned shape at the surface boundary.
+			items: items.map(toProviderRepositoryShape),
 			warnings: warnings,
 			page: { ...paged.page, currentPage: currentPage, truncated: truncated || undefined },
 			hasMore: paged.hasMore,
@@ -1500,7 +1507,7 @@ export class IntegrationService implements Disposable {
 		itemsPerPage?: number;
 		forceSync?: boolean;
 		connectionId?: string;
-	}): Promise<ProviderPagedResult<ProviderPullRequest>> {
+	}): Promise<ProviderPagedResult<PullRequestShape>> {
 		const page = Math.max(1, options.page ?? 1);
 		const integration = await this.getIntegrationForRead(options.providerId, options.connectionId);
 		if (integration == null || isIssuesIntegration(integration)) {
@@ -1566,7 +1573,7 @@ export class IntegrationService implements Disposable {
 					),
 		);
 
-		const items = value?.values ?? [];
+		let items = value?.values ?? [];
 		// Account-wide reads have no meaningful page number (cursor-only), so report page 1 rather than
 		// echoing a requested page the provider never applied; repo-scoped reads report the requested page
 		// unless the provider reports its own.
@@ -1578,8 +1585,9 @@ export class IntegrationService implements Disposable {
 
 		// Cursor-only repo-scoped hosts (e.g. GitHub) ignore a synthesized page-number cursor. When the caller
 		// explicitly asks for page N without supplying a continuation cursor, drain through the opaque cursors
-		// so the returned `currentPage` actually reflects N instead of misreporting page 1. Keep the already-fetched
-		// prefix from each page so a later page failure doesn't discard the earlier pages.
+		// so the returned `currentPage` actually reflects N instead of misreporting page 1. Keep only the last
+		// successfully-read page's items while still merging warnings/metadata across the drained prefix; returning
+		// pages 1..N as "page N" would duplicate items for normal paged consumers.
 		if (
 			!accountWide &&
 			options.page != null &&
@@ -1618,9 +1626,10 @@ export class IntegrationService implements Disposable {
 					break;
 				}
 
-				items.push(...nextValue.values);
+				const nextItems = nextValue.values;
+				items = nextItems;
 				allMetadata = mergeCollectionMetadata(allMetadata, nextValue.metadata);
-				const nextPaged = this.toProviderPageInfo(options.itemsPerPage ?? items.length, nextValue.paging);
+				const nextPaged = this.toProviderPageInfo(options.itemsPerPage ?? nextItems.length, nextValue.paging);
 				currentPage++;
 				const nextCursor = nextPaged.cursor;
 				if (nextCursor == null || nextCursor === currentCursor || nextCursor === '{}') {
@@ -1635,7 +1644,7 @@ export class IntegrationService implements Disposable {
 			}
 
 			paged = {
-				page: { currentPage: currentPage, itemsPerPage: paged.page.itemsPerPage },
+				page: { currentPage: currentPage, itemsPerPage: options.itemsPerPage ?? items.length },
 				hasMore: currentHasMore,
 				cursor: currentCursor,
 				truncated: currentTruncated,
@@ -1651,7 +1660,8 @@ export class IntegrationService implements Disposable {
 			warnings.push(this.truncationWarning(options.providerId, domain, options.connectionId, 'Pull request'));
 		}
 		return {
-			items: items,
+			// Normalize the raw provider-apis PRs to the GitLens-owned shape at the surface boundary.
+			items: items.map(pr => fromProviderPullRequest(pr, integration)),
 			warnings: warnings,
 			page: { ...paged.page, truncated: truncated || undefined },
 			hasMore: paged.hasMore,
@@ -1800,15 +1810,16 @@ export class IntegrationService implements Disposable {
 			),
 		);
 
-		const items = value?.values ?? [];
+		let items = value?.values ?? [];
 		const warnings = warning != null ? [warning] : [];
 		let paged = this.toProviderPageInfo(options.itemsPerPage ?? items.length, value?.paging);
 		let allMetadata = value?.metadata;
 
 		// Cursor-only repo-scoped hosts (e.g. GitHub) ignore a synthesized page-number cursor. When the caller
 		// explicitly asks for page N without supplying a continuation cursor, drain through the opaque cursors so
-		// the returned `currentPage` actually reflects N instead of misreporting page 1. Keep the already-fetched
-		// prefix from each page so a later page failure doesn't discard the earlier pages.
+		// the returned `currentPage` actually reflects N instead of misreporting page 1. Keep only the last
+		// successfully-read page's items while still merging warnings/metadata across the drained prefix; returning
+		// pages 1..N as "page N" would duplicate items for normal paged consumers.
 		if (
 			options.page != null &&
 			options.page > 1 &&
@@ -1846,9 +1857,10 @@ export class IntegrationService implements Disposable {
 					break;
 				}
 
-				items.push(...nextValue.values);
+				const nextItems = nextValue.values;
+				items = nextItems;
 				allMetadata = mergeCollectionMetadata(allMetadata, nextValue.metadata);
-				const nextPaged = this.toProviderPageInfo(options.itemsPerPage ?? items.length, nextValue.paging);
+				const nextPaged = this.toProviderPageInfo(options.itemsPerPage ?? nextItems.length, nextValue.paging);
 				currentPage++;
 				const nextCursor = nextPaged.cursor;
 				if (nextCursor == null || nextCursor === currentCursor || nextCursor === '{}') {
@@ -1862,7 +1874,7 @@ export class IntegrationService implements Disposable {
 			}
 
 			paged = {
-				page: { currentPage: currentPage, itemsPerPage: paged.page.itemsPerPage },
+				page: { currentPage: currentPage, itemsPerPage: options.itemsPerPage ?? items.length },
 				hasMore: currentHasMore,
 				cursor: currentCursor,
 				truncated: currentTruncated,
@@ -2395,7 +2407,7 @@ export class IntegrationService implements Disposable {
 		forceSync?: boolean;
 		connectionId?: string;
 		maxPages?: number;
-	}): Promise<ProviderSweepResult<ProviderPullRequest>> {
+	}): Promise<ProviderSweepResult<PullRequestShape>> {
 		const ids = options?.providerIds ?? supportedOrderedCloudIntegrationIds;
 		const singleProvider = ids.length === 1;
 		const maxPages = options?.maxPages ?? 100;
@@ -2411,7 +2423,7 @@ export class IntegrationService implements Disposable {
 					const early = this.earlyReturnConnectionWarnings(id, connectionId);
 					if (early.warnings.length === 0) return undefined;
 					return {
-						items: [] as ProviderPullRequest[],
+						items: [] as PullRequestShape[],
 						warnings: early.warnings,
 						fetchFailed: true,
 						truncated: false,
@@ -2429,13 +2441,14 @@ export class IntegrationService implements Disposable {
 				if (resolved.unsupported && repos.length > 0) {
 					// Don't drain unfiltered (would return every PR); report a warning and contribute nothing.
 					return {
-						items: [] as ProviderPullRequest[],
+						items: [] as PullRequestShape[],
 						warnings: [this.unsupportedFiltersWarning(id, domain, connectionId)],
 						fetchFailed: true,
 						truncated: false,
 					};
 				}
-				return this.drainPullRequests(
+
+				const drain = await this.drainPullRequests(
 					integration,
 					id,
 					domain,
@@ -2445,10 +2458,13 @@ export class IntegrationService implements Disposable {
 					connectionId,
 					maxPages,
 				);
+				// Normalize the raw provider-apis PRs to the GitLens-owned shape here, where the per-provider
+				// `integration` (the mapper's provider reference) is in scope; the aggregation below only sees drains.
+				return { ...drain, items: drain.items.map(pr => fromProviderPullRequest(pr, integration)) };
 			}),
 		);
 
-		const items: ProviderPullRequest[] = [];
+		const items: PullRequestShape[] = [];
 		const warnings: ProviderWarning[] = [];
 		let fetchFailed = false;
 		let truncated = false;
@@ -2501,7 +2517,7 @@ export class IntegrationService implements Disposable {
 		forceSync?: boolean;
 		connectionId?: string;
 		maxPages?: number;
-	}): Promise<ProviderSweepResult<ProviderPullRequest>> {
+	}): Promise<ProviderSweepResult<PullRequestShape>> {
 		return this.sweepPullRequests({
 			...options,
 			state: ['closed', 'merged'],

--- a/packages/plus/integrations/src/providers/__tests__/models.test.ts
+++ b/packages/plus/integrations/src/providers/__tests__/models.test.ts
@@ -1,10 +1,11 @@
 import * as assert from 'node:assert/strict';
 import { suite, test } from 'mocha';
-import type { ProviderPullRequest } from '../models.js';
+import type { ProviderPullRequest, ProviderRepository } from '../models.js';
 import {
 	providerPullRequestMatchesSearch,
 	toProviderPullRequestState,
 	toProviderPullRequestStates,
+	toProviderRepositoryShape,
 } from '../models.js';
 
 suite('providerPullRequestMatchesSearch', () => {
@@ -60,5 +61,46 @@ suite('toProviderPullRequestStates', () => {
 			toProviderPullRequestState('opened'),
 			toProviderPullRequestState('merged'),
 		]);
+	});
+});
+
+suite('toProviderRepositoryShape', () => {
+	function repo(overrides?: Partial<ProviderRepository>): ProviderRepository {
+		return {
+			id: 'r1',
+			namespace: 'octocat',
+			name: 'hello',
+			webUrl: 'https://github.com/octocat/hello',
+			httpsUrl: 'https://github.com/octocat/hello.git',
+			sshUrl: 'git@github.com:octocat/hello.git',
+			defaultBranch: { name: 'main' },
+			permissions: null,
+			...overrides,
+		};
+	}
+
+	test('maps identity, URLs, and default branch from the SDK repo', () => {
+		assert.deepEqual(toProviderRepositoryShape(repo({ project: 'proj' })), {
+			id: 'r1',
+			namespace: 'octocat',
+			name: 'hello',
+			project: 'proj',
+			url: 'https://github.com/octocat/hello',
+			cloneUrlHttps: 'https://github.com/octocat/hello.git',
+			cloneUrlSsh: 'git@github.com:octocat/hello.git',
+			defaultBranch: 'main',
+		});
+	});
+
+	test('collapses the SDK nullable fields to undefined', () => {
+		const shape = toProviderRepositoryShape(
+			repo({ webUrl: null, httpsUrl: null, sshUrl: null, defaultBranch: null }),
+		);
+		assert.equal(shape.url, undefined);
+		assert.equal(shape.cloneUrlHttps, undefined);
+		assert.equal(shape.cloneUrlSsh, undefined);
+		assert.equal(shape.defaultBranch, undefined);
+		// A repo with no project layer (non-Azure) leaves `project` absent rather than empty-string.
+		assert.equal(shape.project, undefined);
 	});
 });

--- a/packages/plus/integrations/src/providers/__tests__/pullRequestMapping.test.ts
+++ b/packages/plus/integrations/src/providers/__tests__/pullRequestMapping.test.ts
@@ -114,4 +114,16 @@ suite('pull request ref mapping (#5435 clone URLs + fork)', () => {
 
 		assert.equal(roundTrip.repository.remoteInfo, null, 'partial clone info does not produce a remoteInfo');
 	});
+
+	test('fromProviderPullRequest tolerates a missing repository payload', () => {
+		const providerPr = { ...createProviderPullRequest(), repository: undefined } as unknown as ProviderPullRequest;
+
+		const pr = fromProviderPullRequest(providerPr, fakeProvider);
+
+		assert.equal(pr.repository.owner, '');
+		assert.equal(pr.repository.repo, '');
+		assert.equal(pr.repository.id, '');
+		assert.equal(pr.refs?.base.owner, '');
+		assert.equal(pr.refs?.base.repo, '');
+	});
 });

--- a/packages/plus/integrations/src/providers/models.ts
+++ b/packages/plus/integrations/src/providers/models.ts
@@ -143,6 +143,29 @@ export interface ProviderOrganization {
 	name: string;
 	url: string;
 }
+
+/**
+ * Normalized repository shape returned by the ProviderBackend `listRepos` facade. GitLens-owned (carries
+ * no `@gitkraken/provider-apis` types), the repo analogue of {@link ProviderOrganization}. Named to avoid
+ * colliding with the unrelated local-clone `RepositoryShape` in `@gitlens/git/models/repositoryShape.js`.
+ * `namespace` is the owner/workspace/group identifier to pass back into repo-scoped reads (not a display
+ * name), matching {@link ProviderOrganization.name}.
+ */
+export interface ProviderRepositoryShape {
+	id: string;
+	namespace: string;
+	name: string;
+	/** Azure DevOps project; `undefined` for hosts without a project layer. */
+	project?: string;
+	/** Web (browser) URL, when the provider exposes it. */
+	url?: string;
+	/** HTTPS clone URL, when available. */
+	cloneUrlHttps?: string;
+	/** SSH clone URL, when available. */
+	cloneUrlSsh?: string;
+	/** Default branch name, when the provider reports it. */
+	defaultBranch?: string;
+}
 export const ProviderPullRequestReviewState = GitPullRequestReviewState;
 export const ProviderBuildStatusState = GitBuildStatusState;
 export type ProviderRequestFunction = RequestFunction;
@@ -857,6 +880,25 @@ export function toIssueShape(issue: ProviderIssue, provider: ProviderReference):
 	};
 }
 
+/**
+ * Maps a raw provider-apis {@link ProviderRepository} to the GitLens-owned {@link ProviderRepositoryShape}
+ * the ProviderBackend `listRepos` facade surfaces, so consumers don't depend on the SDK repo type. The SDK's
+ * nullable fields (`webUrl`/`httpsUrl`/`sshUrl`/`defaultBranch`) collapse to `undefined`, matching the
+ * `?? undefined` convention in {@link toIssueShape}/{@link toAccount}.
+ */
+export function toProviderRepositoryShape(repo: ProviderRepository): ProviderRepositoryShape {
+	return {
+		id: repo.id,
+		namespace: repo.namespace,
+		name: repo.name,
+		project: repo.project ?? undefined,
+		url: repo.webUrl ?? undefined,
+		cloneUrlHttps: repo.httpsUrl ?? undefined,
+		cloneUrlSsh: repo.sshUrl ?? undefined,
+		defaultBranch: repo.defaultBranch?.name ?? undefined,
+	};
+}
+
 export function issueFilterToReason(filter: IssueFilter): 'authored' | 'assigned' | 'mentioned' {
 	switch (filter) {
 		case IssueFilter.Author:
@@ -1192,6 +1234,13 @@ export function fromProviderPullRequest(
 	provider: Provider,
 	options?: { project?: IssueProject },
 ): PullRequest {
+	const repository = pr.repository;
+	const repositoryName = repository?.name ?? '';
+	const repositoryOwner = repository?.owner?.login ?? '';
+	const repositoryRemoteInfo = repository?.remoteInfo;
+	const headRepository = pr.headRepository;
+	const headRepositoryRemoteInfo = headRepository?.remoteInfo;
+
 	return new PullRequest(
 		provider,
 		fromProviderAccount(pr.author),
@@ -1200,11 +1249,11 @@ export function fromProviderPullRequest(
 		pr.title,
 		pr.url ?? '',
 		{
-			owner: pr.repository.owner.login,
-			repo: pr.repository.name,
+			owner: repositoryOwner,
+			repo: repositoryName,
 			// This has to be here until we can take this information from ProviderPullRequest:
 			accessLevel: RepositoryAccessLevel.Write,
-			id: pr.repository.id,
+			id: repository?.id ?? '',
 		},
 		fromProviderPullRequestState(pr.state),
 		pr.createdDate,
@@ -1217,27 +1266,27 @@ export function fromProviderPullRequest(
 			base: {
 				branch: pr.baseRef?.name ?? '',
 				sha: pr.baseRef?.oid ?? '',
-				repo: pr.repository.name,
-				owner: pr.repository.owner.login,
+				repo: repositoryName,
+				owner: repositoryOwner,
 				exists: pr.baseRef != null,
-				url: pr.repository.remoteInfo?.cloneUrlHTTPS
-					? pr.repository.remoteInfo.cloneUrlHTTPS.replace(gitSuffixRegex, '')
+				url: repositoryRemoteInfo?.cloneUrlHTTPS
+					? repositoryRemoteInfo.cloneUrlHTTPS.replace(gitSuffixRegex, '')
 					: '',
-				cloneHttps: pr.repository.remoteInfo?.cloneUrlHTTPS || undefined,
-				cloneSsh: pr.repository.remoteInfo?.cloneUrlSSH || undefined,
+				cloneHttps: repositoryRemoteInfo?.cloneUrlHTTPS || undefined,
+				cloneSsh: repositoryRemoteInfo?.cloneUrlSSH || undefined,
 			},
 			head: {
 				branch: pr.headRef?.name ?? '',
 				sha: pr.headRef?.oid ?? '',
-				repo: pr.headRepository?.name ?? '',
-				owner: pr.headRepository?.owner.login ?? '',
+				repo: headRepository?.name ?? '',
+				owner: headRepository?.owner?.login ?? '',
 				exists: pr.headRef != null,
-				url: pr.headRepository?.remoteInfo?.cloneUrlHTTPS
-					? pr.headRepository.remoteInfo.cloneUrlHTTPS.replace(gitSuffixRegex, '')
+				url: headRepositoryRemoteInfo?.cloneUrlHTTPS
+					? headRepositoryRemoteInfo.cloneUrlHTTPS.replace(gitSuffixRegex, '')
 					: '',
-				cloneHttps: pr.headRepository?.remoteInfo?.cloneUrlHTTPS || undefined,
-				cloneSsh: pr.headRepository?.remoteInfo?.cloneUrlSSH || undefined,
-				isFork: pr.headRepository?.isFork,
+				cloneHttps: headRepositoryRemoteInfo?.cloneUrlHTTPS || undefined,
+				cloneSsh: headRepositoryRemoteInfo?.cloneUrlSSH || undefined,
+				isFork: headRepository?.isFork,
 			},
 			isCrossRepository: pr.isCrossRepository,
 		},


### PR DESCRIPTION
## Summary

The ProviderBackend surface (`IntegrationService` facade, consumed by Kepler) exported the item types for pull requests and repositories as raw `@gitkraken/provider-apis` SDK re-aliases (`ProviderPullRequest = GitPullRequest`, `ProviderRepository = GitRepository`), whereas issues were already normalized to the GitLens-owned `IssueShape`. This leaked the SDK across the abstraction for everything except issues: a breaking change to any SDK PR/repo type would propagate straight through to consumers with no buffering.

Kepler's `core-gitlens` adapter is still a stub (data methods throw `notImplemented()`), so no consumer maps these raw types yet, which is the ideal moment to normalize before a later breaking migration on Kepler's side.

Closes #5533.

## Changes

- **PRs** → `listPullRequestsPage` / `sweepPullRequests` / `sweepClosedPullRequests` now return the existing GitLens-owned `PullRequestShape` (the PR analogue of `IssueShape`), mapped with the existing `fromProviderPullRequest`.
- **Repos** → `listRepos` now returns a new GitLens-owned `ProviderRepositoryShape` (a local interface next to `ProviderOrganization`), mapped with a new `toProviderRepositoryShape`.
- Removed the raw `ProviderPullRequest` / `ProviderRepository` / `ProviderAccount` / `ProviderIssue` re-exports from the `@gitlens/integrations` facade. `ProviderAccount`/`ProviderIssue` were orphan leaks (never on a public return type; no consumers). `PullRequestShape`/`IssueShape` are reached via the `@gitkraken/core-gitlens/git/models/*` subpath, mirroring how issues are already exposed.

## Approach

Normalization happens **at the facade boundary only**. The internal provider implementations, the SDK boundary (`providersApi.ts`), and the private drain helpers (`drainPullRequests` / `drainRepositories`) keep speaking the raw SDK aliases exactly as before, so the intricate cursor/paging/truncation logic is unchanged; each public method just appends a `.map(...)` at its terminal return (for the sweep, inside the per-provider `ids.map` closure where the correct `ProviderReference` is in scope).

## Testing

- `pnpm run check` clean.
- `pnpm run test` (integrations package): 311 passing. Updated PR stubs across `providerBackendSurface.test.ts` / `sweepAndBroaden.test.ts` (they now flow through `fromProviderPullRequest`, which needs a `repository`) and added a `toProviderRepositoryShape` unit test.

## Notes

- This PR targets `core` (like its sibling surface PRs). Because `core` is not the repo's default branch, merging will **not** auto-close #5533; it will need to be closed manually (or when `core` reaches `main`).
- Sibling issues #5526/#5527/#5529/#5530/#5531 touch other files; the only adjacency is #5531 (import block of `providers/models.ts`, not these definitions) and #5530 (one additive line in `index.ts`) — no content collision.
