### PR TITLE
Adds an inline mode to the Graph header bar for vertically constrained views

### DIFF
--- a/src/webviews/apps/plus/graph/graph-app.ts
+++ b/src/webviews/apps/plus/graph/graph-app.ts
@@ -146,6 +146,13 @@ const detailsMaxPct = 80;
 const detailsAutoBottomEnterPx = 820;
 const detailsAutoBottomExitPx = 920;
 
+// Height thresholds (px) for the account bar's inline mode (issue #5449) — below `enter` the bar
+// gives up its own row and its chips move into the graph header's right group; above `exit` it
+// returns to a full-width row. The dead-band between them prevents flicker when the view is
+// dragged across the boundary (e.g. resizing the bottom panel).
+const headerInlineEnterPx = 400;
+const headerInlineExitPx = 460;
+
 const minimapDefaultPx = 40;
 const minimapMaxPct = 40;
 
@@ -378,6 +385,13 @@ export class GraphApp extends SignalWatcher(LitElement) {
 		context: aiContext,
 		initialValue: this._aiState,
 	});
+	/** Height-driven presentation of the account bar (issue #5449): `false` = full-width row above
+	 *  the header (bar mode); `true` = chips inlined into the graph header's right group. Driven by
+	 *  `_graphSizeObserver` with enter/exit hysteresis (mirrors `_autoEffectiveLocation`, including
+	 *  the `@state` treatment). */
+	@state()
+	private _headerInlineMode = false;
+
 	/** Guards the account-bar context wiring. Set true while wired (see `updated()`); reset by the
 	 *  disarm branch when the home-header flag flips off so it can re-arm. */
 	private _accountContextsInitialized = false;
@@ -494,22 +508,39 @@ export class GraphApp extends SignalWatcher(LitElement) {
 						this.persistState();
 					}
 				}
+
+				// Same hysteresis pattern for the account bar's inline mode (issue #5449), driven by
+				// height. Mode flips only change the header's contents — `.graph`'s own size is
+				// viewport-determined, so this can't feed back into the observer.
+				if (!this._headerInlineMode && height < headerInlineEnterPx) {
+					this._headerInlineMode = true;
+				} else if (this._headerInlineMode && height > headerInlineExitPx) {
+					this._headerInlineMode = false;
+				}
 			}
 		});
 	}
 
-	private _graphObserved = false;
+	private _observedGraphRoot: HTMLElement | undefined;
 
 	// Observe the outer `.graph` div once rendered — it contains the entire layout (header, panes,
-	// sidebar, React mount), so freezing this one element freezes everything inside it. Idempotent and
-	// driven from both `firstUpdated` and `updated`: `.graph` is absent on the first render when the
-	// account-access screen replaces the tree (signed out), so it must attach when the graph appears
-	// after sign-in — where `firstUpdated` no longer fires.
+	// sidebar, React mount), so freezing this one element freezes everything inside it. Identity-tracked
+	// (not a one-shot latch) and driven from both `firstUpdated` and `updated`: the signed-out
+	// account-access screen replaces the whole tree, so `.graph` is absent on the first render in that
+	// state AND is a brand-new element after each sign-out/sign-in cycle — a latch would leave the new
+	// element unobserved, freezing every height/width-driven behavior (inline header mode, `auto`
+	// details location) until a webview reload.
 	private ensureGraphObserved(): void {
-		if (this._graphObserved || this.graphRootEl == null || this._graphSizeObserver == null) return;
+		const el = this.graphRootEl;
+		if (el === this._observedGraphRoot || this._graphSizeObserver == null) return;
 
-		this._graphObserved = true;
-		this._graphSizeObserver.observe(this.graphRootEl);
+		if (this._observedGraphRoot != null) {
+			this._graphSizeObserver.unobserve(this._observedGraphRoot);
+		}
+		this._observedGraphRoot = el;
+		if (el != null) {
+			this._graphSizeObserver.observe(el);
+		}
 	}
 
 	protected override firstUpdated(): void {
@@ -540,6 +571,9 @@ export class GraphApp extends SignalWatcher(LitElement) {
 
 		this._graphSizeObserver?.disconnect();
 		this._graphSizeObserver = undefined;
+		// Reset the identity tracking so a reconnect (which creates a fresh observer) re-observes the
+		// root even when the DOM element survived the disconnect.
+		this._observedGraphRoot = undefined;
 		if (this._releaseSuspensionRafId != null) {
 			cancelAnimationFrame(this._releaseSuspensionRafId);
 			this._releaseSuspensionRafId = undefined;
@@ -1674,6 +1708,7 @@ export class GraphApp extends SignalWatcher(LitElement) {
 		const detailsVisible = this.graphState.details?.visible ?? false;
 		const minimapVisible = this.graphState.minimap?.visible ?? true;
 		const { single, multi } = this.activeSelection;
+		const homeHeaderEnabled = this.graphState.config?.experimentalHomeHeaderEnabled ?? false;
 		// No repository open: render only the empty state — skip the header and the whole graph subtree
 		// (React GraphContainer + minimap + sidebar + details) rather than mounting them just to paint the
 		// empty state over the top. `repositories` is `undefined` during the initial load window, so `=== 0`
@@ -1685,7 +1720,10 @@ export class GraphApp extends SignalWatcher(LitElement) {
 		return html`
 			<div class="graph">
 				${when(
-					this.graphState.config?.experimentalHomeHeaderEnabled ?? false,
+					// With no repository open the header row (the inline chips' host) isn't rendered, so keep
+					// the bar in that case even when vertically constrained — otherwise the account and
+					// integrations info would disappear entirely.
+					homeHeaderEnabled && (!this._headerInlineMode || noRepos),
 					() => html`<gl-account-bar class="graph__account-bar"></gl-account-bar>`,
 				)}
 				${when(
@@ -1693,6 +1731,7 @@ export class GraphApp extends SignalWatcher(LitElement) {
 					() => html`
 						<gl-graph-header
 							class="graph__header"
+							.accountBarInline=${homeHeaderEnabled && this._headerInlineMode}
 							.selectCommits=${this.selectCommits}
 							.getCommits=${this.getCommits}
 							.ensureGraphRendered=${this.ensureGraphRendered}

--- a/src/webviews/apps/plus/graph/graph-header.ts
+++ b/src/webviews/apps/plus/graph/graph-header.ts
@@ -61,6 +61,8 @@ import type { SidebarActions } from './sidebar/sidebarState.js';
 import { isGraphSearchResultsError, shouldRestoreSearchQuery } from './stateProvider.js';
 import { actionButton, linkBase } from './styles/graph.css.js';
 import { graphHeaderControlStyles, titlebarStyles } from './styles/header.css.js';
+import '../shared/components/account-chip.js';
+import '../shared/components/integrations-chip.js';
 import '../../shared/components/branch-name.js';
 import '../../shared/components/button.js';
 import '../../shared/components/code-icon.js';
@@ -141,6 +143,11 @@ export class GlGraphHeader extends SignalWatcher(LitElement) {
 
 			progress-indicator {
 				top: 0;
+			}
+
+			.inline-chip {
+				flex: none;
+				align-self: center;
 			}
 
 			.mcp-tooltip::part(body),
@@ -254,6 +261,12 @@ export class GlGraphHeader extends SignalWatcher(LitElement) {
 
 	@property({ type: Boolean, attribute: 'has-selected-commit' })
 	hasSelectedCommit = false;
+
+	/** When set, the account/integrations chips render inline at the end of the header's right group
+	 *  instead of the standalone account bar row above (issue #5449). Driven by GraphApp's
+	 *  height-based mode tracking; only ever true while the experimental home header is enabled. */
+	@property({ type: Boolean, attribute: 'account-bar-inline' })
+	accountBarInline = false;
 
 	get hasFilters() {
 		// Scope mode forces first-parent rendering, so it always counts as a filter.
@@ -1213,6 +1226,15 @@ export class GlGraphHeader extends SignalWatcher(LitElement) {
 				)}
 				${this.renderGraphWalkthroughBanner(state)} ${this.renderStartMenu()}
 				<gl-graph-launchpad-indicator></gl-graph-launchpad-indicator>
+				${when(
+					this.accountBarInline,
+					// Last in the RIGHT group on purpose: when the row is also width-constrained, the row's
+					// overflow policy (see titlebar__row--wrap in header.css.ts) pushes trailing content past
+					// the right edge — the chips clip away first (whole, reappearing when widened) rather
+					// than displacing the header's primary controls. Accepted degradation; verified live.
+					() => html`<gl-account-chip class="inline-chip" compact></gl-account-chip>
+						<gl-integrations-chip class="inline-chip" compact></gl-integrations-chip>`,
+				)}
 			</div>
 		</div>`;
 	}

--- a/src/webviews/apps/plus/graph/graph.scss
+++ b/src/webviews/apps/plus/graph/graph.scss
@@ -4563,8 +4563,10 @@ web-graph {
 	padding: 0.1rem;
 	overflow: hidden;
 
-	// Account + integrations bar (issue #5411): sits above the graph header, always visible so
-	// account/integrations state is available when the Graph is the main GitLens panel.
+	// Account + integrations bar (issue #5411): sits above the graph header so account/integrations
+	// state is available when the Graph is the main GitLens panel. When the view is vertically
+	// constrained, the row is dropped and compact chips render inline in the graph header instead —
+	// see `headerInlineEnterPx`/`_headerInlineMode` in graph-app.ts (issue #5449).
 	&__account-bar {
 		position: relative;
 		z-index: var(--gl-z-sticky);

--- a/src/webviews/apps/plus/shared/components/account-chip.ts
+++ b/src/webviews/apps/plus/shared/components/account-chip.ts
@@ -1,7 +1,7 @@
 import { SignalWatcher } from '@lit-labs/signals';
 import { consume } from '@lit/context';
 import { css, html, LitElement, nothing } from 'lit';
-import { customElement, property, query } from 'lit/decorators.js';
+import { customElement, property, query, state } from 'lit/decorators.js';
 import { ifDefined } from 'lit/directives/if-defined.js';
 import { when } from 'lit/directives/when.js';
 import { pluralize } from '@gitlens/utils/string.js';
@@ -79,6 +79,12 @@ export class GlAccountChip extends SignalWatcher(LitElement) {
 				line-height: 2rem;
 				text-transform: uppercase;
 				background-color: var(--gl-account-chip-color);
+			}
+
+			/* Avatar-only anchor: the right padding exists to balance the trailing plan-tier label,
+			   which compact mode drops. */
+			:host([compact]) .chip {
+				padding-right: 0;
 			}
 
 			.chip--outlined {
@@ -244,6 +250,11 @@ export class GlAccountChip extends SignalWatcher(LitElement) {
 				}
 			}
 
+			/* Compact hosts get an avatar-only chip, so shrink the loading placeholder to match. */
+			:host([compact]) .chip--skeleton {
+				width: 2.4rem;
+			}
+
 			.chip--skeleton {
 				position: relative;
 				width: 8rem;
@@ -279,11 +290,21 @@ export class GlAccountChip extends SignalWatcher(LitElement) {
 		this._showUpgrade = value;
 	}
 
+	/** Compact presentation for space-constrained hosts (e.g. inlined in the Graph header, issue
+	 *  #5449): avatar-only anchor, no plan-tier label, no upgrade CTA — the popover still carries
+	 *  the full account content. Opt-in via attribute so existing hosts (Home) are unaffected. */
+	@property({ type: Boolean, reflect: true })
+	compact = false;
+
 	@query('#chip')
 	private _chip!: HTMLElement;
 
 	@query('gl-popover')
 	private _popover!: GlPopover;
+
+	/** Mirrors the popover's open state so the compact anchor's `aria-expanded` stays accurate. */
+	@state()
+	private _popoverOpen = false;
 
 	private get accountAvatar() {
 		return this.hasAccount && this._subscription.avatar.get();
@@ -365,12 +386,26 @@ export class GlAccountChip extends SignalWatcher(LitElement) {
 			></span>`;
 		}
 
-		return html`<gl-popover placement="bottom" trigger="hover focus click">
-				<span id="chip" slot="anchor" class="chip" tabindex="0">
+		return html`<gl-popover
+				placement="bottom"
+				trigger="hover focus click"
+				@gl-popover-show=${this.onPopoverShow}
+				@gl-popover-hide=${this.onPopoverHide}
+			>
+				<span
+					id="chip"
+					slot="anchor"
+					class="chip"
+					tabindex="0"
+					role=${this.compact ? 'button' : nothing}
+					aria-label=${this.compact ? `Account (${this.planTier})` : nothing}
+					aria-expanded=${this.compact ? this._popoverOpen : nothing}
+					@keydown=${this.onAnchorKeydown}
+				>
 					${this.accountAvatar
 						? html`<img class="chip__media" src=${this.accountAvatar} />`
 						: html`<code-icon class="chip__media" icon="gl-gitlens" size="16"></code-icon>`}
-					<span>${this.planTier}</span>
+					${this.compact ? nothing : html`<span>${this.planTier}</span>`}
 				</span>
 				<div slot="content" class="content" tabindex="-1">
 					<div class="header">
@@ -410,12 +445,30 @@ export class GlAccountChip extends SignalWatcher(LitElement) {
 					${this.renderAccountInfo()} ${this.renderAccountState()}
 				</div>
 			</gl-popover>
-			${this.renderUpgradeContent()}`;
+			${this.compact ? nothing : this.renderUpgradeContent()}`;
 	}
 
 	show(): void {
 		void this._popover.show();
 		this.focus();
+	}
+
+	/** Enter/Space activation for the compact anchor's `role="button"` — a span doesn't synthesize
+	 *  clicks, so without this the advertised button semantics wouldn't work from the keyboard
+	 *  (e.g. reopening the popover after dismissing it with Escape). */
+	private onAnchorKeydown(e: KeyboardEvent) {
+		if (!this.compact || e.repeat || (e.key !== 'Enter' && e.key !== ' ')) return;
+
+		e.preventDefault();
+		void (this._popover.open ? this._popover.hide() : this._popover.show());
+	}
+
+	private onPopoverShow() {
+		this._popoverOpen = true;
+	}
+
+	private onPopoverHide() {
+		this._popoverOpen = false;
 	}
 
 	private renderAccountInfo() {

--- a/src/webviews/apps/plus/shared/components/integrations-chip.ts
+++ b/src/webviews/apps/plus/shared/components/integrations-chip.ts
@@ -1,7 +1,7 @@
 import { SignalWatcher } from '@lit-labs/signals';
 import { consume } from '@lit/context';
 import { css, html, LitElement, nothing } from 'lit';
-import { customElement, query } from 'lit/decorators.js';
+import { customElement, property, query, state } from 'lit/decorators.js';
 import type { SupportedCloudIntegrationIds } from '@gitlens/integrations/constants.js';
 import type {
 	ConnectCloudIntegrationsCommandArgs,
@@ -13,6 +13,7 @@ import type { SubscriptionUpgradeCommandArgs } from '../../../../../plus/gk/mode
 import { isSubscriptionTrialOrPaidFromState } from '../../../../../plus/gk/utils/subscription.utils.js';
 import { createCommandLink } from '../../../../../system/commands.js';
 import type { AIState, IntegrationStateInfo } from '../../../../rpc/services/types.js';
+import type { GlPopover } from '../../../shared/components/overlays/popover.js';
 import { elementBase, linkBase } from '../../../shared/components/styles/lit/base.css.js';
 import type { AIContextState } from '../../../shared/contexts/ai.js';
 import { aiContext } from '../../../shared/contexts/ai.js';
@@ -176,6 +177,11 @@ export class GlIntegrationsChip extends SignalWatcher(LitElement) {
 				}
 			}
 
+			/* Compact hosts get icon-sized chips, so shrink the loading placeholder to match. */
+			:host([compact]) .chip--skeleton {
+				width: 2.4rem;
+			}
+
 			.chip--skeleton {
 				position: relative;
 				width: 9rem;
@@ -202,8 +208,22 @@ export class GlIntegrationsChip extends SignalWatcher(LitElement) {
 		`,
 	];
 
+	/** Compact presentation for space-constrained hosts (e.g. inlined in the Graph header, issue
+	 *  #5449): collapses the anchor to a single plug icon (the full status-icon strip is too wide
+	 *  for a header) — the popover still carries the full content. Opt-in via attribute so existing
+	 *  hosts (Home) are unaffected. */
+	@property({ type: Boolean, reflect: true })
+	compact = false;
+
 	@query('#chip')
 	private _chip!: HTMLElement;
+
+	@query('gl-popover')
+	private _popover!: GlPopover;
+
+	/** Mirrors the popover's open state so the compact anchor's `aria-expanded` stays accurate. */
+	@state()
+	private _popoverOpen = false;
 
 	private get hasAccount() {
 		return this._subscription.subscription.get()?.account != null;
@@ -237,6 +257,24 @@ export class GlIntegrationsChip extends SignalWatcher(LitElement) {
 		this._chip.focus();
 	}
 
+	/** Enter/Space activation for the compact anchor's `role="button"` — a span doesn't synthesize
+	 *  clicks, so without this the advertised button semantics wouldn't work from the keyboard
+	 *  (e.g. reopening the popover after dismissing it with Escape). */
+	private onAnchorKeydown(e: KeyboardEvent) {
+		if (!this.compact || e.repeat || (e.key !== 'Enter' && e.key !== ' ')) return;
+
+		e.preventDefault();
+		void (this._popover.open ? this._popover.hide() : this._popover.show());
+	}
+
+	private onPopoverShow() {
+		this._popoverOpen = true;
+	}
+
+	private onPopoverHide() {
+		this._popoverOpen = false;
+	}
+
 	override render(): unknown {
 		// Don't show integration state until subscription data has loaded —
 		// otherwise we'd flash "Connect" with an empty list.
@@ -251,20 +289,39 @@ export class GlIntegrationsChip extends SignalWatcher(LitElement) {
 		}
 
 		const anyConnected = this.hasConnectedIntegrations;
-		const statusFilter = createStatusIconFilter(this.integrations);
+		// Capture one array instance — the icon-dedup filter matches items by identity, so it must be
+		// built from the same read it filters.
+		const integrations = this.integrations;
 
-		return html`<gl-popover placement="bottom" trigger="hover click focus">
-			<span slot="anchor" class="chip" tabindex="0"
-				>${!anyConnected ? html`<span class="chip__label">Connect</span>` : ''}${this.integrations
-					.filter(statusFilter)
-					.map(i =>
-						this.renderIntegrationStatus(i),
-					)}${this.renderAIStatus()}${this.renderMcpStatus()}${this.renderDefaultAgentStatus()}${this.renderHooksStatus()}</span
+		return html`<gl-popover
+			placement="bottom"
+			trigger="hover click focus"
+			@gl-popover-show=${this.onPopoverShow}
+			@gl-popover-hide=${this.onPopoverHide}
+		>
+			<span
+				id="chip"
+				slot="anchor"
+				class="chip"
+				tabindex="0"
+				role=${this.compact ? 'button' : nothing}
+				aria-label=${this.compact ? `Integrations (${anyConnected ? 'connected' : 'not connected'})` : nothing}
+				aria-expanded=${this.compact ? this._popoverOpen : nothing}
+				@keydown=${this.onAnchorKeydown}
+				>${this.compact
+					? html`<span class="integration status--${anyConnected ? 'connected' : 'disconnected'}"
+							><code-icon icon="plug"></code-icon
+						></span>`
+					: html`${!anyConnected ? html`<span class="chip__label">Connect</span>` : ''}${integrations
+							.filter(createStatusIconFilter(integrations))
+							.map(i =>
+								this.renderIntegrationStatus(i),
+							)}${this.renderAIStatus()}${this.renderMcpStatus()}${this.renderDefaultAgentStatus()}${this.renderHooksStatus()}`}</span
 			>
 			<div slot="content" class="content">
 				<div class="header">
 					<span class="header__title">Integrations</span>
-					<span class="header__actions"></span>
+					<span class="header__actions">
 						<gl-button
 							appearance="toolbar"
 							href="${createCommandLink<Source>('gitlens.plus.validate', {
@@ -288,8 +345,8 @@ export class GlIntegrationsChip extends SignalWatcher(LitElement) {
 							><code-icon icon="gear"></code-icon></gl-button
 					></span>
 				</div>
-				<div class="integrations">${
-					!anyConnected
+				<div class="integrations">
+					${!anyConnected
 						? html`<p>
 									Connect hosting services like <strong>GitHub</strong> and issue trackers like
 									<strong>Jira</strong> to track progress and take action on PRs and issues related to
@@ -310,8 +367,10 @@ export class GlIntegrationsChip extends SignalWatcher(LitElement) {
 										>Connect Integrations</gl-button
 									>
 								</button-container>`
-						: this.integrations.map(i => this.renderIntegrationRow(i))
-				}${this.renderAIRow()}${this.renderMcpRow()}${this.renderDefaultAgentRow()}${this.renderHooksRow()}</div>
+						: this.integrations.map(i =>
+								this.renderIntegrationRow(i),
+							)}${this.renderAIRow()}${this.renderMcpRow()}${this.renderDefaultAgentRow()}${this.renderHooksRow()}
+				</div>
 			</div>
 		</gl-popover>`;
 	}


### PR DESCRIPTION
Closes #5449 (sub-issue of #5391; follow-up to #5411)

## Summary

Makes the experimental Graph account header adaptive to vertical space (gated by `gitlens.graph.experimental.homeHeader.enabled`):

- **Bar mode** (unchanged current behavior) — the full-width account/integrations bar above the graph header, when the view has room
- **Inline mode** — when the graph webview is vertically constrained (e.g. docked in the bottom panel), the bar gives up its dedicated row and its chips render as compact buttons in the top right of the existing graph header, next to the Start New menu

### How it works

- Mode is driven by the existing `.graph` ResizeObserver with enter/exit hysteresis (`headerInlineEnterPx = 400` / `headerInlineExitPx = 460`), mirroring the `_autoEffectiveLocation` width pattern — no new observers, no height container queries (deliberately avoided: `container-type: size` containment is a layout-loop risk in the graph's observer ecosystem)
- The chips consume the shared subscription/integrations/AI contexts provided at the `GraphApp` level, which cross the header's shadow boundary — no rewiring; context init remains flag-gated and mode-independent, so constrained-at-startup hydrates correctly
- New opt-in `compact` attribute on `gl-account-chip` (avatar-only) and `gl-integrations-chip` (icons-only), with `aria-label`s preserving the accessible names — default off, Home view untouched
- With no repository open the header row (the inline chips' host) isn't rendered, so the bar stays even when constrained
- Fixes a pre-existing observer lifecycle bug exposed by the feature: `ensureGraphObserved` latched a boolean, so after a sign-out/sign-in cycle the recreated `.graph` element was never re-observed, freezing all size-driven behavior (this also froze the `auto` details location on main). Now identity-tracked with re-observe on element change and reset on disconnect.

### Threshold note for review

400/460px were chosen against typical bottom-panel heights and validated live, but the boundary is a product call — feedback welcome before this graduates from the experimental flag.

## Test plan (live-verified)

- [x] Bar mode at height ≥ exit threshold: full-width bar, no chips in header
- [x] Inline mode at height < enter threshold: bar gone, both chips in header right group, fitting within the viewport
- [x] Hysteresis: no flapping across the 400–460 dead band in either direction
- [x] Constrained-at-startup: chips hydrate live data when the first-ever mode is inline
- [x] Both chip popovers open fully on-screen in a 338px-tall viewport (right-edge aligned)
- [x] Sign-out → sign-in → resize: mode switching keeps working (observer re-attach fix)
- [x] Flag off: no bar, no chips, at any height
- [x] Home view header unaffected (chips non-compact there); bar-mode chips unaffected
- [x] Console clean across mode flips
- [ ] Web (vscode.dev) smoke — no environment-specific code touched, but untested

🤖 Generated with [Claude Code](https://claude.com/claude-code)