### PR TITLE
fix: preserve provider PR descriptions on normalized reads

### DIFF
--- a/packages/git/src/models/pullRequest.ts
+++ b/packages/git/src/models/pullRequest.ts
@@ -11,6 +11,7 @@ export type { PullRequestState };
 
 export interface PullRequestShape extends IssueOrPullRequest {
 	readonly author: PullRequestMember;
+	readonly body?: string;
 	readonly mergedDate?: Date;
 	readonly refs?: PullRequestRefs;
 	readonly isDraft?: boolean;
@@ -56,6 +57,7 @@ export class PullRequest implements PullRequestShape {
 		public readonly statusCheckRollupState?: PullRequestStatusCheckRollupState,
 		public readonly project?: IssueProject,
 		public readonly version?: number,
+		public readonly body?: string,
 	) {}
 
 	get closed(): boolean {

--- a/packages/git/src/utils/pullRequest.utils.ts
+++ b/packages/git/src/utils/pullRequest.utils.ts
@@ -93,6 +93,7 @@ export function serializePullRequest(value: PullRequest): PullRequestShape {
 		id: value.id,
 		nodeId: value.nodeId,
 		title: value.title,
+		body: value.body,
 		url: value.url,
 		createdDate: value.createdDate,
 		updatedDate: value.updatedDate,

--- a/packages/plus/git-github/src/api/__tests__/github.test.ts
+++ b/packages/plus/git-github/src/api/__tests__/github.test.ts
@@ -80,6 +80,7 @@ suite('GitHubApi.searchPullRequests', () => {
 			id: `pr-${number}`,
 			number: number,
 			title: `PR ${number}`,
+			body: `Body ${number}`,
 			permalink: `https://github.com/octo/repo/pull/${number}`,
 			url: `https://github.com/octo/repo/pull/${number}`,
 			state: state,
@@ -203,6 +204,126 @@ suite('GitHubApi.searchPullRequests', () => {
 
 		assert.deepStrictEqual(results, []);
 		assert.strictEqual(seenCursors.length, 20);
+	});
+});
+
+suite('GitHubApi direct pull request lookups', () => {
+	const provider = {
+		id: 'github',
+		name: 'GitHub',
+		domain: 'github.com',
+		icon: 'github',
+		getIgnoreSSLErrors: () => false,
+		reauthenticate: () => Promise.resolve(),
+		trackRequestException: () => {},
+	} as unknown as Provider;
+
+	const token: GitHubTokenInfo = {
+		providerId: 'github',
+		accessToken: 'token',
+		microHash: 'hash',
+		cloud: true,
+		type: undefined,
+	};
+
+	function prNode(number: number) {
+		return {
+			id: `pr-${number}`,
+			number: number,
+			title: `PR ${number}`,
+			body: `Body ${number}`,
+			permalink: `https://github.com/octo/repo/pull/${number}`,
+			url: `https://github.com/octo/repo/pull/${number}`,
+			state: 'OPEN',
+			createdAt: '2024-01-01T00:00:00Z',
+			updatedAt: '2024-01-02T00:00:00Z',
+			closedAt: null,
+			mergedAt: null,
+			author: { login: 'octo', avatarUrl: '', url: 'https://github.com/octo' },
+			baseRefName: 'main',
+			baseRefOid: 'base',
+			headRefName: 'feature',
+			headRefOid: 'head',
+			headRepository: {
+				isFork: false,
+				name: 'repo',
+				owner: { login: 'octo' },
+				sshUrl: 'git@github.com:octo/repo.git',
+				url: 'https://github.com/octo/repo',
+			},
+			repository: {
+				isFork: false,
+				name: 'repo',
+				owner: { login: 'octo' },
+				sshUrl: 'git@github.com:octo/repo.git',
+				url: 'https://github.com/octo/repo',
+				viewerPermission: 'WRITE',
+			},
+			isCrossRepository: false,
+			isDraft: false,
+			additions: 1,
+			deletions: 1,
+			checksUrl: '',
+			mergeable: 'MERGEABLE',
+			reviewDecision: 'APPROVED',
+			latestReviews: { nodes: [] },
+			reviewRequests: { nodes: [] },
+			assignees: { nodes: [] },
+			commits: { nodes: [] },
+			totalCommentsCount: 0,
+			viewerCanUpdate: true,
+		};
+	}
+
+	function captureQuery(data: unknown): { config: GitHubApiConfig; getQuery: () => string } {
+		let query = '';
+		const config: GitHubApiConfig = {
+			isWeb: false,
+			fetch: async (_url, init) => {
+				const body = JSON.parse(String(init?.body ?? '{}')) as { query?: string };
+				query = body.query ?? '';
+				return new Response(JSON.stringify({ data: data }), {
+					status: 200,
+					headers: { 'content-type': 'application/json' },
+				});
+			},
+			wrapForForcedInsecureSSL: (_ignore, fn) => fn(),
+		};
+		return { config: config, getQuery: () => query };
+	}
+
+	test('getPullRequest requests and maps the body', async () => {
+		const { config, getQuery } = captureQuery({ repository: { pullRequest: prNode(1) } });
+		const api = new GitHubApi(config);
+
+		const pr = await api.getPullRequest(provider, token, 'octo', 'repo', 1);
+
+		assert.match(getQuery(), /\bbody\b/);
+		assert.strictEqual(pr?.body, 'Body 1');
+	});
+
+	test('getPullRequestForBranch requests and maps the body', async () => {
+		const { config, getQuery } = captureQuery({
+			repository: { ref: { associatedPullRequests: { nodes: [prNode(2)] } } },
+		});
+		const api = new GitHubApi(config);
+
+		const pr = await api.getPullRequestForBranch(provider, token, 'octo', 'repo', 'feature');
+
+		assert.match(getQuery(), /\bbody\b/);
+		assert.strictEqual(pr?.body, 'Body 2');
+	});
+
+	test('getPullRequestForCommit requests and maps the body', async () => {
+		const { config, getQuery } = captureQuery({
+			repository: { object: { associatedPullRequests: { nodes: [prNode(3)] } } },
+		});
+		const api = new GitHubApi(config);
+
+		const pr = await api.getPullRequestForCommit(provider, token, 'octo', 'repo', 'deadbeef');
+
+		assert.match(getQuery(), /\bbody\b/);
+		assert.strictEqual(pr?.body, 'Body 3');
 	});
 });
 

--- a/packages/plus/git-github/src/api/github.ts
+++ b/packages/plus/git-github/src/api/github.ts
@@ -59,12 +59,7 @@ import type {
 	GitHubSshSigningKey,
 	GitHubTag,
 } from '../models.js';
-import {
-	fromGitHubIssue,
-	fromGitHubIssueOrPullRequestState,
-	fromGitHubPullRequest,
-	fromGitHubPullRequestLite,
-} from '../models.js';
+import { fromGitHubIssue, fromGitHubIssueOrPullRequestState, fromGitHubPullRequest } from '../models.js';
 import type { GitHubApiConfig } from './config.js';
 import type { GitHubTokenInfo } from './token.js';
 
@@ -163,6 +158,7 @@ repository {
 const gqlPullRequestFragment = `
 ${gqlPullRequestLiteFragment}
 additions
+body
 assignees(first: 25) {
 	nodes {
 		login
@@ -858,7 +854,7 @@ export class GitHubApi {
 		interface QueryResult {
 			repository:
 				| {
-						pullRequest: GitHubPullRequestLite | null | undefined;
+						pullRequest: GitHubPullRequest | null | undefined;
 				  }
 				| null
 				| undefined;
@@ -893,7 +889,7 @@ export class GitHubApi {
 
 			if (rsp?.repository?.pullRequest == null) return undefined;
 
-			return fromGitHubPullRequestLite(rsp.repository.pullRequest, provider);
+			return fromGitHubPullRequest(rsp.repository.pullRequest, provider);
 		} catch (ex) {
 			if (ex instanceof RequestNotFoundError) return undefined;
 
@@ -930,7 +926,7 @@ export class GitHubApi {
 						ref:
 							| {
 									associatedPullRequests?: {
-										nodes?: GitHubPullRequestLite[];
+										nodes?: GitHubPullRequest[];
 									};
 							  }
 							| null
@@ -953,7 +949,7 @@ export class GitHubApi {
 		ref(qualifiedName: $branch) {
 			associatedPullRequests(first: $limit, orderBy: {field: UPDATED_AT, direction: DESC}, states: $include) {
 				nodes {
-					${gqlPullRequestLiteFragment}
+						${gqlPullRequestFragment}
 				}
 			}
 		}
@@ -990,7 +986,7 @@ export class GitHubApi {
 				);
 			}
 
-			return fromGitHubPullRequestLite(prs[0], provider);
+			return fromGitHubPullRequest(prs[0], provider);
 		} catch (ex) {
 			if (ex instanceof RequestNotFoundError) return undefined;
 
@@ -1026,7 +1022,7 @@ export class GitHubApi {
 				| {
 						object?: {
 							associatedPullRequests?: {
-								nodes?: GitHubPullRequestLite[];
+								nodes?: GitHubPullRequest[];
 							};
 						};
 				  }
@@ -1046,7 +1042,7 @@ export class GitHubApi {
 			... on Commit {
 				associatedPullRequests(first: 2, orderBy: {field: UPDATED_AT, direction: DESC}) {
 					nodes {
-						${gqlPullRequestLiteFragment}
+								${gqlPullRequestFragment}
 					}
 				}
 			}
@@ -1083,7 +1079,7 @@ export class GitHubApi {
 				);
 			}
 
-			return fromGitHubPullRequestLite(prs[0], provider);
+			return fromGitHubPullRequest(prs[0], provider);
 		} catch (ex) {
 			if (ex instanceof RequestNotFoundError) return undefined;
 

--- a/packages/plus/git-github/src/models.ts
+++ b/packages/plus/git-github/src/models.ts
@@ -193,6 +193,7 @@ export type GitHubPullRequestReviewState = 'APPROVED' | 'CHANGES_REQUESTED' | 'C
 
 export interface GitHubPullRequest extends GitHubPullRequestLite {
 	additions: number;
+	body: string;
 	assignees: {
 		nodes: GitHubMember[];
 	};
@@ -471,6 +472,9 @@ export function fromGitHubPullRequest(pr: GitHubPullRequest, provider: Provider)
 			url: r.url,
 		})),
 		fromGitHubPullRequestStatusCheckRollupState(pr.commits.nodes?.[0]?.commit.statusCheckRollup?.state),
+		undefined, // project
+		undefined, // version
+		pr.body,
 	);
 }
 

--- a/packages/plus/integrations/src/__tests__/providerBackendSurface.test.ts
+++ b/packages/plus/integrations/src/__tests__/providerBackendSurface.test.ts
@@ -52,7 +52,7 @@ function providerPr(id: string): ProviderPullRequest {
 		id: id,
 		number: Number(id),
 		title: `PR ${id}`,
-		description: null,
+		description: `Body of PR ${id}`,
 		url: `https://example.com/pull/${id}`,
 		state: GitPullRequestState.Open,
 		isCrossRepository: false,
@@ -101,6 +101,7 @@ function searchPullRequest(id: string, state: 'open' | 'closed' | 'merged'): Pul
 		id: id,
 		nodeId: `node-${id}`,
 		title: `PR ${id}`,
+		body: `Body of PR ${id}`,
 		url: `https://example.com/pull/${id}`,
 		state: state === 'open' ? 'opened' : state,
 		createdDate: new Date('2024-01-01T00:00:00Z'),
@@ -179,6 +180,11 @@ suite('ProviderBackend surface facade (#5438)', () => {
 			result.items.map(pr => pr.id),
 			['2', '3'],
 			'only the requested page is returned after draining',
+		);
+		assert.deepEqual(
+			result.items.map(pr => pr.body),
+			['Body of PR 2', 'Body of PR 3'],
+			'the provider description survives the normalized PullRequestShape (#5549)',
 		);
 		assert.equal(result.page.currentPage, 2, 'currentPage reflects the requested page after draining');
 		assert.equal(result.page.itemsPerPage, 2, 'itemsPerPage reflects the returned page after draining');
@@ -342,6 +348,11 @@ suite('ProviderBackend surface facade (#5438)', () => {
 
 		assert.deepEqual(seenStates, ['closed', 'merged']);
 		assert.equal(result.items.length, 2, 'closed and merged PRs survive the account-wide sweep');
+		assert.deepEqual(
+			result.items.map(pr => pr.body).sort(),
+			['Body of PR 1', 'Body of PR 2'],
+			'the search fragment body survives the per-state round-trip through toProviderPullRequest (#5549)',
+		);
 		assert.equal(result.page.truncated, true, 'GitHub search truncation is surfaced on the page');
 		assert.equal(result.warnings.length, 1, 'a generic truncation warning is emitted when no metadata explains it');
 		assert.equal(result.warnings[0].kind, 'other');

--- a/packages/plus/integrations/src/providers/__tests__/pullRequestMapping.test.ts
+++ b/packages/plus/integrations/src/providers/__tests__/pullRequestMapping.test.ts
@@ -96,6 +96,14 @@ suite('pull request ref mapping (#5435 clone URLs + fork)', () => {
 		assert.equal(roundTrip.headRepository?.isFork, true);
 	});
 
+	test('description round-trips through the normalized PullRequest body', () => {
+		const roundTrip = toProviderPullRequest(
+			fromProviderPullRequest(createProviderPullRequest({ description: 'PR body' }), fakeProvider),
+		);
+
+		assert.equal(roundTrip.description, 'PR body');
+	});
+
 	test('remoteInfo is left null when a ref carries only a partial clone URL pair', () => {
 		const roundTrip = toProviderPullRequest(
 			fromProviderPullRequest(

--- a/packages/plus/integrations/src/providers/models.ts
+++ b/packages/plus/integrations/src/providers/models.ts
@@ -1194,7 +1194,7 @@ export function toProviderPullRequest(pr: PullRequest): ProviderPullRequest {
 		graphQLId: pr.nodeId,
 		number: Number.parseInt(pr.id, 10),
 		title: pr.title,
-		description: null,
+		description: pr.body ?? null,
 		url: pr.url,
 		state: toProviderPullRequestState(pr.state),
 		isCrossRepository: pr.refs?.isCrossRepository ?? false,
@@ -1367,6 +1367,7 @@ export function fromProviderPullRequest(
 			: undefined,
 		options?.project,
 		pr.version,
+		pr.description ?? undefined,
 	);
 }
 


### PR DESCRIPTION
## Summary
- preserve pull request descriptions on the normalized ProviderBackend PullRequestShape
- thread GitHub GraphQL PR body data through the full PR mapper and the provider round-trip path
- add regression coverage for facade paging and provider PR mapping

## Testing
- pnpm --filter @gitlens/integrations test
- pnpm --filter @gitlens/git build
- pnpm --filter @gitlens/git-github build

Fixes #5549
