### PR TITLE
Closes #5550 - Guard duplicated provider-apis enums against drift

### DIFF
--- a/packages/plus/integrations/src/providers/__tests__/enumParity.test.ts
+++ b/packages/plus/integrations/src/providers/__tests__/enumParity.test.ts
@@ -1,0 +1,132 @@
+import * as assert from 'node:assert/strict';
+import {
+	EntityIdentifierProviderType as SdkEntityIdentifierProviderType,
+	EntityType as SdkEntityType,
+	EntityVersion as SdkEntityVersion,
+	GitBuildStatusState as SdkGitBuildStatusState,
+	GitIssueState as SdkGitIssueState,
+	GitPullRequestMergeableState as SdkGitPullRequestMergeableState,
+	GitPullRequestReviewState as SdkGitPullRequestReviewState,
+	GitPullRequestState as SdkGitPullRequestState,
+} from '@gitkraken/provider-apis';
+import { suite, test } from 'mocha';
+import {
+	GitPullRequestMergeableState as BitbucketServerGitPullRequestMergeableState,
+	GitPullRequestReviewState as BitbucketServerGitPullRequestReviewState,
+	GitPullRequestState as BitbucketServerGitPullRequestState,
+} from '../bitbucket-server/models.js';
+import {
+	GitBuildStatusState,
+	GitIssueState,
+	GitPullRequestMergeableState,
+	GitPullRequestReviewState,
+	GitPullRequestState,
+} from '../models.js';
+import { EntityIdentifierProviderType, EntityType, EntityVersion } from '../utils.js';
+
+// Guards the runtime enum copies that #5531 duplicated out of `@gitkraken/provider-apis` (to dodge the
+// CJS-from-ESM named-export breakage) against silent upstream drift. The type-level aliases keep compiling
+// even if a value changes (the const objects cast their literals, e.g. `'OPEN' as GitPullRequestState`), so
+// only a runtime deep-equal against the real SDK enums can catch an added/renamed/changed value. The package
+// test entrypoint at `scripts/test.mjs` bundles this suite through esbuild, which is why the SDK's CJS named
+// exports are available here as runtime values.
+//
+// Two local copies are intentional subsets, not full mirrors, so they're asserted with
+// `assertLocalMatchesSdk` (every local entry must match the SDK; extra SDK members are allowed) rather than
+// a bidirectional deep-equal:
+// - `utils.ts` `EntityVersion` — the package only ever writes version `1`.
+// - `bitbucket-server/models.ts` `GitPullRequestMergeableState` — Bitbucket Server only normalizes to
+//   `Unknown`.
+type EnumLike = Record<string, string>;
+
+function sortEntries(enumLike: EnumLike): [string, string][] {
+	return Object.entries(enumLike).sort(([left], [right]) => left.localeCompare(right));
+}
+
+/** Bidirectional parity: the local copy must be a complete, exact mirror of the SDK enum. */
+function assertFullMirror(local: EnumLike, sdk: EnumLike, name: string): void {
+	assert.deepEqual(
+		sortEntries(local),
+		sortEntries(sdk),
+		`${name} has drifted from @gitkraken/provider-apis (value added, renamed, or changed)`,
+	);
+}
+
+/** Subset parity: every local entry must exist in the SDK with the same value; extra SDK members are allowed. */
+function assertLocalMatchesSdk(local: EnumLike, sdk: EnumLike, name: string): void {
+	for (const [key, value] of Object.entries(local)) {
+		assert.ok(
+			Object.hasOwn(sdk, key),
+			`${name}.${key} is missing from @gitkraken/provider-apis (renamed or removed upstream)`,
+		);
+		assert.equal(sdk[key], value, `${name}.${key} value has drifted from @gitkraken/provider-apis`);
+	}
+}
+
+suite('provider-apis enum parity (drift guard)', () => {
+	suite('providers/models.ts', () => {
+		test('GitBuildStatusState mirrors the SDK', () => {
+			assertFullMirror(GitBuildStatusState, SdkGitBuildStatusState, 'GitBuildStatusState');
+		});
+
+		test('GitIssueState mirrors the SDK', () => {
+			assertFullMirror(GitIssueState, SdkGitIssueState, 'GitIssueState');
+		});
+
+		test('GitPullRequestState mirrors the SDK', () => {
+			assertFullMirror(GitPullRequestState, SdkGitPullRequestState, 'GitPullRequestState');
+		});
+
+		test('GitPullRequestReviewState mirrors the SDK', () => {
+			assertFullMirror(GitPullRequestReviewState, SdkGitPullRequestReviewState, 'GitPullRequestReviewState');
+		});
+
+		test('GitPullRequestMergeableState mirrors the SDK', () => {
+			assertFullMirror(
+				GitPullRequestMergeableState,
+				SdkGitPullRequestMergeableState,
+				'GitPullRequestMergeableState',
+			);
+		});
+	});
+
+	suite('providers/utils.ts', () => {
+		test('EntityIdentifierProviderType mirrors the SDK', () => {
+			assertFullMirror(
+				EntityIdentifierProviderType,
+				SdkEntityIdentifierProviderType,
+				'EntityIdentifierProviderType',
+			);
+		});
+
+		test('EntityType mirrors the SDK', () => {
+			assertFullMirror(EntityType, SdkEntityType, 'EntityType');
+		});
+
+		test('EntityVersion is a subset that matches the SDK', () => {
+			assertLocalMatchesSdk(EntityVersion, SdkEntityVersion, 'EntityVersion');
+		});
+	});
+
+	suite('providers/bitbucket-server/models.ts', () => {
+		test('GitPullRequestState mirrors the SDK', () => {
+			assertFullMirror(BitbucketServerGitPullRequestState, SdkGitPullRequestState, 'GitPullRequestState');
+		});
+
+		test('GitPullRequestReviewState mirrors the SDK', () => {
+			assertFullMirror(
+				BitbucketServerGitPullRequestReviewState,
+				SdkGitPullRequestReviewState,
+				'GitPullRequestReviewState',
+			);
+		});
+
+		test('GitPullRequestMergeableState is a subset that matches the SDK', () => {
+			assertLocalMatchesSdk(
+				BitbucketServerGitPullRequestMergeableState,
+				SdkGitPullRequestMergeableState,
+				'GitPullRequestMergeableState',
+			);
+		});
+	});
+});

--- a/packages/plus/integrations/src/providers/bitbucket-server/models.ts
+++ b/packages/plus/integrations/src/providers/bitbucket-server/models.ts
@@ -9,20 +9,25 @@ type GitPullRequestMergeableState = GitPullRequestMergeableStateType;
 type GitPullRequestReviewState = GitPullRequestReviewStateType;
 type GitPullRequestState = GitPullRequestStateType;
 
-const GitPullRequestState = {
+// Local runtime copies of the `@gitkraken/provider-apis` PR string enums, duplicated for the same
+// CJS-from-ESM reason as the enums in `../models.ts`. Exported so the enum-parity test can guard them
+// against upstream drift. `GitPullRequestMergeableState` is an intentional subset: Bitbucket Server
+// only ever normalizes to `Unknown`, so the parity test asserts each local entry matches the SDK
+// rather than a full mirror.
+export const GitPullRequestState = {
 	Open: 'OPEN' as GitPullRequestState,
 	Closed: 'CLOSED' as GitPullRequestState,
 	Merged: 'MERGED' as GitPullRequestState,
 } as const;
 
-const GitPullRequestReviewState = {
+export const GitPullRequestReviewState = {
 	Approved: 'APPROVED' as GitPullRequestReviewState,
 	ChangesRequested: 'CHANGES_REQUESTED' as GitPullRequestReviewState,
 	Commented: 'COMMENTED' as GitPullRequestReviewState,
 	ReviewRequested: 'REVIEW_REQUESTED' as GitPullRequestReviewState,
 } as const;
 
-const GitPullRequestMergeableState = {
+export const GitPullRequestMergeableState = {
 	Unknown: 'UNKNOWN' as GitPullRequestMergeableState,
 } as const;
 

--- a/packages/plus/integrations/src/providers/models.ts
+++ b/packages/plus/integrations/src/providers/models.ts
@@ -85,7 +85,11 @@ type GitPullRequestState = GitPullRequestStateType;
 const { EntityIdentifierUtils } = entityIdentifiersModule;
 const { GitProviderUtils } = providerUtilsModule;
 
-const GitBuildStatusState = {
+// Local runtime copies of the `@gitkraken/provider-apis` string enums. Duplicated (not imported as
+// values) because the SDK ships as CJS whose named enum exports can't be statically imported as ESM
+// values from the bundled `dist`. Exported so the enum-parity test can deep-equal them against the
+// real SDK enums and turn any upstream drift into a test failure instead of a silent mismatch.
+export const GitBuildStatusState = {
 	ActionRequired: 'ACTION_REQUIRED' as GitBuildStatusState,
 	Cancelled: 'CANCELLED' as GitBuildStatusState,
 	Error: 'ERROR' as GitBuildStatusState,
@@ -98,25 +102,25 @@ const GitBuildStatusState = {
 	OptionalActionRequired: 'OPTIONAL_ACTION_REQUIRED' as GitBuildStatusState,
 } as const;
 
-const GitIssueState = {
+export const GitIssueState = {
 	Open: 'OPEN' as GitIssueState,
 	Closed: 'CLOSED' as GitIssueState,
 } as const;
 
-const GitPullRequestState = {
+export const GitPullRequestState = {
 	Open: 'OPEN' as GitPullRequestState,
 	Closed: 'CLOSED' as GitPullRequestState,
 	Merged: 'MERGED' as GitPullRequestState,
 } as const;
 
-const GitPullRequestReviewState = {
+export const GitPullRequestReviewState = {
 	Approved: 'APPROVED' as GitPullRequestReviewState,
 	ChangesRequested: 'CHANGES_REQUESTED' as GitPullRequestReviewState,
 	Commented: 'COMMENTED' as GitPullRequestReviewState,
 	ReviewRequested: 'REVIEW_REQUESTED' as GitPullRequestReviewState,
 } as const;
 
-const GitPullRequestMergeableState = {
+export const GitPullRequestMergeableState = {
 	Behind: 'BEHIND' as GitPullRequestMergeableState,
 	Blocked: 'BLOCKED' as GitPullRequestMergeableState,
 	Conflicts: 'CONFLICTS' as GitPullRequestMergeableState,

--- a/packages/plus/integrations/src/providers/utils.ts
+++ b/packages/plus/integrations/src/providers/utils.ts
@@ -20,7 +20,11 @@ import type { AzureProjectInputDescriptor } from './azure/models.js';
 import type { GitConfigEntityIdentifier } from './models.js';
 import { isGitHubDotCom, isGitLabDotCom } from './models.js';
 
-const EntityIdentifierProviderType = {
+// Local runtime copies of the `@gitkraken/provider-apis` entity-identifier string enums, duplicated for
+// the same CJS-from-ESM reason as the enums in `models.ts`. Exported so the enum-parity test can guard
+// them against upstream drift. `EntityVersion` is an intentional subset: the package only ever writes
+// version 1, so the parity test asserts each local entry matches the SDK rather than a full mirror.
+export const EntityIdentifierProviderType = {
 	Azure: 'azure',
 	AzureDevOpsServer: 'azureDevOpsServer',
 	Github: 'github',
@@ -35,12 +39,12 @@ const EntityIdentifierProviderType = {
 	Trello: 'trello',
 } as const;
 
-const EntityType = {
+export const EntityType = {
 	PullRequest: 'pr',
 	Issue: 'issue',
 } as const;
 
-const EntityVersion = {
+export const EntityVersion = {
 	One: '1',
 } as const;
 


### PR DESCRIPTION
## Description

#5531 replaced the runtime enum imports from `@gitkraken/provider-apis` with locally duplicated `const` objects to avoid the CJS-from-ESM named-export breakage. Those copies are currently unguarded: if a future `provider-apis` version adds, renames, or changes a value, the local copies silently diverge because the const objects cast their literals (e.g. `'OPEN' as GitPullRequestState`).

This PR exports the local const copies and adds a unit test (`packages/plus/integrations/src/providers/__tests__/enumParity.test.ts`) that deep-equals them against the real SDK enums. Full mirrors are asserted bidirectionally; the two intentional subsets (`utils.ts` `EntityVersion`, `bitbucket-server/models.ts` `GitPullRequestMergeableState`) assert each local entry matches the SDK while tolerating extra SDK members.

The test runs in the existing package test bundle, which uses esbuild to resolve the SDK's CJS named exports as runtime values.

Closes #5550

## Checklist

- [x] I have followed the guidelines in the Contributing document
- [x] My changes follow the coding style of this project
- [x] My changes build without any errors or warnings
- [x] My changes have been formatted and linted
- [x] My changes include any required corresponding changes to the documentation (including CHANGELOG.md and README.md)
- [x] My changes have been rebased and squashed to the minimal number (typically 1) of relevant commits
- [x] My changes have a descriptive commit message with a short title, including a `Fixes $XXX -` or `Closes #XXX -` prefix to auto-close the issue that your PR addresses
