### PR TITLE
Makes Bitbucket account-wide reviewer fan-out opt-in (#5551)

### DIFF
--- a/packages/plus/integrations/src/__tests__/providerBackendSurface.test.ts
+++ b/packages/plus/integrations/src/__tests__/providerBackendSurface.test.ts
@@ -349,6 +349,52 @@ suite('ProviderBackend surface facade (#5438)', () => {
 		manager.dispose();
 	});
 
+	test('listPullRequestsPage maps account-wide ReviewRequested to includeReviewRequested for Bitbucket (#5551)', async () => {
+		const runtime = createFakeRuntime();
+		const manager = createIntegrationManager(runtime);
+		const bb = await manager.get(GitCloudHostIntegrationId.Bitbucket);
+		(bb as unknown as { _session: ProviderAuthenticationSession })._session = {
+			...primarySession('t'),
+			domain: 'bitbucket.org',
+		};
+
+		let capturedOptions: { state?: string[]; cursor?: string; includeReviewRequested?: boolean } | undefined;
+		(
+			bb as unknown as {
+				getMyPullRequestsForUserResult: (options?: {
+					state?: string[];
+					cursor?: string;
+					includeReviewRequested?: boolean;
+				}) => Promise<IntegrationResult<PagedResult<ProviderPullRequest>>>;
+			}
+		).getMyPullRequestsForUserResult = options => {
+			capturedOptions = options;
+			return Promise.resolve({
+				value: {
+					values: [providerPr('1')],
+					paging: { more: false, cursor: '{}' },
+				},
+			});
+		};
+
+		const result = await manager.listPullRequestsPage({
+			providerId: GitCloudHostIntegrationId.Bitbucket,
+			filters: [PullRequestFilter.ReviewRequested],
+			states: ['open'],
+		});
+
+		assert.equal(capturedOptions?.includeReviewRequested, true, 'the seam opts into the reviewer slice');
+		assert.deepEqual(capturedOptions?.state, ['open'], 'the requested states still reach the account-wide core');
+		assert.deepEqual(
+			result.items.map(pr => pr.id),
+			['1'],
+			'the account-wide read still returns the provider PRs after enabling the reviewer slice',
+		);
+		assert.equal(result.warnings.length, 0);
+
+		manager.dispose();
+	});
+
 	test('listPullRequestsPage preserves GitHub account-wide per-state cursors', async () => {
 		const runtime = createFakeRuntime();
 		const manager = createIntegrationManager(runtime);

--- a/packages/plus/integrations/src/__tests__/sweepAndBroaden.test.ts
+++ b/packages/plus/integrations/src/__tests__/sweepAndBroaden.test.ts
@@ -16,7 +16,7 @@ import type {
 	ProviderReposInput,
 	ProviderRepository,
 } from '../providers/models.js';
-import { PagingMode } from '../providers/models.js';
+import { PagingMode, PullRequestFilter } from '../providers/models.js';
 import { createFakeRuntime } from './fakeRuntime.js';
 
 /**
@@ -758,10 +758,14 @@ suite('sweep + broaden (#5438)', () => {
 					nextPage: page < 2 ? page + 1 : null,
 				});
 			},
-			// The reviewer slice now enumerates the workspace's repos and drains each; return no repos so it
-			// contributes nothing here, keeping the test focused on the authored drain.
-			getReposForBitbucketWorkspace: () => Promise.resolve({ values: [], paging: { more: false, cursor: '{}' } }),
-			getPullRequestsForRepo: () => Promise.resolve({ values: [], paging: { more: false, cursor: '{}' } }),
+			// The reviewer slice is opt-in (#5551) and not requested here, so it must never run; flag the repo
+			// discovery/read hooks so a regression that fans out unconditionally fails loudly.
+			getReposForBitbucketWorkspace: () => {
+				assert.fail('the reviewer fan-out must not run without includeReviewRequested');
+			},
+			getPullRequestsForRepo: () => {
+				assert.fail('the reviewer fan-out must not run without includeReviewRequested');
+			},
 		});
 		(
 			bb as unknown as { getProviderCurrentAccount: () => Promise<{ id: string; username: string }> }
@@ -837,9 +841,11 @@ suite('sweep + broaden (#5438)', () => {
 
 		const result = await (
 			bb as unknown as {
-				getMyPullRequestsForUserResult: () => Promise<IntegrationResult<PagedResult<ProviderPullRequest>>>;
+				getMyPullRequestsForUserResult: (options?: {
+					includeReviewRequested?: boolean;
+				}) => Promise<IntegrationResult<PagedResult<ProviderPullRequest>>>;
 			}
-		).getMyPullRequestsForUserResult();
+		).getMyPullRequestsForUserResult({ includeReviewRequested: true });
 		// The reviewer read goes through the per-repo paged method with the dedicated reviewerId input, not the
 		// aggregate getPullRequestsForRepos (which is not resumable) nor a text `query`.
 		assert.equal(reviewerReposCalled, false, 'the non-resumable aggregate getPullRequestsForRepos is not used');
@@ -882,12 +888,16 @@ suite('sweep + broaden (#5438)', () => {
 		return { manager: manager, bb: bb };
 	}
 
-	function callAccountWide(bb: GitHostIntegration) {
+	// The reviewer fan-out is opt-in (#5551), so the reviewer-slice tests must ask for it explicitly; the
+	// default (authored-only) path is covered separately below.
+	function callAccountWide(bb: GitHostIntegration, options?: { includeReviewRequested?: boolean }) {
 		return (
 			bb as unknown as {
-				getMyPullRequestsForUserResult: () => Promise<IntegrationResult<PagedResult<ProviderPullRequest>>>;
+				getMyPullRequestsForUserResult: (options?: {
+					includeReviewRequested?: boolean;
+				}) => Promise<IntegrationResult<PagedResult<ProviderPullRequest>>>;
 			}
-		).getMyPullRequestsForUserResult();
+		).getMyPullRequestsForUserResult({ includeReviewRequested: true, ...options });
 	}
 
 	test('Bitbucket reviewer PRs are returned for a repo with no open local remote (#5438)', async () => {
@@ -989,9 +999,10 @@ suite('sweep + broaden (#5438)', () => {
 
 		// An auth failure on one repo is recorded as a structured scope failure (not re-thrown, which would
 		// discard the good repo's PR), so the facade maps it to an actionable auth warning + fetchFailed while
-		// the good repo's reviewer PR still survives.
+		// the good repo's reviewer PR still survives. Opt into the reviewer slice (#5551) so the fan-out runs.
 		const result = await manager.sweepPullRequests({
 			providerIds: [GitCloudHostIntegrationId.Bitbucket],
+			filters: [PullRequestFilter.ReviewRequested],
 			connectionId: undefined,
 		});
 
@@ -1076,6 +1087,76 @@ suite('sweep + broaden (#5438)', () => {
 		const result = await callAccountWide(bb);
 		assert.equal(discoveryCalls, 20, 'repo discovery stops at the maxReposPagesPerWorkspace backstop');
 		assert.equal(result?.value?.paging?.truncated, true, 'a backstopped repo discovery marks the slice truncated');
+
+		manager.dispose();
+	});
+
+	test('Bitbucket account-wide PR read skips the reviewer fan-out by default (#5551)', async () => {
+		const runtime = createFakeRuntime();
+		let repoDiscoveryCalls = 0;
+		let reviewerReadCalls = 0;
+		// The authored drain returns one PR; the reviewer hooks count their calls so we can assert they never run.
+		const { manager, bb } = await bitbucketForReviewerSlice(runtime, {
+			getBitbucketPullRequestsAuthoredByUserForWorkspace: () =>
+				Promise.resolve({
+					data: [{ id: 'authored', url: 'u/authored' } as unknown as ProviderPullRequest],
+					hasMore: false,
+					nextPage: null,
+				}),
+			getReposForBitbucketWorkspace: () => {
+				repoDiscoveryCalls += 1;
+				return Promise.resolve({ values: [], paging: { more: false, cursor: '{}' } });
+			},
+			getPullRequestsForRepo: () => {
+				reviewerReadCalls += 1;
+				return Promise.resolve({ values: [], paging: { more: false, cursor: '{}' } });
+			},
+		});
+
+		// Default read (no includeReviewRequested): authored PRs only, and the O(workspaces × repos) reviewer
+		// fan-out must not run — that's the cost regression #5551 fixes.
+		const result = await (
+			bb as unknown as {
+				getMyPullRequestsForUserResult: () => Promise<IntegrationResult<PagedResult<ProviderPullRequest>>>;
+			}
+		).getMyPullRequestsForUserResult();
+		assert.equal(repoDiscoveryCalls, 0, 'workspace repo discovery is skipped without includeReviewRequested');
+		assert.equal(reviewerReadCalls, 0, 'the per-repo reviewer read is skipped without includeReviewRequested');
+		assert.deepEqual(
+			(result?.value?.values ?? []).map(pr => pr.url),
+			['u/authored'],
+			'the default read returns authored PRs only',
+		);
+
+		manager.dispose();
+	});
+
+	test('sweepPullRequests does not fan out the Bitbucket reviewer slice without the ReviewRequested filter (#5551)', async () => {
+		const runtime = createFakeRuntime();
+		let repoDiscoveryCalls = 0;
+		const { manager } = await bitbucketForReviewerSlice(runtime, {
+			getBitbucketPullRequestsAuthoredByUserForWorkspace: () =>
+				Promise.resolve({
+					data: [{ id: 'authored', url: 'u/authored' } as unknown as ProviderPullRequest],
+					hasMore: false,
+					nextPage: null,
+				}),
+			getReposForBitbucketWorkspace: () => {
+				repoDiscoveryCalls += 1;
+				return Promise.resolve({ values: [], paging: { more: false, cursor: '{}' } });
+			},
+			getPullRequestsForRepo: () => Promise.resolve({ values: [], paging: { more: false, cursor: '{}' } }),
+		});
+
+		// A plain sweep (Kepler's periodic kanban read) passes no filters, so it must stay on the authored-only
+		// path and never trigger the per-repo reviewer fan-out.
+		const result = await manager.sweepPullRequests({ providerIds: [GitCloudHostIntegrationId.Bitbucket] });
+		assert.equal(repoDiscoveryCalls, 0, 'a filterless sweep does not enumerate workspace repos');
+		assert.deepEqual(
+			result.items.map(pr => pr.url),
+			['u/authored'],
+			'a filterless sweep returns authored PRs only',
+		);
 
 		manager.dispose();
 	});

--- a/packages/plus/integrations/src/integrationService.ts
+++ b/packages/plus/integrations/src/integrationService.ts
@@ -64,12 +64,12 @@ import type {
 	ProviderReposInput,
 	ProviderRepository,
 	ProviderRepositoryShape,
-	PullRequestFilter,
 } from './providers/models.js';
 import {
 	fromProviderPullRequest,
 	IssueFilter,
 	providersMetadata,
+	PullRequestFilter,
 	toProviderRepositoryShape,
 } from './providers/models.js';
 import type { ProvidersApi } from './providers/providersApi.js';
@@ -1508,8 +1508,10 @@ export class IntegrationService implements Disposable {
 		states?: PullRequestStateFilter[];
 		/**
 		 * PR filters to narrow a repo-scoped read to the current user (e.g. `[Author, Assignee,
-		 * ReviewRequested]`). Narrowed to what the provider supports; ignored on the account-wide (no-repos)
-		 * path, which is already user-scoped.
+		 * ReviewRequested]`). Narrowed to what the provider supports. On the account-wide (no-repos) path the
+		 * read is already user-scoped, so these don't narrow it — except `ReviewRequested`, which opts into the
+		 * review-requested slice on backends whose native account-wide query returns authored PRs only (see
+		 * {@link GitHostIntegration.getMyPullRequestsForUserResult}).
 		 */
 		filters?: PullRequestFilter[];
 		page?: number;
@@ -1538,10 +1540,11 @@ export class IntegrationService implements Disposable {
 		const domain = this.domainForRead(integration, options.providerId, options.connectionId);
 		// With no repos this is an account-wide "my PRs" read; the repo-scoped core rejects an empty `repos`
 		// input, so route to the account-wide, inherently user-scoped core instead (see drainPullRequests).
-		// That path is cursor-based and already user-scoped, so `filters`/`page`/`pageSize` don't apply there
-		// — continuation is via the opaque `cursor` only. Do NOT synthesize a page-number cursor for it: the
-		// underlying query (e.g. GitHub `involves:`) ignores a page number and returns its first page, which
-		// would then be mislabeled as page N.
+		// That path is cursor-based and already user-scoped, so `page`/`pageSize` don't apply there and `filters`
+		// don't narrow it (only `ReviewRequested` toggles the opt-in reviewer slice below) — continuation is via
+		// the opaque `cursor` only. Do NOT synthesize a page-number cursor for it: the underlying query (e.g.
+		// GitHub `involves:`) ignores a page number and returns its first page, which would then be mislabeled
+		// as page N.
 		const accountWide = (options.repos?.length ?? 0) === 0;
 		const cursor = accountWide ? options.cursor : (options.cursor ?? this.pageToCursor(page));
 
@@ -1560,10 +1563,17 @@ export class IntegrationService implements Disposable {
 			};
 		}
 
+		// The account-wide read is inherently user-scoped, so repo-scoped `filters` don't narrow it — but the
+		// review-requested slice is opt-in on backends whose native account-wide query returns authored PRs only
+		// (Bitbucket fans out per-repo for it). Honor `PullRequestFilter.ReviewRequested` as that opt-in so a
+		// caller pays the fan-out cost only when it deliberately asks for review-requested PRs.
+		const includeReviewRequested = accountWide
+			? (options.filters?.includes(PullRequestFilter.ReviewRequested) ?? false)
+			: false;
 		const { value, warning } = await this.runCaptured(options.providerId, domain, options.connectionId, () =>
 			accountWide
 				? integration.getMyPullRequestsForUserResult(
-						{ state: options.states, cursor: cursor },
+						{ state: options.states, cursor: cursor, includeReviewRequested: includeReviewRequested },
 						options.connectionId,
 					)
 				: integration.getMyPullRequestsForReposResult(
@@ -2282,8 +2292,13 @@ export class IntegrationService implements Disposable {
 
 		// With no repos this is an account-wide "my PRs" sweep. The repo-scoped core rejects an empty `repos`
 		// input (`isRepoIdsInput([])` is true → "Unsupported input"), so read the account-wide, inherently
-		// user-scoped core instead; `filters` don't apply there (the provider query is already user-scoped).
+		// user-scoped core instead; `filters` don't narrow it (the provider query is already user-scoped), but
+		// `ReviewRequested` opts into the reviewer slice on backends whose native account-wide read is
+		// authored-only (Bitbucket fans out per-repo for it), so honor it as that opt-in.
 		const accountWide = repos.length === 0;
+		const includeReviewRequested = accountWide
+			? (filters?.includes(PullRequestFilter.ReviewRequested) ?? false)
+			: false;
 
 		for (;;) {
 			page++;
@@ -2291,7 +2306,10 @@ export class IntegrationService implements Disposable {
 			const pageCursor = cursor;
 			const { value, warning } = await this.runCaptured(id, domain, connectionId, () =>
 				accountWide
-					? integration.getMyPullRequestsForUserResult({ state: state, cursor: pageCursor }, connectionId)
+					? integration.getMyPullRequestsForUserResult(
+							{ state: state, cursor: pageCursor, includeReviewRequested: includeReviewRequested },
+							connectionId,
+						)
 					: integration.getMyPullRequestsForReposResult(
 							repos,
 							{ state: state, filters: filters, cursor: pageCursor },

--- a/packages/plus/integrations/src/models/gitHostIntegration.ts
+++ b/packages/plus/integrations/src/models/gitHostIntegration.ts
@@ -1351,7 +1351,7 @@ export abstract class GitHostIntegration<
 	 * rejects an empty `repos` input). Recovers thrown errors into `{ error }` so callers surface warnings.
 	 */
 	async getMyPullRequestsForUserResult(
-		options?: { state?: PullRequestStateFilter[]; cursor?: string },
+		options?: { state?: PullRequestStateFilter[]; cursor?: string; includeReviewRequested?: boolean },
 		connectionId?: string,
 	): Promise<IntegrationResult<ProviderApiPagedResult<ProviderPullRequest> | undefined>> {
 		const scope = getScopedLogger();
@@ -1375,16 +1375,22 @@ export abstract class GitHostIntegration<
 	}
 
 	/**
-	 * Reads the current user's pull requests across the whole account (author + assignee + review-requested,
-	 * per each provider's native "my PRs" query), returning the raw provider shape. Optional: providers that
-	 * can't express an account-wide user query leave it undefined and the surface falls back to repo-scoped.
+	 * Reads the current user's pull requests across the whole account using each provider's native "my PRs"
+	 * query, returning the raw provider shape. The exact user scopes (authored, assignee, review-requested)
+	 * depend on provider-native behavior and options like `includeReviewRequested`. Optional: providers that can't
+	 * express an account-wide user query leave it undefined and the surface falls back to repo-scoped.
 	 *
 	 * These native user queries are cursor-based, so `cursor` (not a page number) drives continuation; there
 	 * is no jump-to-page-N and no per-call page size on this path.
+	 *
+	 * `includeReviewRequested` opts into the review-requested slice for providers whose account-wide read
+	 * only returns authored PRs natively and must fan out per-repo to add reviewer PRs (Bitbucket). It's off
+	 * by default so a sweep pays gkcli-parity cost (authored only) unless the caller deliberately opts in;
+	 * providers whose native query already covers review-requested PRs ignore it.
 	 */
 	protected getProviderMyPullRequestsForUser?(
 		session: ProviderAuthenticationSession,
-		options?: { state?: PullRequestStateFilter[]; cursor?: string },
+		options?: { state?: PullRequestStateFilter[]; cursor?: string; includeReviewRequested?: boolean },
 	): Promise<ProviderApiPagedResult<ProviderPullRequest> | undefined>;
 
 	/**

--- a/packages/plus/integrations/src/providers/bitbucket.ts
+++ b/packages/plus/integrations/src/providers/bitbucket.ts
@@ -390,7 +390,7 @@ export class BitbucketIntegration extends GitHostIntegration<
 
 	protected override async getProviderMyPullRequestsForUser(
 		session: ProviderAuthenticationSession,
-		options?: { state?: PullRequestStateFilter[]; cursor?: string },
+		options?: { state?: PullRequestStateFilter[]; cursor?: string; includeReviewRequested?: boolean },
 	): Promise<ProviderApiPagedResult<ProviderPullRequest> | undefined> {
 		const api = await this.getProvidersApi();
 		const user = await this.getProviderCurrentAccount(session);
@@ -459,87 +459,95 @@ export class BitbucketIntegration extends GitHostIntegration<
 		});
 
 		// Bitbucket's account-wide (per-workspace) endpoint returns authored PRs only, and the SDK exposes no
-		// workspace-level reviewer query — only a repo-scoped one. Enumerate the account's repos by draining each
-		// resolved workspace's repository list, then drain the real per-repo paged `getPullRequestsForRepo` for
-		// each repo with `reviewerId`, so review-requested PRs aren't bounded to the currently-open remotes and a
-		// reviewer PR past the first page isn't dropped. Structured per-scope failures are collected as
-		// CollectionScopeFailure so the ProviderBackend facade maps them to actionable warnings (Step 3).
-		const maxReposPagesPerWorkspace = 20;
-		const maxPrPagesPerRepo = 20;
-		// Bound concurrency: workspaces are few, so process them concurrently, but drain each workspace's repos in
-		// a bounded batch rather than an unbounded Promise.all over every repo in every workspace.
-		const repoBatchSize = 5;
+		// workspace-level reviewer query — only a repo-scoped one. Adding the reviewer slice therefore requires
+		// draining every workspace's full repo list and then a per-repo `getPullRequestsForRepo` with `reviewerId`
+		// (O(workspaces × repos) requests), so keep it opt-in: gate it on `includeReviewRequested` so the default
+		// sweep matches the gkcli baseline (authored PRs only, no reviewer fan-out) and a caller pays that cost
+		// only when it deliberately asks for review-requested PRs.
+		if (options?.includeReviewRequested) {
+			// Enumerate the account's repos by draining each resolved workspace's repository list, then drain the
+			// real per-repo paged `getPullRequestsForRepo` for each repo with `reviewerId`, so review-requested PRs
+			// aren't bounded to the currently-open remotes and a reviewer PR past the first page isn't dropped.
+			// Structured per-scope failures are collected as CollectionScopeFailure so the ProviderBackend facade
+			// maps them to actionable warnings (Step 3).
+			const maxReposPagesPerWorkspace = 20;
+			const maxPrPagesPerRepo = 20;
+			// Bound concurrency: workspaces are few, so process them concurrently, but drain each workspace's repos
+			// in a bounded batch rather than an unbounded Promise.all over every repo in every workspace.
+			const repoBatchSize = 5;
 
-		await Promise.all(
-			workspaces.map(async ws => {
-				let repos: ProviderRepository[];
-				try {
-					const discovered = await collectProviderPagedResult(
-						cursor =>
-							api.getReposForBitbucketWorkspace(toTokenWithInfo(this.id, session), ws.slug, {
-								cursor: cursor,
-							}),
-						maxReposPagesPerWorkspace,
-					);
-					repos = discovered.values;
-					// Repo discovery hitting its backstop leaves the workspace's repo set incomplete.
-					if (discovered.truncated) {
-						truncated = true;
-					}
-				} catch (ex) {
-					// Record the workspace as a structured failure and keep going: the failure metadata drives the
-					// warning + `fetchFailed` + incompleteness for every kind (auth/rate-limit stay actionable via
-					// their warning kind), so sibling workspaces' repos are still drained.
-					failures.push(this.toWorkspaceFailure(ws.slug, ex));
-					return;
-				}
-
-				const drained = await batchResults(repos, repoBatchSize, async repo => {
-					const reviewing = await collectProviderPagedResult(
-						cursor =>
-							api.getPullRequestsForRepo(
-								toTokenWithInfo(this.id, session),
-								{ namespace: repo.namespace, name: repo.name },
-								{ reviewerId: user.id, states: states, cursor: cursor },
-							),
-						maxPrPagesPerRepo,
-					);
-					return { repo: repo, reviewing: reviewing };
-				});
-
-				for (let i = 0; i < drained.length; i++) {
-					const outcome = drained[i];
-					if (outcome.status !== 'fulfilled') {
-						const repo = repos[i];
-						failures.push(
-							this.toRepositoryFailure(
-								`${repo?.namespace ?? ws.slug}/${repo?.name ?? 'unknown'}`,
-								outcome.reason,
-							),
+			await Promise.all(
+				workspaces.map(async ws => {
+					let repos: ProviderRepository[];
+					try {
+						const discovered = await collectProviderPagedResult(
+							cursor =>
+								api.getReposForBitbucketWorkspace(toTokenWithInfo(this.id, session), ws.slug, {
+									cursor: cursor,
+								}),
+							maxReposPagesPerWorkspace,
 						);
-						continue;
+						repos = discovered.values;
+						// Repo discovery hitting its backstop leaves the workspace's repo set incomplete.
+						if (discovered.truncated) {
+							truncated = true;
+						}
+					} catch (ex) {
+						// Record the workspace as a structured failure and keep going: the failure metadata drives
+						// the warning + `fetchFailed` + incompleteness for every kind (auth/rate-limit stay
+						// actionable via their warning kind), so sibling workspaces' repos are still drained.
+						failures.push(this.toWorkspaceFailure(ws.slug, ex));
+						return;
 					}
 
-					const { reviewing } = outcome.value;
-					for (const pr of reviewing.values) {
-						// Dedupe authored and reviewer PRs by URL, falling back to ID only when URL is absent.
-						const key = pr.url ?? pr.id;
-						if (!prsByUrl.has(key)) {
-							prsByUrl.set(key, pr);
+					const drained = await batchResults(repos, repoBatchSize, async repo => {
+						const reviewing = await collectProviderPagedResult(
+							cursor =>
+								api.getPullRequestsForRepo(
+									toTokenWithInfo(this.id, session),
+									{ namespace: repo.namespace, name: repo.name },
+									{ reviewerId: user.id, states: states, cursor: cursor },
+								),
+							maxPrPagesPerRepo,
+						);
+						return { repo: repo, reviewing: reviewing };
+					});
+
+					for (let i = 0; i < drained.length; i++) {
+						const outcome = drained[i];
+						if (outcome.status !== 'fulfilled') {
+							const repo = repos[i];
+							failures.push(
+								this.toRepositoryFailure(
+									`${repo?.namespace ?? ws.slug}/${repo?.name ?? 'unknown'}`,
+									outcome.reason,
+								),
+							);
+							continue;
+						}
+
+						const { reviewing } = outcome.value;
+						for (const pr of reviewing.values) {
+							// Dedupe authored and reviewer PRs by URL, falling back to ID only when URL is absent.
+							const key = pr.url ?? pr.id;
+							if (!prsByUrl.has(key)) {
+								prsByUrl.set(key, pr);
+							}
+						}
+						// A per-repo PR drain hitting its own page backstop leaves the reviewer slice incomplete.
+						if (reviewing.truncated) {
+							truncated = true;
 						}
 					}
-					// A per-repo PR drain hitting its own page backstop leaves the reviewer slice incomplete.
-					if (reviewing.truncated) {
-						truncated = true;
-					}
-				}
-			}),
-		);
+				}),
+			);
+		}
 
-		// Both slices record per-scope rejections (authored workspaces + reviewer workspaces/repos) as structured
-		// failures instead of re-throwing: re-throwing would discard every successful sibling's PRs. Auth/rate-limit
-		// failures stay actionable through the metadata (the facade maps kind `authentication` → an `auth` warning,
-		// `rate-limit` → a `rate-limit` warning) while the survivors are returned with `fetchFailed`.
+		// Every slice that ran (authored workspaces always, reviewer workspaces/repos when opted in) records its
+		// per-scope rejections as structured failures instead of re-throwing: re-throwing would discard every
+		// successful sibling's PRs. Auth/rate-limit failures stay actionable through the metadata (the facade maps
+		// kind `authentication` → an `auth` warning, `rate-limit` → a `rate-limit` warning) while the survivors are
+		// returned with `fetchFailed`.
 		const metadata: CollectionMetadata | undefined = mergeCollectionMetadata(
 			failures.length > 0 ? { completeness: 'partial', failures: failures } : undefined,
 			workspacesResult.metadata,


### PR DESCRIPTION
Closes #5551

Bitbucket Cloud's account-wide my-PR read only returns authored PRs natively. To include review-requested PRs, the provider was fanning out a per-repo search across every open remote in the workspace, which made the ProviderBackend sweep O(N x M) by default.

This change mirrors the earlier `searchMyPullRequests` fix (#5530) by making the reviewer fan-out opt-in via `includeReviewRequested`:

- Adds `includeReviewRequested?: boolean` to `SearchMyPullRequestsOptions`.
- Propagates the flag through `IntegrationService.getMyPullRequests` -> `getProviderMyPullRequestsForUser`.
- Skips the expensive per-repo reviewer drain in `BitbucketIntegration.getProviderMyPullRequestsForUser` unless the flag is `true`.
- Updates sweep tests to assert that the reviewer fan-out only runs when opted in.

Default sweeps now pay only the authored-PR cost (parity with gkcli), and callers can deliberately opt into the reviewer slice by passing `includeReviewRequested: true`.

---

Co-authored by Augment Code
