### PR TITLE
Bumps core to v0.5.0

### DIFF
--- a/packages/core/CHANGELOG.md
+++ b/packages/core/CHANGELOG.md
@@ -6,6 +6,8 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/) and this p
 
 ## [Unreleased]
 
+## [0.5.0] - 2026-07-24
+
 ### Added
 
 - Adds an account-wide issue read for GitLab and exposes `includeAllAssignees` on the account-wide seam &mdash; `GitHostIntegration.searchMyIssuesWithTruncationResult`/`IntegrationService.listIssuesPage` now serve GitLab (previously reported as unsupported, since GitLab's issue reads were repo-scoped only) via a new `getIssuesForCurrentUser` REST read (`GET /issues`, open issues only), and honor an `includeAllAssignees` toggle across GitHub (`assignee:@me` → `assignee:*`), GitLab (`scope=all`, no assignee), and Azure DevOps (a single unfiltered per-project drain); requires `@gitkraken/provider-apis` 0.53.0 ([#5535](https://github.com/gitkraken/vscode-gitlens/issues/5535)) (plus/integrations)
@@ -73,7 +75,8 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/) and this p
 
 - Initial release. Bundles `@gitlens/utils`, `@gitlens/git`, `@gitlens/git-cli`, `@gitlens/ai`, and `@gitlens/git-github` into a single core npm package with subpath exports.
 
-[unreleased]: https://github.com/gitkraken/vscode-gitlens/compare/releases/core/v0.4.0...HEAD
+[unreleased]: https://github.com/gitkraken/vscode-gitlens/compare/releases/core/v0.5.0...HEAD
+[0.5.0]: https://github.com/gitkraken/vscode-gitlens/compare/releases/core/v0.4.0...gitkraken:releases/core/v0.5.0
 [0.4.0]: https://github.com/gitkraken/vscode-gitlens/compare/releases/core/v0.3.1...gitkraken:releases/core/v0.4.0
 [0.3.1]: https://github.com/gitkraken/vscode-gitlens/compare/releases/core/v0.3.0...gitkraken:releases/core/v0.3.1
 [0.3.0]: https://github.com/gitkraken/vscode-gitlens/compare/releases/core/v0.2.0...gitkraken:releases/core/v0.3.0

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -1,7 +1,7 @@
 {
 	"name": "@gitkraken/core-gitlens",
 	"description": "GitLens core — shared Git / AI / GitHub primitives for internal GitKraken consumption",
-	"version": "0.4.0",
+	"version": "0.5.0",
 	"license": "SEE LICENSE IN LICENSE",
 	"author": {
 		"name": "GitKraken",


### PR DESCRIPTION
## Summary

Release-tracking follow-up for #5561. Bumps `@gitkraken/core-gitlens` from `0.4.0` to `0.5.0` and cuts the CHANGELOG's `[Unreleased]` section into a `[0.5.0]` release section, so Kepler can express its dependency on the new ProviderBackend surface via a `^0.5.0` range instead of risking a resolve back to the old `0.4.0` artifact (where every adapter method would be missing at runtime).

This is a **minor** bump: the entire ProviderBackend surface landed this cycle is additive (`IntegrationService.listOrgs`/`listProjects`/`listRepos`/`listPullRequestsPage`/`listIssuesPage`/`sweepPullRequests`/`broadenIssues`/`resolveRepository`, the normalized `PullRequestShape.body` / `ProviderRepositoryShape`, the neutral `ProviderResult`/`ProviderWarning` types, multi-account + per-connection reads, Trello, GitLab account-wide issues).

## Changes

- `packages/core/package.json`: `version` `0.4.0` → `0.5.0`
- `packages/core/CHANGELOG.md`: insert `## [0.5.0] - 2026-07-24` under `[Unreleased]`, refresh the `[unreleased]` compare link to `v0.5.0...HEAD`, and add the `[0.5.0]` compare link (`v0.4.0...v0.5.0`)

Follows the exact same cut pattern as the previous `0.4.0` release (640d4fc4d). No git tag is created here; the `releases/core/v0.5.0` tag is cut by the release owner at publish time.

## Sanity check

`pnpm run build:core` output verified against the issue's acceptance criteria:

- dist `package.json` version → `0.5.0`
- `plus/integrations/index.d.ts` exports `ProviderRepositoryShape`, `ProviderOrganization`, and the result types (`ProviderResult`, `ProviderPagedResult`, `ProviderSweepResult`, `ProviderBroadenResult`, `ProviderWarning`, `ResolveRepositoryResult`, ...)
- `git/models/pullRequest.d.ts` → `PullRequestShape.body?: string` present

## Follow-up

The Kepler-side range bump to `^0.5.0` lands together with the first adapter PR that uses the new surface (kepler#1322 sub-issues), so the dependency expresses the real requirement.

Refs #5561

Note: this PR targets `core`, not the default branch, so GitHub won't auto-close the issue on merge; it will be closed manually once the release is cut.
