### PR TITLE
Use the provider's canonical identity in resolveRepository (#5558)

### DIFF
--- a/packages/plus/integrations/src/__tests__/resolveRepository.test.ts
+++ b/packages/plus/integrations/src/__tests__/resolveRepository.test.ts
@@ -88,6 +88,77 @@ suite('resolveRepository (#5438)', () => {
 		}
 	});
 
+	test('builds the identity from the canonical provider response, marking a rename', async () => {
+		const manager = createIntegrationManager(createFakeRuntime());
+		const gh = await connect(manager, GitCloudHostIntegrationId.GitHub, 'github.com');
+		// The remote points at the stale `octocat/old-name`; the provider follows the 301 redirect and
+		// returns the canonical `octocat/hello`.
+		stubGetRepo(gh, () =>
+			Promise.resolve({ id: 'r1', namespace: 'octocat', name: 'hello' } as unknown as ProviderRepository),
+		);
+
+		const result = await manager.resolveRepository({ remoteUrl: 'https://github.com/octocat/old-name.git' });
+		assert.equal(result.resolution.status, 'resolved');
+		assert.equal(result.resolution.identity?.owner, 'octocat', 'owner comes from the canonical response');
+		assert.equal(result.resolution.identity?.name, 'hello', 'name comes from the canonical response');
+		assert.equal(result.resolution.identity?.renamed, true, 'a differing canonical name flags renamed');
+		assert.equal(
+			result.resolution.identity?.remoteUrl,
+			'https://github.com/octocat/old-name.git',
+			'remoteUrl keeps the original input',
+		);
+
+		manager.dispose();
+	});
+
+	test('flags renamed when only the owner changed (repo transferred between accounts)', async () => {
+		const manager = createIntegrationManager(createFakeRuntime());
+		const gh = await connect(manager, GitCloudHostIntegrationId.GitHub, 'github.com');
+		// The repo kept its name but moved to a new owner; the name-only rename test above keeps the owner
+		// constant, so this exercises the owner side of the OR compare.
+		stubGetRepo(gh, () =>
+			Promise.resolve({ id: 'r1', namespace: 'new-org', name: 'hello' } as unknown as ProviderRepository),
+		);
+
+		const result = await manager.resolveRepository({ remoteUrl: 'https://github.com/octocat/hello.git' });
+		assert.equal(result.resolution.status, 'resolved');
+		assert.equal(result.resolution.identity?.owner, 'new-org', 'owner comes from the canonical response');
+		assert.equal(result.resolution.identity?.renamed, true, 'a differing canonical owner flags renamed');
+
+		manager.dispose();
+	});
+
+	test('does not flag renamed when the canonical identity differs only in casing', async () => {
+		const manager = createIntegrationManager(createFakeRuntime());
+		const gh = await connect(manager, GitCloudHostIntegrationId.GitHub, 'github.com');
+		// Some hosts echo the input casing rather than a canonical one; a case-insensitive compare (matching
+		// gkcli's EqualFold) must not treat that as a rename.
+		stubGetRepo(gh, () =>
+			Promise.resolve({ id: 'r1', namespace: 'OctoCat', name: 'Hello' } as unknown as ProviderRepository),
+		);
+
+		const result = await manager.resolveRepository({ remoteUrl: 'https://github.com/octocat/hello.git' });
+		assert.equal(result.resolution.status, 'resolved');
+		assert.equal(result.resolution.identity?.renamed, false, 'a case-only difference is not a rename');
+
+		manager.dispose();
+	});
+
+	test('falls back to the parsed remote when the response omits owner/name (not renamed)', async () => {
+		const manager = createIntegrationManager(createFakeRuntime());
+		const gh = await connect(manager, GitCloudHostIntegrationId.GitHub, 'github.com');
+		// A response without namespace/name must not spuriously flag a rename against empty canonical values.
+		stubGetRepo(gh, () => Promise.resolve({ id: 'r1' } as unknown as ProviderRepository));
+
+		const result = await manager.resolveRepository({ remoteUrl: 'https://github.com/octocat/hello.git' });
+		assert.equal(result.resolution.status, 'resolved');
+		assert.equal(result.resolution.identity?.owner, 'octocat', 'owner falls back to the parsed remote');
+		assert.equal(result.resolution.identity?.name, 'hello', 'name falls back to the parsed remote');
+		assert.equal(result.resolution.identity?.renamed, false);
+
+		manager.dispose();
+	});
+
 	test('resolves an Azure DevOps repo, passing the parsed project through', async () => {
 		const manager = createIntegrationManager(createFakeRuntime());
 		const az = await connect(manager, GitCloudHostIntegrationId.AzureDevOps, 'dev.azure.com');

--- a/packages/plus/integrations/src/integrationService.ts
+++ b/packages/plus/integrations/src/integrationService.ts
@@ -2993,13 +2993,25 @@ export class IntegrationService implements Disposable {
 				return { resolution: { status: 'no-connection' }, cliUnsupported: false };
 			}
 
+			// Prefer the provider's canonical namespace/name (GitHub's REST/GraphQL lookup follows the 301
+			// rename redirect, so a stale old name resolves to the new canonical identity), falling back to the
+			// parsed remote when the response omits them. `renamed` is a case-insensitive compare of input vs
+			// canonical, mirroring gkcli's `EqualFold`, so hosts that merely echo the input casing (e.g.
+			// Bitbucket Server/Azure) don't get spuriously flagged.
+			const canonicalOwner = repo.namespace || owner;
+			const canonicalName = repo.name || name;
+			const renamed =
+				canonicalOwner.toLowerCase() !== owner.toLowerCase() ||
+				canonicalName.toLowerCase() !== name.toLowerCase();
+
 			const identity: RepositoryIdentity = {
 				providerId: id,
 				domain: domain,
-				owner: owner,
-				name: name,
+				owner: canonicalOwner,
+				name: canonicalName,
 				project: project,
 				remoteUrl: options.remoteUrl,
+				renamed: renamed,
 			};
 			return { resolution: { status: 'resolved', identity: identity }, cliUnsupported: false };
 		} catch (ex) {

--- a/packages/plus/integrations/src/results.ts
+++ b/packages/plus/integrations/src/results.ts
@@ -66,10 +66,19 @@ export type RepositoryResolutionStatus = 'resolved' | 'not-found' | 'unsupported
 export interface RepositoryIdentity {
 	providerId: IntegrationIds;
 	domain: string;
+	/** The provider's canonical owner/namespace (follows renames), falling back to the parsed remote when omitted. */
 	owner: string;
+	/** The provider's canonical repo name (follows renames), falling back to the parsed remote when omitted. */
 	name: string;
 	project?: string;
+	/** The original input remote URL, so the caller can key the resolution back to the remote it asked about. */
 	remoteUrl: string;
+	/**
+	 * True when the provider's canonical owner/name differ from what the input remote URL carried — i.e. the
+	 * repo was renamed/moved host-side and the local remote is stale. Case-insensitive, mirroring gkcli's
+	 * `EqualFold` compare so hosts that echo the input casing (e.g. Bitbucket Server/Azure) aren't flagged.
+	 */
+	renamed: boolean;
 }
 
 export interface RepositoryResolution {


### PR DESCRIPTION
## Summary

`IntegrationService.resolveRepository` resolved the repo through the provider and then built the returned `RepositoryIdentity` from the owner/name parsed out of the **input** remote URL, discarding the canonical `namespace`/`name` in the provider response. GitHub's REST/GraphQL repo lookup follows the 301 rename redirect, so a stale old name resolves to the new canonical identity; throwing that away made host-side renames undetectable.

This matters for the Kepler migration (kepler#1329, kepler#999/#1010): the whole point of `gk repo resolve` is canonicalization. Without the canonical values and a rename signal, a `CoreGitLensProviderAdapter` would always see the literal input identity marked `resolved` with `renamed` always `false`, reintroducing the kepler#999 regression (correlations silently missing on renamed repos).

## Changes

- Populate `RepositoryIdentity.owner`/`name` from `repo.namespace`/`repo.name` (canonical), falling back to the parsed values only when the response omits them (truthy `||`, so an empty-string response degrades to the parsed remote rather than emitting an empty identity or a spurious rename).
- Add `renamed: boolean` to `RepositoryIdentity`, computed as a case-insensitive compare of the parsed input owner/name vs the canonical response. This mirrors gkcli's `EqualFold`, so hosts that echo the input casing (e.g. Bitbucket Server/Azure) aren't flagged.
- Keep `remoteUrl` as the original input so the caller can key the resolution back to the remote it asked about.

`project` intentionally stays the parsed value and isn't part of the `renamed` compare: the `getRepoInfo` lookup is scoped by the parsed project, so a mismatching canonical project can't come back (it would 404 into `not-found` instead), matching the issue's owner/name scope.

## Tests

Extended `resolveRepository.test.ts`:
- canonical owner/name come from the provider response, `renamed: true` on a name change, `remoteUrl` preserved
- owner-only rename (repo transferred between accounts) flags `renamed`
- case-only difference does **not** flag `renamed`
- response omitting owner/name falls back to the parsed remote, `renamed: false`

Full package test suite passes; `pnpm run check` and `tsc -b` are clean.

Closes #5558