### PR TITLE
fix(integrations): preserve provider attribution for org/project reads

### DIFF
--- a/packages/plus/integrations/src/__tests__/providerBackendSurface.test.ts
+++ b/packages/plus/integrations/src/__tests__/providerBackendSurface.test.ts
@@ -1268,8 +1268,13 @@ suite('ProviderBackend surface facade (#5438)', () => {
 
 		const result = await manager.listOrgs({ providerId: IssuesCloudHostIntegrationId.Linear });
 		assert.deepEqual(result.items, [
-			{ id: 'id1', name: 'Name1', url: 'https://linear.app/id1' },
-			{ id: 'k2', name: 'k2', url: '' },
+			{
+				id: 'id1',
+				providerId: IssuesCloudHostIntegrationId.Linear,
+				name: 'Name1',
+				url: 'https://linear.app/id1',
+			},
+			{ id: 'k2', providerId: IssuesCloudHostIntegrationId.Linear, name: 'k2', url: '' },
 		]);
 		assert.equal(result.warnings.length, 0);
 
@@ -1294,7 +1299,14 @@ suite('ProviderBackend surface facade (#5438)', () => {
 		).getOrganizationsForUserResult = () =>
 			Promise.resolve({
 				value: {
-					values: [{ id: 'ws-1', name: 'acme', url: 'https://bitbucket.org/acme' }],
+					values: [
+						{
+							id: 'ws-1',
+							providerId: GitCloudHostIntegrationId.Bitbucket,
+							name: 'acme',
+							url: 'https://bitbucket.org/acme',
+						},
+					],
 					metadata: {
 						completeness: 'partial',
 						failures: [{ kind: 'authentication', scope: { resourceId: 'ws-bad' } }],
@@ -1303,7 +1315,14 @@ suite('ProviderBackend surface facade (#5438)', () => {
 			});
 
 		const result = await manager.listOrgs({ providerId: GitCloudHostIntegrationId.Bitbucket });
-		assert.deepEqual(result.items, [{ id: 'ws-1', name: 'acme', url: 'https://bitbucket.org/acme' }]);
+		assert.deepEqual(result.items, [
+			{
+				id: 'ws-1',
+				providerId: GitCloudHostIntegrationId.Bitbucket,
+				name: 'acme',
+				url: 'https://bitbucket.org/acme',
+			},
+		]);
 		assert.equal(result.fetchFailed, true, 'metadata failures mark the read incomplete');
 		assert.ok(
 			result.warnings.some(w => w.kind === 'auth'),
@@ -1334,7 +1353,14 @@ suite('ProviderBackend surface facade (#5438)', () => {
 		});
 
 		const result = await manager.listOrgs({ providerId: GitCloudHostIntegrationId.Bitbucket });
-		assert.deepEqual(result.items, [{ id: 'ws-1', name: 'acme', url: 'https://bitbucket.org/acme' }]);
+		assert.deepEqual(result.items, [
+			{
+				id: 'ws-1',
+				providerId: GitCloudHostIntegrationId.Bitbucket,
+				name: 'acme',
+				url: 'https://bitbucket.org/acme',
+			},
+		]);
 		assert.notEqual(result.fetchFailed, true, 'a backstop is truncation, not a read failure');
 		assert.ok(
 			result.warnings.some(w => /incomplete|omitted|completeness/i.test(w.message)),
@@ -1387,14 +1413,63 @@ suite('ProviderBackend surface facade (#5438)', () => {
 		const linear = await manager.get(IssuesCloudHostIntegrationId.Linear);
 
 		(
+			linear as unknown as { getResourcesForUserResult: () => Promise<{ value: ResourceDescriptor[] }> }
+		).getResourcesForUserResult = () =>
+			Promise.resolve({ value: [{ key: 'linear-org', id: 'org-1', name: 'Linear Org' }] });
+
+		(
 			linear as unknown as {
-				getProjectsForUserWithMetadataResult: () => Promise<{ value: { values: ResourceDescriptor[] } }>;
+				getProjectsForResourcesWithMetadataResult: (
+					resources: ResourceDescriptor[],
+				) => Promise<{ value: { values: ResourceDescriptor[] } }>;
 			}
-		).getProjectsForUserWithMetadataResult = () =>
-			Promise.resolve({ value: { values: [{ key: 'proj', id: 'p1', name: 'Project One' }] } });
+		).getProjectsForResourcesWithMetadataResult = resources => {
+			assert.deepEqual(resources, [{ key: 'linear-org', id: 'org-1', name: 'Linear Org' }]);
+			return Promise.resolve({ value: { values: [{ key: 'proj', id: 'p1', name: 'Project One' }] } });
+		};
 
 		const result = await manager.listProjects({ providerId: IssuesCloudHostIntegrationId.Linear });
-		assert.deepEqual(result.items, [{ id: 'p1', name: 'Project One', url: '' }]);
+		assert.deepEqual(result.items, [
+			{
+				id: 'p1',
+				providerId: IssuesCloudHostIntegrationId.Linear,
+				name: 'Project One',
+				org: 'Linear Org',
+				url: '',
+			},
+		]);
+
+		manager.dispose();
+	});
+
+	test('listProjects does not synthesize a parent org for Trello boards, which are already the project scope', async () => {
+		const runtime = createFakeRuntime();
+		const manager = createIntegrationManager(runtime);
+		const trello = await manager.get(IssuesCloudHostIntegrationId.Trello);
+
+		const boards: ResourceDescriptor[] = [
+			{ key: 'board-1', id: 'board-1', name: 'Board One' },
+			{ key: 'board-2', id: 'board-2', name: 'Board Two' },
+		];
+		(
+			trello as unknown as { getResourcesForUserResult: () => Promise<{ value: ResourceDescriptor[] }> }
+		).getResourcesForUserResult = () => Promise.resolve({ value: boards });
+		(
+			trello as unknown as {
+				getProjectsForResourcesWithMetadataResult: (
+					resources: ResourceDescriptor[],
+				) => Promise<{ value: { values: ResourceDescriptor[] } }>;
+			}
+		).getProjectsForResourcesWithMetadataResult = resources => {
+			assert.deepEqual(resources, boards);
+			return Promise.resolve({ value: { values: boards } });
+		};
+
+		const result = await manager.listProjects({ providerId: IssuesCloudHostIntegrationId.Trello });
+		assert.deepEqual(result.items, [
+			{ id: 'board-1', providerId: IssuesCloudHostIntegrationId.Trello, name: 'Board One', url: '' },
+			{ id: 'board-2', providerId: IssuesCloudHostIntegrationId.Trello, name: 'Board Two', url: '' },
+		]);
 
 		manager.dispose();
 	});
@@ -1417,7 +1492,15 @@ suite('ProviderBackend surface facade (#5438)', () => {
 		).getProjectsForOrgResult = () =>
 			Promise.resolve({
 				value: {
-					values: [{ id: 'p1', name: 'Proj', url: 'https://dev.azure.com/org/Proj' }],
+					values: [
+						{
+							id: 'p1',
+							providerId: GitCloudHostIntegrationId.AzureDevOps,
+							name: 'Proj',
+							org: 'org',
+							url: 'https://dev.azure.com/org/Proj',
+						},
+					],
 					metadata: {
 						completeness: 'partial',
 						failures: [{ kind: 'authentication', scope: { projectId: 'broken' } }],
@@ -1426,7 +1509,15 @@ suite('ProviderBackend surface facade (#5438)', () => {
 			});
 
 		const result = await manager.listProjects({ providerId: GitCloudHostIntegrationId.AzureDevOps });
-		assert.deepEqual(result.items, [{ id: 'p1', name: 'Proj', url: 'https://dev.azure.com/org/Proj' }]);
+		assert.deepEqual(result.items, [
+			{
+				id: 'p1',
+				providerId: GitCloudHostIntegrationId.AzureDevOps,
+				name: 'Proj',
+				org: 'org',
+				url: 'https://dev.azure.com/org/Proj',
+			},
+		]);
 		assert.equal(result.fetchFailed, true, 'metadata failures mark the read incomplete');
 		assert.ok(
 			result.warnings.some(w => w.kind === 'auth'),
@@ -1462,7 +1553,179 @@ suite('ProviderBackend surface facade (#5438)', () => {
 
 		const result = await manager.listProjects({ providerId: IssuesCloudHostIntegrationId.Jira, org: 'org-2' });
 		assert.deepEqual(capturedResources, [resources[1]]);
-		assert.deepEqual(result.items, [{ id: 'p1', name: 'Project One', url: '' }]);
+		assert.deepEqual(result.items, [
+			{
+				id: 'p1',
+				providerId: IssuesCloudHostIntegrationId.Jira,
+				name: 'Project One',
+				org: 'Org Two',
+				url: '',
+			},
+		]);
+
+		manager.dispose();
+	});
+
+	test('listProjects attributes Jira projects to their parent resource by resourceId when multiple resources are present', async () => {
+		const runtime = createFakeRuntime();
+		const manager = createIntegrationManager(runtime);
+		const jira = await manager.get(IssuesCloudHostIntegrationId.Jira);
+
+		const resources: ResourceDescriptor[] = [
+			{ key: 'alpha', id: 'site-1', name: 'Alpha Site' },
+			{ key: 'beta', id: 'site-2', name: 'Beta Site' },
+		];
+		(
+			jira as unknown as { getResourcesForUserResult: () => Promise<{ value: ResourceDescriptor[] }> }
+		).getResourcesForUserResult = () => Promise.resolve({ value: resources });
+		(
+			jira as unknown as {
+				getProjectsForResourcesWithMetadataResult: (
+					resources: ResourceDescriptor[],
+				) => Promise<{ value: { values: ResourceDescriptor[] } }>;
+			}
+		).getProjectsForResourcesWithMetadataResult = scopedResources => {
+			assert.deepEqual(scopedResources, resources);
+			return Promise.resolve({
+				value: {
+					values: [{ key: 'proj-1', id: 'proj-1', name: 'Project One', resourceId: 'site-2' }],
+				},
+			});
+		};
+
+		const result = await manager.listProjects({ providerId: IssuesCloudHostIntegrationId.Jira });
+		assert.deepEqual(result.items, [
+			{
+				id: 'proj-1',
+				providerId: IssuesCloudHostIntegrationId.Jira,
+				name: 'Project One',
+				org: 'Beta Site',
+				url: '',
+			},
+		]);
+
+		manager.dispose();
+	});
+
+	test('listOrgs and listProjects use the same resource label fallback when a resource has no name', async () => {
+		const runtime = createFakeRuntime();
+		const manager = createIntegrationManager(runtime);
+		const jira = await manager.get(IssuesCloudHostIntegrationId.Jira);
+
+		const resources: ResourceDescriptor[] = [{ key: 'site-key', id: 'site-id' }];
+		(
+			jira as unknown as { getResourcesForUserResult: () => Promise<{ value: ResourceDescriptor[] }> }
+		).getResourcesForUserResult = () => Promise.resolve({ value: resources });
+		(
+			jira as unknown as {
+				getProjectsForResourcesWithMetadataResult: () => Promise<{ value: { values: ResourceDescriptor[] } }>;
+			}
+		).getProjectsForResourcesWithMetadataResult = () =>
+			Promise.resolve({
+				value: { values: [{ key: 'proj-key', id: 'proj-id', name: 'Project', resourceId: 'site-id' }] },
+			});
+
+		const orgs = await manager.listOrgs({ providerId: IssuesCloudHostIntegrationId.Jira });
+		const projects = await manager.listProjects({ providerId: IssuesCloudHostIntegrationId.Jira });
+
+		assert.equal(orgs.items[0]?.name, 'site-id');
+		assert.equal(projects.items[0]?.org, 'site-id');
+
+		manager.dispose();
+	});
+
+	test('listOrgs/listProjects preserve provider attribution and project parent orgs across fan-out reads', async () => {
+		const runtime = createFakeRuntime();
+		const manager = createIntegrationManager(runtime);
+		const github = await manager.get(GitCloudHostIntegrationId.GitHub);
+		const jira = await manager.get(IssuesCloudHostIntegrationId.Jira);
+		const azure = await manager.get(GitCloudHostIntegrationId.AzureDevOps);
+
+		(github as unknown as { _session: ProviderAuthenticationSession })._session = primarySession('gh');
+		(azure as unknown as { _session: ProviderAuthenticationSession })._session = {
+			...primarySession('az'),
+			domain: 'dev.azure.com',
+		};
+
+		(
+			github as unknown as {
+				getOrganizationsForUserResult: () => Promise<{ value: { values: ProviderOrganization[] } }>;
+			}
+		).getOrganizationsForUserResult = () =>
+			Promise.resolve({
+				value: {
+					values: [
+						{
+							id: 'gh-org',
+							providerId: GitCloudHostIntegrationId.GitHub,
+							name: 'octo',
+							url: 'https://github.com/octo',
+						},
+					],
+				},
+			});
+		(
+			jira as unknown as { getResourcesForUserResult: () => Promise<{ value: ResourceDescriptor[] }> }
+		).getResourcesForUserResult = () =>
+			Promise.resolve({ value: [{ key: 'jira-site', id: 'site-1', name: 'Jira Site' }] });
+		(
+			jira as unknown as {
+				getProjectsForResourcesWithMetadataResult: (
+					resources: ResourceDescriptor[],
+				) => Promise<{ value: { values: ResourceDescriptor[] } }>;
+			}
+		).getProjectsForResourcesWithMetadataResult = resources => {
+			assert.deepEqual(resources, [{ key: 'jira-site', id: 'site-1', name: 'Jira Site' }]);
+			return Promise.resolve({ value: { values: [{ key: 'proj', id: 'jira-proj', name: 'Platform' }] } });
+		};
+		(
+			azure as unknown as {
+				getProjectsForOrgResult: (org?: string) => Promise<{ value: PagedResult<ProviderOrganization> }>;
+			}
+		).getProjectsForOrgResult = () =>
+			Promise.resolve({
+				value: {
+					values: [
+						{
+							id: 'az-proj',
+							providerId: GitCloudHostIntegrationId.AzureDevOps,
+							name: 'Services',
+							org: 'acme',
+							url: 'https://dev.azure.com/acme/Services',
+						},
+					],
+				},
+			});
+
+		const orgs = await manager.listOrgs();
+		assert.ok(
+			orgs.items.some(item => item.providerId === GitCloudHostIntegrationId.GitHub && item.name === 'octo'),
+			'aggregated org items retain their provider attribution',
+		);
+		assert.ok(
+			orgs.items.some(item => item.providerId === IssuesCloudHostIntegrationId.Jira && item.name === 'Jira Site'),
+			'issue-tracker org items retain their provider attribution',
+		);
+
+		const projects = await manager.listProjects();
+		assert.ok(
+			projects.items.some(
+				item =>
+					item.providerId === IssuesCloudHostIntegrationId.Jira &&
+					item.name === 'Platform' &&
+					item.org === 'Jira Site',
+			),
+			'aggregated Jira project items retain the parent org',
+		);
+		assert.ok(
+			projects.items.some(
+				item =>
+					item.providerId === GitCloudHostIntegrationId.AzureDevOps &&
+					item.name === 'Services' &&
+					item.org === 'acme',
+			),
+			'aggregated Azure project items retain the parent org',
+		);
 
 		manager.dispose();
 	});
@@ -1605,10 +1868,30 @@ suite('ProviderBackend surface facade (#5438)', () => {
 				getProjectsForOrgResult: (org?: string) => Promise<{ value: PagedResult<ProviderOrganization> }>;
 			}
 		).getProjectsForOrgResult = () =>
-			Promise.resolve({ value: { values: [{ id: 'p1', name: 'Proj', url: 'https://dev.azure.com/org/Proj' }] } });
+			Promise.resolve({
+				value: {
+					values: [
+						{
+							id: 'p1',
+							providerId: GitCloudHostIntegrationId.AzureDevOps,
+							name: 'Proj',
+							org: 'org',
+							url: 'https://dev.azure.com/org/Proj',
+						},
+					],
+				},
+			});
 
 		const result = await manager.listProjects({ providerId: GitCloudHostIntegrationId.AzureDevOps });
-		assert.deepEqual(result.items, [{ id: 'p1', name: 'Proj', url: 'https://dev.azure.com/org/Proj' }]);
+		assert.deepEqual(result.items, [
+			{
+				id: 'p1',
+				providerId: GitCloudHostIntegrationId.AzureDevOps,
+				name: 'Proj',
+				org: 'org',
+				url: 'https://dev.azure.com/org/Proj',
+			},
+		]);
 
 		manager.dispose();
 	});

--- a/packages/plus/integrations/src/integrationService.ts
+++ b/packages/plus/integrations/src/integrationService.ts
@@ -1067,12 +1067,55 @@ export class IntegrationService implements Disposable {
 	/**
 	 * Maps an issue-tracker resource descriptor to the unified {@link ProviderOrganization} org shape.
 	 * The base `ResourceDescriptor` only guarantees `key`, so read `id`/`name` off the concrete
-	 * `IssueResourceDescriptor` (falling back to `key`) and synthesize `url` when absent, rather than
-	 * widening the shared `ProviderOrganization.url` to optional.
+	 * `IssueResourceDescriptor` (falling back through `id`, then `key`) and synthesize `url` when absent,
+	 * rather than widening the shared `ProviderOrganization.url` to optional.
 	 */
-	private resourceToOrg(resource: ResourceDescriptor): ProviderOrganization {
+	private resourceToOrg(
+		providerId: IntegrationIds,
+		resource: ResourceDescriptor,
+		org?: string,
+	): ProviderOrganization {
 		const typed = resource as IssueResourceDescriptor & { url?: string };
-		return { id: typed.id ?? resource.key, name: typed.name ?? resource.key, url: typed.url ?? '' };
+		return {
+			id: typed.id ?? resource.key,
+			providerId: providerId,
+			name: this.resourceLabel(resource),
+			...(org != null ? { org: org } : {}),
+			url: typed.url ?? '',
+		};
+	}
+
+	private resourceLabel(resource: ResourceDescriptor): string {
+		const typed = resource as IssueResourceDescriptor;
+		return typed.name ?? typed.id ?? resource.key;
+	}
+
+	private orgForProject(
+		providerId: IntegrationIds,
+		project: ResourceDescriptor,
+		resources: ResourceDescriptor[],
+	): string | undefined {
+		if (providerId === IssuesCloudHostIntegrationId.Trello) return undefined;
+
+		const typedProject = project as IssueResourceDescriptor & { resourceId?: string };
+		const parentMatch = [typedProject.resourceId, typedProject.id, project.key]
+			.filter((value): value is string => value != null)
+			.map(candidate => resources.find(resource => this.resourceMatchesOrg(resource, candidate)))
+			.find((resource): resource is ResourceDescriptor => resource != null);
+
+		return parentMatch != null
+			? this.resourceLabel(parentMatch)
+			: resources.length === 1
+				? this.resourceLabel(resources[0])
+				: undefined;
+	}
+
+	private withProviderContext(providerId: IntegrationIds, item: ProviderOrganization): ProviderOrganization {
+		return {
+			...item,
+			providerId: providerId,
+			...(item.org != null ? { org: item.org } : {}),
+		};
 	}
 
 	private resourceMatchesOrg(resource: ResourceDescriptor, org: string): boolean {
@@ -1173,7 +1216,7 @@ export class IntegrationService implements Disposable {
 						integration.getResourcesForUserResult(connectionId),
 					);
 					if (resources != null) {
-						items.push(...resources.map(r => this.resourceToOrg(r)));
+						items.push(...resources.map(r => this.resourceToOrg(id, r)));
 					}
 					if (warning != null) {
 						warnings.push(warning);
@@ -1199,7 +1242,7 @@ export class IntegrationService implements Disposable {
 						integration.getOrganizationsForUserResult(connectionId),
 					);
 					if (value != null) {
-						items.push(...value.values);
+						items.push(...value.values.map(org => this.withProviderContext(id, org)));
 						if (value.truncated) {
 							warnings.push({
 								providerId: id,
@@ -1250,11 +1293,11 @@ export class IntegrationService implements Disposable {
 	}
 
 	/**
-	 * Lists the projects visible to the user, unified into the {@link ProviderOrganization} `{ id, name, url }`
-	 * shape. Covers issue-tracker providers (Jira/Linear, which expose projects under their resources) *and*
-	 * git hosts that have a project tier (Azure DevOps, whose repos are org + project scoped). Scoped to
-	 * `providerId` when given, else fanned out over both the supported issue trackers and Azure DevOps.
-	 * Providers with no project tier (GitHub, GitLab, Bitbucket) contribute nothing.
+	 * Lists the projects visible to the user, unified into the {@link ProviderOrganization}
+	 * `{ providerId, id, name, org?, url }` shape. Covers issue-tracker providers (Jira/Linear, which expose
+	 * projects under their resources) *and* git hosts that have a project tier (Azure DevOps, whose repos are
+	 * org + project scoped). Scoped to `providerId` when given, else fanned out over both the supported issue
+	 * trackers and Azure DevOps. Providers with no project tier (GitHub, GitLab, Bitbucket) contribute nothing.
 	 */
 	async listProjects(options?: {
 		providerId?: IntegrationIds;
@@ -1305,7 +1348,7 @@ export class IntegrationService implements Disposable {
 						}
 					}
 					if (projects != null) {
-						items.push(...projects.values);
+						items.push(...projects.values.map(project => this.withProviderContext(id, project)));
 
 						if (mergeAssessmentInto(warnings, id, domain, connectionId, projects.metadata).fetchFailed) {
 							fetchFailed = true;
@@ -1314,54 +1357,40 @@ export class IntegrationService implements Disposable {
 					return { items: items, warnings: warnings, fetchFailed: fetchFailed };
 				}
 
-				if (org != null) {
-					const { value: resources, warning: resourcesWarning } = await this.runCaptured(
+				const { value: resources, warning: resourcesWarning } = await this.runCaptured(
+					id,
+					domain,
+					connectionId,
+					() => integration.getResourcesForUserResult(connectionId),
+				);
+				if (resourcesWarning != null) {
+					warnings.push(resourcesWarning);
+					if (resources == null) {
+						fetchFailed = true;
+					}
+				}
+
+				const scopedResources =
+					org != null ? resources?.filter(resource => this.resourceMatchesOrg(resource, org)) : resources;
+				if (scopedResources != null && scopedResources.length !== 0) {
+					const { value: projects, warning: projectsWarning } = await this.runCaptured(
 						id,
 						domain,
 						connectionId,
-						() => integration.getResourcesForUserResult(connectionId),
+						() => integration.getProjectsForResourcesWithMetadataResult(scopedResources, connectionId),
 					);
-					if (resourcesWarning != null) {
-						warnings.push(resourcesWarning);
-						if (resources == null) {
-							fetchFailed = true;
-						}
-					}
-					const resource = resources?.find(r => this.resourceMatchesOrg(r, org));
-					if (resource != null) {
-						const { value: projects, warning: projectsWarning } = await this.runCaptured(
-							id,
-							domain,
-							connectionId,
-							() => integration.getProjectsForResourcesWithMetadataResult([resource], connectionId),
-						);
-						if (projectsWarning != null) {
-							warnings.push(projectsWarning);
-							if (projects == null) {
-								fetchFailed = true;
-							}
-						}
-						if (projects != null) {
-							items.push(...projects.values.map(p => this.resourceToOrg(p)));
-						}
-						// Fold in per-resource completeness/failures so a partial fan-out warns and marks fetchFailed
-						// without dropping the resources that succeeded.
-						if (mergeAssessmentInto(warnings, id, domain, connectionId, projects?.metadata).fetchFailed) {
-							fetchFailed = true;
-						}
-					}
-				} else {
-					const { value: projects, warning } = await this.runCaptured(id, domain, connectionId, () =>
-						integration.getProjectsForUserWithMetadataResult(connectionId),
-					);
-					if (warning != null) {
-						warnings.push(warning);
+					if (projectsWarning != null) {
+						warnings.push(projectsWarning);
 						if (projects == null) {
 							fetchFailed = true;
 						}
 					}
 					if (projects != null) {
-						items.push(...projects.values.map(p => this.resourceToOrg(p)));
+						items.push(
+							...projects.values.map(project =>
+								this.resourceToOrg(id, project, this.orgForProject(id, project, scopedResources)),
+							),
+						);
 					}
 					if (mergeAssessmentInto(warnings, id, domain, connectionId, projects?.metadata).fetchFailed) {
 						fetchFailed = true;

--- a/packages/plus/integrations/src/providers/__tests__/hierarchyResults.test.ts
+++ b/packages/plus/integrations/src/providers/__tests__/hierarchyResults.test.ts
@@ -43,7 +43,9 @@ suite('provider hierarchy results', () => {
 
 		const result = await integration.getOrganizationsForUser();
 
-		assert.deepEqual(result, { values: [{ id: '1', name: 'acme', url: 'https://github.com/acme' }] });
+		assert.deepEqual(result, {
+			values: [{ id: '1', providerId: 'github', name: 'acme', url: 'https://github.com/acme' }],
+		});
 	});
 
 	test('GitHub organization listing propagates truncation', async () => {
@@ -90,7 +92,7 @@ suite('provider hierarchy results', () => {
 		const result = await integration.getOrganizationsForUser();
 
 		assert.deepEqual(result, {
-			values: [{ id: '1', name: 'acme/platform', url: 'https://gitlab.com/acme/platform' }],
+			values: [{ id: '1', providerId: 'gitlab', name: 'acme/platform', url: 'https://gitlab.com/acme/platform' }],
 		});
 	});
 

--- a/packages/plus/integrations/src/providers/azureDevOps.ts
+++ b/packages/plus/integrations/src/providers/azureDevOps.ts
@@ -320,7 +320,12 @@ export abstract class AzureDevOpsIntegrationBase<
 		if (orgs == null) return undefined;
 
 		return {
-			values: orgs.map(o => ({ id: o.id, name: o.name, url: `${this.apiBaseUrl}/${o.name}` })),
+			values: orgs.map(o => ({
+				id: o.id,
+				providerId: this.id,
+				name: o.name,
+				url: `${this.apiBaseUrl}/${o.name}`,
+			})),
 		};
 	}
 
@@ -343,7 +348,9 @@ export abstract class AzureDevOpsIntegrationBase<
 		return {
 			values: projects.values.map(p => ({
 				id: p.id,
+				providerId: this.id,
 				name: p.name,
+				org: p.resourceName,
 				url: `${this.apiBaseUrl}/${p.resourceName}/${p.name}`,
 			})),
 			...(projects.metadata != null ? { metadata: projects.metadata } : {}),

--- a/packages/plus/integrations/src/providers/bitbucket.ts
+++ b/packages/plus/integrations/src/providers/bitbucket.ts
@@ -283,7 +283,12 @@ export class BitbucketIntegration extends GitHostIntegration<
 		if (workspaces == null) return undefined;
 
 		return {
-			values: workspaces.values.map(w => ({ id: w.id, name: w.slug, url: `https://bitbucket.org/${w.slug}` })),
+			values: workspaces.values.map(w => ({
+				id: w.id,
+				providerId: this.id,
+				name: w.slug,
+				url: `https://bitbucket.org/${w.slug}`,
+			})),
 			...(workspaces.metadata != null ? { metadata: workspaces.metadata } : {}),
 		};
 	}

--- a/packages/plus/integrations/src/providers/github.ts
+++ b/packages/plus/integrations/src/providers/github.ts
@@ -324,6 +324,7 @@ abstract class GitHubIntegrationBase<ID extends GitHubIntegrationIds> extends Gi
 		return {
 			values: result.values.map(o => ({
 				id: o.id,
+				providerId: this.id,
 				name: o.username,
 				url: `https://${this.domain}/${o.username}`,
 			})),

--- a/packages/plus/integrations/src/providers/gitlab.ts
+++ b/packages/plus/integrations/src/providers/gitlab.ts
@@ -312,7 +312,7 @@ abstract class GitLabIntegrationBase<ID extends GitLabIntegrationIds> extends Gi
 			baseUrl: this.isEnterprise ? `https://${this.domain}` : undefined,
 		});
 		return {
-			values: result.values.map(g => ({ id: g.id, name: g.fullPath, url: g.webUrl })),
+			values: result.values.map(g => ({ id: g.id, providerId: this.id, name: g.fullPath, url: g.webUrl })),
 			...(result.truncated ? { truncated: true } : {}),
 		};
 	}

--- a/packages/plus/integrations/src/providers/models.ts
+++ b/packages/plus/integrations/src/providers/models.ts
@@ -190,10 +190,14 @@ export type ProviderApiCollectionResult<T> = {
  * `name` is the identifier to pass back into `getRepositoriesForOrg` (GitHub login, Bitbucket
  * workspace slug, Azure DevOps org name, GitLab full namespace path) — not a display name; hosts
  * where those differ (Bitbucket, GitLab) must map to the identifier, not the human-readable label.
+ * `providerId` attributes fan-out ProviderBackend reads to their source provider, and `org` carries
+ * the parent org/resource for project-tier entries (Azure org, Jira site, etc.) when applicable.
  */
 export interface ProviderOrganization {
 	id: string;
+	providerId: IntegrationIds;
 	name: string;
+	org?: string;
 	url: string;
 }
 


### PR DESCRIPTION
## Summary

Fixes ProviderBackend aggregated `listOrgs` / `listProjects` results so items preserve provider attribution and project parent org context.

## What changed

- extend `ProviderOrganization` with `providerId` and optional `org`
- populate `providerId` in git-host org listing providers
- preserve parent org context for project-tier providers during aggregated `listProjects` fan-out
- map Azure DevOps projects with their org context
- avoid synthesizing an invalid parent org for Trello boards
- add regression tests covering fan-out attribution, Trello behavior, and Jira `resourceId` mapping

## Validation

- `pnpm --filter @gitlens/integrations run test`
- `tsc -b`

Part of gitkraken/kepler#1322 / gitkraken/kepler#1326.
