### PR TITLE
Resolve Trello issue lookups by stable card id (#5560)

### DIFF
--- a/packages/plus/integrations/scripts/test.mjs
+++ b/packages/plus/integrations/scripts/test.mjs
@@ -44,19 +44,21 @@ execFileSync(process.execPath, [mocha, '--ui', 'tdd', '--timeout', '30000', `${o
 	cwd: packageRoot,
 });
 
-// Keep the package's external-consumer boundary test in the standard integrations test flow so
-// `pnpm run test:packages` catches public-facade regressions too.
+// Build the package before exercising any external-consumer boundary. Both the fixture and the direct
+// facade smoke test import the published `@gitlens/integrations/*` exports, which resolve through this
+// package's `dist/` folder in the workspace link; without a fresh build they'd type-check/runtime-fail on
+// a clean checkout even when the sources themselves are correct.
 const pnpm = process.platform === 'win32' ? 'pnpm.cmd' : 'pnpm';
-execFileSync(pnpm, ['--filter', '@gitlens/integrations-consumer-fixture', 'test'], {
-	stdio: 'inherit',
-	cwd: workspaceRoot,
-});
-
-// Build the package before importing the published facade so the smoke test validates the current sources,
-// not a stale or missing dist/ directory from a prior run.
 execFileSync(pnpm, ['build'], {
 	stdio: 'inherit',
 	cwd: packageRoot,
+});
+
+// Keep the package's external-consumer boundary test in the standard integrations test flow so
+// `pnpm run test:packages` catches public-facade regressions too.
+execFileSync(pnpm, ['--filter', '@gitlens/integrations-consumer-fixture', 'test'], {
+	stdio: 'inherit',
+	cwd: workspaceRoot,
 });
 
 // Smoke-test the published ESM facade directly under Node too. Bundled tests/fixtures can mask CommonJS named

--- a/packages/plus/integrations/src/__tests__/trello.test.ts
+++ b/packages/plus/integrations/src/__tests__/trello.test.ts
@@ -1,7 +1,8 @@
 import * as assert from 'node:assert/strict';
 import { suite, test } from 'mocha';
 import type { Issue } from '@gitlens/git/models/issue.js';
-import type { ProviderAuthenticationSession } from '../authentication/models.js';
+import type { ProviderAuthenticationSession, TokenWithInfo } from '../authentication/models.js';
+import { toTokenWithInfo } from '../authentication/models.js';
 import { IssuesCloudHostIntegrationId } from '../constants.js';
 import { createIntegrationManager } from '../index.js';
 import type { IssuesIntegration } from '../models/issuesIntegration.js';
@@ -36,9 +37,9 @@ function stubApi(integration: IssuesIntegration, api: Record<string, unknown>): 
 		Promise.resolve(api);
 }
 
-function fakeIssue(): ProviderIssue {
+function fakeIssue(overrides?: Partial<ProviderIssue>): ProviderIssue {
 	return {
-		id: '1',
+		id: 'card-1',
 		number: '1',
 		title: 'Card',
 		url: 'https://trello.com/c/1',
@@ -50,6 +51,7 @@ function fakeIssue(): ProviderIssue {
 		author: null,
 		assignees: [],
 		labels: [],
+		...overrides,
 	} as unknown as ProviderIssue;
 }
 
@@ -144,8 +146,44 @@ suite('Trello integration (#5438)', () => {
 		assert.equal(identifier.provider, 'trello');
 		assert.deepEqual(captured, {
 			resource: { id: 'b1', key: 'b1', owner: undefined, name: 'Board 1' },
-			id: '1',
+			id: 'card-1',
 		});
+		assert.equal(resolved?.id, '1');
+
+		manager.dispose();
+	});
+
+	test('cached Trello branch-association lookups fall back from idShort to the stable card id', async () => {
+		const manager = createIntegrationManager(createFakeRuntime());
+		const trello = await manager.get(IssuesCloudHostIntegrationId.Trello);
+		(trello as unknown as { _session: ProviderAuthenticationSession })._session = trelloSession('my-app-key');
+
+		stubApi(trello, {
+			getTrelloListsForBoard: () => Promise.resolve([{ id: 'l1', name: 'To Do' }]),
+			getTrelloIssuesForBoard: () =>
+				Promise.resolve({ values: [fakeIssue()], metadata: { completeness: 'complete' } }),
+		});
+
+		const issue = (await trello.getIssuesForProject({ key: 'b1', id: 'b1', name: 'Board 1' }))?.[0];
+		assert.ok(issue != null, 'a Trello issue was mapped');
+		if (issue == null) throw new Error('Expected a Trello issue');
+
+		const owner = getIssueOwner(issue);
+		assert.ok(owner != null, 'a Trello board owner descriptor can be derived');
+		if (owner == null) throw new Error('Expected a Trello owner descriptor');
+
+		const identifier = encodeIssueOrPullRequestForGitConfig({ ...issue, type: 'issue' } satisfies Issue, owner);
+		const peekedIds: string[] = [];
+		const resolved = await getIssueFromGitConfigEntityIdentifier(async () => undefined, identifier, {
+			cached: true,
+			peekCachedIssue: (_integration, resource, id) => {
+				assert.deepEqual(resource, { id: 'b1', key: 'b1', owner: undefined, name: 'Board 1' });
+				peekedIds.push(id);
+				return id === 'card-1' ? ({ ...issue, type: 'issue' } satisfies Issue) : undefined;
+			},
+		});
+
+		assert.deepEqual(peekedIds, ['1', 'card-1']);
 		assert.equal(resolved?.id, '1');
 
 		manager.dispose();
@@ -157,11 +195,17 @@ suite('Trello integration (#5438)', () => {
 		(trello as unknown as { _session: ProviderAuthenticationSession })._session = trelloSession('my-app-key');
 
 		let boardReads = 0;
+		let cardReads = 0;
 		stubApi(trello, {
 			getTrelloListsForBoard: () => Promise.resolve([{ id: 'l1', name: 'To Do' }]),
 			getTrelloIssuesForBoard: () => {
 				boardReads++;
 				return Promise.resolve({ values: [fakeIssue()], metadata: { completeness: 'complete' } });
+			},
+			getTrelloCard: (_t: unknown, _appKey: string, cardId: string) => {
+				cardReads++;
+				assert.equal(cardId, 'card-1', 'identifier resolution uses the stable Trello card id');
+				return Promise.resolve(fakeIssue());
 			},
 		});
 
@@ -176,14 +220,123 @@ suite('Trello integration (#5438)', () => {
 		const identifier = encodeIssueOrPullRequestForGitConfig({ ...issue, type: 'issue' } satisfies Issue, owner);
 		const resolved = await getIssueFromGitConfigEntityIdentifier(id => manager.get(id), identifier);
 
-		assert.equal(boardReads, 2, 'the identifier resolution performs a real board read on cache miss');
+		assert.equal(boardReads, 1, 'only the initial project listing reads the board');
+		assert.equal(cardReads, 1, 'the cache miss resolves via a direct Trello card read');
 		assert.equal(resolved?.id, '1');
+		assert.equal(resolved?.nodeId, 'card-1');
+		assert.equal(resolved?.number, '1');
 		assert.deepEqual(resolved?.project, {
 			id: 'b1',
 			name: 'Board 1',
 			resourceId: 'b1',
 			resourceName: 'Board 1',
 		});
+
+		manager.dispose();
+	});
+
+	test('numeric Trello issue lookups fall back to a board scan when direct card lookup misses', async () => {
+		const runtime = createFakeRuntime();
+		const cardReadUrls: string[] = [];
+		runtime.http.fetch = url => {
+			cardReadUrls.push(url.toString());
+			return Promise.resolve(
+				new Response(JSON.stringify({ message: 'not found' }), {
+					status: 404,
+					statusText: 'Not Found',
+					headers: { 'content-type': 'application/json' },
+				}),
+			);
+		};
+
+		const manager = createIntegrationManager(runtime);
+		const trello = await manager.get(IssuesCloudHostIntegrationId.Trello);
+		(trello as unknown as { _session: ProviderAuthenticationSession })._session = trelloSession('my-app-key');
+
+		let boardReads = 0;
+		const api = await (
+			trello as unknown as {
+				getProvidersApi: () => Promise<{ providers: Record<string, Record<string, unknown>> }>;
+			}
+		).getProvidersApi();
+		const provider = api.providers[IssuesCloudHostIntegrationId.Trello];
+		provider.getTrelloListsForBoardFn = () => Promise.resolve({ data: [{ id: 'l1', name: 'To Do' }] });
+		provider.getTrelloIssuesForBoardFn = () => {
+			boardReads++;
+			return Promise.resolve({
+				data: [fakeIssue({ id: 'card-7', number: '7' })],
+				metadata: { completeness: 'complete' },
+			});
+		};
+
+		const issue = await trello.getIssue({ key: 'b1', id: 'b1', name: 'Board 1' }, '7');
+
+		assert.equal(cardReadUrls.length, 1, 'the direct card lookup is attempted first');
+		assert.match(cardReadUrls[0], /\/1\/cards\/7\?members=true$/);
+		assert.equal(boardReads, 1, 'a numeric id falls back to the board scan for compatibility');
+		assert.equal(issue?.id, '7');
+		assert.equal(issue?.nodeId, 'card-7');
+		assert.equal(issue?.number, '7');
+		assert.deepEqual(issue?.project, {
+			id: 'b1',
+			name: 'Board 1',
+			resourceId: 'b1',
+			resourceName: 'Board 1',
+		});
+
+		manager.dispose();
+	});
+
+	test('direct Trello card lookups do not depend on the board-lists SDK function', async () => {
+		const runtime = createFakeRuntime();
+		const cardReadUrls: string[] = [];
+		runtime.http.fetch = url => {
+			cardReadUrls.push(url.toString());
+			return Promise.resolve(
+				new Response(
+					JSON.stringify({
+						id: '64b5abcd0000000000000000',
+						idShort: 7,
+						name: 'Card',
+						url: 'https://trello.com/c/7',
+						dateLastActivity: new Date(0).toISOString(),
+						labels: [{ color: null, id: 'label-1', name: 'Uncolored' }],
+					}),
+					{ status: 200, headers: { 'content-type': 'application/json' } },
+				),
+			);
+		};
+
+		const manager = createIntegrationManager(runtime);
+		const trello = await manager.get(IssuesCloudHostIntegrationId.Trello);
+		const session = trelloSession('my-app-key');
+		(trello as unknown as { _session: ProviderAuthenticationSession })._session = session;
+
+		const api = await (
+			trello as unknown as {
+				getProvidersApi: () => Promise<{
+					getTrelloCard: (
+						token: TokenWithInfo<IssuesCloudHostIntegrationId.Trello>,
+						appKey: string,
+						cardId: string,
+					) => Promise<ProviderIssue | undefined>;
+					providers: Record<string, Record<string, unknown>>;
+				}>;
+			}
+		).getProvidersApi();
+		api.providers[IssuesCloudHostIntegrationId.Trello].getTrelloListsForBoardFn = undefined;
+
+		const issue = await api.getTrelloCard(
+			toTokenWithInfo(IssuesCloudHostIntegrationId.Trello, session),
+			'my-app-key',
+			'64b5abcd0000000000000000',
+		);
+
+		assert.equal(cardReadUrls.length, 1, 'the direct card lookup uses the custom Trello REST read');
+		assert.match(cardReadUrls[0], /\/1\/cards\/64b5abcd0000000000000000\?members=true$/);
+		assert.equal(issue?.id, '64b5abcd0000000000000000');
+		assert.equal(issue?.number, '7');
+		assert.deepEqual(issue?.labels, [{ color: null, description: null, id: 'label-1', name: 'Uncolored' }]);
 
 		manager.dispose();
 	});

--- a/packages/plus/integrations/src/providers/models.ts
+++ b/packages/plus/integrations/src/providers/models.ts
@@ -1386,8 +1386,8 @@ export function fromProviderIssue(
 ): Issue {
 	return new Issue(
 		integration,
-		issue.id,
-		issue.graphQLId,
+		issue.number,
+		issue.graphQLId ?? issue.id,
 		issue.title,
 		issue.url ?? '',
 		issue.createdDate,

--- a/packages/plus/integrations/src/providers/providersApi.ts
+++ b/packages/plus/integrations/src/providers/providersApi.ts
@@ -112,8 +112,86 @@ function isGraphQLRepoNotFoundError(ex: unknown): boolean {
 	return ex instanceof Error && repoNotFoundMessage.test(ex.message);
 }
 
+const trelloBaseUrl = 'https://api.trello.com';
+
+type TrelloMemberResponse = {
+	id: string;
+	username?: string | null;
+	fullName?: string | null;
+	avatarHash?: string | null;
+	avatarUrl?: string | null;
+};
+
+type TrelloCardResponse = {
+	id: string;
+	idShort: number;
+	name: string;
+	url: string;
+	dateLastActivity: string;
+	idList?: string | null;
+	badges?: {
+		comments?: number | null;
+		votes?: number | null;
+	};
+	members?: TrelloMemberResponse[];
+	labels?: Array<{ color: string | null; id: string; name: string }>;
+};
+
+function getTrelloAuthHeaders(appKey: string, token: string): Record<string, string> {
+	return {
+		Authorization: `OAuth oauth_consumer_key="${appKey}", oauth_token="${token}"`,
+	};
+}
+
+function getTrelloMemberAvatarUrl(member: TrelloMemberResponse): string | null {
+	if (member.avatarUrl != null) return member.avatarUrl;
+	if (member.avatarHash == null) return null;
+
+	return `https://trello-members.s3.amazonaws.com/${member.id}/${member.avatarHash}/50.png`;
+}
+
+function fromTrelloCard(
+	card: TrelloCardResponse,
+	trelloBoardListsById: Record<string, { name: string }>,
+): ProviderIssue {
+	const createdDate = new Date(1000 * parseInt(card.id.substring(0, 8), 16));
+	const list = card.idList != null ? trelloBoardListsById[card.idList] : undefined;
+
+	return {
+		id: card.id,
+		commentCount: card.badges?.comments ?? null,
+		number: String(card.idShort),
+		title: card.name,
+		url: card.url,
+		closedDate: null,
+		createdDate: new Date(createdDate.toISOString()),
+		author: null,
+		updatedDate: new Date(card.dateLastActivity),
+		assignees: (card.members ?? []).map(member => ({
+			id: member.id,
+			username: member.username ?? null,
+			name: member.fullName ?? null,
+			email: null,
+			avatarUrl: getTrelloMemberAvatarUrl(member),
+			url: null,
+		})),
+		description: null,
+		state: list != null ? { id: card.idList!, name: list.name, color: null } : null,
+		type: null,
+		repository: null,
+		upvoteCount: card.badges?.votes ?? null,
+		labels: (card.labels ?? []).map(label => ({
+			color: label.color,
+			description: null,
+			id: label.id,
+			name: label.name,
+		})),
+	};
+}
+
 export class ProvidersApi {
 	private readonly providers: Providers;
+	private readonly request: ProviderRequestFunction;
 
 	constructor(private readonly authenticationService: IntegrationAuthenticationService) {
 		const http = authenticationService.ctx.http;
@@ -132,6 +210,7 @@ export class ProvidersApi {
 
 			return parseFetchResponseForApi<T>(response);
 		};
+		this.request = customFetch;
 		const providerApis = createProviderApis({ request: customFetch });
 		this.providers = {
 			[GitCloudHostIntegrationId.GitHub]: {
@@ -413,9 +492,8 @@ export class ProvidersApi {
 		return base64(`PAT:${oauthToken}`);
 	}
 
-	private async ensureProviderTokenAndFunction<T extends IntegrationIds>(
+	private async ensureProviderToken<T extends IntegrationIds>(
 		tokenOptInfo: TokenOptInfo<T>,
-		providerFn: keyof ProviderInfo,
 	): Promise<{ provider: ProviderInfo; tokenWithInfo: TokenWithInfo<T> }> {
 		const providerId = tokenOptInfo.providerId;
 		const provider = this.providers[providerId];
@@ -436,6 +514,16 @@ export class ProvidersApi {
 		if (tokenWithInfo == null) {
 			throw new Error(`Not connected to provider ${providerId}`);
 		}
+
+		return { provider: provider, tokenWithInfo: tokenWithInfo };
+	}
+
+	private async ensureProviderTokenAndFunction<T extends IntegrationIds>(
+		tokenOptInfo: TokenOptInfo<T>,
+		providerFn: keyof ProviderInfo,
+	): Promise<{ provider: ProviderInfo; tokenWithInfo: TokenWithInfo<T> }> {
+		const { provider, tokenWithInfo } = await this.ensureProviderToken(tokenOptInfo);
+		const providerId = tokenOptInfo.providerId;
 
 		if (provider[providerFn] == null) {
 			throw new Error(`Provider with id ${providerId} does not support function: ${providerFn}`);
@@ -1470,6 +1558,31 @@ export class ProvidersApi {
 			};
 		} catch (e) {
 			return this.handleProviderError(tokenWithInfo, e);
+		}
+	}
+
+	async getTrelloCard(
+		tokenOptInfo: TokenWithInfo<IssuesCloudHostIntegrationId.Trello>,
+		appKey: string,
+		cardId: string,
+		options?: { trelloBoardListsById?: Record<string, { name: string }> },
+	): Promise<ProviderIssue | undefined> {
+		const { tokenWithInfo } = await this.ensureProviderToken(tokenOptInfo);
+
+		try {
+			const result = await this.request<TrelloCardResponse>({
+				url: `${trelloBaseUrl}/1/cards/${encodeURIComponent(cardId)}?members=true`,
+				headers: getTrelloAuthHeaders(appKey, tokenWithInfo.accessToken),
+			});
+
+			return fromTrelloCard(result.body, options?.trelloBoardListsById ?? {});
+		} catch (e) {
+			try {
+				return this.handleProviderError<ProviderIssue | undefined>(tokenWithInfo, e);
+			} catch (ex) {
+				if (RequestNotFoundError.is(ex)) return undefined;
+				throw ex;
+			}
 		}
 	}
 

--- a/packages/plus/integrations/src/providers/trello.ts
+++ b/packages/plus/integrations/src/providers/trello.ts
@@ -176,11 +176,20 @@ export class TrelloIntegration extends IssuesIntegration<IssuesCloudHostIntegrat
 			acc[list.id] = { name: list.name };
 			return acc;
 		}, {});
-		const issue = (
-			await api.getTrelloIssuesForBoard(tokenWithInfo, appKey, resource.id, {
-				trelloBoardListsById: trelloBoardListsById,
-			})
-		)?.values.find(issue => issue.number === id || issue.id === id);
+
+		// Branch-association round-trips use the encoded entity identifier's stable Trello card id. Resolve that
+		// directly so large boards don't require a capped whole-board scan; keep a numeric idShort fallback so
+		// legacy/manual callers that still pass the board-local display number continue to resolve.
+		let issue = await api.getTrelloCard(tokenWithInfo, appKey, id, {
+			trelloBoardListsById: trelloBoardListsById,
+		});
+		if (issue == null && /^[0-9]+$/.test(id)) {
+			issue = (
+				await api.getTrelloIssuesForBoard(tokenWithInfo, appKey, resource.id, {
+					trelloBoardListsById: trelloBoardListsById,
+				})
+			).values.find(issue => issue.number === id);
+		}
 
 		return issue != null
 			? fromProviderIssue(issue, this, {

--- a/packages/plus/integrations/src/providers/utils.ts
+++ b/packages/plus/integrations/src/providers/utils.ts
@@ -366,20 +366,27 @@ export async function getIssueFromGitConfigEntityIdentifier(
 		owner: identifier.metadata.owner.owner,
 		name: identifier.metadata.owner.name,
 	};
+	const remoteLookupId =
+		identifier.provider === EntityIdentifierProviderType.Trello ? identifier.entityId : identifier.metadata.id;
 
 	// Cache-only read (no remote fetch). The package can't reach the host cache directly, so defer to the
 	// host-supplied reader; without one, honor the no-fetch contract by returning undefined. The cache key
 	// is resource+id (the integration only affects the etag), so peek even when the integration is
 	// unresolvable — a still-cached issue must survive an unconfigured/disconnected integration.
 	if (options?.cached) {
-		return options.peekCachedIssue?.(integration, resource, identifier.metadata.id);
+		const cachedIssue = options.peekCachedIssue?.(integration, resource, identifier.metadata.id);
+		if (cachedIssue != null || identifier.provider !== EntityIdentifierProviderType.Trello) {
+			return cachedIssue;
+		}
+
+		return options.peekCachedIssue?.(integration, resource, identifier.entityId);
 	}
 
 	if (integration == null) {
 		return undefined;
 	}
 
-	return integration.getIssue(resource, identifier.metadata.id);
+	return integration.getIssue(resource, remoteLookupId);
 }
 
 export function getIssueOwner(

--- a/tests/fixtures/integrations-consumer/tsconfig.json
+++ b/tests/fixtures/integrations-consumer/tsconfig.json
@@ -6,6 +6,7 @@
 		"strict": true,
 		"esModuleInterop": true,
 		"skipLibCheck": true,
+		"types": ["node"],
 		"declaration": false,
 		"sourceMap": true,
 		"outDir": "dist",


### PR DESCRIPTION
## Summary
- resolve branch-associated Trello issue lookups by reading the stable card id directly instead of scanning the whole board
- preserve compatibility for numeric `idShort` lookups and cover the Trello cache-only fallback path
- build `@gitlens/integrations` before running the external consumer fixture and add Node types to that fixture tsconfig

## Testing
- pnpm --filter @gitlens/integrations test -- trello.test.ts

Refs #5560
