### PR TITLE
Classify GraphQL repo not-found in resolveRepository (#5559)

### DIFF
--- a/packages/core/CHANGELOG.md
+++ b/packages/core/CHANGELOG.md
@@ -21,6 +21,7 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/) and this p
 
 ### Fixed
 
+- Fixes `IntegrationService.resolveRepository` misclassifying a nonexistent GitHub/GitLab repository as a generic `error` instead of `not-found` &mdash; those providers' `getRepo` clients are GraphQL, so a missing repo returns HTTP 200 with a null node and the SDK throws an error with no `response.status` (a `GraphQLErrors` for GitHub, a bare `Error` for GitLab) that `ProvidersApi.handleProviderError`'s status-based mapping never recognized. `ProvidersApi.getRepo` now detects the SDK's not-found shapes (GitHub's `NOT_FOUND`-typed GraphQL error, GitLab's `Repository … not found` message) and rethrows them as `RequestNotFoundError` so the resolution reports `not-found` ([#5559](https://github.com/gitkraken/vscode-gitlens/issues/5559)) (plus/integrations)
 - Fixes GitLab self-hosted repo-scoped reads (issues and pull requests) 404ing &mdash; `getSelfManagedApiBaseUrl` was producing a URL with a redundant `/api` segment, which then caused the provider SDK to double-append its own path; it now correctly strips these segments so the final request URL is correct ([#5526](https://github.com/gitkraken/vscode-gitlens/issues/5526)) (plus/integrations)
 
 ### Changed

--- a/packages/plus/integrations/src/__tests__/resolveRepository.test.ts
+++ b/packages/plus/integrations/src/__tests__/resolveRepository.test.ts
@@ -1,4 +1,6 @@
 import * as assert from 'node:assert/strict';
+import { GraphQLErrors } from '@gitkraken/provider-apis';
+import type { GraphQLError } from '@gitkraken/provider-apis';
 import { suite, test } from 'mocha';
 import type { ProviderAuthenticationSession } from '../authentication/models.js';
 import {
@@ -10,6 +12,7 @@ import { AuthenticationError, RequestNotFoundError } from '../errors.js';
 import { createIntegrationManager } from '../index.js';
 import type { GitHostIntegration } from '../models/gitHostIntegration.js';
 import type { ProviderRepository } from '../providers/models.js';
+import type { ProvidersApi } from '../providers/providersApi.js';
 import { createFakeRuntime } from './fakeRuntime.js';
 
 /**
@@ -61,6 +64,29 @@ async function connectSelfManaged(
 	assert.ok(gh != null, `${id} integration should construct for ${domain}`);
 	(gh as unknown as { _session: ProviderAuthenticationSession })._session = primarySession('t', domain);
 	return gh;
+}
+
+/**
+ * Overrides the real `getRepoFn` on the manager's `ProvidersApi` so the resolution goes through the
+ * actual `ProvidersApi.getRepo` (and its GraphQL not-found classification), NOT the pre-classified stub
+ * that `stubGetRepo` installs. This is what lets these tests feed the real SDK error shapes and verify
+ * they map to `not-found` (#5559).
+ */
+async function stubRealGetRepoFn(
+	manager: ReturnType<typeof createIntegrationManager>,
+	id: GitCloudHostIntegrationId,
+	impl: () => never,
+): Promise<void> {
+	const api = await (manager as unknown as { getProvidersApi: () => Promise<ProvidersApi> }).getProvidersApi();
+	const providers = (api as unknown as { providers: Record<string, { getRepoFn?: unknown } | undefined> }).providers;
+	const provider = providers[id];
+	assert.ok(provider != null, `provider ${id} should be registered on ProvidersApi`);
+	provider.getRepoFn = impl;
+}
+
+/** A GraphQL error entry as the SDK receives it from the provider's `body.errors`. */
+function graphQLError(type: string | undefined, message: string): GraphQLError {
+	return { type: type, message: message, path: ['repository'], locations: [] };
 }
 
 suite('resolveRepository (#5438)', () => {
@@ -305,6 +331,127 @@ suite('resolveRepository (#5438)', () => {
 		const repo = await az.getRepoInfo?.({ owner: 'myorg', name: 'myrepo', project: 'myproject' });
 		assert.equal(repo, undefined);
 		assert.equal(called, false, 'Azure DevOps Server should not call ProvidersApi.getRepo');
+
+		manager.dispose();
+	});
+});
+
+// #5559: GitHub/GitLab `getRepo` are GraphQL and never throw `RequestNotFoundError` for a missing repo —
+// they throw a `GraphQLErrors` (GitHub) or a bare `Error` (GitLab). These tests stub the REAL `getRepoFn`
+// with those SDK error shapes and go through the real `ProvidersApi.getRepo`, so they exercise the
+// classification the previous `RequestNotFoundError`-shaped stub could never reach.
+suite('resolveRepository — GraphQL not-found classification (#5559)', () => {
+	test('GitHub: a GraphQLErrors with a NOT_FOUND-typed entry maps to not-found', async () => {
+		const manager = createIntegrationManager(createFakeRuntime());
+		await connect(manager, GitCloudHostIntegrationId.GitHub, 'github.com');
+		await stubRealGetRepoFn(manager, GitCloudHostIntegrationId.GitHub, () => {
+			throw new GraphQLErrors('Repository octocat/gone not found', [
+				graphQLError('NOT_FOUND', "Could not resolve to a Repository with the name 'octocat/gone'."),
+			]);
+		});
+
+		const result = await manager.resolveRepository({ remoteUrl: 'https://github.com/octocat/gone.git' });
+		assert.equal(result.resolution.status, 'not-found');
+		assert.equal(result.resolution.warning, undefined);
+
+		manager.dispose();
+	});
+
+	test('GitHub: a GraphQLErrors with no entries falls back to the not-found message', async () => {
+		const manager = createIntegrationManager(createFakeRuntime());
+		await connect(manager, GitCloudHostIntegrationId.GitHub, 'github.com');
+		// The SDK throws with `body.errors` undefined when the node is simply null with no error array.
+		await stubRealGetRepoFn(manager, GitCloudHostIntegrationId.GitHub, () => {
+			throw new GraphQLErrors('Repository octocat/gone not found', undefined);
+		});
+
+		const result = await manager.resolveRepository({ remoteUrl: 'https://github.com/octocat/gone.git' });
+		assert.equal(result.resolution.status, 'not-found');
+
+		manager.dispose();
+	});
+
+	test('GitHub: a GraphQLErrors with no entries but a non-repo message stays an error (narrow fallback)', async () => {
+		const manager = createIntegrationManager(createFakeRuntime());
+		await connect(manager, GitCloudHostIntegrationId.GitHub, 'github.com');
+		// An empty/undefined errors array for a reason other than a missing repo must not be swept into
+		// not-found: the message fallback is anchored to the repo-specific `Repository … not found` shape.
+		await stubRealGetRepoFn(manager, GitCloudHostIntegrationId.GitHub, () => {
+			throw new GraphQLErrors('Something else went wrong', undefined);
+		});
+
+		const result = await manager.resolveRepository({ remoteUrl: 'https://github.com/octocat/gone.git' });
+		assert.equal(result.resolution.status, 'error');
+		assert.notEqual(result.resolution.warning, undefined);
+
+		manager.dispose();
+	});
+
+	test('GitHub: a GraphQLErrors with a non-NOT_FOUND entry stays an error (never misclassified as not-found)', async () => {
+		const manager = createIntegrationManager(createFakeRuntime());
+		await connect(manager, GitCloudHostIntegrationId.GitHub, 'github.com');
+		// FORBIDDEN surfaces the null repository node too, so the SDK message is still "... not found"; the
+		// structured type must win so a permission error is not reported as a confident negative.
+		await stubRealGetRepoFn(manager, GitCloudHostIntegrationId.GitHub, () => {
+			throw new GraphQLErrors('Repository octocat/secret not found', [
+				graphQLError('FORBIDDEN', 'Resource not accessible by integration'),
+			]);
+		});
+
+		const result = await manager.resolveRepository({ remoteUrl: 'https://github.com/octocat/secret.git' });
+		assert.equal(result.resolution.status, 'error');
+		assert.notEqual(result.resolution.warning, undefined);
+
+		manager.dispose();
+	});
+
+	test('GitHub: a NOT_FOUND entry on a non-repository path stays an error (path-scoped)', async () => {
+		const manager = createIntegrationManager(createFakeRuntime());
+		await connect(manager, GitCloudHostIntegrationId.GitHub, 'github.com');
+		// A NOT_FOUND scoped to some other selection (were the query to grow one) must not be read as the
+		// repository being missing; only a `repository`-pathed NOT_FOUND is a real repo not-found.
+		await stubRealGetRepoFn(manager, GitCloudHostIntegrationId.GitHub, () => {
+			throw new GraphQLErrors('Something under a different field not found', [
+				{
+					type: 'NOT_FOUND',
+					message: 'Could not resolve node',
+					path: ['viewer', 'somethingElse'],
+					locations: [],
+				},
+			]);
+		});
+
+		const result = await manager.resolveRepository({ remoteUrl: 'https://github.com/octocat/gone.git' });
+		assert.equal(result.resolution.status, 'error');
+		assert.notEqual(result.resolution.warning, undefined);
+
+		manager.dispose();
+	});
+
+	test('GitLab: a bare Error("Repository <path> not found") maps to not-found', async () => {
+		const manager = createIntegrationManager(createFakeRuntime());
+		await connect(manager, GitCloudHostIntegrationId.GitLab, 'gitlab.com');
+		await stubRealGetRepoFn(manager, GitCloudHostIntegrationId.GitLab, () => {
+			throw new Error('Repository group/proj not found');
+		});
+
+		const result = await manager.resolveRepository({ remoteUrl: 'https://gitlab.com/group/proj.git' });
+		assert.equal(result.resolution.status, 'not-found');
+		assert.equal(result.resolution.warning, undefined);
+
+		manager.dispose();
+	});
+
+	test('GitLab: an unrelated bare Error stays an error (message guard is specific)', async () => {
+		const manager = createIntegrationManager(createFakeRuntime());
+		await connect(manager, GitCloudHostIntegrationId.GitLab, 'gitlab.com');
+		await stubRealGetRepoFn(manager, GitCloudHostIntegrationId.GitLab, () => {
+			throw new Error('Something else failed');
+		});
+
+		const result = await manager.resolveRepository({ remoteUrl: 'https://gitlab.com/group/proj.git' });
+		assert.equal(result.resolution.status, 'error');
+		assert.notEqual(result.resolution.warning, undefined);
 
 		manager.dispose();
 	});

--- a/packages/plus/integrations/src/providers/providersApi.ts
+++ b/packages/plus/integrations/src/providers/providersApi.ts
@@ -1,5 +1,11 @@
-import ProviderApis from '@gitkraken/provider-apis';
-import type { CollectionMetadata, GitPullRequestState, TrelloBoard, TrelloList } from '@gitkraken/provider-apis';
+import ProviderApis, { GraphQLErrors } from '@gitkraken/provider-apis';
+import type {
+	CollectionMetadata,
+	GitPullRequestState,
+	GraphQLError,
+	TrelloBoard,
+	TrelloList,
+} from '@gitkraken/provider-apis';
 import type { PullRequest, PullRequestMergeMethod } from '@gitlens/git/models/pullRequest.js';
 import { base64 } from '@gitlens/utils/base64.js';
 import type { PagedResult } from '@gitlens/utils/paging.js';
@@ -18,6 +24,7 @@ import {
 	RequestClientError,
 	RequestNotFoundError,
 	RequestRateLimitError,
+	toError,
 } from '../errors.js';
 import type {
 	GetIssueFn,
@@ -68,6 +75,42 @@ import { collectProviderPagedResult } from './utils/providerPaging.js';
 type ProviderApisFactory = typeof ProviderApis;
 const createProviderApis: ProviderApisFactory =
 	(ProviderApis as ProviderApisFactory & { default?: ProviderApisFactory }).default ?? ProviderApis;
+
+// Both GitHub and GitLab `getRepo` throw a missing-repo error whose message is exactly
+// `Repository <x> not found`. Anchoring to that shape (rather than a loose `not found` substring) keeps
+// the message fallbacks from misclassifying unrelated GraphQL/transport failures as a confident negative.
+const repoNotFoundMessage = /^Repository .+ not found$/i;
+
+// `handleProviderError` classifies not-found by HTTP status (404/410/422), which only works for the
+// REST `getRepo` clients (Bitbucket, Bitbucket Server, Azure DevOps). GitHub and GitLab `getRepo` are
+// GraphQL: a missing repo comes back as HTTP 200 with a null node, and the SDK throws an unclassified
+// error with no `response.status`, so it would otherwise fall through to the generic error bucket. This
+// detects the SDK's not-found shapes so `getRepo` can rethrow them as `RequestNotFoundError`, keeping the
+// facade's by-type mapping intact.
+function isGraphQLRepoNotFoundError(ex: unknown): boolean {
+	// GitHub throws `GraphQLErrors`. The SDK reports the null repository node with the same
+	// `Repository <x> not found` message regardless of the underlying cause, so a `FORBIDDEN` or
+	// `RATE_LIMITED` GraphQL error would also surface with that message. Trust the structured error type
+	// when entries are present (only `NOT_FOUND` is a real not-found), and fall back to the repo-specific
+	// message only when there are no entries to disambiguate (a bare null node).
+	if (ex instanceof GraphQLErrors) {
+		const errors = ex.graphQLErrors;
+		// Scope NOT_FOUND to the `repository` field: `getRepo`'s query only selects that node today, but
+		// were it to grow other selections that can emit NOT_FOUND, an unscoped check would misclassify
+		// them. Tolerate a missing `path` so we degrade to the current behavior if the SDK stops populating
+		// it, rather than silently regressing to `error`.
+		if (errors?.length) {
+			return errors.some(
+				(e: GraphQLError) => e.type === 'NOT_FOUND' && (e.path == null || e.path.includes('repository')),
+			);
+		}
+		return repoNotFoundMessage.test(ex.message);
+	}
+
+	// GitLab's `getRepo` throws a plain Error; match its not-found message specifically so unrelated
+	// bare Errors (network/parse failures) still reach the generic error bucket.
+	return ex instanceof Error && repoNotFoundMessage.test(ex.message);
+}
 
 export class ProvidersApi {
 	private readonly providers: Providers;
@@ -571,6 +614,7 @@ export class ProvidersApi {
 				);
 				return result?.data;
 			} catch (e) {
+				if (isGraphQLRepoNotFoundError(e)) throw new RequestNotFoundError(toError(e));
 				return this.handleProviderError<ProviderRepository>(tokenWithInfo, e);
 			}
 		} else {
@@ -584,6 +628,7 @@ export class ProvidersApi {
 				);
 				return result?.data;
 			} catch (e) {
+				if (isGraphQLRepoNotFoundError(e)) throw new RequestNotFoundError(toError(e));
 				return this.handleProviderError<ProviderRepository>(tokenWithInfo, e);
 			}
 		}


### PR DESCRIPTION
## Summary

`IntegrationService.resolveRepository` maps a missing repo by error type: `RequestNotFoundError` → `not-found`, everything else → `error`. That works for the REST `getRepo` clients (Bitbucket Cloud, Bitbucket Server, Azure DevOps), because `ProvidersApi.handleProviderError` classifies not-found by HTTP status (404/410/422).

But GitHub and GitLab `getRepo` are **GraphQL**: a missing repo returns HTTP 200 with a null node, and the SDK throws an unclassified error with no `response.status` (a `GraphQLErrors` for GitHub, a bare `Error('Repository … not found')` for GitLab). `handleProviderError` rethrows those as-is, so a nonexistent GitHub/GitLab repo resolved to `status: 'error'` with a generic warning instead of `not-found`.

This matters for the Kepler migration (kepler#1329, kepler#1010): the canonicalization policy treats the two statuses very differently. `not-found` is a confident negative (`keep-literal`, do not consult the PR-cache heuristic); `error` falls back to the heuristic, which is exactly the accidental same-org retargeting `gk repo resolve` exists to prevent. Since GitHub/GitLab are the dominant providers, the misclassification hit the main path, not an edge case.

## Changes

Classify the GraphQL not-found shape at the `ProvidersApi.getRepo` boundary (keeps the facade's by-type mapping intact) and rethrow it as `RequestNotFoundError`:

- **GitHub** (`GraphQLErrors`): trust the structured error type when entries are present (only `NOT_FOUND` is a real not-found), and fall back to the `not found` message only when there are no entries to disambiguate (a bare null node). The SDK surfaces the same `Repository … not found` message for `FORBIDDEN` / `RATE_LIMITED` too, so a message-only check would misclassify a permission error as a confident negative.
- **GitLab** (bare `Error`): match the specific `^Repository … not found$` message its `getRepo` throws, so unrelated bare Errors (network/parse failures) still reach the generic error bucket.

The change only alters the **type** of the thrown error (to `RequestNotFoundError extends Error`), never whether one is thrown, so the other `getRepo`/`getRepoInfo` consumers that don't discriminate by type are unaffected.

## Tests

Extended `resolveRepository.test.ts` with a new suite that stubs the **real** `getRepoFn` with the actual SDK error shapes and goes through the real `ProvidersApi.getRepo` (the existing test stubbed a pre-classified `RequestNotFoundError`, a shape the GraphQL clients never produce):

- GitHub `GraphQLErrors` with a `NOT_FOUND` entry → `not-found`
- GitHub `GraphQLErrors` with no entries → falls back to the message → `not-found`
- GitHub `GraphQLErrors` with a `FORBIDDEN` entry → stays `error` (guardrail)
- GitLab bare `Error('Repository … not found')` → `not-found`
- GitLab unrelated bare `Error` → stays `error` (guardrail)

Full `@gitlens/integrations` suite passes (371 tests); `pnpm run check` and `tsc -b` are clean.

Part of the Kepler migration epic (gitkraken/kepler#1322, sub-issue kepler#1329).

Closes #5559