### PR TITLE
Fixes transient backend error disconnecting cloud integrations (#5569)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -27,14 +27,12 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/) and this p
 - Fixes the _Commit Graph_ working changes (WIP) details continuing to show files after they were committed or discarded outside of VS Code (e.g. from a terminal)
 - Fixes the _Commit Graph_ view's progress indicator repeatedly flashing while nothing appears to change (most noticeable after the VS Code window regains focus) &mdash; last-fetched updates now coalesce into a single pending update instead of queuing one per `FETCH_HEAD` change
 - Fixes the _Commit Graph_ sidebar list hovers repeatedly opening and closing in narrow viewports &mdash; when there's no room beside the list the hover now falls back below/above the row instead of flipping over the pointer, and moving the pointer into the hover keeps it open (like VS Code's own tree hovers) instead of dismissing it
+- Fixes self-managed cloud integrations (e.g. GitHub Enterprise, GitLab Self-Hosted) repeatedly issuing a token request that the server rejects on every session refresh, and legacy connections getting stuck reported as connected with no usable token &mdash; the per-connection token fetch no longer uses the host domain as the token id, and a connection whose token can no longer be fetched is now cleanly disconnected instead of left token-less ([#5497](https://github.com/gitkraken/vscode-gitlens/issues/5497))
+- Fixes a healthy cloud integration (e.g. GitLab.com, Jira, Azure DevOps, Bitbucket Cloud) being fully disconnected when a backend error happens to land during an automatic session-expiry refresh &mdash; only a definitive "this connection no longer has a token" response now disconnects it; any other failure (a server error, a rate limit, or a rejected account token) preserves the connection so it self-heals on the next successful sync ([#5569](https://github.com/gitkraken/vscode-gitlens/issues/5569))
 
 ### Removed
 
 - Removes the _Pro_ feature badge from the _Commit Graph_ header &mdash; the _Start New_ menu now occupies that area ([#5447](https://github.com/gitkraken/vscode-gitlens/issues/5447))
-
-### Fixed
-
-- Fixes self-managed cloud integrations (e.g. GitHub Enterprise, GitLab Self-Hosted) repeatedly issuing a token request that the server rejects on every session refresh, and legacy connections getting stuck reported as connected with no usable token &mdash; the per-connection token fetch no longer uses the host domain as the token id, and a connection whose token can no longer be fetched is now cleanly disconnected instead of left token-less ([#5497](https://github.com/gitkraken/vscode-gitlens/issues/5497))
 
 ## [18.3.0] - 2026-07-09
 

--- a/packages/plus/integrations/src/__tests__/cloudIntegrationService.test.ts
+++ b/packages/plus/integrations/src/__tests__/cloudIntegrationService.test.ts
@@ -22,6 +22,36 @@ function createCloudService(responder: (path: string, init?: RequestInit) => unk
 	return { service: new CloudIntegrationService(runtime), calls: calls };
 }
 
+/** Wires a fake `fetchGkApi` that returns a fixed non-ok status for every call (failure-path tests). */
+function createFailingCloudService(status: number) {
+	const runtime = createFakeRuntime();
+	runtime.account.fetchGkApi = () =>
+		Promise.resolve(new Response(JSON.stringify({ error: 'boom' }), { status: status }));
+	return new CloudIntegrationService(runtime);
+}
+
+/**
+ * Wires a fake `fetchGkApi` that fails with a different non-ok status per call, in call order, and records
+ * the paths. Drives the refresh fallback: call 1 is the `/refresh` POST, call 2 the plain GET retry.
+ */
+function createSequentiallyFailingCloudService(...statuses: number[]) {
+	const runtime = createFakeRuntime();
+	const paths: string[] = [];
+	runtime.account.fetchGkApi = (path: string) => {
+		paths.push(path);
+		const status = statuses[paths.length - 1] ?? statuses.at(-1);
+		return Promise.resolve(new Response(JSON.stringify({ error: 'boom' }), { status: status }));
+	};
+	return { service: new CloudIntegrationService(runtime), paths: paths, runtime: runtime };
+}
+
+/** The reported fetch failures, in emission order, so tests can pin what diagnostics actually saw. */
+function reportedFetchFailures(runtime: ReturnType<typeof createFakeRuntime>) {
+	return runtime.emittedEvents
+		.filter(e => e.event === 'integration.connection.fetch.failed')
+		.map(e => ({ code: e.props?.code, refreshing: e.props?.refreshing }));
+}
+
 suite('CloudIntegrationService — multi-account wire mapping (#5430)', () => {
 	test('getConnections flattens primary + secondaries and maps tokenId/positional primary', async () => {
 		const { service } = createCloudService(() => ({
@@ -190,5 +220,109 @@ suite('CloudIntegrationService — multi-account wire mapping (#5430)', () => {
 		assert.equal(ok, true);
 		assert.equal(calls[0].path, 'v1/provider-tokens/tokens/secondary-tok');
 		assert.equal(calls[0].method, 'DELETE');
+	});
+});
+
+suite('CloudIntegrationService — transient vs terminal failure classification (#5569)', () => {
+	test('getConnectionSession throws on a transient 5xx failure so callers can retry', async () => {
+		const service = createFailingCloudService(503);
+
+		// Match the error, not just "something threw": a 5xx must be reported as retryable, and an unrelated
+		// failure (e.g. a JSON parse error on the body) must not be mistaken for that.
+		await assert.rejects(
+			service.getConnectionSession(GitCloudHostIntegrationId.GitHub),
+			/Retryable failure \(503\)/,
+		);
+	});
+
+	test('getConnectionSession throws on a 429 rate-limit failure', async () => {
+		const service = createFailingCloudService(429);
+
+		await assert.rejects(
+			service.getConnectionSession(GitCloudHostIntegrationId.GitHub),
+			/Retryable failure \(429\)/,
+		);
+	});
+
+	test('getConnectionSession throws on a 401 — a rejected account token is not evidence the connection is gone', async () => {
+		// A 401 means OUR GK account token was rejected, which says nothing about whether the integration
+		// connection still exists. Treating it as terminal would disconnect a healthy integration (#5569).
+		const service = createFailingCloudService(401);
+
+		await assert.rejects(
+			service.getConnectionSession(GitCloudHostIntegrationId.GitHub),
+			/Retryable failure \(401\)/,
+		);
+	});
+
+	test('getConnectionSession throws on a 403 — the GK API returns it for rate limits, so it must stay retryable', async () => {
+		const service = createFailingCloudService(403);
+
+		await assert.rejects(
+			service.getConnectionSession(GitCloudHostIntegrationId.GitHub),
+			/Retryable failure \(403\)/,
+		);
+	});
+
+	test('getConnectionSession returns undefined on a terminal 404 so the connection can be dropped', async () => {
+		const service = createFailingCloudService(404);
+
+		assert.equal(await service.getConnectionSession(GitCloudHostIntegrationId.GitHub), undefined);
+	});
+
+	test('getConnectionSession returns undefined on a terminal 400 (a malformed request can never succeed on retry)', async () => {
+		const service = createFailingCloudService(400);
+
+		assert.equal(await service.getConnectionSession(GitCloudHostIntegrationId.GitHub), undefined);
+	});
+
+	test('getConnectionSession returns undefined on an ok-but-empty response (the connection has no token)', async () => {
+		const { service } = createCloudService(() => ({ data: null }));
+
+		assert.equal(await service.getConnectionSession(GitCloudHostIntegrationId.GitHub), undefined);
+	});
+
+	test('a failed refresh whose fallback GET fails transiently throws (classified by the fallback)', async () => {
+		// The refresh POST fails terminally, but the fallback GET — the request that actually decides whether
+		// the token is still fetchable — fails transiently, so the failure must surface as retryable.
+		const { service, paths, runtime } = createSequentiallyFailingCloudService(400, 503);
+
+		await assert.rejects(
+			service.getConnectionSession(GitCloudHostIntegrationId.GitHub, 'stale-access-token'),
+			/Retryable failure \(503\)/,
+		);
+		assert.deepEqual(
+			paths,
+			['v1/provider-tokens/github/refresh', 'v1/provider-tokens/github'],
+			'a failed refresh falls back to a plain GET before the failure is classified',
+		);
+		assert.deepEqual(
+			reportedFetchFailures(runtime),
+			[
+				{ code: 400, refreshing: true },
+				{ code: 503, refreshing: false },
+			],
+			'both failures are reported, so diagnostics see the fallback status that drove the classification',
+		);
+	});
+
+	test('a failed refresh whose fallback GET fails terminally returns undefined, even if the refresh was transient', async () => {
+		// The reverse pairing: the refresh POST fails transiently, but the fallback GET answers definitively
+		// that the token is gone. The fallback is authoritative, so this is terminal (droppable), not retryable.
+		const { service, paths, runtime } = createSequentiallyFailingCloudService(503, 404);
+
+		assert.equal(
+			await service.getConnectionSession(GitCloudHostIntegrationId.GitHub, 'stale-access-token'),
+			undefined,
+		);
+		assert.deepEqual(paths, ['v1/provider-tokens/github/refresh', 'v1/provider-tokens/github']);
+		assert.deepEqual(
+			reportedFetchFailures(runtime),
+			[
+				{ code: 503, refreshing: true },
+				{ code: 404, refreshing: false },
+			],
+			'the terminal fallback status is reported, not just the transient refresh status',
+		);
 	});
 });

--- a/packages/plus/integrations/src/__tests__/reconcileConnections.test.ts
+++ b/packages/plus/integrations/src/__tests__/reconcileConnections.test.ts
@@ -17,6 +17,8 @@ interface TokenBackend {
 	connections: unknown;
 	/** Per-path token responses; return null to simulate a failed/absent token. */
 	token: (path: string) => unknown;
+	/** HTTP status for a failed token fetch (token() returned null). Defaults to 500 (transient). */
+	errorStatus?: number;
 }
 
 function createManager(backend: TokenBackend) {
@@ -32,7 +34,7 @@ function createManager(backend: TokenBackend) {
 		} else if (path.startsWith('v1/provider-tokens/')) {
 			const data = backend.token(path);
 			if (data == null) {
-				status = 500;
+				status = backend.errorStatus ?? 500;
 				payload = { error: 'boom' };
 			} else {
 				payload = { data: data };
@@ -910,13 +912,15 @@ suite('cloud sync — multi-account reconcile (#5430)', () => {
 		manager.dispose();
 	});
 
-	test('a failed forced re-sync drops the connection instead of leaving it token-less (#5497)', async () => {
-		// The backend still lists the connection (state = 'connected'), but every token fetch fails (500). A
-		// forced re-sync deletes the cloud secret up front while preserving the descriptor; the replacement
-		// fetch then fails. The descriptor (and its secret) must not be left behind reported as connected.
+	test('a terminal forced re-sync failure drops the connection instead of leaving it token-less (#5497)', async () => {
+		// The backend still lists the connection (state = 'connected'), but the token fetch fails terminally
+		// (404 — the token is genuinely gone). A forced re-sync deletes the cloud secret up front while
+		// preserving the descriptor; the replacement fetch then fails terminally. The descriptor (and its
+		// secret) must not be left behind reported as connected.
 		const { runtime, manager } = createManager({
 			connections: [{ tokenId: 'p1', provider: 'github', type: 'oauth', domain: 'github.com' }],
-			token: () => null, // every token fetch fails
+			token: () => null, // the token is gone
+			errorStatus: 404, // terminal: the connection no longer has a fetchable token
 		});
 		await runtime.storage.store('integrations:configured', {
 			github: [{ id: 'p1', cloud: true, integrationId: 'github', scopes: 'repo', primary: true }],
@@ -931,11 +935,61 @@ suite('cloud sync — multi-account reconcile (#5430)', () => {
 		assert.deepEqual(
 			manager.getConfigured(GitCloudHostIntegrationId.GitHub),
 			[],
-			'the token-less descriptor is removed after the failed forced re-sync',
+			'the token-less descriptor is removed after the terminal forced re-sync failure',
 		);
 		assert.ok(
 			(await runtime.storage.getSecret('integration.auth.cloud:github|p1')) == null,
 			'the deleted cloud secret is not restored',
+		);
+
+		manager.dispose();
+	});
+
+	test('a transient forced re-sync failure preserves the connection so it self-heals (#5569)', async () => {
+		// The backend still lists the connection, but the token fetch fails transiently (503). A forced re-sync
+		// deletes the cloud secret up front while preserving the descriptor; the replacement fetch then fails
+		// transiently. Unlike the terminal case (#5497), the descriptor must be KEPT so a healthy integration
+		// isn't disconnected by a momentary backend blip — it self-heals on the next successful sync (#5569).
+		let failing = true;
+		const { runtime, manager } = createManager({
+			connections: [{ tokenId: 'p1', provider: 'github', type: 'oauth', domain: 'github.com' }],
+			token: () =>
+				failing
+					? null
+					: { tokenId: 'p1', accessToken: 'fresh-p1', expiresIn: 3600, scopes: 'repo', type: 'oauth' },
+			errorStatus: 503, // transient: the backend momentarily can't serve the token
+		});
+		await runtime.storage.store('integrations:configured', {
+			github: [{ id: 'p1', cloud: true, integrationId: 'github', scopes: 'repo', primary: true }],
+		});
+		await runtime.storage.storeSecret(
+			'integration.auth.cloud:github|p1',
+			JSON.stringify({ id: 'p1', accessToken: 'old-p1', scopes: ['repo'], cloud: true, type: 'oauth' }),
+		);
+
+		await manager.refreshConnections();
+
+		assert.deepEqual(
+			manager.getConfigured(GitCloudHostIntegrationId.GitHub).map(c => c.id),
+			['p1'],
+			'the descriptor is preserved through a transient failure (not dropped)',
+		);
+
+		// The backend recovers: the next sync fetches a fresh token and re-hydrates the secret.
+		failing = false;
+		await manager.refreshConnections();
+
+		assert.deepEqual(
+			manager.getConfigured(GitCloudHostIntegrationId.GitHub).map(c => c.id),
+			['p1'],
+			'the connection is still configured after recovery',
+		);
+		const secret = await runtime.storage.getSecret('integration.auth.cloud:github|p1');
+		assert.ok(secret != null, 'the cloud secret is restored on the next successful sync (self-heal)');
+		assert.equal(
+			(JSON.parse(secret) as { accessToken: string }).accessToken,
+			'fresh-p1',
+			'the restored secret holds the freshly fetched token',
 		);
 
 		manager.dispose();

--- a/packages/plus/integrations/src/authentication/cloudIntegrationService.ts
+++ b/packages/plus/integrations/src/authentication/cloudIntegrationService.ts
@@ -34,6 +34,24 @@ interface GKProviderToken {
 	domain?: string;
 }
 
+/**
+ * Whether the backend definitively answered that this connection has no fetchable token, so it can be
+ * cleanly disconnected (#5497). Everything else is retryable — notably 401/403, which reject our GK
+ * *account* token rather than the connection. The asymmetry is deliberate: a wrongly-kept descriptor
+ * self-corrects on the next sync, a wrongly-dropped one needs a manual reconnect (#5569).
+ */
+function isTerminalStatus(status: number): boolean {
+	switch (status) {
+		case 400: // e.g. a non-uuid token id (#5497)
+		case 404:
+		case 410:
+		case 422:
+			return true;
+		default:
+			return false;
+	}
+}
+
 function toSession(data: GKProviderToken): CloudIntegrationAuthenticationSession {
 	// Normalize the backend's `tokenId` onto our `id` so callers get a stable per-connection identity.
 	return {
@@ -102,6 +120,14 @@ export class CloudIntegrationService {
 		return connections;
 	}
 
+	/**
+	 * Fetches a connection's token, refreshing it first when `refreshToken` is given; `connectionId` targets
+	 * a specific connection (multi-account) rather than the provider's primary.
+	 *
+	 * Resolves `undefined` ONLY on a terminal failure (see {@link isTerminalStatus}, or an ok response with
+	 * no `data`), which callers may treat as "the connection is gone" (#5497). THROWS on every other
+	 * failure, which they must catch and treat as retryable instead of disconnecting (#5569).
+	 */
 	async getConnectionSession(
 		id: IntegrationIds,
 		refreshToken?: string,
@@ -159,9 +185,22 @@ export class CloudIntegrationService {
 					const data = ((await newTokenRsp.json()) as { data?: GKProviderToken })?.data;
 					return data != null ? toSession(data) : undefined;
 				}
+
+				// Report the fallback's own status (as a get, not a refresh) — it's what decides the outcome.
+				this.ctx.hooks?.connection?.onConnectionFetchFailed?.({
+					id: id,
+					code: newTokenRsp.status,
+					refreshing: false,
+				});
+
+				if (isTerminalStatus(newTokenRsp.status)) return undefined;
+
+				throw new Error(`Retryable failure (${newTokenRsp.status}) refreshing ${id} token from cloud`);
 			}
 
-			return undefined;
+			if (isTerminalStatus(tokenRsp.status)) return undefined;
+
+			throw new Error(`Retryable failure (${tokenRsp.status}) getting ${id} token from cloud`);
 		}
 
 		const data = ((await tokenRsp.json()) as { data?: GKProviderToken })?.data;

--- a/packages/plus/integrations/src/models/integration.ts
+++ b/packages/plus/integrations/src/models/integration.ts
@@ -331,6 +331,7 @@ export abstract class IntegrationBase<
 	private skippedNonCloudReported = false;
 	@debug()
 	async syncCloudConnection(state: 'connected' | 'disconnected', forceSync: boolean): Promise<void> {
+		const scope = getScopedLogger();
 		// Initially the condition on `this._session.cloud` has been added here: https://github.com/gitkraken/vscode-gitlens/commit/e95e70c430bd162924cc3bd5c1e8ab90e6293449#diff-4213141a45cccaab7aa2e40028b155a87eb913b07388485831403e60ce5555e4R237
 		// I'm not sure about reasons, but it seems we want to replace it with the cloud session if it's connected.
 		// Gradually we'll stop having non-cloud sessions.
@@ -374,17 +375,27 @@ export abstract class IntegrationBase<
 
 				// sync option, rather than createIfNeeded, makes sure we don't call connectCloudIntegrations and open a gkdev window
 				// if there was no session or some problem fetching/refreshing the existing session from the cloud api
-				const newSession = await this.ensureSession({ sync: forceSync });
+				let newSession: ProviderAuthenticationSession | undefined;
+				let refetchFailed = false;
+				try {
+					newSession = await this.ensureSession({ sync: forceSync });
+				} catch (ex) {
+					// Not evidence the connection is gone (#5569). Also leaves `_session` as-is rather than
+					// latching null, so the next access can re-resolve it.
+					if (!isCancellationError(ex)) {
+						scope?.error(ex);
+					}
+					refetchFailed = true;
+				}
 
 				if (oldSession && newSession && newSession.accessToken !== oldSession.accessToken) {
 					this.resetRequestExceptionCount('all');
 				}
 
-				// The forced re-sync above deleted the cloud secret but preserved the descriptor to avoid UI
-				// churn while a fresh token is fetched. If that fetch failed, drop the now token-less descriptor
-				// so the connection isn't reported connected without a backing token (matches the pre-multi-account
-				// clean-disconnect-on-failure behavior). The success path leaves the descriptor untouched.
-				if (resyncing && newSession == null) {
+				// The forced re-sync above deleted the cloud secret but kept the descriptor to avoid UI churn.
+				// Drop it only when the replacement fetch came back definitively empty, so a connection whose
+				// token is really gone is cleanly disconnected (#5497) while a healthy one survives a blip (#5569).
+				if (resyncing && newSession == null && !refetchFailed) {
 					const authProvider = await this.authenticationService.get(this.authProvider.id);
 					await authProvider.deleteSession(this.authProviderDescriptor, { preserveConfigured: false });
 				}
@@ -509,8 +520,17 @@ export abstract class IntegrationBase<
 		} catch (ex) {
 			await this.ctx.storage.deleteWorkspace(this.connectedKey);
 
-			if (ex instanceof Error && ex.message.includes('User did not consent')) {
+			// Only interactive paths can prompt for consent, so a sync failure must reach the rethrow below.
+			if (!sync && ex instanceof Error && ex.message.includes('User did not consent')) {
 				return undefined;
+			}
+
+			// On a forced re-sync, propagate so syncCloudConnection can tell a failure from a definitive empty
+			// result (#5569); other callers keep swallowing to null so reads never throw.
+			if (sync) {
+				// Throwing skips the reset below, and a lingering count blocks the next non-forced sync.
+				this.smoothifyRequestExceptionCount();
+				throw ex;
 			}
 
 			session = null;


### PR DESCRIPTION
Closes #5569

## Problem

An **automatic** session-expiry refresh (`refreshSessionIfExpired` → `syncCloudConnection` with `forceSync`) collapsed every non-ok GK backend response into an empty refetch. The #5497 failure-path hardening (`bf3f1cb0a`) then dropped the descriptor, fully disconnecting an otherwise-healthy cloud integration on a momentary backend blip and forcing a manual reconnect.

The forced resync deletes the cloud secret up front, so the sequence was: session expires (normal) → next read triggers a forced resync → secret deleted → backend momentarily fails → refetch is empty → descriptor dropped → integration disconnected.

This affects all cloud integrations carrying a real token expiry (GitLab.com, Jira, Azure DevOps, Bitbucket Cloud). GitHub.com and self-managed cloud are largely shielded because they're assigned a max expiry and rarely hit the expired-refresh path.

## Fix

`getConnectionSession` now surfaces the failure *kind* instead of collapsing every non-ok response to `undefined`. The polarity is deliberately asymmetric — only a **definitive** answer is terminal:

- resolves `undefined` **only** on 400 / 404 / 410 / 422, or an ok response with no `data` — the request is malformed or names something that doesn't exist, so retrying it unchanged can never succeed
- **throws** on everything else, including an unreachable backend

Notably 401 and 403 are retryable: those mean our GK *account* token was rejected or rate-limited, which says nothing about whether the integration connection still exists. (`serverConnection.ts` already treats 403 + `rate limit` as a rate-limit condition in two places.) The asymmetry is the point — preserving a connection through a failure that turns out to be permanent costs a stale descriptor the next successful sync reconciles, while dropping one through a failure that turns out to be transient fully disconnects a healthy integration.

On the refresh path, the fallback GET — not the failed refresh POST — is authoritative and decides the classification, and its status is now reported to diagnostics too.

`syncCloudConnection` drops the token-less descriptor only on a definitive empty refetch, preserving it on any thrown failure. A genuinely-gone connection is still cleanly disconnected, preserving #5497.

`ensureSession` propagates the failure on the forced-resync path only (`sync`); every other caller keeps its swallow-to-null behavior so reads never throw. The `@gate()` on `ensureSession` keys on the serialized options, so the `{ sync: true }` rejection can't leak into a concurrent read caller's `{ createIfNeeded: false }` call. Throwing skips the method's tail bookkeeping, so it now mirrors the `smoothifyRequestExceptionCount()` reset a resync always performs — leaving the count set would trip the `requestExceptionCount > 0` guard and early-return the next non-forced sync, the path meant to self-heal this very failure.

Two conditions that previously disconnected the integration now also preserve it, since both throw rather than return empty: `AuthenticationRequiredError` (no GK session) and `RequestsAreBlockedTemporarilyError`.

## Tests

`cloudIntegrationService.test.ts` — classification:

- 5xx, 429, **401**, and **403** all reject (retryable)
- terminal **404** and **400** resolve `undefined` (droppable)
- ok-but-empty response resolves `undefined`
- the refresh fallback decides transient vs terminal in both pairings (terminal POST + retryable GET → rejects; retryable POST + terminal GET → `undefined`), including which statuses reach diagnostics

`reconcileConnections.test.ts` — end-to-end through `refreshConnections` → `syncCloudIntegrations` → `syncCloudConnection`:

- **transient (503):** the descriptor is preserved, then re-hydrated with a fresh token once the backend recovers (self-heal)
- **terminal (404):** the descriptor and its secret are dropped (the #5497 regression test, re-pinned to a terminal status)

## Validation

`pnpm run check` ✅ · `pnpm run fmt:check` ✅ · `pnpm run test:packages` ✅ (159 passing)

`pnpm run build` currently fails locally with `TypeError: The 'compilation' argument must be an instance of Compilation` — two peer-resolution variants of webpack 5.108.4 are linked (top-level vs. `webpack-cli`'s), so the `instanceof` check fails across copies. This reproduces on a clean checkout of the base commit with no working-tree changes and survives `pnpm install --force`, so it's a local environment issue independent of this change, which type-checks clean. Flagging it for CI to confirm.