### PR TITLE
e2e cleanup: remove dead Commit Composer refs + fix graphReview panel maximize

### DIFF
--- a/.claude/agents/inspector-driver.md
+++ b/.claude/agents/inspector-driver.md
@@ -27,7 +27,7 @@ then call them directly.
 ## GitLens webview reference (root elements)
 
 - Graph → `gl-graph-app` — **commit rows/messages render on canvas, NOT in the DOM.** Read commit/git data via the `evaluate` (extension-host `vscode` API) bridge, not by scraping graph DOM.
-- Home → `gl-home-app` (may not hydrate unless it's the active/visible view). Inspect / Commit Details → `gl-commit-details-app`. Timeline → `gl-timeline-app`. Settings → `gl-settings-app`. Composer → `gl-composer-app`.
+- Home → `gl-home-app` (may not hydrate unless it's the active/visible view). Inspect / Commit Details → `gl-commit-details-app`. Timeline → `gl-timeline-app`. Settings → `gl-settings-app`.
 
 ## Return format
 

--- a/.claude/skills/live-inspect/SKILL.md
+++ b/.claude/skills/live-inspect/SKILL.md
@@ -258,7 +258,6 @@ When the session model is Opus or Fable, **default to dispatching the mechanical
 | _(sidebar)_                     | Commit Graph Inspect | `gl-commit-details-app` | `gitlens.views.graphDetails.refresh`  |
 | `gitlens.showTimelinePage`      | Visual History       | `gl-timeline-app`       | `gitlens.timeline.refresh`            |
 | `gitlens.showTimelineView`      | Visual File History  | `gl-timeline-app`       | `gitlens.views.timeline.refresh`      |
-| `gitlens.showComposerPage`      | Commit Composer      | `gl-composer-app`       | `gitlens.composer.refresh`            |
 | `gitlens.showPatchDetailsPage`  | Patch                | `gl-patch-details-app`  | `gitlens.patchDetails.refresh`        |
 | `gitlens.showSettingsPage`      | GitLens Settings     | `gl-settings-app`       | `gitlens.settings.refresh`            |
 

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -52,7 +52,7 @@ Git Execution (Node: child_process | Browser: APIs (GitHub))
 - **State Management**: Context providers with Lit reactive patterns and signals
 - **Major webviews**:
   - **Community**: Commit Details, Rebase, Settings
-  - **Pro** (`apps/plus/`): Home (includes Launchpad), Commit Graph, Timeline, Patch Details, Commit Composer
+  - **Pro** (`apps/plus/`): Home (includes Launchpad), Commit Graph, Timeline, Patch Details
 - Webviews bundled separately from extension (separate webpack config)
 
 ### 5. Caching Strategy

--- a/tests/e2e/pageObjects/gitLensPage.ts
+++ b/tests/e2e/pageObjects/gitLensPage.ts
@@ -333,11 +333,6 @@ export class GitLensPage extends VSCodePage {
 		return this.getGitLensWebview('Interactive Rebase', 'customEditor');
 	}
 
-	/** Commit Composer webview (editor panel, id `gitlens.composer`) */
-	async getCommitComposerWebview(timeout?: number): Promise<FrameLocator | null> {
-		return this.getGitLensWebview('Commit Composer', 'webviewPanel', timeout);
-	}
-
 	/**
 	 * Get a webview frame locator within a specific parent.
 	 * This avoids needing to know specific content inside the webview.

--- a/tests/e2e/specs/graphReview.test.ts
+++ b/tests/e2e/specs/graphReview.test.ts
@@ -43,6 +43,11 @@ test.describe('Review & Compose Sub-Panels', () => {
 
 	let graphWebview: FrameLocator;
 	let dispose: (() => Promise<void>) | undefined;
+	// Tracks whether beforeAll maximized the panel, so afterAll restores the non-maximized baseline.
+	// `toggleMaximizedPanel` is a stateful toggle and the VS Code instance is worker-scoped and reused
+	// across spec files, so an unrestored maximize would leak into later specs on the same worker
+	// (mirrors graphDetails.test.ts).
+	let panelMaximized = false;
 
 	async function ensureDetailsPanelOpen(): Promise<void> {
 		const toggleButton = graphWebview.locator('gl-button[aria-label$="Details Panel"]').first();
@@ -109,6 +114,14 @@ test.describe('Review & Compose Sub-Panels', () => {
 
 		await vscode.gitlens.showCommitGraphView();
 		await vscode.gitlens.panel.open();
+		// Maximize the panel so the graph has room to paint its rows. In a short (non-maximized) bottom
+		// panel the graph tree lays out but reports `hidden`, so the readiness gate below times out
+		// (mirrors openGraphWithPro in graphDetails/treeView). Guard the stateful toggle on
+		// `panelMaximized` so it only fires from the non-maximized baseline, which afterAll restores.
+		if (!panelMaximized) {
+			await vscode.gitlens.executeCommand<void>('workbench.action.toggleMaximizedPanel');
+			panelMaximized = true;
+		}
 
 		const wv = await vscode.gitlens.getGitLensWebview('Graph', 'webviewView', 60000);
 		expect(wv).not.toBeNull();
@@ -131,6 +144,13 @@ test.describe('Review & Compose Sub-Panels', () => {
 	test.afterAll(async ({ vscode }) => {
 		await dispose?.();
 		await vscode.gitlens.resetUI();
+		// Restore the non-maximized baseline so the one-time maximize above doesn't leak into other
+		// specs running later on the same worker-scoped VS Code instance (resetUI keeps the panel
+		// maximized). Mirrors graphDetails.test.ts.
+		if (panelMaximized) {
+			await vscode.gitlens.executeCommand<void>('workbench.action.toggleMaximizedPanel');
+			panelMaximized = false;
+		}
 	});
 
 	test.beforeEach(async () => {


### PR DESCRIPTION
Post-#5506/#5508 e2e hygiene — two independent commits, docs/tests only, no product code changes.

### 1. Remove dead Commit Composer webview references (Closes #5575)
The standalone Commit Composer webview was removed in #5506 and its `gitlens_commit_composer` MCP e2e test in #5508, but a few references lingered:
- Removes the now-unused `getCommitComposerWebview` e2e page-object helper (its only caller — the removed MCP test — is gone; no other consumers in the repo).
- Removes the stale Commit Composer entries in the live-inspect skill, the inspector-driver agent doc, and `docs/architecture.md`.

### 2. Fix `graphReview` e2e panel maximize
`graphReview`'s `beforeAll` opened the graph in a non-maximized bottom panel, unlike `graphDetails`/`treeView`'s `openGraphWithPro` which maximize it. In a short panel the graph tree (`role="tree"` "Commit graph") lays out but reports `hidden`, so the readiness gate timed out (30s) and the serial block cascaded to "did not run". Deterministic on a short Windows-local panel; masked on CI where the default panel height is tall enough. Maximizing in `beforeAll` (mirroring `openGraphWithPro`) fixes it — not a product bug, the graph renders correctly.

### Validation
- `pnpm run check` (type-check + lint) clean.
- Full VS Code e2e project run; `graphReview` **10/10** after the fix. The remaining intermittent `graphHeader`/`graphPin` failures on a heavily-parallel local run are pre-existing contention flakes (pass at `--workers=1`), unrelated to these changes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
