### PR TITLE
Fixes clipped Show button on the dormant Changes column

### DIFF
--- a/src/webviews/apps/plus/graph/graph-wrapper/gl-lit-graph.ts
+++ b/src/webviews/apps/plus/graph/graph-wrapper/gl-lit-graph.ts
@@ -16,7 +16,12 @@ import type { LaneSweep, LaneWindow } from '@gitkraken/commit-graph/laneClamp.js
 import { computeLaneWindow, laneWindowCovers, resolveGroupedLaneCap } from '@gitkraken/commit-graph/laneClamp.js';
 import { computePrefetchDistance } from '@gitkraken/commit-graph/paging.js';
 import type { ChangesColumnMode } from '@gitkraken/commit-graph/stats.js';
-import { changesFitWidth, changesModeOrDefault, changesStageForWidth } from '@gitkraken/commit-graph/stats.js';
+import {
+	changesFitWidth,
+	changesModeOrDefault,
+	changesStageCompact,
+	changesStageForWidth,
+} from '@gitkraken/commit-graph/stats.js';
 import type {
 	GraphPlacement,
 	RefsPlacement,
@@ -4807,19 +4812,29 @@ export class GlLitGraph extends LitElement {
 		if (zone == null) return nothing;
 
 		const narrow = zone.width < 150;
+		// The overlay degrades with width like the column's cells do (changesStageForWidth), but on its OWN
+		// threshold: the "Show" text button is ~57px, so it can't fit until well past the cells' 44px icon
+		// stage — below `changesStageCompact` it renders as a bare glyph and the tooltip carries all the copy.
+		const collapsed = zone.width < changesStageCompact;
 		// `gl-tooltip` is `display: contents`, so its slotted buttons stay flex items of the overlay stack.
 		// wa-popup anchors to the FIRST slotted element (the Show button), while the button's `::before`
 		// expands its hit area to the whole overlay surface (see graph.scss) — hover/click anywhere on the
 		// dormant column triggers the button + its tooltip, but the tooltip stays pinned above the button.
 		return html`<div
 			${ref(this.changesOptInRef)}
-			class="gl-graph__changes-optin"
+			class="gl-graph__changes-optin${narrow ? ' gl-graph__changes-optin--narrow' : ''}${
+				collapsed ? ' gl-graph__changes-optin--collapsed' : ''
+			}"
 			style=${cspStyleMap({ width: `${zone.width}px`, visibility: 'hidden' })}
 			@click=${this.onChangesOptInClick}
 		>
 			<gl-tooltip placement="top" show-delay="280">
-				<button type="button" class="gl-graph__changes-optin-button" aria-label="Show Changes Column">
-					Show
+				<button
+					type="button"
+					class="gl-graph__changes-optin-button${collapsed ? ' gl-graph__changes-optin-button--icon' : ''}"
+					aria-label="Show Changes Column"
+				>
+					${collapsed ? html`<code-icon icon="eye"></code-icon>` : 'Show'}
 				</button>
 				<button
 					type="button"

--- a/src/webviews/apps/plus/graph/graph.scss
+++ b/src/webviews/apps/plus/graph/graph.scss
@@ -2256,7 +2256,7 @@ gl-lit-graph {
 		display: flex;
 		flex-direction: column;
 		align-items: center;
-		justify-content: center;
+		justify-content: flex-start;
 		gap: 0.8rem;
 		padding: 1.2rem 1.4rem;
 		overflow: hidden;
@@ -2265,8 +2265,29 @@ gl-lit-graph {
 		background-color: color-mix(in srgb, var(--vscode-focusBorder) 8%, transparent);
 		border: 1px solid color-mix(in srgb, var(--vscode-focusBorder) 40%, transparent);
 
+		// Flex spacers at 1:2 park the stack in the upper third of the rows area rather than dead center —
+		// closer to the header it belongs to. Both shrink to 0 on a short rows area, so it never clips. The
+		// container `gap` applies around them too (+0.8rem each side), so the split is approximate.
+		// Unpositioned, so the Show button's absolute `::before` hit area still paints over them.
+		&::before {
+			content: '';
+			flex: 1 1 0;
+		}
+		&::after {
+			content: '';
+			flex: 2 1 0;
+		}
+
 		&:hover {
 			border-color: var(--vscode-focusBorder);
+		}
+
+		// Narrow stages: the default inline padding starves the button of the column's already-scarce width.
+		&.gl-graph__changes-optin--narrow {
+			padding-inline: 0.6rem;
+		}
+		&.gl-graph__changes-optin--collapsed {
+			padding-inline: 0.2rem;
 		}
 	}
 	.gl-graph__changes-optin-button {
@@ -2298,6 +2319,25 @@ gl-lit-graph {
 		&:focus-visible {
 			outline: 1px solid var(--vscode-focusBorder);
 			outline-offset: 0.2rem;
+		}
+	}
+	// Collapsed stage: a 2.4rem square glyph instead of the ~57px "Show" text button, which can't fit the
+	// column at its 36px default (= its min) without being clipped by the overlay's `overflow: hidden`.
+	.gl-graph__changes-optin-button--icon {
+		display: inline-flex;
+		align-items: center;
+		justify-content: center;
+		width: 2.4rem;
+		padding: 0;
+
+		> code-icon {
+			--code-icon-size: 1.4rem;
+			flex: none;
+		}
+
+		// The default 0.2rem offset gets shaved by the overlay's clip at this width.
+		&:focus-visible {
+			outline-offset: 0.1rem;
 		}
 	}
 	.gl-graph__changes-optin-hide {


### PR DESCRIPTION
Fixes #5582

## Problem

The _Changes_ column's default width is also its minimum (36px), so the opt-in overlay's ~55px _Show_ button overflowed the column and was clipped on both sides by the overlay's `overflow: hidden`. Because the default *is* the minimum, every user hit this on first run.

The overlay had a single breakpoint (`< 150px`) that only dropped the help text — the buttons rendered unconditionally at every width. Reported in [Slack](https://gitkraken-hq.slack.com/archives/C06QFFUSVUZ/p1785178919338839).

## Approach

The _Changes_ column already has a degradation ladder (`changesStageForWidth`) that collapses its cells to a single glyph when narrow. The opt-in overlay was the one part of the column that didn't participate in it — now it does, on its own threshold:

| Column width | Stage | Renders |
| --- | --- | --- |
| `< 76` (`changesStageCompact`) | collapsed | `eye` glyph button + _Hide_, tight padding |
| `76 – 149` | narrow (existing) | _Show_ text button + _Hide_, no help text |
| `>= 150` | full (existing) | text button + _Hide_ + help + sub |

The cells' own 44px icon threshold is too low to reuse here — the text button can't fit until well past it, so the collapsed stage extends to `changesStageCompact` (76). The narrow stages also tighten the overlay's inline padding so the button has room.

`aria-label="Show Changes Column"` is unchanged, so the accessible name survives the icon-only stage, and the tooltip (untouched) carries the full explanation — preserving the collapsed-by-default + rich-tooltip design.

Separately, the prompt moves from vertically centered to the upper third via flex spacers (no extra DOM), so it sits nearer the header it belongs to instead of floating mid-viewport on a tall graph.

Per thread discussion, the _Show_ → _Load_ rename was **not** taken: it buys ~3px, doesn't affect the collapsed stage at all, and would desync the visible label from the aria-label and tooltip title.

## Validation

`pnpm run check` clean, `pnpm run build` succeeds, `pnpm run test` 1430 passing / 0 failing.

Verified live against a running instance, measuring the button rect against the overlay's clip box at each width:

| Width | Stage | Renders | Clearance each side |
| --- | --- | --- | --- |
| 36 (default) | collapsed | `eye` glyph | 6px |
| 44 / 60 / 75 | collapsed | `eye` glyph | 10 / 18 / 25px |
| 76 | narrow | _Show_ (55px) | 10px |
| 100 / 126 | narrow | _Show_ | 22 / 35px |
| 220 | full | _Show_ + help + sub | 82px, no scroll overflow |

Nothing clips at any width — 76 is the tight case and it clears. Vertical fraction is a constant 0.309 across widths.

Also confirmed: overlay left matches the header cell exactly (0 drift, including with grouped refs); the _Show_ button is still `gl-tooltip`'s first slotted child so tooltip anchoring is intact; the full-surface click target survives; clicking the glyph enables the column and clears the dormant tint; _Hide_ still hides it; light theme resolves the correct button/border tokens; no console errors.

## Notes

No new unit tests: the only new logic is one comparison against `changesStageCompact`, whose ladder is already covered in `packages/plus/commit-graph/src/__tests__/stats.test.ts`. The rest is CSS.