### PR TITLE
Fixes misaligned hunks in the graph compose preview diff

### DIFF
--- a/src/virtual/__tests__/hunkApply.test.ts
+++ b/src/virtual/__tests__/hunkApply.test.ts
@@ -159,6 +159,27 @@ suite('applyHunks Test Suite', () => {
 			];
 			assert.throws(() => applyHunks(base, hunks), /end of file/);
 		});
+
+		// An additions-only body has nothing to verify, so an out-of-range start would otherwise
+		// collapse onto EOF and append silently instead of reporting the wrong base.
+		test('throws when a hunk starts past the end of the base', () => {
+			const base = toBytes('a\nb\n');
+			const hunks: ApplyableHunk[] = [{ hunkHeader: '@@ -50,0 +50,1 @@', content: '+x' }];
+			assert.throws(() => applyHunks(base, hunks), /starts past the end of the base/);
+		});
+
+		test('throws when a hunk starts one line past the end of the base', () => {
+			const base = toBytes('a\nb\n');
+			const hunks: ApplyableHunk[] = [{ hunkHeader: '@@ -4,0 +4,1 @@', content: '+x' }];
+			assert.throws(() => applyHunks(base, hunks), /starts past the end of the base/);
+		});
+
+		test('appends when a hunk starts exactly at the end of the base', () => {
+			const base = toBytes('a\nb\n');
+			const hunks: ApplyableHunk[] = [{ hunkHeader: '@@ -3,0 +3,1 @@', content: '+x' }];
+			const result = fromBytes(applyHunks(base, hunks));
+			assert.strictEqual(result, 'a\nb\nx\n');
+		});
 	});
 
 	suite('carriage returns', () => {

--- a/src/virtual/__tests__/hunkApply.test.ts
+++ b/src/virtual/__tests__/hunkApply.test.ts
@@ -245,5 +245,35 @@ suite('applyHunks Test Suite', () => {
 			const result = fromBytes(applyHunks(base, hunks));
 			assert.strictEqual(result, 'P\nq');
 		});
+
+		// No marker is emitted for a region the diff never reached, so an unterminated base has to
+		// carry its own ending forward rather than silently gaining a newline.
+		test('leaves an unterminated base unterminated when the hunk stops short of EOF', () => {
+			const base = toBytes('a\nb\nc');
+			const hunks: ApplyableHunk[] = [{ hunkHeader: '@@ -1,1 +1,1 @@', content: ['-a', '+A'].join('\n') }];
+			const result = fromBytes(applyHunks(base, hunks));
+			assert.strictEqual(result, 'A\nb\nc');
+		});
+
+		test('leaves an unterminated CRLF base unterminated when the hunk stops short of EOF', () => {
+			const base = toBytes('a\r\nb\r\nc');
+			const hunks: ApplyableHunk[] = [{ hunkHeader: '@@ -1,1 +1,1 @@', content: ['-a\r', '+A\r'].join('\n') }];
+			const result = fromBytes(applyHunks(base, hunks));
+			assert.strictEqual(result, 'A\r\nb\r\nc');
+		});
+
+		test('keeps a terminated base terminated when the hunk stops short of EOF', () => {
+			const base = toBytes('a\nb\nc\n');
+			const hunks: ApplyableHunk[] = [{ hunkHeader: '@@ -1,1 +1,1 @@', content: ['-a', '+A'].join('\n') }];
+			const result = fromBytes(applyHunks(base, hunks));
+			assert.strictEqual(result, 'A\nb\nc\n');
+		});
+
+		test('emits no trailing newline for a file emptied by deletions', () => {
+			const base = toBytes('a\nb\n');
+			const hunks: ApplyableHunk[] = [{ hunkHeader: '@@ -1,2 +0,0 @@', content: ['-a', '-b'].join('\n') }];
+			const result = fromBytes(applyHunks(base, hunks));
+			assert.strictEqual(result, '');
+		});
 	});
 });

--- a/src/virtual/__tests__/hunkApply.test.ts
+++ b/src/virtual/__tests__/hunkApply.test.ts
@@ -13,6 +13,8 @@ function fromBytes(bytes: Uint8Array): string {
 	return decoder.decode(bytes);
 }
 
+const noNewlineMarker = '\\ No newline at end of file';
+
 suite('applyHunks Test Suite', () => {
 	test('applies a single modification hunk', () => {
 		const base = toBytes(['one', 'two', 'three', 'four', 'five', ''].join('\n'));
@@ -75,7 +77,7 @@ suite('applyHunks Test Suite', () => {
 		assert.strictEqual(result, 'hello world\n');
 	});
 
-	test('preserves CRLF line endings when base uses CRLF', () => {
+	test('preserves CRLF line endings when the diff body omits the CR', () => {
 		const base = toBytes(['one', 'two', 'three', ''].join('\r\n'));
 		const hunks: ApplyableHunk[] = [
 			{ hunkHeader: '@@ -1,3 +1,3 @@', content: [' one', '-two', '+TWO', ' three'].join('\n') },
@@ -89,13 +91,7 @@ suite('applyHunks Test Suite', () => {
 		const hunks: ApplyableHunk[] = [
 			{
 				hunkHeader: '@@ -1,2 +1,2 @@',
-				content: [
-					' alpha',
-					'-beta',
-					'\\ No newline at end of file',
-					'+BETA',
-					'\\ No newline at end of file',
-				].join('\n'),
+				content: [' alpha', '-beta', noNewlineMarker, '+BETA', noNewlineMarker].join('\n'),
 			},
 		];
 		const result = fromBytes(applyHunks(base, hunks));
@@ -104,5 +100,150 @@ suite('applyHunks Test Suite', () => {
 
 	test('throws on malformed hunk header', () => {
 		assert.throws(() => applyHunks(toBytes('x\n'), [{ hunkHeader: 'NOT A HEADER', content: '' }]));
+	});
+
+	suite('base-relative application', () => {
+		// A proposed compose commit receives an arbitrary subset of one combined diff's hunks, so the
+		// line numbers of the hunks it did not receive must not shift the ones it did.
+		test('applies a non-contiguous subset of a file’s hunks', () => {
+			const base = toBytes(['a', 'b', 'c', 'd', 'e', 'f', ''].join('\n'));
+			const hunks: ApplyableHunk[] = [
+				{ hunkHeader: '@@ -1,1 +1,1 @@', content: ['-a', '+A'].join('\n') },
+				{ hunkHeader: '@@ -5,1 +5,1 @@', content: ['-e', '+E'].join('\n') },
+			];
+			const result = fromBytes(applyHunks(base, hunks));
+			assert.strictEqual(result, ['A', 'b', 'c', 'd', 'E', 'f', ''].join('\n'));
+		});
+
+		test('applies a hunk anchored where the previous hunk ended', () => {
+			const base = toBytes(['a', 'b', 'c', ''].join('\n'));
+			const hunks: ApplyableHunk[] = [
+				{ hunkHeader: '@@ -1,1 +1,2 @@', content: [' a', '+X'].join('\n') },
+				{ hunkHeader: '@@ -2,2 +3,2 @@', content: ['-b', '+B', ' c'].join('\n') },
+			];
+			const result = fromBytes(applyHunks(base, hunks));
+			assert.strictEqual(result, ['a', 'X', 'B', 'c', ''].join('\n'));
+		});
+
+		test('throws when hunks are not ordered ascending by old-side start', () => {
+			const base = toBytes(['a', 'b', 'c', 'd', ''].join('\n'));
+			const hunks: ApplyableHunk[] = [
+				{ hunkHeader: '@@ -3,1 +3,1 @@', content: ['-c', '+C'].join('\n') },
+				{ hunkHeader: '@@ -1,1 +1,1 @@', content: ['-a', '+A'].join('\n') },
+			];
+			assert.throws(() => applyHunks(base, hunks), /ordered ascending/);
+		});
+	});
+
+	suite('base verification', () => {
+		test('throws when a context line does not match the base', () => {
+			const base = toBytes(['one', 'two', ''].join('\n'));
+			const hunks: ApplyableHunk[] = [
+				{ hunkHeader: '@@ -1,2 +1,2 @@', content: [' MISMATCH', '-two', '+TWO'].join('\n') },
+			];
+			assert.throws(() => applyHunks(base, hunks), /does not match the base at line 1/);
+		});
+
+		test('throws when a deleted line does not match the base', () => {
+			const base = toBytes(['one', 'two', ''].join('\n'));
+			const hunks: ApplyableHunk[] = [
+				{ hunkHeader: '@@ -1,2 +1,2 @@', content: [' one', '-MISMATCH', '+TWO'].join('\n') },
+			];
+			assert.throws(() => applyHunks(base, hunks), /does not match the base at line 2/);
+		});
+
+		test('throws when a hunk claims context past the end of the file', () => {
+			const base = toBytes('only\n');
+			const hunks: ApplyableHunk[] = [
+				{ hunkHeader: '@@ -1,3 +1,3 @@', content: [' only', ' ghost', '-gone', '+new'].join('\n') },
+			];
+			assert.throws(() => applyHunks(base, hunks), /end of file/);
+		});
+	});
+
+	suite('carriage returns', () => {
+		// git emits the terminator's CR inside each body line of a CRLF file's diff, which is the
+		// shape the other CRLF test above deliberately does not cover.
+		test('preserves CRLF line endings when the diff body carries the CR', () => {
+			const base = toBytes(['one', 'two', 'three', ''].join('\r\n'));
+			const hunks: ApplyableHunk[] = [
+				{ hunkHeader: '@@ -1,3 +1,3 @@', content: [' one\r', '-two\r', '+TWO\r', ' three\r'].join('\n') },
+			];
+			const result = fromBytes(applyHunks(base, hunks));
+			assert.strictEqual(result, ['one', 'TWO', 'three', ''].join('\r\n'));
+		});
+
+		test('keeps a trailing CR that is genuine content when the base is not CRLF', () => {
+			const base = toBytes('alpha\nbeta\r'); // unterminated last line whose content ends in CR
+			const hunks: ApplyableHunk[] = [
+				{
+					hunkHeader: '@@ -1,2 +1,2 @@',
+					content: [' alpha', '-beta\r', noNewlineMarker, '+BETA\r', noNewlineMarker].join('\n'),
+				},
+			];
+			const result = fromBytes(applyHunks(base, hunks));
+			assert.strictEqual(result, 'alpha\nBETA\r');
+		});
+
+		test('accepts a CRLF context line when the base is mostly LF', () => {
+			const base = toBytes('a\r\nb\nc\n');
+			const hunks: ApplyableHunk[] = [
+				{ hunkHeader: '@@ -1,3 +1,3 @@', content: [' a\r', '-b', '+B', ' c'].join('\n') },
+			];
+			const result = fromBytes(applyHunks(base, hunks));
+			assert.strictEqual(result, 'a\nB\nc\n');
+		});
+
+		test('matches an empty context line in a CRLF base', () => {
+			const base = toBytes(['x', '', 'y', ''].join('\r\n'));
+			const hunks: ApplyableHunk[] = [
+				{ hunkHeader: '@@ -1,3 +1,3 @@', content: [' x\r', ' \r', '-y\r', '+Y\r'].join('\n') },
+			];
+			const result = fromBytes(applyHunks(base, hunks));
+			assert.strictEqual(result, ['x', '', 'Y', ''].join('\r\n'));
+		});
+	});
+
+	suite('no-newline-at-eof marker', () => {
+		// The marker describes the line directly above it, so which side it belongs to decides
+		// whether the result is terminated.
+		test('keeps the trailing newline when only the old side lacked one', () => {
+			const base = toBytes('line1\nlastline');
+			const hunks: ApplyableHunk[] = [
+				{
+					hunkHeader: '@@ -1,2 +1,2 @@',
+					content: [' line1', '-lastline', noNewlineMarker, '+newlast'].join('\n'),
+				},
+			];
+			const result = fromBytes(applyHunks(base, hunks));
+			assert.strictEqual(result, 'line1\nnewlast\n');
+		});
+
+		test('drops the trailing newline when the new side lacks one', () => {
+			const base = toBytes('x\ny\n');
+			const hunks: ApplyableHunk[] = [
+				{ hunkHeader: '@@ -1,2 +1,2 @@', content: [' x', '-y', '+Y', noNewlineMarker].join('\n') },
+			];
+			const result = fromBytes(applyHunks(base, hunks));
+			assert.strictEqual(result, 'x\nY');
+		});
+
+		test('keeps the surviving terminator when deleting the final unterminated line', () => {
+			const base = toBytes('a\r\nb\r\nc');
+			const hunks: ApplyableHunk[] = [
+				{ hunkHeader: '@@ -2,2 +2,1 @@', content: [' b\r', '-c', noNewlineMarker].join('\n') },
+			];
+			const result = fromBytes(applyHunks(base, hunks));
+			assert.strictEqual(result, 'a\r\nb\r\n');
+		});
+
+		test('honors the marker after a context line', () => {
+			const base = toBytes('p\nq');
+			const hunks: ApplyableHunk[] = [
+				{ hunkHeader: '@@ -1,2 +1,2 @@', content: ['-p', '+P', ' q', noNewlineMarker].join('\n') },
+			];
+			const result = fromBytes(applyHunks(base, hunks));
+			assert.strictEqual(result, 'P\nq');
+		});
 	});
 });

--- a/src/virtual/hunkApply.ts
+++ b/src/virtual/hunkApply.ts
@@ -144,15 +144,20 @@ export function applyHunks(base: Uint8Array | undefined, hunks: readonly Applyab
 		}
 	}
 
+	// A "\ No newline at end of file" marker only appears where the diff reaches EOF, so it decides
+	// the result's ending only when a hunk consumed through the last base line. When the hunks
+	// stopped short, the untouched tail carries the base's own ending forward.
+	const hunksReachedEof = cursor >= baseLines.length;
+
 	// Copy any remaining unchanged tail.
 	while (cursor < baseLines.length) {
 		out.push(baseLines[cursor]);
 		cursor++;
 	}
 
+	const terminated = hunksReachedEof ? !trailingEolSuppressed : endsWithEol;
 	const joined = out.join(eol);
-	const final = !trailingEolSuppressed && (endsWithEol || out.length > 0) ? `${joined}${eol}` : joined;
-	return textEncoder.encode(final);
+	return textEncoder.encode(terminated && out.length > 0 ? `${joined}${eol}` : joined);
 }
 
 /**

--- a/src/virtual/hunkApply.ts
+++ b/src/virtual/hunkApply.ts
@@ -3,6 +3,10 @@
  * hunks (same shape as `ComposerHunk`), returns the post-apply bytes. No git process spawn, no
  * object-store writes — pure in-memory transformation.
  *
+ * Hunk line numbers must be relative to `base` and hunks must be ordered ascending by `oldStart`;
+ * context and deleted lines are verified against `base`, so a violation throws rather than silently
+ * splicing. There is deliberately no `git apply`-style offset search.
+ *
  * Scope: text content. Binary and intent-to-add hunks are passed through as no-ops
  * (caller should detect binary mode upstream). Pure renames (no content change) return the base
  * unchanged. "\ No newline at end of file" markers are honored when present at hunk boundaries.
@@ -45,6 +49,9 @@ function parseHunkHeader(header: string): HunkRange | undefined {
  * Apply `hunks` in order on top of `base`. Returns the resulting bytes.
  *
  * Empty/undefined base is treated as "new file" — typically only `+` lines will appear in hunks.
+ *
+ * @throws when a hunk header is malformed, or when a context/deleted line doesn't match the base at
+ * the position the header points at.
  */
 export function applyHunks(base: Uint8Array | undefined, hunks: readonly ApplyableHunk[]): Uint8Array {
 	// Pure-rename commits change metadata, not content.
@@ -78,6 +85,12 @@ export function applyHunks(base: Uint8Array | undefined, hunks: readonly Applyab
 		// Copy unchanged base lines up to the hunk's start. Diff line numbers are 1-based; a
 		// header of `-N` aligns with base index `N-1` for the first consumed line.
 		const targetIdx = Math.max(0, range.oldStart - 1);
+		if (targetIdx < cursor) {
+			throw new Error(
+				`applyHunks: hunk '${hunk.hunkHeader}' starts before the previous hunk ended (base line ${String(cursor + 1)}) — hunks must be ordered ascending by old-side start`,
+			);
+		}
+
 		while (cursor < targetIdx && cursor < baseLines.length) {
 			out.push(baseLines[cursor]);
 			cursor++;
@@ -86,39 +99,48 @@ export function applyHunks(base: Uint8Array | undefined, hunks: readonly Applyab
 		// Walk hunk body lines. Split on \n only — unified diff uses LF between hunk lines.
 		const body = hunk.content.endsWith('\n') ? hunk.content.slice(0, -1) : hunk.content;
 		const bodyLines = body.length === 0 ? [] : body.split('\n');
-		for (const line of bodyLines) {
-			if (line.length === 0) {
+		let prevMarker = '';
+		for (const bodyLine of bodyLines) {
+			if (bodyLine.length === 0) {
 				// Rare but legal: an empty line in the body corresponds to a context line that was
 				// itself empty. Treat as a context match.
-				out.push('');
+				out.push(matchBaseLine(baseLines, cursor, '', hunk.hunkHeader));
 				cursor++;
+				prevMarker = ' ';
 				continue;
 			}
 
-			const marker = line[0];
-			const text = line.slice(1);
+			const marker = bodyLine[0];
+			const text = bodyLine.slice(1);
 			switch (marker) {
 				case ' ':
-					out.push(text);
+					out.push(matchBaseLine(baseLines, cursor, text, hunk.hunkHeader));
 					cursor++;
 					break;
 				case '-':
+					matchBaseLine(baseLines, cursor, text, hunk.hunkHeader);
 					cursor++;
 					break;
 				case '+':
-					out.push(text);
+					// With no base line to check against, go by the base's own terminator: when it
+					// isn't CRLF a trailing CR is real content rather than a terminator artifact.
+					out.push(eol === '\r\n' && text.endsWith('\r') ? text.slice(0, -1) : text);
 					break;
 				case '\\':
-					// "\ No newline at end of file". The preceding line (added or context) should not
-					// gain a trailing EOL when we rejoin.
-					trailingEolSuppressed = true;
+					// "\ No newline at end of file" describes the line above it, so after a deletion it
+					// is the old side that was unterminated — which says nothing about the result.
+					if (prevMarker !== '-') {
+						trailingEolSuppressed = true;
+					}
 					break;
 				default:
 					// Unknown marker — treat as context (defensive; permissive parsing matches git behavior).
-					out.push(line);
+					out.push(bodyLine);
 					cursor++;
 					break;
 			}
+
+			prevMarker = marker;
 		}
 	}
 
@@ -131,6 +153,22 @@ export function applyHunks(base: Uint8Array | undefined, hunks: readonly Applyab
 	const joined = out.join(eol);
 	const final = !trailingEolSuppressed && (endsWithEol || out.length > 0) ? `${joined}${eol}` : joined;
 	return textEncoder.encode(final);
+}
+
+/**
+ * Resolve a context/deleted hunk line against the base line it claims to consume, returning the
+ * base's own text. A CRLF base's diff carries that CR inside each body line while `baseLines` was
+ * split on the full terminator, so a trailing CR is tolerated only when dropping it is what makes
+ * the two agree; a line that still disagrees after that is a genuine mismatch.
+ */
+function matchBaseLine(baseLines: readonly string[], cursor: number, text: string, hunkHeader: string): string {
+	const actual = baseLines[cursor];
+	if (actual === text) return actual;
+	if (text.endsWith('\r') && actual === text.slice(0, -1)) return actual;
+
+	throw new Error(
+		`applyHunks: hunk '${hunkHeader}' does not match the base at line ${String(cursor + 1)}: expected '${text}', found ${actual == null ? 'end of file' : `'${actual}'`}`,
+	);
 }
 
 /** Detect the dominant line terminator in `text` and whether the text ends with one. */

--- a/src/virtual/hunkApply.ts
+++ b/src/virtual/hunkApply.ts
@@ -91,6 +91,16 @@ export function applyHunks(base: Uint8Array | undefined, hunks: readonly Applyab
 			);
 		}
 
+		// A diff taken against this base can't point past its end, so an out-of-range start means the
+		// hunks belong to some other content. Additions-only bodies have no line to verify, so without
+		// this they would collapse onto EOF and append silently. `targetIdx === baseLines.length` is
+		// the legitimate append-at-EOF case.
+		if (targetIdx > baseLines.length) {
+			throw new Error(
+				`applyHunks: hunk '${hunk.hunkHeader}' starts past the end of the base (${String(baseLines.length)} lines) — these hunks don't belong to this base`,
+			);
+		}
+
 		while (cursor < targetIdx && cursor < baseLines.length) {
 			out.push(baseLines[cursor]);
 			cursor++;

--- a/src/webviews/plus/graph/__tests__/graphComposeVirtualContentProvider.test.ts
+++ b/src/webviews/plus/graph/__tests__/graphComposeVirtualContentProvider.test.ts
@@ -1,0 +1,172 @@
+import * as assert from 'assert';
+import type { Container } from '../../../../container.js';
+import type { ComposerHunk } from '../compose/protocol.js';
+import type { GraphComposeVirtualCommitInput } from '../graphComposeVirtualContentProvider.js';
+import { GraphComposeVirtualContentProvider } from '../graphComposeVirtualContentProvider.js';
+
+const utf8 = new TextEncoder();
+const decoder = new TextDecoder();
+
+const repoPath = '/mock/repo';
+const baseSha = '0000000000000000000000000000000000000000';
+const fileName = 'src/sample.ts';
+
+function createContainer(baseContentByPath: Map<string, string>): Container {
+	return {
+		git: {
+			getRepositoryService: () => ({
+				revision: {
+					getRevisionContent: (path: string) => {
+						const content = baseContentByPath.get(path);
+						return Promise.resolve(content == null ? undefined : utf8.encode(content));
+					},
+				},
+			}),
+		},
+	} as unknown as Container;
+}
+
+function hunk(index: number, hunkHeader: string, lines: string[], overrides?: Partial<ComposerHunk>): ComposerHunk {
+	return {
+		index: index,
+		fileName: fileName,
+		additions: lines.filter(l => l.startsWith('+')).length,
+		deletions: lines.filter(l => l.startsWith('-')).length,
+		source: 'unknown',
+		diffHeader: `diff --git a/${fileName} b/${fileName}`,
+		hunkHeader: hunkHeader,
+		content: lines.join('\n'),
+		...overrides,
+	};
+}
+
+function commit(id: string, hunks: ComposerHunk[]): GraphComposeVirtualCommitInput {
+	return { id: id, message: `message for ${id}`, hunks: hunks };
+}
+
+/**
+ * A 12-line base plus a two-hunk combined diff whose first hunk removes two lines. The second
+ * hunk's old-side start therefore sits two lines beyond where it lands in the first hunk's result,
+ * which is what makes cross-commit synthesis order-sensitive.
+ */
+const baseLines = ['L01', 'L02', 'L03', 'L04', 'L05', 'L06', 'L07', 'L08', 'L09', 'L10', 'L11', 'L12'];
+const baseContent = [...baseLines, ''].join('\n');
+
+const earlyHunk = hunk(1, '@@ -2,3 +2,1 @@', [' L02', '-L03', '-L04']);
+const lateHunk = hunk(2, '@@ -9,1 +7,1 @@', ['-L09', '+L09-MOD']);
+
+const afterEarlyOnly = ['L01', 'L02', 'L05', 'L06', 'L07', 'L08', 'L09', 'L10', 'L11', 'L12', ''].join('\n');
+const afterBoth = ['L01', 'L02', 'L05', 'L06', 'L07', 'L08', 'L09-MOD', 'L10', 'L11', 'L12', ''].join('\n');
+
+function createProvider(baseContentByPath?: Map<string, string>): GraphComposeVirtualContentProvider {
+	return new GraphComposeVirtualContentProvider(
+		createContainer(baseContentByPath ?? new Map([[fileName, baseContent]])),
+	);
+}
+
+async function readAll(
+	provider: GraphComposeVirtualContentProvider,
+	commits: GraphComposeVirtualCommitInput[],
+	path = fileName,
+): Promise<string[]> {
+	const sessionId = provider.startSession({ repoPath: repoPath, baseSha: baseSha, commits: commits });
+	const contents: string[] = [];
+	for (const c of commits) {
+		contents.push(decoder.decode(await provider.readFile(sessionId, c.id, path)));
+	}
+	return contents;
+}
+
+suite('GraphComposeVirtualContentProvider Test Suite', () => {
+	test('synthesizes each commit against the base rather than its predecessor', async () => {
+		const provider = createProvider();
+		const [first, second] = await readAll(provider, [commit('c1', [earlyHunk]), commit('c2', [lateHunk])]);
+
+		assert.strictEqual(first, afterEarlyOnly);
+		assert.strictEqual(second, afterBoth);
+	});
+
+	test('synthesizes correctly when the later hunk lands in the earlier commit', async () => {
+		const provider = createProvider();
+		const [first, second] = await readAll(provider, [commit('c1', [lateHunk]), commit('c2', [earlyHunk])]);
+
+		assert.strictEqual(first, ['L01', ...baseLines.slice(1, 8), 'L09-MOD', 'L10', 'L11', 'L12', ''].join('\n'));
+		assert.strictEqual(second, afterBoth);
+	});
+
+	test('sorts hunks into base order regardless of their order within a commit', async () => {
+		const provider = createProvider();
+		const [only] = await readAll(provider, [commit('c1', [lateHunk, earlyHunk])]);
+
+		assert.strictEqual(only, afterBoth);
+	});
+
+	test('spreads a file’s hunks across three commits', async () => {
+		const provider = createProvider();
+		const tailHunk = hunk(3, '@@ -12,1 +10,1 @@', ['-L12', '+L12-MOD']);
+		const [first, second, third] = await readAll(provider, [
+			commit('c1', [earlyHunk]),
+			commit('c2', [tailHunk]),
+			commit('c3', [lateHunk]),
+		]);
+
+		assert.strictEqual(first, afterEarlyOnly);
+		assert.strictEqual(
+			second,
+			['L01', 'L02', 'L05', 'L06', 'L07', 'L08', 'L09', 'L10', 'L11', 'L12-MOD', ''].join('\n'),
+		);
+		assert.strictEqual(
+			third,
+			['L01', 'L02', 'L05', 'L06', 'L07', 'L08', 'L09-MOD', 'L10', 'L11', 'L12-MOD', ''].join('\n'),
+		);
+	});
+
+	test('ignores hunks belonging to other files', async () => {
+		const provider = createProvider();
+		const otherFileHunk = hunk(2, '@@ -1,1 +1,1 @@', ['-x', '+X'], { fileName: 'src/other.ts' });
+		const [only] = await readAll(provider, [commit('c1', [earlyHunk, otherFileHunk])]);
+
+		assert.strictEqual(only, afterEarlyOnly);
+	});
+
+	test('treats a file absent from the base as a new file', async () => {
+		const provider = createProvider(new Map());
+		const addHunk = hunk(1, '@@ -0,0 +1,2 @@', ['+new1', '+new2']);
+		const [only] = await readAll(provider, [commit('c1', [addHunk])]);
+
+		assert.strictEqual(only, 'new1\nnew2\n');
+	});
+
+	test('returns the base unchanged for a commit that only renames the file', async () => {
+		const provider = createProvider(new Map([['src/old.ts', baseContent]]));
+		const renameHunk = hunk(1, 'rename', ['Rename from src/old.ts'], {
+			isRename: true,
+			originalFileName: 'src/old.ts',
+		});
+		const [only] = await readAll(provider, [commit('c1', [renameHunk])]);
+
+		assert.strictEqual(only, baseContent);
+	});
+
+	test('reports the base as the first commit’s parent and the predecessor thereafter', async () => {
+		const provider = createProvider();
+		const commits = [commit('c1', [earlyHunk]), commit('c2', [lateHunk])];
+		const sessionId = provider.startSession({ repoPath: repoPath, baseSha: baseSha, commits: commits });
+
+		assert.deepStrictEqual(await provider.getParent(sessionId, 'c1'), {
+			kind: 'ref',
+			repoPath: repoPath,
+			sha: baseSha,
+		});
+		assert.deepStrictEqual(await provider.getParent(sessionId, 'c2'), { kind: 'virtual', commitId: 'c1' });
+	});
+
+	test('throws once a session has ended', async () => {
+		const provider = createProvider();
+		const commits = [commit('c1', [earlyHunk])];
+		const sessionId = provider.startSession({ repoPath: repoPath, baseSha: baseSha, commits: commits });
+		provider.endSession(sessionId);
+
+		await assert.rejects(() => provider.readFile(sessionId, 'c1', fileName), /virtual session not found/);
+	});
+});

--- a/src/webviews/plus/graph/compose/__tests__/simulator.test.ts
+++ b/src/webviews/plus/graph/compose/__tests__/simulator.test.ts
@@ -1,0 +1,73 @@
+import * as assert from 'assert';
+import type { GitRepositoryService } from '../../../../../git/gitRepositoryService.js';
+import { applyHunks } from '../../../../../virtual/hunkApply.js';
+import type { ScopeSelection } from '../../graphService.js';
+import { runSimulatedComposeChanges } from '../simulator.js';
+
+const decoder = new TextDecoder();
+const utf8 = new TextEncoder();
+
+const wipScope: Extract<ScopeSelection, { type: 'wip' }> = {
+	type: 'wip',
+	includeStaged: true,
+	includeUnstaged: true,
+	includeShas: [],
+};
+
+function createService(paths: string[]): GitRepositoryService {
+	return {
+		commits: { getCommit: () => Promise.resolve({ sha: 'a'.repeat(40) }) },
+		status: {
+			getStatus: () =>
+				Promise.resolve({
+					files: paths.map(path => ({
+						path: path,
+						originalPath: undefined,
+						status: 'M',
+						staged: false,
+						workingTreeStatus: 'M',
+					})),
+				}),
+		},
+	} as unknown as GitRepositoryService;
+}
+
+function runSimulator(paths: string[]) {
+	return runSimulatedComposeChanges({ svc: createService(paths), scope: wipScope, onProgress: () => {} });
+}
+
+suite('compose simulator Test Suite', () => {
+	// The simulator's plan flows through `deriveComposeCommits` into the virtual content provider, so
+	// its hunks are applied against real base file content. Invented deleted/context text can never
+	// match that, which is why the synthetic hunk has to be addition-only.
+	test('produces hunks that apply against unrelated base content', async () => {
+		const result = await runSimulator(['src/one.ts', 'src/two.ts']);
+		assert.strictEqual(result.sourceHunks.length, 2);
+
+		const base = utf8.encode(['import * as x from "y";', 'const a = 1;', ''].join('\n'));
+		for (const hunk of result.sourceHunks) {
+			const applied = decoder.decode(applyHunks(base, [hunk]));
+			assert.ok(
+				applied.includes('(simulated changed line)'),
+				`expected the simulated line in the result for ${hunk.fileName}, got ${JSON.stringify(applied)}`,
+			);
+			assert.ok(applied.includes('const a = 1;'), 'expected the base content to survive');
+		}
+	});
+
+	test('produces hunks that apply against an empty base', async () => {
+		const result = await runSimulator(['src/new.ts']);
+
+		const applied = decoder.decode(applyHunks(undefined, result.sourceHunks));
+		assert.strictEqual(applied, '(simulated changed line)\n');
+	});
+
+	test('reports no deletions, so nothing is verified against the base', async () => {
+		const result = await runSimulator(['src/one.ts']);
+		const [hunk] = result.sourceHunks;
+
+		assert.strictEqual(hunk.deletions, 0);
+		assert.strictEqual(hunk.additions, 1);
+		assert.ok(!hunk.content.split('\n').some(l => l.startsWith('-')), 'expected no deleted lines');
+	});
+});

--- a/src/webviews/plus/graph/compose/simulator.ts
+++ b/src/webviews/plus/graph/compose/simulator.ts
@@ -200,10 +200,12 @@ function makeSyntheticHunk(
 	const path = fileName;
 	const oldPath = originalFileName ?? fileName;
 	const diffHeader = [`diff --git a/${oldPath} b/${path}`, `--- a/${oldPath}`, `+++ b/${path}`].join('\n');
-	const hunkHeader = '@@ -1,1 +1,1 @@';
-	// One-line synthetic content — enough to render a non-empty diff but small enough
-	// to keep memory + serialization trivial across the IPC boundary.
-	const content = ['-(simulated original line)', '+(simulated changed line)'].join('\n');
+	// One-line synthetic content — enough to render a non-empty diff but small enough to keep memory
+	// + serialization trivial across the IPC boundary. Addition-only, anchored ahead of the first
+	// line: `applyHunks` verifies context and deleted lines against the real base file when
+	// synthesizing the preview, and no invented text could match it.
+	const hunkHeader = '@@ -0,0 +1,1 @@';
+	const content = '+(simulated changed line)';
 	return {
 		index: index,
 		fileName: path,
@@ -211,7 +213,7 @@ function makeSyntheticHunk(
 		hunkHeader: hunkHeader,
 		content: content,
 		additions: 1,
-		deletions: 1,
+		deletions: 0,
 		isRename: isRename || undefined,
 		originalFileName: originalFileName,
 	};

--- a/src/webviews/plus/graph/graphComposeVirtualContentProvider.ts
+++ b/src/webviews/plus/graph/graphComposeVirtualContentProvider.ts
@@ -3,7 +3,6 @@ import { EventEmitter, FileType } from 'vscode';
 import { ShowError } from '@gitlens/git/errors.js';
 import { Logger } from '@gitlens/utils/logger.js';
 import type { Container } from '../../../container.js';
-import type { ApplyableHunk } from '../../../virtual/hunkApply.js';
 import { applyHunks } from '../../../virtual/hunkApply.js';
 import type {
 	VirtualContentChangeEvent,
@@ -46,8 +45,9 @@ interface Session {
  *
  * Each session owns a parent-chained list of proposed commits anchored to a real base SHA; the
  * first commit's parent is `{ kind: 'ref', sha: baseSha }`, subsequent commits point at their
- * predecessor. File content at commit N is synthesized by starting from the base file and
- * applying in order every earlier commit's hunks that touch the requested path.
+ * predecessor. File content at commit N is synthesized by taking the base file and applying, in a
+ * single pass and in base order, the hunks from commits 0..N that {@link collectHunksForPath}
+ * resolves for the requested path.
  */
 export class GraphComposeVirtualContentProvider implements VirtualContentProvider {
 	readonly namespace = GraphComposeVirtualNamespace;
@@ -178,19 +178,18 @@ export class GraphComposeVirtualContentProvider implements VirtualContentProvide
 			nameAtCommit[i] = renameSource ?? nameAfter;
 		}
 
-		let content = await this.getBaseContent(session, nameAtCommit[0]);
+		// Every hunk comes from one combined `base..final` diff, so every `@@` header is relative to
+		// `baseSha`, never to the preceding commit — they have to be applied in one pass against the
+		// base. `index` is that diff's emission order, i.e. ascending old-line order per file.
+		const hunks: ComposerHunk[] = [];
 		for (let i = 0; i <= commitIdx; i++) {
-			const nameAfter = nameAtCommit[i + 1];
-			const hunks = collectHunksForPath(session.commits[i].hunks, nameAfter);
-			if (hunks.length === 0) continue;
-
-			content = applyHunks(
-				content,
-				hunks.map(h => h.hunk),
-			);
+			for (const h of collectHunksForPath(session.commits[i].hunks, nameAtCommit[i + 1])) {
+				hunks.push(h.hunk);
+			}
 		}
+		hunks.sort((a, b) => a.index - b.index);
 
-		const result = content ?? new Uint8Array(0);
+		const result = applyHunks(await this.getBaseContent(session, nameAtCommit[0]), hunks);
 		session.contentCache.set(cacheKey, result);
 		return result;
 	}
@@ -221,8 +220,8 @@ export class GraphComposeVirtualContentProvider implements VirtualContentProvide
 function collectHunksForPath(
 	hunks: readonly ComposerHunk[],
 	path: string,
-): Array<{ hunk: ApplyableHunk; isRename: boolean; toPath: string; fromPath: string }> {
-	const out: Array<{ hunk: ApplyableHunk; isRename: boolean; toPath: string; fromPath: string }> = [];
+): Array<{ hunk: ComposerHunk; isRename: boolean; toPath: string; fromPath: string }> {
+	const out: Array<{ hunk: ComposerHunk; isRename: boolean; toPath: string; fromPath: string }> = [];
 	for (const h of hunks) {
 		if (h.fileName !== path) continue;
 


### PR DESCRIPTION
Closes #5596

The graph compose preview rendered a garbled diff on the second and every later proposed commit: content that already existed was re-emitted as additions while adjacent lines were consumed as deletions.

### Cause

compose-tools collects every hunk from a single combined `parent(from) → finalTree` diff, so every `@@` header is **base-relative**. `GraphComposeVirtualContentProvider.readFile` synthesized commit *N* by chaining applications — apply commit 0's hunks to the base, then commit 1's hunks to *that result*, and so on. From commit 1 onward the input had already shifted by the net line delta of every previously applied hunk, while the headers still pointed at base positions, so hunks landed at the wrong offset. `applyHunks` never verified that the lines it consumed were the ones the hunk described, so it spliced silently instead of failing.

The applied commits were never affected: compose-tools pipes the same headers to `git apply --cached`, which verifies context and anchors on the new-side line number, and `verifyResultingDiff` gates the ref moves. Verified empirically by running the real commit chain and comparing every commit boundary across 2-commit, 3-commit, and reverse-order plans.

### Changes

**`graphComposeVirtualContentProvider.ts`** — gather every hunk for the path from commits `0..N`, sort into base order, and apply once against the base. Offsets are correct by construction, with no delta bookkeeping. The sort also fixes a latent issue where a commit's hunk array is not guaranteed to be in ascending base order, since `moveFileBetweenCommits` appends moved indices with `push`.

**`hunkApply.ts`** — context and deleted lines are now verified against the base and out-of-order hunks throw, so a future offset error surfaces instead of corrupting content. No offset search is added: base-relative numbers are exact here, and searching would mask bugs.

Two pre-existing defects in the same file surfaced while hardening it and are fixed here:

- **CRLF files were corrupted.** A CRLF base's diff carries the `CR` inside each body line while `baseLines` was split on the full terminator, so every touched line came out as `\r\r\n`. A trailing `CR` is now dropped only where that is what makes the line agree with the base, so a `CR` that is genuine content still fails as the mismatch it is.
- **`\ No newline at end of file` was misattributed.** The marker describes the line above it, but the flag was set regardless of side. After a `-` line it describes the *old* file, so the common "file had no trailing newline, this commit adds one" shape silently lost the trailing newline.

### Verification

`pnpm run build` and `pnpm run check` are clean.

Behavior was validated by driving the compiled `applyHunks` over the real combined diff from the reporting repository. The old chained path fails at exactly the lines from the original report; the fixed path produces content byte-identical to the real file across 2-commit, 3-commit, reversed-order, reverse-plan, and single-commit splits. Edge cases covered: CRLF round-trip against a real `git diff`, a bare trailing `CR` as content, mixed line endings, empty context lines, unterminated final lines, new files, pure renames, and the no-newline marker on each side independently.

### Known, not addressed

For a file renamed-with-edits whose hunks are split across proposed commits, the `nameAtCommit` backward walk pins the rename to the wrong commit and drops earlier commits' hunks. This is pre-existing, a different mechanism from the bug fixed here, and left for separate work.
