### PR TITLE
Include untracked files in reviews of working changes

### DIFF
--- a/packages/git-cli/src/providers/__tests__/integration/diff.test.ts
+++ b/packages/git-cli/src/providers/__tests__/integration/diff.test.ts
@@ -2,6 +2,7 @@ import * as assert from 'assert';
 import { execFileSync } from 'node:child_process';
 import { writeFileSync } from 'node:fs';
 import { join } from 'node:path';
+import { uncommitted } from '@gitlens/git/models/revision.js';
 import type { TestRepo } from './helpers.js';
 import { addCommit, createTestRepo } from './helpers.js';
 
@@ -410,6 +411,73 @@ suite('DiffSubProvider.includeUntracked', () => {
 				1,
 				'When a pathspec filter is active, untracked files must not be merged into the count',
 			);
+		} finally {
+			r.cleanup();
+		}
+	});
+});
+
+// Guards the assumption the review fix (#5586) rests on: `git diff` (working-vs-index) never contains
+// untracked content, but after `git add -N` (intent-to-add) it does — and unstaging cleanly restores the
+// untracked state. `getDiff(uncommitted)` maps to that unstaged `git diff`.
+suite('DiffSubProvider.getDiff — untracked via intent-to-add (#5586)', () => {
+	test('unstaged diff omits untracked files until intent-to-add staging, then restores', async () => {
+		const r = createTestRepo();
+		try {
+			addCommit(r.path, 'tracked.txt', 'v1\n', 'Add tracked.txt');
+			// An unstaged change to a tracked file + a brand-new untracked file.
+			writeFileSync(join(r.path, 'tracked.txt'), 'v2\n');
+			writeFileSync(join(r.path, 'untracked.txt'), 'brand new\n');
+
+			const before = await r.provider.diff.getDiff?.(r.path, uncommitted);
+			assert.ok(before?.contents, 'Expected an unstaged diff for the tracked change');
+			assert.ok(before.contents.includes('tracked.txt'), 'Unstaged diff should include the tracked change');
+			assert.ok(
+				!before.contents.includes('untracked.txt'),
+				'Root cause: untracked files are absent from the unstaged diff',
+			);
+
+			// Mirror the review fix: stage untracked with intent-to-add, then re-diff.
+			const untracked = (await r.provider.status?.getUntrackedFiles(r.path))?.map(f => f.path) ?? [];
+			assert.deepStrictEqual(untracked, ['untracked.txt'], 'Expected exactly the untracked file');
+			await r.provider.staging?.stageFiles(r.path, untracked, { intentToAdd: true });
+
+			const after = await r.provider.diff.getDiff?.(r.path, uncommitted);
+			assert.ok(after?.contents, 'Expected an unstaged diff after intent-to-add staging');
+			assert.ok(
+				after.contents.includes('untracked.txt'),
+				'After intent-to-add, the untracked file must appear in the unstaged diff',
+			);
+			assert.ok(after.contents.includes('brand new'), 'Untracked file contents must be present');
+			assert.ok(after.contents.includes('tracked.txt'), 'Tracked change must still be present');
+
+			// Cleanup restores the untracked state (working tree unchanged).
+			await r.provider.staging?.unstageFiles(r.path, untracked);
+			const restored = (await r.provider.status?.getUntrackedFiles(r.path))?.map(f => f.path) ?? [];
+			assert.deepStrictEqual(restored, ['untracked.txt'], 'Unstaging must restore the file to untracked');
+		} finally {
+			r.cleanup();
+		}
+	});
+
+	test('untracked-only working tree: unstaged diff is empty until intent-to-add (#5586 hard failure)', async () => {
+		const r = createTestRepo();
+		try {
+			addCommit(r.path, 'a.txt', 'a\n', 'Add a.txt');
+			writeFileSync(join(r.path, 'only-untracked.txt'), 'content\n');
+
+			// No tracked changes → the unstaged diff is empty. This is what surfaced as "No changes found".
+			const before = await r.provider.diff.getDiff?.(r.path, uncommitted);
+			assert.ok(!before?.contents, 'With only untracked content, the unstaged diff is empty');
+
+			const untracked = (await r.provider.status?.getUntrackedFiles(r.path))?.map(f => f.path) ?? [];
+			await r.provider.staging?.stageFiles(r.path, untracked, { intentToAdd: true });
+
+			const after = await r.provider.diff.getDiff?.(r.path, uncommitted);
+			assert.ok(after?.contents, 'After intent-to-add, the untracked-only diff is non-empty');
+			assert.ok(after.contents.includes('only-untracked.txt'), 'The untracked file must be reviewable');
+
+			await r.provider.staging?.unstageFiles(r.path, untracked);
 		} finally {
 			r.cleanup();
 		}

--- a/src/webviews/plus/graph/__tests__/graphInspectServices.test.ts
+++ b/src/webviews/plus/graph/__tests__/graphInspectServices.test.ts
@@ -13,9 +13,9 @@ import type { ScopeSelection } from '../graphService.js';
 type DiffForScopeResult = { diff: string; message: string; context: string } | undefined;
 type GetDiffForScope = (repoPath: string, scope: ScopeSelection, signal?: AbortSignal) => Promise<DiffForScopeResult>;
 
-function invoke(fakeThis: unknown, scope: ScopeSelection): Promise<DiffForScopeResult> {
+function invoke(fakeThis: unknown, scope: ScopeSelection, signal?: AbortSignal): Promise<DiffForScopeResult> {
 	const fn = (GraphInspectServices.prototype as unknown as { getDiffForScope: GetDiffForScope }).getDiffForScope;
-	return fn.call(fakeThis, '/repo', scope, undefined);
+	return fn.call(fakeThis, '/repo', scope, signal);
 }
 
 function wipScope(o: { includeUnstaged?: boolean; includeStaged?: boolean }): ScopeSelection {
@@ -29,20 +29,24 @@ function wipScope(o: { includeUnstaged?: boolean; includeStaged?: boolean }): Sc
 
 function createMocks(opts: {
 	untracked?: string[];
+	untrackedError?: Error;
 	unstagedDiff?: string;
 	unstagedError?: Error;
 	stagedDiff?: string;
 	noStaging?: boolean;
+	abortOnStage?: AbortController;
 }) {
 	// Shared, ordered log so tests can assert the exact stage → diff → unstage sequence.
 	const order: string[] = [];
 
 	const getUntrackedFiles = sinon.stub().callsFake(async () => {
 		order.push('getUntracked');
+		if (opts.untrackedError != null) throw opts.untrackedError;
 		return (opts.untracked ?? []).map(p => ({ path: p }));
 	});
 	const stageFiles = sinon.stub().callsFake(async () => {
 		order.push('stage');
+		opts.abortOnStage?.abort();
 	});
 	const unstageFiles = sinon.stub().callsFake(async () => {
 		order.push('unstage');
@@ -155,5 +159,29 @@ suite('graphInspectServices — getDiffForScope untracked handling (#5586)', () 
 		sinon.assert.notCalled(m.unstageFiles);
 		assert.deepStrictEqual(m.order, ['diff:unstaged']);
 		assert.ok(result?.diff.includes('tracked.txt'), 'the unstaged diff is still produced');
+	});
+
+	test('degrades to the plain unstaged diff when untracked enumeration fails', async () => {
+		const m = createMocks({
+			untrackedError: new Error('git status failed'),
+			unstagedDiff: 'diff --git a/tracked.txt b/tracked.txt\n',
+		});
+
+		const result = await invoke(m.fakeThis, wipScope({ includeUnstaged: true }));
+
+		sinon.assert.notCalled(m.stageFiles);
+		sinon.assert.notCalled(m.unstageFiles);
+		assert.deepStrictEqual(m.order, ['getUntracked', 'diff:unstaged']);
+		assert.ok(result?.diff.includes('tracked.txt'), 'the review still covers the tracked change');
+	});
+
+	test('honors cancellation after staging without running the unstaged diff', async () => {
+		const ac = new AbortController();
+		const m = createMocks({ untracked: ['new.txt'], unstagedDiff: 'x', abortOnStage: ac });
+
+		await assert.rejects(invoke(m.fakeThis, wipScope({ includeUnstaged: true }), ac.signal));
+
+		// Staging ran and was cleaned up, but the abort was honored before the diff was requested.
+		assert.deepStrictEqual(m.order, ['getUntracked', 'stage', 'unstage']);
 	});
 });

--- a/src/webviews/plus/graph/__tests__/graphInspectServices.test.ts
+++ b/src/webviews/plus/graph/__tests__/graphInspectServices.test.ts
@@ -1,0 +1,141 @@
+import * as assert from 'assert';
+import * as sinon from 'sinon';
+import { uncommitted, uncommittedStaged } from '@gitlens/git/models/revision.js';
+import type { Container } from '../../../../container.js';
+import { GraphInspectServices } from '../graphInspectServices.js';
+import type { ScopeSelection } from '../graphService.js';
+
+// `getDiffForScope` is private and only reaches `this.container.git.getRepositoryService(repoPath)` and
+// `this.buildChangesContext(...)`, so we exercise it against a minimal fake `this` rather than constructing
+// the full service. Fix under test (#5586): a WIP review must include untracked file contents by staging
+// them intent-to-add around the unstaged diff, then unstaging in a `finally`.
+
+type DiffForScopeResult = { diff: string; message: string; context: string } | undefined;
+type GetDiffForScope = (repoPath: string, scope: ScopeSelection, signal?: AbortSignal) => Promise<DiffForScopeResult>;
+
+function invoke(fakeThis: unknown, scope: ScopeSelection): Promise<DiffForScopeResult> {
+	const fn = (GraphInspectServices.prototype as unknown as { getDiffForScope: GetDiffForScope }).getDiffForScope;
+	return fn.call(fakeThis, '/repo', scope, undefined);
+}
+
+function wipScope(o: { includeUnstaged?: boolean; includeStaged?: boolean }): ScopeSelection {
+	return {
+		type: 'wip',
+		includeUnstaged: o.includeUnstaged ?? false,
+		includeStaged: o.includeStaged ?? false,
+		includeShas: [],
+	};
+}
+
+function createMocks(opts: {
+	untracked?: string[];
+	unstagedDiff?: string;
+	unstagedError?: Error;
+	stagedDiff?: string;
+}) {
+	// Shared, ordered log so tests can assert the exact stage → diff → unstage sequence.
+	const order: string[] = [];
+
+	const getUntrackedFiles = sinon.stub().callsFake(async () => {
+		order.push('getUntracked');
+		return (opts.untracked ?? []).map(p => ({ path: p }));
+	});
+	const stageFiles = sinon.stub().callsFake(async () => {
+		order.push('stage');
+	});
+	const unstageFiles = sinon.stub().callsFake(async () => {
+		order.push('unstage');
+	});
+
+	const getDiff = sinon.stub();
+	getDiff.withArgs(uncommitted).callsFake(async () => {
+		order.push('diff:unstaged');
+		if (opts.unstagedError != null) throw opts.unstagedError;
+		return opts.unstagedDiff != null ? { contents: opts.unstagedDiff } : undefined;
+	});
+	getDiff.withArgs(uncommittedStaged).callsFake(async () => {
+		order.push('diff:staged');
+		return opts.stagedDiff != null ? { contents: opts.stagedDiff } : undefined;
+	});
+
+	const svc = {
+		diff: { getDiff: getDiff },
+		status: { getUntrackedFiles: getUntrackedFiles },
+		staging: { stageFiles: stageFiles, unstageFiles: unstageFiles },
+		branches: { getBranch: sinon.stub().resolves(undefined) },
+	};
+
+	const container = {
+		git: { getRepositoryService: sinon.stub().returns(svc) },
+	} as unknown as Container;
+
+	const fakeThis = { container: container, buildChangesContext: async () => '' };
+
+	return {
+		fakeThis: fakeThis,
+		order: order,
+		getUntrackedFiles: getUntrackedFiles,
+		stageFiles: stageFiles,
+		unstageFiles: unstageFiles,
+	};
+}
+
+suite('graphInspectServices — getDiffForScope untracked handling (#5586)', () => {
+	test('stages untracked files intent-to-add for the unstaged diff, then unstages', async () => {
+		const m = createMocks({
+			untracked: ['new.txt'],
+			unstagedDiff:
+				'diff --git a/new.txt b/new.txt\nnew file mode 100644\n--- /dev/null\n+++ b/new.txt\n@@ -0,0 +1 @@\n+brand new\n',
+		});
+
+		const result = await invoke(m.fakeThis, wipScope({ includeUnstaged: true }));
+
+		sinon.assert.calledOnceWithExactly(m.stageFiles, ['new.txt'], { intentToAdd: true });
+		sinon.assert.calledOnceWithExactly(m.unstageFiles, ['new.txt']);
+		assert.deepStrictEqual(m.order, ['getUntracked', 'stage', 'diff:unstaged', 'unstage']);
+		assert.ok(result?.diff.includes('new.txt'), 'reviewed diff should include the untracked file');
+	});
+
+	test('unstages untracked files even when the unstaged diff throws', async () => {
+		const m = createMocks({ untracked: ['new.txt'], unstagedError: new Error('diff failed') });
+
+		await assert.rejects(invoke(m.fakeThis, wipScope({ includeUnstaged: true })), /diff failed/);
+
+		sinon.assert.calledOnceWithExactly(m.stageFiles, ['new.txt'], { intentToAdd: true });
+		sinon.assert.calledOnceWithExactly(m.unstageFiles, ['new.txt']);
+		assert.deepStrictEqual(m.order, ['getUntracked', 'stage', 'diff:unstaged', 'unstage']);
+	});
+
+	test('unstages untracked before the staged diff so they never leak into staged content', async () => {
+		const m = createMocks({
+			untracked: ['new.txt'],
+			unstagedDiff: 'diff --git a/new.txt b/new.txt\n',
+			stagedDiff: 'diff --git a/tracked.txt b/tracked.txt\n',
+		});
+
+		await invoke(m.fakeThis, wipScope({ includeUnstaged: true, includeStaged: true }));
+
+		assert.deepStrictEqual(m.order, ['getUntracked', 'stage', 'diff:unstaged', 'unstage', 'diff:staged']);
+	});
+
+	test('does not stage anything when there are no untracked files', async () => {
+		const m = createMocks({ untracked: [], unstagedDiff: 'diff --git a/tracked.txt b/tracked.txt\n' });
+
+		await invoke(m.fakeThis, wipScope({ includeUnstaged: true }));
+
+		sinon.assert.notCalled(m.stageFiles);
+		sinon.assert.notCalled(m.unstageFiles);
+		assert.deepStrictEqual(m.order, ['getUntracked', 'diff:unstaged']);
+	});
+
+	test('does not touch untracked files for a staged-only scope', async () => {
+		const m = createMocks({ untracked: ['new.txt'], stagedDiff: 'diff --git a/tracked.txt b/tracked.txt\n' });
+
+		await invoke(m.fakeThis, wipScope({ includeStaged: true }));
+
+		sinon.assert.notCalled(m.getUntrackedFiles);
+		sinon.assert.notCalled(m.stageFiles);
+		sinon.assert.notCalled(m.unstageFiles);
+		assert.deepStrictEqual(m.order, ['diff:staged']);
+	});
+});

--- a/src/webviews/plus/graph/__tests__/graphInspectServices.test.ts
+++ b/src/webviews/plus/graph/__tests__/graphInspectServices.test.ts
@@ -32,6 +32,7 @@ function createMocks(opts: {
 	unstagedDiff?: string;
 	unstagedError?: Error;
 	stagedDiff?: string;
+	noStaging?: boolean;
 }) {
 	// Shared, ordered log so tests can assert the exact stage → diff → unstage sequence.
 	const order: string[] = [];
@@ -61,7 +62,8 @@ function createMocks(opts: {
 	const svc = {
 		diff: { getDiff: getDiff },
 		status: { getUntrackedFiles: getUntrackedFiles },
-		staging: { stageFiles: stageFiles, unstageFiles: unstageFiles },
+		// `staging` is optional on the repo service (e.g. virtual repos lack it).
+		staging: opts.noStaging ? undefined : { stageFiles: stageFiles, unstageFiles: unstageFiles },
 		branches: { getBranch: sinon.stub().resolves(undefined) },
 	};
 
@@ -137,5 +139,21 @@ suite('graphInspectServices — getDiffForScope untracked handling (#5586)', () 
 		sinon.assert.notCalled(m.stageFiles);
 		sinon.assert.notCalled(m.unstageFiles);
 		assert.deepStrictEqual(m.order, ['diff:staged']);
+	});
+
+	test('skips the untracked query entirely when there is no staging provider', async () => {
+		const m = createMocks({
+			noStaging: true,
+			untracked: ['new.txt'],
+			unstagedDiff: 'diff --git a/tracked.txt b/tracked.txt\n',
+		});
+
+		const result = await invoke(m.fakeThis, wipScope({ includeUnstaged: true }));
+
+		sinon.assert.notCalled(m.getUntrackedFiles);
+		sinon.assert.notCalled(m.stageFiles);
+		sinon.assert.notCalled(m.unstageFiles);
+		assert.deepStrictEqual(m.order, ['diff:unstaged']);
+		assert.ok(result?.diff.includes('tracked.txt'), 'the unstaged diff is still produced');
 	});
 });

--- a/src/webviews/plus/graph/graphInspectServices.ts
+++ b/src/webviews/plus/graph/graphInspectServices.ts
@@ -2438,12 +2438,16 @@ export class GraphInspectServices {
 				// Untracked files never appear in `git diff` (working-vs-index); intent-to-add stages them so
 				// the unstaged diff includes their contents. Mirrors patches.ts. Unstaged before the staged
 				// diff below so intent-to-add entries can't also surface there as empty new-file headers.
-				untrackedPaths = (await svc.status.getUntrackedFiles()).map(f => f.path);
-				if (untrackedPaths?.length) {
-					try {
-						await svc.staging?.stageFiles(untrackedPaths, { intentToAdd: true });
-					} catch (ex) {
-						Logger.error(ex, `Failed to stage (${untrackedPaths.length}) untracked files for review`);
+				// Skipped entirely without a staging provider (e.g. virtual repos) — there's nothing to stage into.
+				if (svc.staging != null) {
+					untrackedPaths = (await svc.status.getUntrackedFiles(signal)).map(f => f.path);
+					if (untrackedPaths.length) {
+						signal?.throwIfAborted();
+						try {
+							await svc.staging.stageFiles(untrackedPaths, { intentToAdd: true });
+						} catch (ex) {
+							Logger.error(ex, `Failed to stage (${untrackedPaths.length}) untracked files for review`);
+						}
 					}
 				}
 

--- a/src/webviews/plus/graph/graphInspectServices.ts
+++ b/src/webviews/plus/graph/graphInspectServices.ts
@@ -2433,12 +2433,35 @@ export class GraphInspectServices {
 		const labels: string[] = [];
 
 		if (scope.includeUnstaged) {
-			const d = await svc.diff?.getDiff?.(uncommitted);
-			signal?.throwIfAborted();
-			if (d?.contents) {
-				parts.push(d.contents);
+			let untrackedPaths: string[] | undefined;
+			try {
+				// Untracked files never appear in `git diff` (working-vs-index); intent-to-add stages them so
+				// the unstaged diff includes their contents. Mirrors patches.ts. Unstaged before the staged
+				// diff below so intent-to-add entries can't also surface there as empty new-file headers.
+				untrackedPaths = (await svc.status.getUntrackedFiles()).map(f => f.path);
+				if (untrackedPaths?.length) {
+					try {
+						await svc.staging?.stageFiles(untrackedPaths, { intentToAdd: true });
+					} catch (ex) {
+						Logger.error(ex, `Failed to stage (${untrackedPaths.length}) untracked files for review`);
+					}
+				}
+
+				const d = await svc.diff?.getDiff?.(uncommitted);
+				signal?.throwIfAborted();
+				if (d?.contents) {
+					parts.push(d.contents);
+				}
+				labels.push('unstaged');
+			} finally {
+				if (untrackedPaths?.length) {
+					try {
+						await svc.staging?.unstageFiles(untrackedPaths);
+					} catch (ex) {
+						Logger.error(ex, `Failed to unstage (${untrackedPaths.length}) untracked files for review`);
+					}
+				}
 			}
-			labels.push('unstaged');
 		}
 		if (scope.includeStaged) {
 			const d = await svc.diff?.getDiff?.(uncommittedStaged);

--- a/src/webviews/plus/graph/graphInspectServices.ts
+++ b/src/webviews/plus/graph/graphInspectServices.ts
@@ -2438,10 +2438,16 @@ export class GraphInspectServices {
 				// Untracked files never appear in `git diff` (working-vs-index); intent-to-add stages them so
 				// the unstaged diff includes their contents. Mirrors patches.ts. Unstaged before the staged
 				// diff below so intent-to-add entries can't also surface there as empty new-file headers.
-				// Skipped entirely without a staging provider (e.g. virtual repos) — there's nothing to stage into.
+				// Skipped without a staging provider (e.g. virtual repos) — there's nothing to stage into.
+				// Best-effort: failing to enumerate or stage untracked files falls back to the plain unstaged
+				// diff rather than sinking the whole review.
 				if (svc.staging != null) {
-					untrackedPaths = (await svc.status.getUntrackedFiles(signal)).map(f => f.path);
-					if (untrackedPaths.length) {
+					try {
+						untrackedPaths = (await svc.status.getUntrackedFiles(signal)).map(f => f.path);
+					} catch (ex) {
+						Logger.error(ex, `Failed to enumerate untracked files for review`);
+					}
+					if (untrackedPaths?.length) {
 						signal?.throwIfAborted();
 						try {
 							await svc.staging.stageFiles(untrackedPaths, { intentToAdd: true });
@@ -2450,6 +2456,8 @@ export class GraphInspectServices {
 						}
 					}
 				}
+				// Honor cancellation after any index mutation and before the (potentially expensive) diff.
+				signal?.throwIfAborted();
 
 				const d = await svc.diff?.getDiff?.(uncommitted);
 				signal?.throwIfAborted();


### PR DESCRIPTION
Closes #5586

### Problem

In the Commit Graph's Review panel, a review of working changes never sent untracked files to the AI, even though they appear (and are check-included) in the Files Changed curation list:

- **Silent omission** — with a mix of tracked and untracked changes, the review runs, the overview claims coverage, and the untracked file is quietly absent from the reviewed diff.
- **Hard failure** — when untracked files are the *only* unstaged content and the scope is unstaged-only, the assembled diff is empty and the panel drops into `Something went wrong — No changes found`, even though the picker and file list both show one included file.

The curation list is built from `git status` (so untracked files show up under the unstaged area), but the review content is assembled from `getDiff(uncommitted)` / `getDiff(uncommittedStaged)`, which map to `git diff` and `git diff --staged` — neither of which ever contains untracked content. The two sources disagreed. Compose does not have this problem because it explicitly opts untracked content in.

### Fix

In `getDiffForScope`'s WIP `includeUnstaged` branch, stage untracked files with intent-to-add (`git add -N`) just around the unstaged `getDiff(uncommitted)` call, then unstage them in a `finally`. Because `git diff` (working-vs-index) surfaces intent-to-add files as new-file additions, their contents now appear in the reviewed diff. This mirrors the existing pattern in `src/commands/patches.ts`.

Key details:

- Staging is **gated on `scope.includeUnstaged`**, matching where the curation list places untracked rows, so the reviewed diff stays aligned with what the UI shows.
- Staging is **isolated to the unstaged call and unstaged before the staged call**, so intent-to-add entries can't also surface in `git diff --staged` as empty new-file headers (no duplication or leakage into staged content).
- The `finally` guarantees the working tree is restored even if the diff is aborted mid-flight.
- `svc.staging` is accessed via optional chaining, so environments without a staging provider (e.g. virtual/GitHub repos) degrade gracefully to today's behavior rather than throwing.

This resolves both the silent omission and the untracked-only hard failure.

### Tests

- **Unit** (`src/webviews/plus/graph/__tests__/graphInspectServices.test.ts`): stages intent-to-add before the unstaged diff and unstages after; unstages even when the diff throws; unstages before the staged call (no leakage); no-op when there are no untracked files; and no staging under a staged-only scope.
- **Integration** (`packages/git-cli/src/providers/__tests__/integration/diff.test.ts`): real-repo tests proving the unstaged diff omits untracked content until intent-to-add staging, then includes it, and that unstaging restores the untracked state — covering both the mixed and untracked-only cases.