### PR TITLE
Fix compose scope picker showing a forbidden unstaged-only selection

### DIFF
--- a/src/webviews/apps/plus/graph/components/__tests__/gl-commits-scope-pane.utils.test.ts
+++ b/src/webviews/apps/plus/graph/components/__tests__/gl-commits-scope-pane.utils.test.ts
@@ -1,0 +1,124 @@
+import * as assert from 'assert';
+import type { ScopeItem, ScopeItemState } from '../gl-commits-scope-pane.js';
+import {
+	getDefaultEnd,
+	getDefaultStart,
+	getMinEndIndex,
+	resolveEndIndex,
+	resolveStartIndex,
+} from '../gl-commits-scope-pane.utils.js';
+
+function item(id: string, state: ScopeItemState): ScopeItem {
+	return { id: id, label: id, state: state };
+}
+
+const unstaged = item('unstaged', 'uncommitted');
+const staged = item('staged', 'uncommitted');
+const commitA = item('a', 'unpushed');
+const commitB = item('b', 'pushed');
+const mergeBase = item('merge-base:x', 'merge-base');
+const loadMore = item('load-more', 'load-more');
+
+suite('gl-commits-scope-pane range/floor utils', () => {
+	suite('getMinEndIndex', () => {
+		test('review mode never floors', () => {
+			const items = [unstaged, staged, commitA];
+			assert.strictEqual(getMinEndIndex('review', items, 0), 0);
+		});
+
+		test('compose with no unstaged row does not floor', () => {
+			const items = [staged, commitA];
+			assert.strictEqual(getMinEndIndex('compose', items, 0), 0);
+		});
+
+		test('compose does not floor when the start is below unstaged (unstaged excluded)', () => {
+			const items = [unstaged, staged, commitA];
+			// rangeStart at staged (1): unstaged is not in the selection, so no floor is imposed.
+			assert.strictEqual(getMinEndIndex('compose', items, 1), 1);
+		});
+
+		test('compose floors the end down to staged when unstaged is included', () => {
+			const items = [unstaged, staged, commitA];
+			assert.strictEqual(getMinEndIndex('compose', items, 0), 1);
+		});
+
+		test('compose with unstaged but no staged row does not floor (unstaged-only is legitimate)', () => {
+			const items = [unstaged, commitA];
+			assert.strictEqual(getMinEndIndex('compose', items, 0), 0);
+		});
+	});
+
+	suite('resolveEndIndex (the fix — floor applies to a derived range, not just interactive moves)', () => {
+		test('compose: an end derived at unstaged is floored to staged when a staged row is present', () => {
+			const items = [unstaged, staged, commitA, mergeBase];
+			// This is the #5587 scenario: selection ended on `unstaged`, a `staged` row appeared under it.
+			// Pre-fix this returned 0 (unstaged only, contradicting the floor); now it reconciles to staged.
+			assert.strictEqual(resolveEndIndex('compose', items, 'unstaged', 0), 1);
+		});
+
+		test('compose: an end already at staged is unchanged', () => {
+			const items = [unstaged, staged, commitA];
+			assert.strictEqual(resolveEndIndex('compose', items, 'staged', 0), 1);
+		});
+
+		test('compose: unstaged end with no staged row stays at unstaged', () => {
+			const items = [unstaged, commitA];
+			assert.strictEqual(resolveEndIndex('compose', items, 'unstaged', 0), 0);
+		});
+
+		test('review: unstaged end is not floored even with a staged row present', () => {
+			const items = [unstaged, staged, commitA];
+			assert.strictEqual(resolveEndIndex('review', items, 'unstaged', 0), 0);
+		});
+
+		test('undefined end falls back to the default end (floor applied)', () => {
+			const items = [unstaged, staged, commitA, mergeBase];
+			// default end for WIP-present is the last WIP row (staged, index 1); floor is a no-op here.
+			assert.strictEqual(resolveEndIndex('compose', items, undefined, 0), 1);
+		});
+
+		test('an end id that no longer resolves falls back to the default end', () => {
+			const items = [unstaged, staged, commitA];
+			assert.strictEqual(resolveEndIndex('compose', items, 'gone', 0), 1);
+		});
+	});
+
+	suite('getDefaultStart', () => {
+		test('starts at the first WIP row when WIP is present', () => {
+			assert.strictEqual(getDefaultStart([commitB, unstaged, staged]), 1);
+		});
+
+		test('starts at 0 when there is no WIP row', () => {
+			assert.strictEqual(getDefaultStart([commitA, commitB]), 0);
+		});
+	});
+
+	suite('getDefaultEnd', () => {
+		test('ends at the last WIP row when WIP is present', () => {
+			assert.strictEqual(getDefaultEnd([unstaged, staged, commitA]), 1);
+		});
+
+		test('ends at the last unpushed row when no WIP but unpushed commits exist', () => {
+			// pushed and merge-base/load-more rows are excluded from the unpushed end.
+			assert.strictEqual(getDefaultEnd([commitA, commitB, loadMore, mergeBase]), 0);
+		});
+
+		test('ends at 0 when only pushed/footer rows exist', () => {
+			assert.strictEqual(getDefaultEnd([commitB, mergeBase]), 0);
+		});
+	});
+
+	suite('resolveStartIndex', () => {
+		test('resolves a stored start id to its index', () => {
+			assert.strictEqual(resolveStartIndex([unstaged, staged, commitA], 'staged'), 1);
+		});
+
+		test('falls back to the default start when the id is missing', () => {
+			assert.strictEqual(resolveStartIndex([commitB, unstaged, staged], 'gone'), 1);
+		});
+
+		test('falls back to the default start when no id is given', () => {
+			assert.strictEqual(resolveStartIndex([commitB, unstaged, staged], undefined), 1);
+		});
+	});
+});

--- a/src/webviews/apps/plus/graph/components/gl-commits-scope-pane.ts
+++ b/src/webviews/apps/plus/graph/components/gl-commits-scope-pane.ts
@@ -2,6 +2,8 @@ import { html, LitElement, nothing } from 'lit';
 import { customElement, property, state } from 'lit/decorators.js';
 import { elementBase, scrollableBase } from '../../../shared/components/styles/lit/base.css.js';
 import { commitsScopePaneStyles } from './gl-commits-scope-pane.css.js';
+import type { ScopeMode } from './gl-commits-scope-pane.utils.js';
+import { getMinEndIndex, resolveEndIndex, resolveStartIndex } from './gl-commits-scope-pane.utils.js';
 import '../../../shared/components/code-icon.js';
 import '../../../shared/components/avatar/avatar.js';
 import '../../../shared/components/commit/commit-stats.js';
@@ -40,7 +42,7 @@ export class GlCommitsScopePane extends LitElement {
 	/** Both handles are fully draggable in both modes; 'compose' additionally enforces the
 	 *  unstaged-requires-staged floor on the end handle. */
 	@property()
-	mode: 'compose' | 'review' = 'compose';
+	mode: ScopeMode = 'compose';
 
 	/** Controlled selected IDs from the current ScopeSelection. Must represent a contiguous range. */
 	@property({ type: Array })
@@ -300,53 +302,12 @@ export class GlCommitsScopePane extends LitElement {
 
 	/** Effective start: resolves stored ID to index, falls back to default-start. */
 	private get rangeStart(): number {
-		if (this._userRangeStartId != null) {
-			const idx = this.items.findIndex(item => item.id === this._userRangeStartId);
-			return idx >= 0 ? idx : this.defaultStart;
-		}
-		return this.defaultStart;
+		return resolveStartIndex(this.items, this._userRangeStartId);
 	}
 
-	/** Effective end: resolves stored ID to index, falls back to default-end. */
+	/** Effective end: resolves stored ID to index, falls back to default-end, then honors the floor. */
 	private get rangeEnd(): number {
-		if (this._userRangeEndId != null) {
-			const idx = this.items.findIndex(item => item.id === this._userRangeEndId);
-			return idx >= 0 ? idx : this.defaultEnd;
-		}
-		return this.defaultEnd;
-	}
-
-	/**
-	 * Default start index. If any uncommitted (WIP) items exist, start at the first one
-	 * so the default selection covers only the WIP rows. Otherwise start at 0.
-	 */
-	private get defaultStart(): number {
-		const firstWip = this.items.findIndex(i => i.state === 'uncommitted');
-		if (firstWip >= 0) return firstWip;
-		return 0;
-	}
-
-	/**
-	 * Default end index, derived from items:
-	 *  - If any WIP items exist, end at the last WIP item (select WIP only).
-	 *  - Else, end at the last unpushed (non-pushed, non-merge-base, non-load-more) item.
-	 *  - Else, end at the first item.
-	 */
-	private get defaultEnd(): number {
-		let lastWip = -1;
-		let lastUnpushed = -1;
-		for (let i = 0; i < this.items.length; i++) {
-			const state = this.items[i].state;
-			if (state === 'uncommitted') {
-				lastWip = i;
-			}
-			if (state !== 'pushed' && state !== 'merge-base' && state !== 'load-more') {
-				lastUnpushed = i;
-			}
-		}
-		if (lastWip >= 0) return lastWip;
-		if (lastUnpushed >= 0) return lastUnpushed;
-		return 0;
+		return resolveEndIndex(this.mode, this.items, this._userRangeEndId, this.rangeStart);
 	}
 
 	/** Last index that a drag handle can land on (excludes merge-base and load-more items). */
@@ -362,21 +323,9 @@ export class GlCommitsScopePane extends LitElement {
 		return Math.min(this.maxDraggableIndex, this.rangeEnd);
 	}
 
-	/**
-	 * Shallowest index the end (bottom) handle may reach. Compose-only: a selection containing the
-	 * unstaged row must also contain the staged row — unstaged diffs are relative to the index, so
-	 * composing unstaged changes without the staged ones is ill-defined (the engine cannot exclude
-	 * staged content from a working-directory source). Review's diff calls handle staged/unstaged
-	 * independently, so it has no such floor.
-	 */
+	/** Shallowest index the end (bottom) handle may reach; compose-only floor (unstaged requires staged). */
 	private get minEndIndex(): number {
-		if (this.mode !== 'compose') return this.rangeStart;
-
-		const unstagedIndex = this.items.findIndex(i => i.id === 'unstaged');
-		if (unstagedIndex < 0 || this.rangeStart > unstagedIndex) return this.rangeStart;
-
-		const stagedIndex = this.items.findIndex(i => i.id === 'staged');
-		return stagedIndex >= 0 ? Math.max(this.rangeStart, stagedIndex) : this.rangeStart;
+		return getMinEndIndex(this.mode, this.items, this.rangeStart);
 	}
 
 	override render() {

--- a/src/webviews/apps/plus/graph/components/gl-commits-scope-pane.utils.ts
+++ b/src/webviews/apps/plus/graph/components/gl-commits-scope-pane.utils.ts
@@ -1,0 +1,84 @@
+import type { ScopeItem } from './gl-commits-scope-pane.js';
+
+export type ScopeMode = 'compose' | 'review';
+
+/**
+ * Default start index. If any uncommitted (WIP) items exist, start at the first one so the default
+ * selection covers only the WIP rows. Otherwise start at 0.
+ */
+export function getDefaultStart(items: readonly ScopeItem[]): number {
+	const firstWip = items.findIndex(i => i.state === 'uncommitted');
+	if (firstWip >= 0) return firstWip;
+	return 0;
+}
+
+/**
+ * Default end index, derived from items:
+ *  - If any WIP items exist, end at the last WIP item (select WIP only).
+ *  - Else, end at the last unpushed (non-pushed, non-merge-base, non-load-more) item.
+ *  - Else, end at the first item.
+ */
+export function getDefaultEnd(items: readonly ScopeItem[]): number {
+	let lastWip = -1;
+	let lastUnpushed = -1;
+	for (let i = 0; i < items.length; i++) {
+		const state = items[i].state;
+		if (state === 'uncommitted') {
+			lastWip = i;
+		}
+		if (state !== 'pushed' && state !== 'merge-base' && state !== 'load-more') {
+			lastUnpushed = i;
+		}
+	}
+	if (lastWip >= 0) return lastWip;
+	if (lastUnpushed >= 0) return lastUnpushed;
+	return 0;
+}
+
+/**
+ * Shallowest index the end (bottom) handle may reach. Compose-only: a selection containing the
+ * unstaged row must also contain the staged row — unstaged diffs are relative to the index, so
+ * composing unstaged changes without the staged ones is ill-defined (the engine cannot exclude
+ * staged content from a working-directory source). Review's diff calls handle staged/unstaged
+ * independently, so it has no such floor.
+ */
+export function getMinEndIndex(mode: ScopeMode, items: readonly ScopeItem[], rangeStart: number): number {
+	if (mode !== 'compose') return rangeStart;
+
+	const unstagedIndex = items.findIndex(i => i.id === 'unstaged');
+	if (unstagedIndex < 0 || rangeStart > unstagedIndex) return rangeStart;
+
+	const stagedIndex = items.findIndex(i => i.id === 'staged');
+	return stagedIndex >= 0 ? Math.max(rangeStart, stagedIndex) : rangeStart;
+}
+
+/** Effective start: resolves stored ID to index, falls back to default-start. */
+export function resolveStartIndex(items: readonly ScopeItem[], startId: string | undefined): number {
+	if (startId != null) {
+		const idx = items.findIndex(item => item.id === startId);
+		if (idx >= 0) return idx;
+	}
+	return getDefaultStart(items);
+}
+
+/**
+ * Effective end: resolves stored/derived end (falls back to default-end), then clamps UP to the
+ * floor. Clamping here — not only in the interactive drag/keyboard/click writers — is what keeps a
+ * range derived from the controlled `selection` prop (e.g. after a working-tree change adds a staged
+ * row under an unstaged-ending selection) from rendering a floor-violating, unstaged-only scope.
+ */
+export function resolveEndIndex(
+	mode: ScopeMode,
+	items: readonly ScopeItem[],
+	endId: string | undefined,
+	rangeStart: number,
+): number {
+	let raw = getDefaultEnd(items);
+	if (endId != null) {
+		const idx = items.findIndex(item => item.id === endId);
+		if (idx >= 0) {
+			raw = idx;
+		}
+	}
+	return Math.max(raw, getMinEndIndex(mode, items, rangeStart));
+}


### PR DESCRIPTION
Closes #5587

### Problem

The compose scope picker enforces a **floor**: in compose mode, a selection that includes the `Unstaged changes` row must also include the `Staged changes` row (unstaged diffs are index-relative, so composing unstaged without staged is ill-defined). That floor was only applied while the user was *moving* an edge — drag, keyboard, or row-click — never when the selected range was derived from the controlled `selection` prop.

As a result, if compose opened with only unstaged changes present (a legitimate unstaged-only scope, since no staged row existed yet) and the user then staged a file from outside the panel, a `Staged changes` row appeared but the rendered selection still ended on `Unstaged changes` — the staged row rendered *excluded*, a state the floor forbids. Clicking Compose then silently widened the scope to include staged and composed the staged file too, with no cue that the excluded row had been re-included.

### Fix

Make the **effective end edge honor the floor** in the one getter every consumer reads, so the invariant "the end never sits above the floor" holds no matter how the end was set — including the controlled-derivation path, not just interactive moves.

- Extracted the pure range/floor logic (`getDefaultStart`/`getDefaultEnd`, `getMinEndIndex`, `resolveStartIndex`, `resolveEndIndex`) into a new lit-free `gl-commits-scope-pane.utils.ts`. `resolveEndIndex` clamps the resolved/derived end **up** to the floor.
- The component's `rangeStart` / `rangeEnd` / `minEndIndex` getters now delegate to those helpers.

This single reconciliation makes the **display** (the staged row now renders as included, and the end handle sits below it), the **keyboard target**, the public **`selectedIds`** getter, and therefore the **compose run** all reflect the truth — the run composes exactly what is shown, with no silent widening. It is also self-healing: if the staged row later disappears, the floor falls back to the range start and the end returns to unstaged.

The `buildScopeFromPicker` / `runCompose` widening backstops are kept as defense-in-depth for non-picker entry points; with this change they are no-ops for the picker flow rather than silent corrections.

### Tests

The extraction is what makes this unit-testable: the component registers a custom element at import and pulls in `lit` + `.css.js`, so it can't be imported in the DOM-less test env — mirroring the existing `signature.utils.ts` / `signature-badge.test.ts` precedent. Added `__tests__/gl-commits-scope-pane.utils.test.ts` (19 cases). The `resolveEndIndex` cases fail against the pre-fix behavior (which returned the unstaged index), so they guard the regression; plus mode/default/fallback coverage.

### Notes

The related idle scope-state / Files-Changed list staleness on a working-tree change (the picker highlight vs. the curation list drifting) is tracked separately by #5588 and is intentionally out of scope here.