### PR TITLE
Stages untracked files for review in a scratch index, never the repository index

### DIFF
--- a/packages/git-cli/src/providers/__tests__/integration/diff.test.ts
+++ b/packages/git-cli/src/providers/__tests__/integration/diff.test.ts
@@ -1,8 +1,9 @@
 import * as assert from 'assert';
 import { execFileSync } from 'node:child_process';
-import { writeFileSync } from 'node:fs';
-import { join } from 'node:path';
-import { uncommitted } from '@gitlens/git/models/revision.js';
+import { createHash } from 'node:crypto';
+import { existsSync, readFileSync, rmSync, statSync, writeFileSync } from 'node:fs';
+import { dirname, join } from 'node:path';
+import { uncommitted, uncommittedStaged } from '@gitlens/git/models/revision.js';
 import type { TestRepo } from './helpers.js';
 import { addCommit, createTestRepo } from './helpers.js';
 
@@ -478,6 +479,167 @@ suite('DiffSubProvider.getDiff — untracked via intent-to-add (#5586)', () => {
 			assert.ok(after.contents.includes('only-untracked.txt'), 'The untracked file must be reviewable');
 
 			await r.provider.staging?.unstageFiles(r.path, untracked);
+		} finally {
+			r.cleanup();
+		}
+	});
+});
+
+// The review used to intent-to-add into the REAL index and unstage afterwards. That cost two defects: a user
+// `git add` landing inside the window was silently reverted by the cleanup (#5604), and the write itself read
+// as a working-tree change, so a finished review could mark itself stale (#5605). The fix stages into a
+// scratch index (`createTemporaryIndex('current')`) and diffs against that, so the real index is never
+// written. These guard the git-level behavior that makes that possible.
+suite('DiffSubProvider.getDiff — untracked via a scratch index (#5604, #5605)', () => {
+	function porcelain(repoPath: string): string {
+		return execFileSync('git', ['status', '--porcelain'], { cwd: repoPath, encoding: 'utf-8' });
+	}
+
+	test('scratch-index intent-to-add surfaces untracked content and leaves the real index untouched', async () => {
+		const r = createTestRepo();
+		try {
+			addCommit(r.path, 'staged.txt', 's1\n', 'Add staged.txt');
+			addCommit(r.path, 'tracked.txt', 'v1\n', 'Add tracked.txt');
+			// A pre-staged change (what the user stands to lose), an unstaged change, and an untracked file.
+			writeFileSync(join(r.path, 'staged.txt'), 's2\n');
+			execFileSync('git', ['add', 'staged.txt'], { cwd: r.path, stdio: 'pipe' });
+			writeFileSync(join(r.path, 'tracked.txt'), 'v2\n');
+			writeFileSync(join(r.path, 'untracked.txt'), 'brand new\n');
+
+			const statusBefore = porcelain(r.path);
+
+			const untracked = (await r.provider.status?.getUntrackedFiles(r.path))?.map(f => f.path) ?? [];
+			assert.deepStrictEqual(untracked, ['untracked.txt'], 'Expected exactly the untracked file');
+
+			const index = await r.provider.staging.createTemporaryIndex(r.path, 'current');
+			try {
+				await r.provider.staging.stageFiles(r.path, untracked, { index: index, intentToAdd: true });
+
+				const diff = await r.provider.diff.getDiff?.(r.path, uncommitted, undefined, { index: index });
+				assert.ok(diff?.contents, 'Expected an unstaged diff against the scratch index');
+				assert.ok(diff.contents.includes('untracked.txt'), 'Untracked file must appear in the diff');
+				assert.ok(diff.contents.includes('brand new'), 'Untracked file contents must be present');
+				assert.ok(diff.contents.includes('tracked.txt'), 'The unstaged tracked change must still be present');
+				assert.ok(
+					!diff.contents.includes('staged.txt'),
+					'The scratch index inherits the staged entry, so the staged change is not also unstaged',
+				);
+
+				// The whole point of #5604: the real index never saw the intent-to-add entry.
+				assert.strictEqual(porcelain(r.path), statusBefore, 'The repository index must be unchanged');
+			} finally {
+				await index.dispose();
+			}
+
+			assert.strictEqual(porcelain(r.path), statusBefore, 'Disposal must not touch the repository index');
+		} finally {
+			r.cleanup();
+		}
+	});
+
+	test('a concurrent user `git add` of the same untracked path survives the review window', async () => {
+		const r = createTestRepo();
+		try {
+			writeFileSync(join(r.path, 'untracked.txt'), 'brand new\n');
+
+			const untracked = (await r.provider.status?.getUntrackedFiles(r.path))?.map(f => f.path) ?? [];
+			const index = await r.provider.staging.createTemporaryIndex(r.path, 'current');
+			try {
+				await r.provider.staging.stageFiles(r.path, untracked, { index: index, intentToAdd: true });
+
+				// The user stages the same path mid-review — from the SCM view, a terminal, or elsewhere.
+				execFileSync('git', ['add', 'untracked.txt'], { cwd: r.path, stdio: 'pipe' });
+
+				await r.provider.diff.getDiff?.(r.path, uncommitted, undefined, { index: index });
+			} finally {
+				await index.dispose();
+			}
+
+			assert.strictEqual(
+				porcelain(r.path),
+				'A  untracked.txt\n',
+				'The staging the user performed must still be in place after the review window closes',
+			);
+		} finally {
+			r.cleanup();
+		}
+	});
+
+	test(`'current' treats a repo with no index file as an empty index rather than throwing`, async () => {
+		const r = createTestRepo();
+		try {
+			// A repo that has never staged anything has no `.git/index`; `createTemporaryIndex('current')`
+			// must not fail there (it would silently drop untracked files from every review).
+			rmSync(join(r.path, '.git', 'index'));
+
+			const index = await r.provider.staging.createTemporaryIndex(r.path, 'current');
+			const tempDir = dirname(index.path);
+			try {
+				assert.ok(!existsSync(index.path), 'A missing source index yields an (absent) empty temp index');
+
+				writeFileSync(join(r.path, 'untracked.txt'), 'brand new\n');
+				await r.provider.staging.stageFiles(r.path, ['untracked.txt'], {
+					index: index,
+					intentToAdd: true,
+				});
+
+				const diff = await r.provider.diff.getDiff?.(r.path, uncommitted, undefined, { index: index });
+				assert.ok(diff?.contents?.includes('untracked.txt'), 'The untracked file must still be reviewable');
+			} finally {
+				await index.dispose();
+			}
+
+			assert.ok(!existsSync(tempDir), 'Disposal must remove the scratch index directory');
+			assert.ok(!existsSync(join(r.path, '.git', 'index')), 'The repository index must not be recreated');
+		} finally {
+			r.cleanup();
+		}
+	});
+
+	// #5605: the review's staging used to write the real index, and that write registers as a working-tree
+	// change — enough to mark a just-finished review stale and to let a scoped-list refetch catch an untracked
+	// row mid-stage, showing it as added. Content equality is too weak to guard that: a watcher fires on the
+	// write, and git rewrites the index with identical content just to refresh its stat cache. So assert the
+	// file is not WRITTEN — same mtime and same bytes across the whole review sequence.
+	test('the review sequence performs no write at all to the repository index', async () => {
+		const r = createTestRepo();
+		try {
+			addCommit(r.path, 'staged.txt', 's1\n', 'Add staged.txt');
+			addCommit(r.path, 'tracked.txt', 'v1\n', 'Add tracked.txt');
+			writeFileSync(join(r.path, 'staged.txt'), 's2\n');
+			execFileSync('git', ['add', 'staged.txt'], { cwd: r.path, stdio: 'pipe' });
+			writeFileSync(join(r.path, 'tracked.txt'), 'v2\n');
+			writeFileSync(join(r.path, 'untracked.txt'), 'brand new\n');
+
+			const indexPath = join(r.path, '.git', 'index');
+			const stamp = () => {
+				const { mtimeMs, size } = statSync(indexPath);
+				return `${createHash('sha256').update(readFileSync(indexPath)).digest('hex')} ${mtimeMs} ${size}`;
+			};
+
+			// Settle first: the `git add` above leaves the stat cache stale, and the next status refreshes it by
+			// rewriting the index once (identical content, new mtime). That write converges and is not the
+			// review's doing — measuring from before it would blame the review for it.
+			await r.provider.status?.getStatus(r.path, { force: true });
+			const before = stamp();
+
+			// Now the review's full unstaged-scope sequence.
+			const untracked = (await r.provider.status?.getUntrackedFiles(r.path))?.map(f => f.path) ?? [];
+			const index = await r.provider.staging.createTemporaryIndex(r.path, 'current');
+			try {
+				await r.provider.staging.stageFiles(r.path, untracked, { index: index, intentToAdd: true });
+				const unstaged = await r.provider.diff.getDiff?.(r.path, uncommitted, undefined, { index: index });
+				assert.ok(
+					unstaged?.contents?.includes('untracked.txt'),
+					'Sanity: the review must still be picking up untracked content',
+				);
+				// The staged half of a both-scopes review reads the real index.
+				await r.provider.diff.getDiff?.(r.path, uncommittedStaged);
+			} finally {
+				await index.dispose();
+			}
+
+			assert.strictEqual(stamp(), before, 'The review must not write the repository index at all');
 		} finally {
 			r.cleanup();
 		}

--- a/packages/git-cli/src/providers/staging.ts
+++ b/packages/git-cli/src/providers/staging.ts
@@ -58,7 +58,14 @@ export class StagingGitSubProvider implements GitStagingSubProvider {
 					if (gitDir == null) throw new Error(`Unable to determine git directory for ${repoPath}`);
 
 					const currentIndex = joinPaths(gitDir.uri.fsPath, 'index');
-					await fs.copyFile(currentIndex, tempIndex);
+					try {
+						await fs.copyFile(currentIndex, tempIndex);
+					} catch (ex) {
+						// A repo that has never staged anything has no index file yet; git reads a missing
+						// `GIT_INDEX_FILE` as an empty index, which is what 'current' means there. Any other
+						// failure is real — don't silently hand back an index claiming everything is deleted.
+						if ((ex as NodeJS.ErrnoException)?.code !== 'ENOENT') throw ex;
+					}
 					break;
 				}
 				case 'ref': {

--- a/src/webviews/plus/graph/__tests__/graphInspectServices.test.ts
+++ b/src/webviews/plus/graph/__tests__/graphInspectServices.test.ts
@@ -8,7 +8,9 @@ import type { ScopeSelection } from '../graphService.js';
 // `getDiffForScope` is private and only reaches `this.container.git.getRepositoryService(repoPath)` and
 // `this.buildChangesContext(...)`, so we exercise it against a minimal fake `this` rather than constructing
 // the full service. Fix under test (#5586): a WIP review must include untracked file contents by staging
-// them intent-to-add around the unstaged diff, then unstaging in a `finally`.
+// them intent-to-add around the unstaged diff — and that the staging must land in a scratch index, never the
+// repository index, so a concurrent user `git add` can't be silently undone (#5604) and the review emits no
+// index change that would mark its own result stale (#5605).
 
 type DiffForScopeResult = { diff: string; message: string; context: string } | undefined;
 type GetDiffForScope = (repoPath: string, scope: ScopeSelection, signal?: AbortSignal) => Promise<DiffForScopeResult>;
@@ -34,9 +36,11 @@ function createMocks(opts: {
 	unstagedError?: Error;
 	stagedDiff?: string;
 	noStaging?: boolean;
+	indexError?: Error;
+	stageError?: Error;
 	abortOnStage?: AbortController;
 }) {
-	// Shared, ordered log so tests can assert the exact stage → diff → unstage sequence.
+	// Shared, ordered log so tests can assert the exact snapshot → stage → diff → dispose sequence.
 	const order: string[] = [];
 
 	const getUntrackedFiles = sinon.stub().callsFake(async () => {
@@ -44,10 +48,22 @@ function createMocks(opts: {
 		if (opts.untrackedError != null) throw opts.untrackedError;
 		return (opts.untracked ?? []).map(p => ({ path: p }));
 	});
+	const dispose = sinon.stub().callsFake(async () => {
+		order.push('dispose');
+	});
+	const tempIndex = { path: '/tmp/gl-x/index', env: { GIT_INDEX_FILE: '/tmp/gl-x/index' }, dispose: dispose };
+	const createTemporaryIndex = sinon.stub().callsFake(async () => {
+		order.push('createIndex');
+		if (opts.indexError != null) throw opts.indexError;
+		return tempIndex;
+	});
 	const stageFiles = sinon.stub().callsFake(async () => {
 		order.push('stage');
+		if (opts.stageError != null) throw opts.stageError;
+
 		opts.abortOnStage?.abort();
 	});
+	// Retained only so tests can assert it is NEVER called — the repository index must stay untouched.
 	const unstageFiles = sinon.stub().callsFake(async () => {
 		order.push('unstage');
 	});
@@ -67,7 +83,13 @@ function createMocks(opts: {
 		diff: { getDiff: getDiff },
 		status: { getUntrackedFiles: getUntrackedFiles },
 		// `staging` is optional on the repo service (e.g. virtual repos lack it).
-		staging: opts.noStaging ? undefined : { stageFiles: stageFiles, unstageFiles: unstageFiles },
+		staging: opts.noStaging
+			? undefined
+			: {
+					createTemporaryIndex: createTemporaryIndex,
+					stageFiles: stageFiles,
+					unstageFiles: unstageFiles,
+				},
 		branches: { getBranch: sinon.stub().resolves(undefined) },
 	};
 
@@ -80,14 +102,18 @@ function createMocks(opts: {
 	return {
 		fakeThis: fakeThis,
 		order: order,
+		tempIndex: tempIndex,
 		getUntrackedFiles: getUntrackedFiles,
+		createTemporaryIndex: createTemporaryIndex,
 		stageFiles: stageFiles,
 		unstageFiles: unstageFiles,
+		dispose: dispose,
+		getDiff: getDiff,
 	};
 }
 
-suite('graphInspectServices — getDiffForScope untracked handling (#5586)', () => {
-	test('stages untracked files intent-to-add for the unstaged diff, then unstages', async () => {
+suite('graphInspectServices — getDiffForScope untracked handling (#5586, #5604, #5605)', () => {
+	test('stages untracked files intent-to-add into a scratch index and diffs against it', async () => {
 		const m = createMocks({
 			untracked: ['new.txt'],
 			unstagedDiff:
@@ -96,23 +122,28 @@ suite('graphInspectServices — getDiffForScope untracked handling (#5586)', () 
 
 		const result = await invoke(m.fakeThis, wipScope({ includeUnstaged: true }));
 
-		sinon.assert.calledOnceWithExactly(m.stageFiles, ['new.txt'], { intentToAdd: true });
-		sinon.assert.calledOnceWithExactly(m.unstageFiles, ['new.txt']);
-		assert.deepStrictEqual(m.order, ['getUntracked', 'stage', 'diff:unstaged', 'unstage']);
+		sinon.assert.calledOnceWithExactly(m.createTemporaryIndex, 'current');
+		sinon.assert.calledOnceWithExactly(m.stageFiles, ['new.txt'], { index: m.tempIndex, intentToAdd: true });
+		sinon.assert.calledWithExactly(m.getDiff, uncommitted, undefined, { index: m.tempIndex });
+		// The repository index is never mutated, so there is nothing to unstage.
+		sinon.assert.notCalled(m.unstageFiles);
+		sinon.assert.calledOnce(m.dispose);
+		assert.deepStrictEqual(m.order, ['getUntracked', 'createIndex', 'stage', 'diff:unstaged', 'dispose']);
 		assert.ok(result?.diff.includes('new.txt'), 'reviewed diff should include the untracked file');
 	});
 
-	test('unstages untracked files even when the unstaged diff throws', async () => {
+	test('disposes the scratch index even when the unstaged diff throws', async () => {
 		const m = createMocks({ untracked: ['new.txt'], unstagedError: new Error('diff failed') });
 
 		await assert.rejects(invoke(m.fakeThis, wipScope({ includeUnstaged: true })), /diff failed/);
 
-		sinon.assert.calledOnceWithExactly(m.stageFiles, ['new.txt'], { intentToAdd: true });
-		sinon.assert.calledOnceWithExactly(m.unstageFiles, ['new.txt']);
-		assert.deepStrictEqual(m.order, ['getUntracked', 'stage', 'diff:unstaged', 'unstage']);
+		sinon.assert.calledOnceWithExactly(m.stageFiles, ['new.txt'], { index: m.tempIndex, intentToAdd: true });
+		sinon.assert.notCalled(m.unstageFiles);
+		sinon.assert.calledOnce(m.dispose);
+		assert.deepStrictEqual(m.order, ['getUntracked', 'createIndex', 'stage', 'diff:unstaged', 'dispose']);
 	});
 
-	test('unstages untracked before the staged diff so they never leak into staged content', async () => {
+	test('never mutates the repository index, so the staged diff is unaffected', async () => {
 		const m = createMocks({
 			untracked: ['new.txt'],
 			unstagedDiff: 'diff --git a/new.txt b/new.txt\n',
@@ -121,16 +152,28 @@ suite('graphInspectServices — getDiffForScope untracked handling (#5586)', () 
 
 		await invoke(m.fakeThis, wipScope({ includeUnstaged: true, includeStaged: true }));
 
-		assert.deepStrictEqual(m.order, ['getUntracked', 'stage', 'diff:unstaged', 'unstage', 'diff:staged']);
+		sinon.assert.notCalled(m.unstageFiles);
+		// The staged diff reads the real index, which the scratch-index staging never touched — no `index`
+		// option, and no ordering constraint needed to keep intent-to-add entries out of it.
+		sinon.assert.calledWithExactly(m.getDiff, uncommittedStaged);
+		assert.deepStrictEqual(m.order, [
+			'getUntracked',
+			'createIndex',
+			'stage',
+			'diff:unstaged',
+			'dispose',
+			'diff:staged',
+		]);
 	});
 
-	test('does not stage anything when there are no untracked files', async () => {
+	test('does not create a scratch index when there are no untracked files', async () => {
 		const m = createMocks({ untracked: [], unstagedDiff: 'diff --git a/tracked.txt b/tracked.txt\n' });
 
 		await invoke(m.fakeThis, wipScope({ includeUnstaged: true }));
 
+		sinon.assert.notCalled(m.createTemporaryIndex);
 		sinon.assert.notCalled(m.stageFiles);
-		sinon.assert.notCalled(m.unstageFiles);
+		sinon.assert.calledWithExactly(m.getDiff, uncommitted, undefined, undefined);
 		assert.deepStrictEqual(m.order, ['getUntracked', 'diff:unstaged']);
 	});
 
@@ -140,8 +183,8 @@ suite('graphInspectServices — getDiffForScope untracked handling (#5586)', () 
 		await invoke(m.fakeThis, wipScope({ includeStaged: true }));
 
 		sinon.assert.notCalled(m.getUntrackedFiles);
+		sinon.assert.notCalled(m.createTemporaryIndex);
 		sinon.assert.notCalled(m.stageFiles);
-		sinon.assert.notCalled(m.unstageFiles);
 		assert.deepStrictEqual(m.order, ['diff:staged']);
 	});
 
@@ -155,8 +198,8 @@ suite('graphInspectServices — getDiffForScope untracked handling (#5586)', () 
 		const result = await invoke(m.fakeThis, wipScope({ includeUnstaged: true }));
 
 		sinon.assert.notCalled(m.getUntrackedFiles);
+		sinon.assert.notCalled(m.createTemporaryIndex);
 		sinon.assert.notCalled(m.stageFiles);
-		sinon.assert.notCalled(m.unstageFiles);
 		assert.deepStrictEqual(m.order, ['diff:unstaged']);
 		assert.ok(result?.diff.includes('tracked.txt'), 'the unstaged diff is still produced');
 	});
@@ -169,9 +212,45 @@ suite('graphInspectServices — getDiffForScope untracked handling (#5586)', () 
 
 		const result = await invoke(m.fakeThis, wipScope({ includeUnstaged: true }));
 
+		sinon.assert.notCalled(m.createTemporaryIndex);
+		sinon.assert.notCalled(m.stageFiles);
+		assert.deepStrictEqual(m.order, ['getUntracked', 'diff:unstaged']);
+		assert.ok(result?.diff.includes('tracked.txt'), 'the review still covers the tracked change');
+	});
+
+	test('degrades to the plain unstaged diff when the scratch index cannot be created', async () => {
+		const m = createMocks({
+			untracked: ['new.txt'],
+			indexError: new Error('cannot copy index'),
+			unstagedDiff: 'diff --git a/tracked.txt b/tracked.txt\n',
+		});
+
+		const result = await invoke(m.fakeThis, wipScope({ includeUnstaged: true }));
+
+		// No scratch index means nothing was staged anywhere — the review loses untracked content rather
+		// than falling back to mutating the real index.
 		sinon.assert.notCalled(m.stageFiles);
 		sinon.assert.notCalled(m.unstageFiles);
-		assert.deepStrictEqual(m.order, ['getUntracked', 'diff:unstaged']);
+		sinon.assert.calledWithExactly(m.getDiff, uncommitted, undefined, undefined);
+		assert.deepStrictEqual(m.order, ['getUntracked', 'createIndex', 'diff:unstaged']);
+		assert.ok(result?.diff.includes('tracked.txt'), 'the review still covers the tracked change');
+	});
+
+	test('discards a partially staged scratch index rather than reviewing an arbitrary subset', async () => {
+		const m = createMocks({
+			untracked: ['new.txt'],
+			stageError: new Error('add -N failed'),
+			unstagedDiff: 'diff --git a/tracked.txt b/tracked.txt\n',
+		});
+
+		const result = await invoke(m.fakeThis, wipScope({ includeUnstaged: true }));
+
+		// `stageFiles` batches, so the scratch index could hold any subset — degrade to the plain unstaged
+		// diff instead of reviewing a silently partial set of untracked files.
+		sinon.assert.calledWithExactly(m.getDiff, uncommitted, undefined, undefined);
+		// Disposed eagerly on the failure, and not a second time from the `finally`.
+		sinon.assert.calledOnce(m.dispose);
+		assert.deepStrictEqual(m.order, ['getUntracked', 'createIndex', 'stage', 'dispose', 'diff:unstaged']);
 		assert.ok(result?.diff.includes('tracked.txt'), 'the review still covers the tracked change');
 	});
 
@@ -181,7 +260,8 @@ suite('graphInspectServices — getDiffForScope untracked handling (#5586)', () 
 
 		await assert.rejects(invoke(m.fakeThis, wipScope({ includeUnstaged: true }), ac.signal));
 
-		// Staging ran and was cleaned up, but the abort was honored before the diff was requested.
-		assert.deepStrictEqual(m.order, ['getUntracked', 'stage', 'unstage']);
+		// Staging into the scratch index ran and the scratch index was disposed, but the abort was honored
+		// before the diff was requested.
+		assert.deepStrictEqual(m.order, ['getUntracked', 'createIndex', 'stage', 'dispose']);
 	});
 });

--- a/src/webviews/plus/graph/__tests__/graphInspectServices.test.ts
+++ b/src/webviews/plus/graph/__tests__/graphInspectServices.test.ts
@@ -38,6 +38,7 @@ function createMocks(opts: {
 	noStaging?: boolean;
 	indexError?: Error;
 	stageError?: Error;
+	disposeError?: Error;
 	abortOnStage?: AbortController;
 }) {
 	// Shared, ordered log so tests can assert the exact snapshot → stage → diff → dispose sequence.
@@ -50,6 +51,7 @@ function createMocks(opts: {
 	});
 	const dispose = sinon.stub().callsFake(async () => {
 		order.push('dispose');
+		if (opts.disposeError != null) throw opts.disposeError;
 	});
 	const tempIndex = { path: '/tmp/gl-x/index', env: { GIT_INDEX_FILE: '/tmp/gl-x/index' }, dispose: dispose };
 	const createTemporaryIndex = sinon.stub().callsFake(async () => {
@@ -252,6 +254,32 @@ suite('graphInspectServices — getDiffForScope untracked handling (#5586, #5604
 		sinon.assert.calledOnce(m.dispose);
 		assert.deepStrictEqual(m.order, ['getUntracked', 'createIndex', 'stage', 'dispose', 'diff:unstaged']);
 		assert.ok(result?.diff.includes('tracked.txt'), 'the review still covers the tracked change');
+	});
+
+	test('a failing scratch-index teardown neither sinks the review nor masks a cancellation', async () => {
+		const m = createMocks({
+			untracked: ['new.txt'],
+			unstagedDiff: 'diff --git a/new.txt b/new.txt\n',
+			disposeError: new Error('EBUSY: temp dir locked'),
+		});
+
+		// Teardown runs in a `finally`, where a rejection would replace whatever the body was throwing.
+		const result = await invoke(m.fakeThis, wipScope({ includeUnstaged: true }));
+		assert.ok(result?.diff.includes('new.txt'), 'the completed review must survive a cleanup failure');
+
+		// Same teardown on the cancelled path: the abort must still be what surfaces.
+		const ac = new AbortController();
+		const c = createMocks({
+			untracked: ['new.txt'],
+			unstagedDiff: 'x',
+			abortOnStage: ac,
+			disposeError: new Error('EBUSY: temp dir locked'),
+		});
+		await assert.rejects(
+			invoke(c.fakeThis, wipScope({ includeUnstaged: true }), ac.signal),
+			(ex: Error) => !/EBUSY/.test(ex.message),
+			'the cancellation must surface, not the cleanup error',
+		);
 	});
 
 	test('honors cancellation after staging without running the unstaged diff', async () => {

--- a/src/webviews/plus/graph/graphInspectServices.ts
+++ b/src/webviews/plus/graph/graphInspectServices.ts
@@ -2750,9 +2750,11 @@ export class GraphInspectServices {
 								// `stageFiles` batches, so a mid-way failure leaves the scratch index holding an
 								// arbitrary subset — a review silently covering some untracked files and not
 								// others, with nothing in the output saying which. Drop it and degrade uniformly
-								// to the plain unstaged diff instead.
-								await index.dispose();
+								// to the plain unstaged diff instead. Cleared before the (best-effort) teardown so
+								// which index we diff against never depends on cleanup succeeding.
+								const partial = index;
 								index = undefined;
+								await disposeScratchIndex(partial);
 							}
 						}
 					}
@@ -2771,7 +2773,7 @@ export class GraphInspectServices {
 				}
 				labels.push('unstaged');
 			} finally {
-				await index?.dispose();
+				await disposeScratchIndex(index);
 			}
 		}
 		if (scope.includeStaged) {
@@ -2850,6 +2852,18 @@ export class GraphInspectServices {
 /** How much of a snapshot to sniff for binary-ness — mirrors VS Code's own text-file heuristic,
  *  which only inspects the head of the buffer before refusing to open it as text. */
 const binarySniffLength = 512;
+
+/** Best-effort teardown of a review's scratch index. `dispose` is typed `() => Promise<void>` with no
+ *  promise not to reject — today's implementation swallows its own `fs.rm` errors, but relying on that
+ *  couples this path to a detail of one provider. A rejection from the `finally` would replace the
+ *  in-flight exception, turning a cancelled review into an unrelated filesystem error. */
+async function disposeScratchIndex(index: DisposableTemporaryGitIndex | undefined): Promise<void> {
+	try {
+		await index?.dispose();
+	} catch (ex) {
+		Logger.error(ex, `Failed to dispose the scratch index for review`);
+	}
+}
 
 /** Whether a recorded before/after snapshot can be shown in a text diff. Snapshots are decoded from
  *  the working tree with no binary check (any bytes decode to *some* string), so a binary conflict

--- a/src/webviews/plus/graph/graphInspectServices.ts
+++ b/src/webviews/plus/graph/graphInspectServices.ts
@@ -5,6 +5,7 @@ import type { GitGraphSession } from '@gitlens/git/models/graphSession.js';
 import type { GitPausedOperationStatus } from '@gitlens/git/models/pausedOperationStatus.js';
 import { rootSha, uncommitted, uncommittedStaged } from '@gitlens/git/models/revision.js';
 import type { GitCommitSearchContext } from '@gitlens/git/models/search.js';
+import type { DisposableTemporaryGitIndex } from '@gitlens/git/providers/staging.js';
 import { classifyConflictAction, getConflictKindLabel } from '@gitlens/git/utils/conflictResolution.utils.js';
 import { createReference } from '@gitlens/git/utils/reference.utils.js';
 import { createRevisionRange, shortenRevision } from '@gitlens/git/utils/revision.utils.js';
@@ -2714,46 +2715,63 @@ export class GraphInspectServices {
 		const labels: string[] = [];
 
 		if (scope.includeUnstaged) {
-			let untrackedPaths: string[] | undefined;
+			// Untracked files never appear in `git diff` (working-vs-index); intent-to-add stages them so the
+			// unstaged diff includes their contents. That staging goes into a scratch index copy and the diff is
+			// taken against that, so the real index is never written — which is what let the teardown undo a
+			// `git add` the user made mid-review (#5604), and what made the review's own churn register as a
+			// working-tree change, marking a just-finished review stale (#5605).
+			let index: DisposableTemporaryGitIndex | undefined;
 			try {
-				// Untracked files never appear in `git diff` (working-vs-index); intent-to-add stages them so
-				// the unstaged diff includes their contents. Mirrors patches.ts. Unstaged before the staged
-				// diff below so intent-to-add entries can't also surface there as empty new-file headers.
-				// Skipped without a staging provider (e.g. virtual repos) — there's nothing to stage into.
-				// Best-effort: failing to enumerate or stage untracked files falls back to the plain unstaged
-				// diff rather than sinking the whole review.
+				// No staging provider (e.g. virtual repos) means there's nothing to stage into.
 				if (svc.staging != null) {
+					let untrackedPaths: string[] | undefined;
 					try {
 						untrackedPaths = (await svc.status.getUntrackedFiles(signal)).map(f => f.path);
 					} catch (ex) {
+						// Best-effort: fall back to the plain unstaged diff rather than sinking the whole review.
 						Logger.error(ex, `Failed to enumerate untracked files for review`);
 					}
 					if (untrackedPaths?.length) {
 						signal?.throwIfAborted();
 						try {
-							await svc.staging.stageFiles(untrackedPaths, { intentToAdd: true });
+							index = await svc.staging.createTemporaryIndex('current');
 						} catch (ex) {
-							Logger.error(ex, `Failed to stage (${untrackedPaths.length}) untracked files for review`);
+							Logger.error(ex, `Failed to create a scratch index for review`);
+						}
+						// Without a scratch index, skip staging entirely — never fall back to the real index.
+						if (index != null) {
+							try {
+								await svc.staging.stageFiles(untrackedPaths, { index: index, intentToAdd: true });
+							} catch (ex) {
+								Logger.error(
+									ex,
+									`Failed to stage (${untrackedPaths.length}) untracked files for review`,
+								);
+								// `stageFiles` batches, so a mid-way failure leaves the scratch index holding an
+								// arbitrary subset — a review silently covering some untracked files and not
+								// others, with nothing in the output saying which. Drop it and degrade uniformly
+								// to the plain unstaged diff instead.
+								await index.dispose();
+								index = undefined;
+							}
 						}
 					}
 				}
-				// Honor cancellation after any index mutation and before the (potentially expensive) diff.
+				// Honor cancellation before the (potentially expensive) diff.
 				signal?.throwIfAborted();
 
-				const d = await svc.diff?.getDiff?.(uncommitted);
+				const d = await svc.diff?.getDiff?.(
+					uncommitted,
+					undefined,
+					index != null ? { index: index } : undefined,
+				);
 				signal?.throwIfAborted();
 				if (d?.contents) {
 					parts.push(d.contents);
 				}
 				labels.push('unstaged');
 			} finally {
-				if (untrackedPaths?.length) {
-					try {
-						await svc.staging?.unstageFiles(untrackedPaths);
-					} catch (ex) {
-						Logger.error(ex, `Failed to unstage (${untrackedPaths.length}) untracked files for review`);
-					}
-				}
+				await index?.dispose();
 			}
 		}
 		if (scope.includeStaged) {


### PR DESCRIPTION
Closes #5604
Closes #5605

A review of working changes temporarily stages untracked files with intent-to-add so their contents reach the reviewed diff (#5599). That staging went into the **repository index** and was undone afterwards. Both issues here are that same window, seen from two sides — so one fix closes both.

## What was wrong

**#5604 — the user's own staging got silently undone.** The cleanup unstaged exactly the paths the review had enumerated, without checking whether the index entry it removed was still the one the review created. Any `git add` of the same path inside the window — from the SCM view, a terminal, or another GitLens flow — was reverted with no error and no indication. The window measured 50–115 ms in a small repository and grows with repository size and untracked-file count.

**#5605 — a finished review reported itself stale.** The index write itself registers as a working-tree change. Since any working-tree/WIP update marks the open review stale and refetches the scoped file list (#5588 / #5601), the review's own churn could fire that signal with nothing external having changed — and a refetch landing inside the window could capture an untracked row in its transient staged state, rendering it as added.

## How both are fixed

The staging now goes into a **scratch copy of the index** — `createTemporaryIndex('current')` — and the unstaged diff is taken against that copy via the `index` option `stageFiles` and `getDiff` already accept. The repository index is never written.

That removes the cause of both symptoms rather than compensating for either:

- There is no cleanup left to undo anything. `unstageFiles` is gone from this path; disposing the scratch index is the only teardown, so a concurrent `git add` cannot be reverted (**#5604**).
- No index write means no working-tree change is emitted, so the review cannot mark its own result stale and no refetch can observe a transient staged state. Nothing outside the review — the SCM view, other editors, external tooling — sees the intent-to-add entries at any point (**#5605**).

The staged half of a review still reads the real index, unchanged. It also no longer depends on the untracked entries being unstaged before it runs, since they never enter the real index in the first place.

## Supporting changes

**`createTemporaryIndex('current')` had no callers before this.** A repository that has never staged anything has no `.git/index` to copy, which would have thrown and silently dropped untracked files from every review there. Git reads a missing `GIT_INDEX_FILE` as an empty index — exactly what `'current'` means in that repository — so `ENOENT` now falls through to an empty scratch index. Other errno values still throw, rather than handing back an index that claims every tracked file was deleted.

**Uniform degradation on a partial staging failure.** `stageFiles` batches paths to stay under the CLI length limit, so a mid-way failure would leave the scratch index holding an arbitrary subset — a review silently covering some untracked files and not others, with nothing in the output saying which. That case now drops the scratch index and degrades to the plain unstaged diff. Failing to enumerate, snapshot, or stage never sinks the whole review, and each failure logs distinctly.

## Tests

Integration (`packages/git-cli`, real repositories):

- A concurrent user `git add` of the same untracked path survives the review window — the direct #5604 repro. Verified it fails against the previous implementation.
- The review sequence performs **no write at all** to the repository index — the #5605 mechanism. Asserted on mtime *and* content: the old code left the index byte-identical and only bumped its mtime, so a content-only assertion would have passed against the bug. The test settles a forced status first, because a `git add` leaves the stat cache stale and the next status rewrites the index once on its own — that write converges and is not the review's doing.
- Untracked content reaches the diff while `git status --porcelain` stays byte-identical across the window, with a pre-staged change in place.
- `'current'` tolerates a repository with no index file, and disposal removes the scratch directory without recreating `.git/index`.

Unit (`getDiffForScope`): staging targets the scratch index and the diff is taken against it; `unstageFiles` is asserted **never** called; the scratch index is disposed on every path including a throwing diff and a mid-flight cancellation; and each fallback — no staging provider, enumeration failure, scratch-index creation failure, partial staging failure — degrades as intended.

## Verification

`pnpm run build` clean (includes `oxlint --type-aware --type-check`). The `packages/git-cli` diff integration suite passes 24/24.

The extension unit suite was not executed on the final state: `vscode-test` cannot launch from this worktree because its path pushes the workbench URL to 272 characters, which Electron's file loader rejects at `MAX_PATH` regardless of `LongPathsEnabled`. Those tests need a run from a shorter checkout path before merge.

## Not addressed here

Three other call sites carry the same pattern — temporary intent-to-add staging against the real index, undone in a `finally`. All predate this change and are outside the scope of these two issues, but the same silent-undo reproduces through each, and this fix transfers directly:

- `src/commands/git/worktree/copyChanges.ts` — stages **without** `intentToAdd`, so it commits real content to the index before resetting
- `src/webviews/rpc/services/drafts.ts` — `copyWipPatchToClipboard`
- `src/commands/patches.ts` — `CreatePatchCommandBase.getDiff`

Related: #4634 records that intent-to-add staging leaves the index in an unstable state and should be avoided, and #4635 that it triggers index changes as a side effect.
