### PR TITLE
Excludes an untracked nested repository from a review

### DIFF
--- a/src/webviews/plus/graph/__tests__/graphInspectServices.test.ts
+++ b/src/webviews/plus/graph/__tests__/graphInspectServices.test.ts
@@ -1,9 +1,10 @@
 import * as assert from 'assert';
 import * as sinon from 'sinon';
 import { uncommitted, uncommittedStaged } from '@gitlens/git/models/revision.js';
+import { LruMap } from '@gitlens/utils/lruMap.js';
 import type { Container } from '../../../../container.js';
 import { GraphInspectServices } from '../graphInspectServices.js';
-import type { ScopeSelection } from '../graphService.js';
+import type { GraphInspectService, ScopeSelection } from '../graphService.js';
 
 // `getDiffForScope` is private and only reaches `this.container.git.getRepositoryService(repoPath)` and
 // `this.buildChangesContext(...)`, so we exercise it against a minimal fake `this` rather than constructing
@@ -291,5 +292,161 @@ suite('graphInspectServices — getDiffForScope untracked handling (#5586, #5604
 		// Staging into the scratch index ran and the scratch index was disposed, but the abort was honored
 		// before the diff was requested.
 		assert.deepStrictEqual(m.order, ['getUntracked', 'createIndex', 'stage', 'dispose']);
+	});
+});
+
+// Fix under test (#5603): git reports an untracked directory that is itself a repository with a
+// trailing slash (`nested-repo/`), which is what the Files Changed rows — and so the exclusion set —
+// carry, but the intent-to-add staging above lands it in the diff as a gitlink named without one
+// (`nested-repo`). Exclusion has to match across that difference. These drive the real RPC handlers
+// (and the real diff parser) so the assertions are on the payload that would actually reach the AI.
+
+/** An unstaged diff shaped like the one the bug reproduces against: an ordinary modification, a
+ *  plain untracked file, and the gitlink entry an untracked embedded repository stages down to. */
+const diffWithNestedRepoGitlink = [
+	'diff --git a/changed.txt b/changed.txt',
+	'index 1111111..2222222 100644',
+	'--- a/changed.txt',
+	'+++ b/changed.txt',
+	'@@ -1 +1 @@',
+	'-before',
+	'+after',
+	'diff --git a/new.txt b/new.txt',
+	'new file mode 100644',
+	'index 0000000..4444444',
+	'--- /dev/null',
+	'+++ b/new.txt',
+	'@@ -0,0 +1 @@',
+	'+brand new',
+	'diff --git a/nested-repo b/nested-repo',
+	'new file mode 160000',
+	'index 0000000..3333333',
+	'--- /dev/null',
+	'+++ b/nested-repo',
+	'@@ -0,0 +1 @@',
+	'+Subproject commit 3333333333333333333333333333333333333333',
+	'',
+].join('\n');
+
+type CreateServices = () => { graphInspect: GraphInspectService };
+
+function createReviewFake() {
+	const getDiff = sinon.stub();
+	getDiff.withArgs(uncommitted).resolves({ contents: diffWithNestedRepoGitlink });
+	getDiff.withArgs(uncommittedStaged).resolves(undefined);
+
+	// Mirrors the scratch-index staging the review performs (#5604/#5605) so these tests run the same
+	// path production does; without `createTemporaryIndex` the staging step fails and is skipped, which
+	// would still let the assertions below pass while quietly testing nothing.
+	const tempIndex = { path: '/tmp/gl-x/index', env: { GIT_INDEX_FILE: '/tmp/gl-x/index' }, dispose: async () => {} };
+
+	const svc = {
+		diff: { getDiff: getDiff },
+		// The paths the curation list carries — the embedded repo keeps its trailing slash.
+		status: { getUntrackedFiles: async () => [{ path: 'new.txt' }, { path: 'nested-repo/' }] },
+		staging: {
+			createTemporaryIndex: async () => tempIndex,
+			stageFiles: async () => {},
+			unstageFiles: async () => {},
+		},
+		branches: { getBranch: async () => undefined },
+	};
+
+	const reviewChanges = sinon.stub().returns({ promise: Promise.resolve({ result: { mode: 'single-pass' } }) });
+	const reviewFocusArea = sinon.stub().returns({ promise: Promise.resolve({ result: {} }) });
+
+	const container = {
+		git: { getRepositoryService: () => svc },
+		ai: {
+			// No model → the conservative single-pass threshold, which this small diff clears, so the
+			// assertions can read the diff straight off the single-pass request.
+			getModel: async () => undefined,
+			actions: { reviewChanges: reviewChanges, reviewFocusArea: reviewFocusArea },
+		},
+	} as unknown as Container;
+
+	// Prototype-backed fake so the private helpers the handlers lean on (`getReviewTypeForScope`,
+	// `getDiffCacheKey`, `getDiffForScope`) run for real; only instance state is supplied. `container`
+	// is a getter over the injected context, so it's fed through `context`.
+	// `buildChangesContext` is shadowed to keep the AI-context gather out of the test.
+	const noopEvent = { subscribe: () => () => {} };
+	const fakeThis = Object.assign(Object.create(GraphInspectServices.prototype) as object, {
+		context: { container: container },
+		buildChangesContext: async () => '',
+		_aiCancellations: new Set(),
+		_graphDetailsDiffCache: new LruMap(4),
+		_reviewHistoryCache: new LruMap(4),
+		_composeProgressEvent: noopEvent,
+		_resolveProgressEvent: noopEvent,
+	});
+
+	const { graphInspect } = (GraphInspectServices.prototype.createServices as unknown as CreateServices).call(
+		fakeThis,
+	);
+
+	return { graphInspect: graphInspect, reviewChanges: reviewChanges, reviewFocusArea: reviewFocusArea };
+}
+
+function reviewedDiff(stub: sinon.SinonStub): string {
+	assert.ok(stub.called, 'the AI review action should have been invoked');
+	return (stub.firstCall.args[0] as { diff: string }).diff;
+}
+
+suite('graphInspectServices — review exclusions across path shapes (#5603)', () => {
+	test('excluding an untracked nested repository drops its gitlink entry from the reviewed diff', async () => {
+		const m = createReviewFake();
+
+		const result = await m.graphInspect.reviewChanges('/repo', wipScope({ includeUnstaged: true }), undefined, [
+			'nested-repo/',
+		]);
+
+		assert.ok(!('error' in result), `review should not have errored: ${JSON.stringify(result)}`);
+
+		const diff = reviewedDiff(m.reviewChanges);
+		assert.ok(!diff.includes('nested-repo'), 'the excluded nested repository must not reach the AI');
+		assert.ok(diff.includes('changed.txt'), 'the still-included change must survive the filter');
+		assert.ok(diff.includes('new.txt'), 'the still-included untracked file must survive the filter');
+	});
+
+	test('excluding a plain untracked file still works', async () => {
+		const m = createReviewFake();
+
+		await m.graphInspect.reviewChanges('/repo', wipScope({ includeUnstaged: true }), undefined, ['new.txt']);
+
+		const diff = reviewedDiff(m.reviewChanges);
+		assert.ok(!diff.includes('new.txt'), 'the excluded untracked file must not reach the AI');
+		assert.ok(diff.includes('nested-repo'), 'an unexcluded nested repository is left alone');
+	});
+
+	test('leaves the nested repository in the diff when it is not excluded', async () => {
+		const m = createReviewFake();
+
+		await m.graphInspect.reviewChanges('/repo', wipScope({ includeUnstaged: true }), undefined, undefined);
+
+		const diff = reviewedDiff(m.reviewChanges);
+		assert.ok(diff.includes('nested-repo'), 'normalizing must not drop an entry the user left checked');
+		assert.ok(diff.includes('changed.txt'));
+	});
+
+	test('excluding an untracked nested repository also holds on the two-pass focus-area request', async () => {
+		const m = createReviewFake();
+
+		// The focus-area file list comes back from the AI naming diff paths, so it has no trailing
+		// slash — the exclusion set does. Both sides have to normalize for the row to be dropped.
+		const result = await m.graphInspect.reviewFocusArea(
+			'/repo',
+			wipScope({ includeUnstaged: true }),
+			'focus-1',
+			['changed.txt', 'nested-repo'],
+			'overview',
+			undefined,
+			['nested-repo/'],
+		);
+
+		assert.ok(!('error' in result), `focus-area review should not have errored: ${JSON.stringify(result)}`);
+
+		const diff = reviewedDiff(m.reviewFocusArea);
+		assert.ok(!diff.includes('nested-repo'), 'the excluded nested repository must not reach the AI');
+		assert.ok(diff.includes('changed.txt'), 'the focus area still covers its included file');
 	});
 });

--- a/src/webviews/plus/graph/graphInspectServices.ts
+++ b/src/webviews/plus/graph/graphInspectServices.ts
@@ -15,6 +15,7 @@ import { annotateDiffWithNewLineNumbers } from '@gitlens/utils/diff.js';
 import { lazy } from '@gitlens/utils/lazy.js';
 import { Logger } from '@gitlens/utils/logger.js';
 import { LruMap } from '@gitlens/utils/lruMap.js';
+import { normalizePath } from '@gitlens/utils/path.js';
 import { getSettledValue } from '@gitlens/utils/promise.js';
 import { pluralize } from '@gitlens/utils/string.js';
 import { getAvatarUri } from '../../../avatars.js';
@@ -716,14 +717,20 @@ export class GraphInspectServices {
 						if (!data) return { error: { message: 'No changes found.' } };
 
 						if (cachedData == null) {
-							// Filter out user-excluded files before review (cached entries are already filtered)
-							const excluded = excludedFiles?.length ? new Set(excludedFiles) : undefined;
+							// Filter out user-excluded files before review (cached entries are already filtered).
+							// Normalized on both sides: git reports an untracked directory that is itself a
+							// repository with a trailing slash (`nested-repo/`), which is the path the Files
+							// Changed rows — and so the exclusion set — carry, but staging it intent-to-add lands
+							// it in the diff as a gitlink named without one. An exact compare never matches.
+							const excluded = excludedFiles?.length
+								? new Set(excludedFiles.map(normalizePath))
+								: undefined;
 							if (excluded?.size) {
 								const { filterDiffFiles } = await loadChunk(
 									() => import(/* webpackChunkName: "ai" */ '@gitlens/git/parsers/diffParser.js'),
 								);
 								data.diff = await filterDiffFiles(data.diff, paths =>
-									paths.filter(p => !excluded.has(p)),
+									paths.filter(p => !excluded.has(normalizePath(p))),
 								);
 								signal?.throwIfAborted();
 
@@ -852,13 +859,17 @@ export class GraphInspectServices {
 							this._graphDetailsDiffCache.touch(diffCacheKey);
 						}
 
-						// Filter diff to only include focus area files, excluding user-excluded files
-						const excluded = excludedFiles?.length ? new Set(excludedFiles) : undefined;
+						// Filter diff to only include focus area files, excluding user-excluded files. Both
+						// sides normalized — the focus-area list names diff paths (no trailing slash) while the
+						// exclusion set can carry one; see the `reviewChanges` filter above.
+						const excluded = excludedFiles?.length ? new Set(excludedFiles.map(normalizePath)) : undefined;
 						const { filterDiffFiles } = await loadChunk(
 							() => import(/* webpackChunkName: "ai" */ '@gitlens/git/parsers/diffParser.js'),
 						);
 						const filteredDiff = await filterDiffFiles(data.diff, () =>
-							excluded?.size ? focusAreaFiles.filter(f => !excluded.has(f)) : focusAreaFiles,
+							excluded?.size
+								? focusAreaFiles.filter(f => !excluded.has(normalizePath(f)))
+								: focusAreaFiles,
 						);
 						signal?.throwIfAborted();
 


### PR DESCRIPTION
Closes #5603

Unchecking a row in the Review panel's Files Changed list had no effect when that row was an untracked directory that is itself a git repository — its entry still reached the AI provider. Ordinary untracked files excluded correctly.

## Why it happened

Git cannot recurse past an embedded repository boundary, so `git ls-files --others` reports such a directory as one entry **with a trailing slash** (`nested-repo/`). That is the path the curation rows carry, and therefore the path the exclusion set carries when the row is unchecked.

Once the review stages untracked entries with intent-to-add so their contents reach the diff (#5586 / #5599, now via a scratch index after #5614), the same directory lands in that diff as a **gitlink named without the slash** (`nested-repo`, mode `160000`).

Both filter sites compared the two by exact string, so the excluded row never matched and stayed in the payload. Because nothing was removed, `filterDiffFiles` then took its `includedPaths.length === allPaths.length` short circuit and returned the diff untouched — which is why the outgoing request was byte-identical to a run with no exclusions at all.

## How it is fixed

Both sides of the comparison are normalized with `normalizePath`, at both places the review joins a curated path list against diff-derived paths:

- **`reviewChanges`** — the single-pass diff filter. The two-pass **overview** inherits this for free: its file manifest is parsed from the already-filtered diff, and that filter runs before the single-pass/two-pass branch, so an excluded entry can never reach the manifest.
- **`reviewFocusArea`** — the two-pass focus-area filter, where the mismatch runs the *other* direction: the focus-area list comes back from the model naming diff paths (no trailing slash) while the exclusion set carries one. Normalizing only the review filter would have left this path leaking.

`normalizePath` rather than a local trailing-slash strip because it is the same helper the diff parser already applies to paths from this source, and its other transformations (backslash folding, the Windows drive-root case) are inert for repo-relative git paths — verified against the built module.

The fix deliberately does **not** drop directory-shaped entries from the review content wholesale, which was the other option floated on the issue. A gitlink is not reviewable, but dropping it unconditionally would also remove the row when the user left it *checked*, making the curation list lie about what was reviewed. Normalizing honors the user's choice in both directions.

## Scope of the leak

A gitlink carries no file contents, so the only thing that ever left the machine was the directory name and the embedded repository's commit SHA. The defect is that a privacy-facing control silently did nothing — systematic rather than timing dependent, so it reproduced on every run.

## Tests

Four cases in `graphInspectServices.test.ts`, driving the real RPC handlers and the real diff parser against a fixture shaped like the reproducing diff (an ordinary modification, a plain untracked file, and the gitlink entry), asserting on the payload that would actually reach the provider:

- excluding `nested-repo/` drops the gitlink chunk while `changed.txt` and `new.txt` survive
- excluding a plain untracked file still works — the control against the normalization breaking the ordinary case
- with nothing excluded the gitlink entry is still present — guards against over-eager dropping
- the same exclusion holds on the two-pass focus-area request

The two nested-repo cases were confirmed to fail without the fix (verified by neutralizing the normalization and re-running); the other two pass either way by design, as no-regression controls.

## Note on a sibling surface

The Compose panel has the same unnormalized comparison and is reachable by the same repro. It is filed separately as #5611 with the four affected sites and is intentionally **not** touched here — its apply-time filter changes which hunks get committed, so it wants its own change and its own verification.