### PR TITLE
Fix compose previews dropping earlier hunks of a renamed file

### DIFF
--- a/src/webviews/plus/graph/__tests__/graphComposeVirtualContentProvider.test.ts
+++ b/src/webviews/plus/graph/__tests__/graphComposeVirtualContentProvider.test.ts
@@ -10,6 +10,7 @@ const decoder = new TextDecoder();
 const repoPath = '/mock/repo';
 const baseSha = '0000000000000000000000000000000000000000';
 const fileName = 'src/sample.ts';
+const oldFileName = 'src/old.ts';
 
 function createContainer(baseContentByPath: Map<string, string>): Container {
 	return {
@@ -52,8 +53,21 @@ function commit(id: string, hunks: ComposerHunk[]): GraphComposeVirtualCommitInp
 const baseLines = ['L01', 'L02', 'L03', 'L04', 'L05', 'L06', 'L07', 'L08', 'L09', 'L10', 'L11', 'L12'];
 const baseContent = [...baseLines, ''].join('\n');
 
-const earlyHunk = hunk(1, '@@ -2,3 +2,1 @@', [' L02', '-L03', '-L04']);
-const lateHunk = hunk(2, '@@ -9,1 +7,1 @@', ['-L09', '+L09-MOD']);
+const earlyHunkLines = [' L02', '-L03', '-L04'];
+const lateHunkLines = ['-L09', '+L09-MOD'];
+
+const earlyHunk = hunk(1, '@@ -2,3 +2,1 @@', earlyHunkLines);
+const lateHunk = hunk(2, '@@ -9,1 +7,1 @@', lateHunkLines);
+
+/**
+ * Rename-with-edits overrides: git's combined diff reports the file under its final name with the
+ * pre-rename name in the header, on every hunk of the file, however those hunks are later split
+ * across proposed commits.
+ */
+const renamed: Partial<ComposerHunk> = {
+	diffHeader: `diff --git a/${oldFileName} b/${fileName}`,
+	originalFileName: oldFileName,
+};
 
 const afterEarlyOnly = ['L01', 'L02', 'L05', 'L06', 'L07', 'L08', 'L09', 'L10', 'L11', 'L12', ''].join('\n');
 const afterBoth = ['L01', 'L02', 'L05', 'L06', 'L07', 'L08', 'L09-MOD', 'L10', 'L11', 'L12', ''].join('\n');
@@ -146,6 +160,59 @@ suite('GraphComposeVirtualContentProvider Test Suite', () => {
 		const [only] = await readAll(provider, [commit('c1', [renameHunk])]);
 
 		assert.strictEqual(only, baseContent);
+	});
+
+	test('keeps an earlier commit’s hunks when the file is renamed with edits across commits', async () => {
+		const provider = createProvider(new Map([[oldFileName, baseContent]]));
+		const [first, second] = await readAll(provider, [
+			commit('c1', [hunk(1, earlyHunk.hunkHeader, earlyHunkLines, renamed)]),
+			commit('c2', [hunk(2, lateHunk.hunkHeader, lateHunkLines, renamed)]),
+		]);
+
+		assert.strictEqual(first, afterEarlyOnly);
+		assert.strictEqual(second, afterBoth);
+	});
+
+	test('spreads a renamed file’s hunks across three commits', async () => {
+		const provider = createProvider(new Map([[oldFileName, baseContent]]));
+		const tailHunkLines = ['-L12', '+L12-MOD'];
+		const [first, second, third] = await readAll(provider, [
+			commit('c1', [hunk(1, earlyHunk.hunkHeader, earlyHunkLines, renamed)]),
+			commit('c2', [hunk(3, '@@ -12,1 +10,1 @@', tailHunkLines, renamed)]),
+			commit('c3', [hunk(2, lateHunk.hunkHeader, lateHunkLines, renamed)]),
+		]);
+
+		assert.strictEqual(first, afterEarlyOnly);
+		assert.strictEqual(
+			second,
+			['L01', 'L02', 'L05', 'L06', 'L07', 'L08', 'L09', 'L10', 'L11', 'L12-MOD', ''].join('\n'),
+		);
+		assert.strictEqual(
+			third,
+			['L01', 'L02', 'L05', 'L06', 'L07', 'L08', 'L09-MOD', 'L10', 'L11', 'L12-MOD', ''].join('\n'),
+		);
+	});
+
+	/**
+	 * The two sides the diff editor requests for a rename row: `buildDiffArgs` takes the left from
+	 * `originalPath` against the row's parent, and a rename row only renders for the earliest commit
+	 * holding the file — so the pre-rename name is only ever read at a commit with none of its hunks.
+	 */
+	test('reads the pre-rename name as untouched base at the commit before the rename', async () => {
+		const provider = createProvider(
+			new Map([
+				[oldFileName, baseContent],
+				['src/other.ts', 'x\n'],
+			]),
+		);
+		const commits = [
+			commit('c1', [hunk(1, '@@ -1,1 +1,1 @@', ['-x', '+X'], { fileName: 'src/other.ts' })]),
+			commit('c2', [hunk(2, earlyHunk.hunkHeader, earlyHunkLines, renamed)]),
+		];
+		const sessionId = provider.startSession({ repoPath: repoPath, baseSha: baseSha, commits: commits });
+
+		assert.strictEqual(decoder.decode(await provider.readFile(sessionId, 'c1', oldFileName)), baseContent);
+		assert.strictEqual(decoder.decode(await provider.readFile(sessionId, 'c2', fileName)), afterEarlyOnly);
 	});
 
 	test('reports the base as the first commit’s parent and the predecessor thereafter', async () => {

--- a/src/webviews/plus/graph/graphComposeVirtualContentProvider.ts
+++ b/src/webviews/plus/graph/graphComposeVirtualContentProvider.ts
@@ -46,8 +46,8 @@ interface Session {
  * Each session owns a parent-chained list of proposed commits anchored to a real base SHA; the
  * first commit's parent is `{ kind: 'ref', sha: baseSha }`, subsequent commits point at their
  * predecessor. File content at commit N is synthesized by taking the base file and applying, in a
- * single pass and in base order, the hunks from commits 0..N that {@link collectHunksForPath}
- * resolves for the requested path.
+ * single pass and in base order, every hunk from commits 0..N keyed under the requested path — read
+ * from the base name {@link resolveBasePath} resolves for it.
  */
 export class GraphComposeVirtualContentProvider implements VirtualContentProvider {
 	readonly namespace = GraphComposeVirtualNamespace;
@@ -164,32 +164,26 @@ export class GraphComposeVirtualContentProvider implements VirtualContentProvide
 		const commitIdx = session.commits.findIndex(c => c.id === commitId);
 		if (commitIdx < 0) throw new Error(`virtual commit not found: ${sessionId}/${commitId}`);
 
-		// `nameAtCommit[i]` is the file's name AFTER commit i (the destination-path the diff
-		// output uses); `nameAtCommit[0]` is the name at base. Walking backward from `path` lets
-		// a multi-hop chain (`original → renamed → wip-renamed` split across commits) resolve to
-		// the actual base file. `fromPath !== toPath` catches rename-with-edits too — those carry
-		// `originalFileName` on every hunk with `isRename: false`.
-		const nameAtCommit: string[] = new Array(commitIdx + 2);
-		nameAtCommit[commitIdx + 1] = path;
-		for (let i = commitIdx; i >= 0; i--) {
-			const nameAfter = nameAtCommit[i + 1];
-			const hunks = collectHunksForPath(session.commits[i].hunks, nameAfter);
-			const renameSource = hunks.find(h => h.fromPath !== h.toPath)?.fromPath;
-			nameAtCommit[i] = renameSource ?? nameAfter;
-		}
-
-		// Every hunk comes from one combined `base..final` diff, so every `@@` header is relative to
-		// `baseSha`, never to the preceding commit — they have to be applied in one pass against the
-		// base. `index` is that diff's emission order, i.e. ascending old-line order per file.
+		// Every hunk comes from one combined `base..final` diff, so a file's hunks are keyed under its
+		// final name in every proposed commit they're split across — a rename never re-keys them
+		// commit by commit, which is why matching each commit on the requested path is correct here.
+		//
+		// Because that diff is base-relative, every `@@` header is too — never relative to the
+		// preceding commit — so they have to be applied in one pass against the base. `index` is
+		// that diff's emission order, i.e. ascending old-line order per file.
 		const hunks: ComposerHunk[] = [];
 		for (let i = 0; i <= commitIdx; i++) {
-			for (const h of collectHunksForPath(session.commits[i].hunks, nameAtCommit[i + 1])) {
-				hunks.push(h.hunk);
+			for (const h of session.commits[i].hunks) {
+				if (h.fileName === path) {
+					hunks.push(h);
+				}
 			}
 		}
 		hunks.sort((a, b) => a.index - b.index);
 
-		const result = applyHunks(await this.getBaseContent(session, nameAtCommit[0]), hunks);
+		// Base content comes from the pre-rename name when the file was renamed.
+		const basePath = resolveBasePath(session.commits, commitIdx, path);
+		const result = applyHunks(await this.getBaseContent(session, basePath), hunks);
 		session.contentCache.set(cacheKey, result);
 		return result;
 	}
@@ -216,21 +210,28 @@ export class GraphComposeVirtualContentProvider implements VirtualContentProvide
 	}
 }
 
-/** Narrow a commit's hunks to those affecting `path`, converting to `{ hunk, isRename, toPath, fromPath }`. */
-function collectHunksForPath(
-	hunks: readonly ComposerHunk[],
-	path: string,
-): Array<{ hunk: ComposerHunk; isRename: boolean; toPath: string; fromPath: string }> {
-	const out: Array<{ hunk: ComposerHunk; isRename: boolean; toPath: string; fromPath: string }> = [];
-	for (const h of hunks) {
-		if (h.fileName !== path) continue;
-
-		out.push({
-			hunk: h,
-			isRename: h.isRename === true,
-			toPath: h.fileName,
-			fromPath: h.originalFileName ?? h.fileName,
-		});
+/**
+ * Resolve the base-revision name of the file whose hunks are keyed under `path`, looking only at the
+ * commits up to and including `throughIdx`. Returns `path` itself when nothing renamed it.
+ *
+ * Rename-with-edits carries `originalFileName` on every hunk of the file with `isRename: false`,
+ * while a pure rename carries one hunk with `isRename: true` — taking the first `originalFileName`
+ * among the file's hunks covers both shapes without depending on `isRename`. Uniform tagging is
+ * compose-tools' doing, not this repo's: it collects hunks once over the whole `base..final` range
+ * and the plan only slices that one list by index, so no per-commit re-keying happens.
+ *
+ * The diff editor does ask for the pre-rename name, but only on the left side of a rename row, and
+ * `buildDiffArgs` resolves that side against the row's *parent* — and a rename row is only ever
+ * rendered for the earliest commit holding the file's hunks (`resolveProposedFileStatus` in
+ * `compose/utils.ts`, gated on `earliestCommitByFile`; change that ownership rule and this reasoning
+ * needs re-checking). So the pre-rename name arrives with a `throughIdx` that excludes every hunk of
+ * that file, and returning it unchanged is what makes that side read as the untouched base.
+ */
+function resolveBasePath(commits: readonly GraphComposeVirtualCommitInput[], throughIdx: number, path: string): string {
+	for (let i = 0; i <= throughIdx; i++) {
+		for (const h of commits[i].hunks) {
+			if (h.fileName === path && h.originalFileName != null) return h.originalFileName;
+		}
 	}
-	return out;
+	return path;
 }


### PR DESCRIPTION
Closes #5606

When a file is renamed with edits and its hunks are split across two or more proposed commits, the compose preview for the **later** commit dropped the earlier commit's hunks. That commit therefore rendered as if it re-introduced content the earlier one had removed — the diff a user approves misrepresented both commits.

## Why it happened

Preview content for proposed commit *N* is synthesized by applying, in a single pass against the base file, every hunk that commits `0..N` contribute for the requested path. Resolving *which* hunks those are walked the commit chain backwards, building "the file's name after commit `i`", then asked each commit for its hunks under that name.

Those two halves cannot both be right. Every hunk comes from one combined `base..final` diff, so a file's hunks are keyed under its **final** name in every proposed commit they are split across — a rename never re-keys them commit by commit. The backward walk saw the later commit's hunks announce the rename, recorded the *pre-rename* name for the earlier commit, and then looked that commit's hunks up under a name they never carry. Nothing matched, and the earlier commit's contribution silently vanished from the later commit's synthesized content.

## How it's fixed

Hunks are now collected by the requested path directly, which is correct for every commit in the range, and the rename lookup is kept only for the one thing that genuinely needs it — the name to read base content from.

`resolveBasePath` takes the first `originalFileName` among the file's hunks. That covers both shapes the diff produces without depending on `isRename`: rename-with-edits tags `originalFileName` on every hunk with `isRename: false`, while a pure rename emits one hunk with `isRename: true`.

This replaces `collectHunksForPath`, whose per-hunk `isRename`, `toPath` and `fromPath` fields were all computed but never read at the call site — so the change is a net simplification rather than a swap of one helper for another.

The pre-rename name *does* still reach the provider, on the left side of a rename row. That side stays correct: `buildDiffArgs` resolves it against the row's **parent**, and a rename row only ever renders for the earliest commit holding the file's hunks, so the pre-rename name arrives with a commit range that excludes all of them and correctly reads as the untouched base.

## Verifying the issue's repro

Following the issue's validation steps, for a rename split across two commits:

- **Earlier commit** — left side reads the base under the pre-rename name, right side applies just that commit's hunks.
- **Later commit** — left side is the earlier commit's state, right side applies both commits' hunks. The diff now shows only what the later commit contributes, on top of the earlier commit's state.

## Tests

- The rename split across two commits — this is the actual regression test; it fails against the previous logic with exactly the reported symptom (the earlier commit's removed lines back in place).
- The same split across **three** commits, asserting the middle one, where multi-commit ordering and rename resolution interact. The pre-existing three-commit test used an unrenamed file.
- The pre-rename read at the commit before the rename, which locks in the left-side behavior described above. This one passes on the old code too — it is an invariant guard, not a second reproducer.

## Notes

Preview only, as the issue records. Apply is unaffected: hunk headers go through `git apply --cached` with context verification and the result is checked before any refs move.

Two invariants the fix rests on are now documented where they are relied on, because neither is local knowledge: the uniform `originalFileName` tagging is compose-tools' doing rather than this repo's, and the "earliest commit owns the rename row" rule lives in `earliestCommitByFile` / `resolveProposedFileStatus` in `compose/utils.ts`. Changing that ownership rule would invalidate the base-path reasoning, so it is called out as a pair.

No overlap with #5614 or #5615 — those touch review diff assembly (`graphInspectServices.ts`, `staging.ts`); this touches compose preview synthesis. Rebased on top of both and built clean.
