### PR TITLE
Excludes an untracked nested repository from a compose

### DIFF
--- a/src/webviews/plus/graph/compose/__tests__/integration.test.ts
+++ b/src/webviews/plus/graph/compose/__tests__/integration.test.ts
@@ -2,6 +2,7 @@ import * as assert from 'assert';
 import type { Container } from '../../../../../container.js';
 import type { CachedPlan } from '../../../../../plus/coretools/compose/integration.js';
 import type { ComposeHunk, ComposePlan } from '../../../../../plus/coretools/compose/types.js';
+import { REDACTED_HUNK_CONTENT } from '../../../../../plus/coretools/compose/utils.js';
 import { GraphComposeIntegration } from '../integration.js';
 
 type TestCommit = ComposePlan['allOrderedCommits'][number];
@@ -10,14 +11,14 @@ function makeCommit(id: string): TestCommit {
 	return { id: id, message: `msg-${id}`, explanation: '', hunkIndices: [] };
 }
 
-function makeHunk(index: number, fileName: string, originalFileName?: string): ComposeHunk {
+function makeHunk(index: number, fileName: string, originalFileName?: string, content = ''): ComposeHunk {
 	return {
 		index: index,
 		fileName: fileName,
 		originalFileName: originalFileName,
 		diffHeader: '',
 		hunkHeader: '',
-		content: '',
+		content: content,
 		additions: 0,
 		deletions: 0,
 	};
@@ -77,10 +78,17 @@ function makePlanWithHunks(
 	return { plan: plan, sourceHunks: sourceHunks };
 }
 
-function seedFull(sut: GraphComposeIntegration, cacheKey: string, plan: ComposePlan, sourceHunks: ComposeHunk[]): void {
+function seedFull(
+	sut: GraphComposeIntegration,
+	cacheKey: string,
+	plan: ComposePlan,
+	sourceHunks: ComposeHunk[],
+	aiExcludedFiles?: string[],
+): void {
 	(sut as unknown as { _cache: Map<string, CachedPlan> })._cache.set(cacheKey, {
 		plan: plan,
 		sourceHunks: sourceHunks,
+		aiExcludedFiles: aiExcludedFiles,
 	} as CachedPlan);
 }
 
@@ -306,5 +314,73 @@ suite('graph/compose/integration moveFilesBetweenCommits', () => {
 			['c1', 'c2'],
 		);
 		assert.deepStrictEqual(plan.allOrderedCommits.find(c => c.id === 'c1')!.hunkIndices, [0]);
+	});
+
+	// Git names an untracked directory that is itself a repository with a trailing slash
+	// (`nested-repo/`), but the compose hunk for it is a slash-less gitlink (`nested-repo`) — the
+	// webview's path list for a move can carry either shape, and both must match the same hunk.
+	test('matches a trailing-slash path against its slash-less gitlink hunk', () => {
+		const sut = new GraphComposeIntegration({} as Container);
+		const sourceHunks = [makeHunk(0, 'nested-repo'), makeHunk(1, 'b.ts')];
+		const { plan } = makePlanWithHunks(
+			[
+				{ id: 'c1', hunkIndices: [0, 1] },
+				{ id: 'c2', hunkIndices: [] },
+			],
+			sourceHunks,
+		);
+		seedFull(sut, cacheKey, plan, sourceHunks);
+
+		const ok = sut.moveFilesBetweenCommits(cacheKey, 'c1', 'c2', ['nested-repo/']);
+
+		assert.strictEqual(ok, true);
+		assert.deepStrictEqual(plan.allOrderedCommits.find(c => c.id === 'c1')!.hunkIndices, [1]);
+		assert.deepStrictEqual(plan.allOrderedCommits.find(c => c.id === 'c2')!.hunkIndices, [0]);
+	});
+});
+
+// `getMaskedHunksForCachedCommit` normalizes `aiExcludedFiles` at read time (idempotent
+// defense on top of the normalize-on-write in `generatePlanForGraphDetails`) so a trailing-slash
+// exclusion entry still matches a slash-less gitlink hunk. These tests seed the cache directly via
+// `seedFull`, bypassing the write-side normalization, to exercise the read-side normalization itself.
+suite('graph/compose/integration getMaskedHunksForCachedCommit', () => {
+	const cacheKey = 'test-key';
+
+	test('redacts an ai-excluded untracked nested repository despite the trailing-slash mismatch', () => {
+		const sut = new GraphComposeIntegration({} as Container);
+		const sourceHunks = [
+			makeHunk(0, 'nested-repo', undefined, 'gitlink content'),
+			makeHunk(1, 'b.ts', undefined, 'plain content'),
+		];
+		const { plan } = makePlanWithHunks([{ id: 'c1', hunkIndices: [0, 1] }], sourceHunks);
+		seedFull(sut, cacheKey, plan, sourceHunks, ['nested-repo/']);
+
+		const result = sut.getMaskedHunksForCachedCommit(cacheKey, 'c1');
+
+		assert.ok(result != null);
+		assert.strictEqual(result.hunks.find(h => h.fileName === 'nested-repo')!.content, REDACTED_HUNK_CONTENT);
+		assert.strictEqual(result.hunks.find(h => h.fileName === 'b.ts')!.content, 'plain content');
+	});
+
+	test('leaves content alone when nothing is ai-excluded', () => {
+		const sut = new GraphComposeIntegration({} as Container);
+		const sourceHunks = [makeHunk(0, 'a.ts', undefined, 'plain content')];
+		const { plan } = makePlanWithHunks([{ id: 'c1', hunkIndices: [0] }], sourceHunks);
+		seedFull(sut, cacheKey, plan, sourceHunks, []);
+
+		const result = sut.getMaskedHunksForCachedCommit(cacheKey, 'c1');
+
+		assert.strictEqual(result!.hunks[0].content, 'plain content');
+	});
+
+	test('matches a rename via originalFileName after normalization', () => {
+		const sut = new GraphComposeIntegration({} as Container);
+		const sourceHunks = [makeHunk(0, 'nested-repo-renamed', 'nested-repo', 'gitlink content')];
+		const { plan } = makePlanWithHunks([{ id: 'c1', hunkIndices: [0] }], sourceHunks);
+		seedFull(sut, cacheKey, plan, sourceHunks, ['nested-repo/']);
+
+		const result = sut.getMaskedHunksForCachedCommit(cacheKey, 'c1');
+
+		assert.strictEqual(result!.hunks[0].content, REDACTED_HUNK_CONTENT);
 	});
 });

--- a/src/webviews/plus/graph/compose/integration.ts
+++ b/src/webviews/plus/graph/compose/integration.ts
@@ -1,5 +1,6 @@
 import type { CancellationToken } from 'vscode';
 import { rootSha } from '@gitlens/git/models/revision.js';
+import { normalizePath } from '@gitlens/utils/path.js';
 import type { Source } from '../../../../constants.telemetry.js';
 import type { GitRepositoryService } from '../../../../git/gitRepositoryService.js';
 import { ComposeToolsIntegration } from '../../../../plus/coretools/compose/integration.js';
@@ -131,9 +132,12 @@ export class GraphComposeIntegration extends ComposeToolsIntegration {
 
 			await this.confirmInteriorRefsOrThrow(git, source);
 
-			const aiExcluded = input.aiExcludedFiles?.length ? new Set(input.aiExcludedFiles) : undefined;
+			// Normalize sets for like-for-like comparison with hunk names; see `hunkMatchesPath`.
+			const aiExcluded = input.aiExcludedFiles?.length
+				? new Set(input.aiExcludedFiles.map(normalizePath))
+				: undefined;
 			const userExcluded = input.excludedFiles?.length
-				? new Set(input.excludedFiles.filter(p => !aiExcluded?.has(p)))
+				? new Set(input.excludedFiles.map(normalizePath).filter(p => !aiExcluded?.has(p)))
 				: undefined;
 			// An interior range's leftover hunks have nowhere to go — the commits above the range
 			// depend on the excluded content, and the worktree isn't the rewrite destination. The
@@ -145,14 +149,9 @@ export class GraphComposeIntegration extends ComposeToolsIntegration {
 			}
 
 			const hunkFilter = userExcluded?.size
-				? (hunks: ComposeHunk[]) =>
-						hunks.filter(
-							h => !userExcluded.has(h.fileName) && !userExcluded.has(h.originalFileName ?? h.fileName),
-						)
+				? (hunks: ComposeHunk[]) => hunks.filter(h => !hunkMatchesPath(h, userExcluded))
 				: undefined;
-			const redactHunkContent = aiExcluded?.size
-				? (h: ComposeHunk) => aiExcluded.has(h.fileName) || aiExcluded.has(h.originalFileName ?? h.fileName)
-				: undefined;
+			const redactHunkContent = aiExcluded?.size ? (h: ComposeHunk) => hunkMatchesPath(h, aiExcluded) : undefined;
 
 			const result: ComposePlanResult = await composePlan({
 				git: git,
@@ -181,7 +180,7 @@ export class GraphComposeIntegration extends ComposeToolsIntegration {
 				source: source,
 				sourceHunks: result.source.hunks,
 				excludedFiles: userExcluded?.size ? [...userExcluded] : undefined,
-				aiExcludedFiles: input.aiExcludedFiles?.length ? [...input.aiExcludedFiles] : undefined,
+				aiExcludedFiles: aiExcluded?.size ? [...aiExcluded] : undefined,
 				session: result.session,
 				extras: extras,
 			});
@@ -337,10 +336,9 @@ export class GraphComposeIntegration extends ComposeToolsIntegration {
 		// filter at apply time, the library's drift check sees the fresh unfiltered diff and
 		// reports a false-positive SAFETY_CHECK_FAILED. aiexclude-masked files were NOT filtered
 		// (only their AI prompt content was masked), so they don't participate here.
-		const excluded = cached.excludedFiles?.length ? new Set(cached.excludedFiles) : undefined;
+		const excluded = cached.excludedFiles?.length ? new Set(cached.excludedFiles.map(normalizePath)) : undefined;
 		const hunkFilter = excluded?.size
-			? (hunks: ComposeHunk[]) =>
-					hunks.filter(h => !excluded.has(h.fileName) && !excluded.has(h.originalFileName ?? h.fileName))
+			? (hunks: ComposeHunk[]) => hunks.filter(h => !hunkMatchesPath(h, excluded))
 			: undefined;
 
 		try {
@@ -387,14 +385,19 @@ export class GraphComposeIntegration extends ComposeToolsIntegration {
 		if (commit == null) return undefined;
 
 		const indexSet = new Set(commit.hunkIndices);
-		const aiExcluded = cached.aiExcludedFiles?.length ? new Set(cached.aiExcludedFiles) : undefined;
+		// `aiExcludedFiles` is already normalized on the way into the cache (see
+		// `generatePlanForGraphDetails`); re-normalizing here is idempotent and keeps this read
+		// site defensive against a future write path that forgets to.
+		const aiExcluded = cached.aiExcludedFiles?.length
+			? new Set(cached.aiExcludedFiles.map(normalizePath))
+			: undefined;
 
 		const hunks: ComposerHunk[] = [];
 		for (const h of cached.sourceHunks) {
 			if (!indexSet.has(h.index)) continue;
 
 			const composerHunk = toComposerHunk(h);
-			if (aiExcluded?.has(h.fileName) || (h.originalFileName != null && aiExcluded?.has(h.originalFileName))) {
+			if (aiExcluded != null && hunkMatchesPath(h, aiExcluded)) {
 				composerHunk.content = REDACTED_HUNK_CONTENT;
 			}
 			hunks.push(composerHunk);
@@ -502,12 +505,8 @@ export class GraphComposeIntegration extends ComposeToolsIntegration {
 		if (from == null || to == null) return false;
 
 		// Hunk indices for these files (renames match either side of the move).
-		const pathSet = new Set(paths);
-		const fileIndices = new Set(
-			cached.sourceHunks
-				.filter(h => pathSet.has(h.fileName) || (h.originalFileName != null && pathSet.has(h.originalFileName)))
-				.map(h => h.index),
-		);
+		const pathSet = new Set(paths.map(normalizePath));
+		const fileIndices = new Set(cached.sourceHunks.filter(h => hunkMatchesPath(h, pathSet)).map(h => h.index));
 		const movingSet = new Set(from.hunkIndices.filter(i => fileIndices.has(i)));
 		if (movingSet.size === 0) return false;
 
@@ -691,6 +690,18 @@ export class GraphComposeIntegration extends ComposeToolsIntegration {
 			},
 		};
 	}
+}
+
+/**
+ * Whether `hunk`'s current name or (if it's a rename) its original name matches any entry in
+ * `paths`, comparing `normalizePath`d values on both sides so a trailing-slash path (as git
+ * porcelain reports an untracked nested repository) matches the hunk's slash-less gitlink name.
+ */
+function hunkMatchesPath(hunk: ComposeHunk, paths: ReadonlySet<string>): boolean {
+	return (
+		paths.has(normalizePath(hunk.fileName)) ||
+		(hunk.originalFileName != null && paths.has(normalizePath(hunk.originalFileName)))
+	);
 }
 
 /**


### PR DESCRIPTION
Closes #5611

Unchecking a row in the Commit Graph Compose panel's Files Changed list had no effect when that row was an untracked directory that is itself a git repository. Its entry still reached the AI provider, and — unlike the Review panel case in #5603 — still landed in the applied commits. Ordinary untracked files excluded correctly.

## Why it happened

Git reports an untracked directory that contains its own repository as a single entry with a **trailing slash** (`nested-repo/`), because it cannot recurse past the embedded repository boundary. That is the path the curation rows carry, and therefore the path the exclusion set carries.

Compose requests untracked content via `includeUntracked`, which stages with `git add -A` into a scratch index before diffing `HEAD` against it. `git add -A` records an untracked embedded repository as a **gitlink** (mode `160000`), so the resulting `diff --git a/nested-repo b/nested-repo` header — and the hunk built from it — names the same entry **without** the slash.

Every comparison between the exclusion set and a hunk name was an exact string match, so the excluded row never matched anything. The mismatch is systematic rather than timing-dependent, which is why it reproduced on every run.

## How it's resolved

Both sides of every comparison are now normalized with `normalizePath` from `@gitlens/utils/path.js`, which strips the trailing slash. This is the same approach taken for the Review panel, so the two surfaces now share one idiom rather than diverging.

Six comparison sites in `src/webviews/plus/graph/compose/integration.ts` were affected — four identified in the issue, plus two more found while tracing it:

| Site | Symptom it caused |
| --- | --- |
| Plan-generation `hunkFilter` | The gitlink hunk went into the prompt sent to the provider |
| `redactHunkContent` | Content redaction missed the entry *(not in the issue)* |
| Exclusion-set construction, including the cross-check that removes aiexclude-masked paths from the user set | Mismatched shapes on both sides of that filter *(not in the issue)* |
| Apply-time `hunkFilter`, rebuilt from the cached snapshot | The excluded entry was **committed** rather than left in the working tree |
| `aiExcludedFiles` masking on the per-commit message-regen path | Content redaction missed on regeneration |
| `moveFilesBetweenCommits` | Moving that row between draft commits silently did nothing |

Alongside the fix:

- **The five hunk-name comparisons collapse into one `hunkMatchesPath` helper.** They had drifted into two outcome-equivalent idioms — three testing `originalFileName != null && …`, two testing `originalFileName ?? fileName` — and a single predicate keeps the next site added here from drifting again. Verified behavior-preserving at each site in both the rename and non-rename branches.
- **`aiExcludedFiles` is now normalized on the way into the cache**, matching `excludedFiles`, so the two structurally identical fields no longer follow different conventions. The read sites still normalize; that is idempotent and stays defensive if a future write path forgets. Confirmed safe because neither cached field is read outside this file or sent back to the webview, where checkbox state is matched against the raw `file.path` — normalizing a value that round-tripped there would have broken the panel.

### Note on the apply-time behavior change

The apply-time site changes *what gets committed*, not only what matches: the excluded entry is now genuinely filtered out and left in the working tree. That rides an existing library path rather than a new one — `@gitkraken/compose-tools` already treats filtered hunks as first-class, materializing leftovers as uncommitted worktree changes and deriving the snapshot's `diffHash` from the filtered hunk set, so the drift check still compares filtered to filtered and there is no new `SAFETY_CHECK_FAILED` exposure.

## Impact

A gitlink carries no file contents, so only the directory name and the embedded repository's commit SHA were ever sent to the provider. But a privacy control that silently does nothing is the defect regardless — and on this surface it also committed content the user had explicitly excluded, which is a correctness problem on top of the privacy one.

## Tests

Added to `src/webviews/plus/graph/compose/__tests__/integration.test.ts`:

- `moveFilesBetweenCommits` matches a trailing-slash path (`nested-repo/`) against its slash-less gitlink hunk
- `getMaskedHunksForCachedCommit` redacts a trailing-slash ai-excluded entry against a slash-less hunk
- the same via `originalFileName`, covering the rename path
- a regression guard that nothing is redacted when the exclusion set is empty

The two sites inside `generatePlanForGraphDetails` / `applyPlanForGraphDetails` are not directly covered: they call `composePlan` / `applyComposePlan` imported directly from the library with no injection seam, and no existing test in the repo stubs them. Adding one would mean introducing a production abstraction purely for tests. Both sites now route through the same `hunkMatchesPath` helper the covered sites exercise.

## Validation

1. In a repository with some working changes, create an untracked directory that is itself a git repository (`git init nested-repo`, then commit something inside it).
2. Select the Working Changes row in the Commit Graph and open the Compose panel with a scope that includes unstaged changes — `nested-repo` is listed as an untracked (U) row.
3. Uncheck it in Files Changed, leave at least one other row included, and generate a plan.
4. The nested repository is not part of the composed content, and not part of any applied commit — it remains in the working tree.

Related: #5603 (same root cause, Review panel), #5586 / #5599 (the untracked staging that surfaces the gitlink entry), #5588 / #5601 (adjacent curation-list problems).
