### PR TITLE
MCP E2E: tool surface and mode contract

### DIFF
--- a/tests/e2e/fixtures/mcp.ts
+++ b/tests/e2e/fixtures/mcp.ts
@@ -3,7 +3,14 @@ import { test as base, createTmpDir, GitFixture } from '../baseTest.js';
 import { findGkCliFromArgs, findIpcFileByWorkspace, McpClient, waitForCliInstall } from '../helpers/mcpHelper.js';
 
 export { expect } from '@playwright/test';
-export type { IpcDiscoveryData, McpConfigResult, McpMessage, McpClient } from '../helpers/mcpHelper.js';
+export type {
+	IpcDiscoveryData,
+	McpConfigResult,
+	McpMessage,
+	McpClient,
+	McpServerMode,
+	McpToolDefinition,
+} from '../helpers/mcpHelper.js';
 export { readIpcDiscoveryFile } from '../helpers/mcpHelper.js';
 
 interface McpFixtures {

--- a/tests/e2e/fixtures/mcp.ts
+++ b/tests/e2e/fixtures/mcp.ts
@@ -8,7 +8,6 @@ export type {
 	McpConfigResult,
 	McpMessage,
 	McpClient,
-	McpServerMode,
 	McpToolDefinition,
 } from '../helpers/mcpHelper.js';
 export { readIpcDiscoveryFile } from '../helpers/mcpHelper.js';

--- a/tests/e2e/helpers/mcpHelper.ts
+++ b/tests/e2e/helpers/mcpHelper.ts
@@ -22,6 +22,21 @@ export type McpConfigResult = {
 	version?: string;
 };
 
+/**
+ * Mode the `gk mcp` server is started in, which decides the published tool surface.
+ *
+ * `readonly` drops the mutating tools, `experimental` adds the experimental ones — both are
+ * process arguments, so every call spawns its own server (see `McpClient.sendRequests`).
+ */
+export type McpServerMode = { readonly?: boolean; experimental?: boolean };
+
+/** A tool as published by `tools/list`, including the schema clients validate arguments against. */
+export type McpToolDefinition = {
+	name: string;
+	description?: string;
+	inputSchema?: { type?: string; required?: string[]; properties?: Record<string, unknown> };
+};
+
 export type IpcDiscoveryData = {
 	token: string;
 	address: string;
@@ -128,8 +143,17 @@ export class McpClient {
 		private readonly host: 'vscode' | 'cursor' = 'vscode',
 	) {}
 
-	/** Returns names of all tools exposed by the MCP server. */
-	async listTools(): Promise<string[]> {
+	/** Returns names of all tools exposed by the MCP server, optionally started in a specific mode. */
+	async listTools(mode?: McpServerMode): Promise<string[]> {
+		return (await this.listToolDefinitions(mode)).map(t => t.name);
+	}
+
+	/**
+	 * Returns the full tool definitions from `tools/list`, optionally starting the server in a
+	 * specific mode. Callers that only need names should use `listTools`; this exists for assertions
+	 * about the published contract itself (declared parameters, descriptions).
+	 */
+	async listToolDefinitions(mode?: McpServerMode): Promise<McpToolDefinition[]> {
 		const msg = await this.sendRequests(
 			[
 				this.initMsg(),
@@ -137,15 +161,16 @@ export class McpClient {
 				{ jsonrpc: '2.0' as const, id: 2, method: 'tools/list', params: {} },
 			],
 			2,
+			mode,
 		);
 		if (msg?.error) {
 			throw new Error(`MCP tools/list failed: [${msg.error.code}] ${msg.error.message}`);
 		}
-		return ((msg?.result as { tools?: { name: string }[] })?.tools ?? []).map(t => t.name);
+		return (msg?.result as { tools?: McpToolDefinition[] })?.tools ?? [];
 	}
 
 	/** Calls a single MCP tool and returns the tool-response message. */
-	async callTool(toolName: string, args: Record<string, unknown>): Promise<McpMessage> {
+	async callTool(toolName: string, args: Record<string, unknown>, mode?: McpServerMode): Promise<McpMessage> {
 		return this.sendRequests(
 			[
 				this.initMsg(),
@@ -153,6 +178,7 @@ export class McpClient {
 				{ jsonrpc: '2.0' as const, id: 3, method: 'tools/call', params: { name: toolName, arguments: args } },
 			],
 			3,
+			mode,
 		);
 	}
 
@@ -258,16 +284,38 @@ export class McpClient {
 	}
 
 	/**
+	 * Builds the `gk mcp` arguments for a server mode.
+	 *
+	 * Both flags are passed bare, never as `--flag=false`: the CLI derives read-only from the flag
+	 * being *present* (`cmd.Flags().Changed`), so `--readonly=false` would still start a read-only
+	 * server. Omitting the flag is the only way to express "not read-only".
+	 */
+	private serverArgs(mode: McpServerMode | undefined): string[] {
+		const args = ['mcp', `--host=${this.host}`, '--source=gitlens', `--scheme=${this.host}`];
+		if (mode?.readonly) {
+			args.push('--readonly');
+		}
+		if (mode?.experimental) {
+			args.push('--experimental');
+		}
+		return args;
+	}
+
+	/**
 	 * Spawns gk mcp, sends all messages, waits for the response with `targetId`,
 	 * and handles elicitation/create by auto-cancelling (safe default for tests).
 	 */
-	private sendRequests(messages: object[], targetId: number, timeoutMs = 30_000): Promise<McpMessage> {
+	private sendRequests(
+		messages: object[],
+		targetId: number,
+		mode?: McpServerMode,
+		timeoutMs = 30_000,
+	): Promise<McpMessage> {
 		return new Promise((resolve, reject) => {
-			const proc = spawn(
-				this.gkPath,
-				['mcp', `--host=${this.host}`, '--source=gitlens', `--scheme=${this.host}`],
-				{ env: this.buildEnv(), stdio: ['pipe', 'pipe', 'pipe'] },
-			);
+			const proc = spawn(this.gkPath, this.serverArgs(mode), {
+				env: this.buildEnv(),
+				stdio: ['pipe', 'pipe', 'pipe'],
+			});
 
 			let settled = false;
 			let stderr = '';

--- a/tests/e2e/helpers/mcpHelper.ts
+++ b/tests/e2e/helpers/mcpHelper.ts
@@ -286,9 +286,10 @@ export class McpClient {
 	/**
 	 * Builds the `gk mcp` arguments for a server mode.
 	 *
-	 * Both flags are passed bare, never as `--flag=false`: the CLI derives read-only from the flag
-	 * being *present* (`cmd.Flags().Changed`), so `--readonly=false` would still start a read-only
-	 * server. Omitting the flag is the only way to express "not read-only".
+	 * Flags are passed bare, never as `--flag=false`. That is mandatory for `--readonly`, which the
+	 * CLI derives from the flag being *present* (`cmd.Flags().Changed`), so `--readonly=false` would
+	 * still start a read-only server — omitting it is the only way to express "not read-only".
+	 * `--experimental` is read by value, but is passed the same way for consistency.
 	 */
 	private serverArgs(mode: McpServerMode | undefined): string[] {
 		const args = ['mcp', `--host=${this.host}`, '--source=gitlens', `--scheme=${this.host}`];

--- a/tests/e2e/specs/mcpSurface.test.ts
+++ b/tests/e2e/specs/mcpSurface.test.ts
@@ -1,28 +1,31 @@
 /**
  * MCP E2E — Surface and Mode Contract
  *
- * Guards the tool surface GitLens owns: which `gitlens_*` tools the bundled MCP server publishes
- * in each mode, and the parameters they declare. A regression on either side of the boundary — the
- * extension dropping an IPC route, or the CLI changing its gating — shows up here as a diff in the
- * published list rather than as a mysterious failure deep in a round-trip test.
+ * Guards the tool surface GitLens depends on: which `gitlens_*` tools the bundled MCP server
+ * publishes in each server mode, and the parameters those tools declare. GitLens installs the gk
+ * binary itself and pins no version, so this is the guard that notices when the surface the
+ * extension was written against changes underneath it.
  *
  * Source of truth (gk CLI `internal/mcp/internal/tools/gitlens.go` + `cmd/gk/mcp/mcp.go`):
  * - `GetToolset(readOnly)` publishes `gitlens_launchpad` always, `gitlens_start_work` and
  *   `gitlens_start_review` only when not read-only, and `gitlens_open_graph` only with
- *   `--experimental`.
+ *   `--experimental`. The read-only and experimental gates are independent.
+ * - Each mode is a process argument, so every mode is its own `gk mcp` spawn — modes cannot be
+ *   switched on a live server.
  * - Exactly four tools carry the `gitlens_` prefix, so asserting the *exact* set per mode doubles as
- *   the rename guard the tracker asks for: a renamed, dropped, or newly added GitLens tool fails
- *   here and has to be acknowledged in this spec.
- * - Every mode is a process argument, so each mode is a separate `gk mcp` spawn — the modes cannot
- *   be switched on a live server.
+ *   the rename guard: a renamed, dropped, or added GitLens tool fails here and has to be
+ *   acknowledged in this spec. The prefix has moved before (v3.1.69's `gitlens_commit_composer`
+ *   became `git_commit_composer` in v3.1.70), which is exactly why it is pinned.
  *
- * Ambient requirement: the `gitlens_*` tools are published only once the CLI has pinged the live
- * extension and learned its version (`supportsRegisteredTool`), which in turn needs the IPC handlers
- * registered — i.e. GitLens' AI features enabled (`gitlens.ai.enabled`, on by default). If that
- * breaks, *all* GitLens tools vanish at once, which `expectGitlensSurface` reports explicitly
- * instead of letting it read as a gating regression.
+ * What this spec deliberately does NOT claim: it does not prove the round-trip into the live
+ * extension. Publication is decided at server construction from the CLI's own registry — the version
+ * gate (`supportsRegisteredTool`) treats an *unknown* GitLens version as compatible, so a dead
+ * extension, a missing IPC discovery file, or unregistered handlers all still yield the full set.
+ * Round-trip coverage lives in `mcpGitlensTools.test.ts`. Consequently a failure here points at the
+ * gk build GitLens resolved (or at a GitLens version below the registry minimum of v17.10.0), not at
+ * extension-side state.
  */
-import type { McpServerMode, McpToolDefinition } from '../fixtures/mcp.js';
+import type { McpToolDefinition } from '../fixtures/mcp.js';
 import { expect, mcpTest as test } from '../fixtures/mcp.js';
 
 const launchpad = 'gitlens_launchpad';
@@ -35,15 +38,24 @@ const expectedSurface = {
 	default: [launchpad, startReview, startWork],
 	readonly: [launchpad],
 	experimental: [launchpad, openGraph, startReview, startWork],
+	readonlyExperimental: [launchpad, openGraph],
 } satisfies Record<string, string[]>;
 
-/** The parameters each GitLens tool declares as required (`mcp.Required()` in the CLI registry). */
-const expectedRequiredParams: Record<string, string[]> = {
-	[launchpad]: ['directory'],
-	[openGraph]: ['directory'],
-	[startReview]: ['directory', 'pr_url'],
-	[startWork]: ['directory', 'issue_url'],
-};
+/**
+ * The parameters each GitLens tool declares (`mcp.WithString` + `mcp.Required()` in the CLI
+ * registry), split by whether the schema marks them required.
+ *
+ * The optional ones matter as much as the required ones: GitLens reads `instructions` positionally
+ * out of the forwarded args (`src/env/node/gk/cli/commands.ts` `handleStartReviewCommand` /
+ * `handleStartWorkCommand`), so a dropped or renamed optional parameter breaks that plumbing
+ * silently — no error, just instructions that never arrive.
+ */
+const expectedParams = {
+	[launchpad]: { required: ['directory'], optional: [] },
+	[openGraph]: { required: ['directory'], optional: [] },
+	[startReview]: { required: ['directory', 'pr_url'], optional: ['instructions'] },
+	[startWork]: { required: ['directory', 'issue_url'], optional: ['instructions'] },
+} satisfies Record<string, { required: string[]; optional: string[] }>;
 
 function gitlensToolNames(definitions: McpToolDefinition[]): string[] {
 	return definitions
@@ -55,84 +67,80 @@ function gitlensToolNames(definitions: McpToolDefinition[]): string[] {
 /**
  * Asserts the exact set of `gitlens_*` tools for a mode.
  *
- * An empty set is called out separately: it means the CLI never resolved the live extension (no IPC
- * discovery file, handlers not registered, or a version gate), not that mode gating changed.
+ * An empty set is called out separately because it has a different cause than a wrong set: the CLI
+ * registry no longer publishes GitLens tools at all, or it pinged GitLens and rejected its version —
+ * neither of which is a mode-gating change.
  */
 function expectGitlensSurface(definitions: McpToolDefinition[], expected: string[], mode: string): void {
 	const published = gitlensToolNames(definitions);
 
 	expect(
 		published.length,
-		`no gitlens_* tools published in ${mode} mode — the CLI could not resolve the live extension (IPC discovery missing, IPC handlers not registered, or the GitLens version gate rejected it), so mode gating cannot be evaluated. Published tools: ${definitions
+		`no gitlens_* tools published in ${mode} mode — the gk build dropped its GitLens registry entries, or it rejected the running GitLens version (registry minimum v17.10.0), so mode gating cannot be evaluated. Published tools: ${definitions
 			.map(t => t.name)
 			.sort()
 			.join(', ')}`,
 	).toBeGreaterThan(0);
 
-	expect(published, `unexpected gitlens_* surface in ${mode} mode`).toEqual(expected);
+	expect(published, `unexpected gitlens_* surface in ${mode} mode — check the resolved gk build`).toEqual(expected);
 }
 
 test.describe('MCP — Surface and Mode Contract', () => {
+	// Serial so the tests share this file's single worker: the worker-scoped VS Code instance is the
+	// expensive part, and under the config's `fullyParallel` these otherwise-independent tests would
+	// be spread across workers, each launching its own editor for a listing that needs none.
 	test.describe.configure({ mode: 'serial' });
 
 	// ── Mode gating ──────────────────────────────────────────────────────────
 
 	test('publishes the read-write, non-experimental surface by default', async ({ mcpClient }) => {
-		const definitions = await mcpClient.listToolDefinitions();
-
-		expectGitlensSurface(definitions, expectedSurface.default, 'default');
-		// Called out explicitly (though implied by the exact set above): the experimental tool must
-		// stay behind its flag, since it opens UI in the live instance.
-		expect(gitlensToolNames(definitions)).not.toContain(openGraph);
+		expectGitlensSurface(await mcpClient.listToolDefinitions(), expectedSurface.default, 'default');
 	});
 
 	test('drops the mutating tools in read-only mode', async ({ mcpClient }) => {
-		const mode: McpServerMode = { readonly: true };
-		const definitions = await mcpClient.listToolDefinitions(mode);
-
 		// Both write-path tools create refs in the working tree (a branch, and a worktree for review),
 		// so read-only mode must not offer them at all.
+		const definitions = await mcpClient.listToolDefinitions({ readonly: true });
+
 		expectGitlensSurface(definitions, expectedSurface.readonly, 'read-only');
 	});
 
 	test('adds gitlens_open_graph with --experimental', async ({ mcpClient }) => {
-		const mode: McpServerMode = { experimental: true };
-		const definitions = await mcpClient.listToolDefinitions(mode);
+		const definitions = await mcpClient.listToolDefinitions({ experimental: true });
 
 		expectGitlensSurface(definitions, expectedSurface.experimental, 'experimental');
 	});
 
 	test('keeps read-only gating under --experimental', async ({ mcpClient }) => {
-		// The two flags are independent: the experimental flag must not smuggle the mutating tools
-		// back into a read-only server.
-		const mode: McpServerMode = { readonly: true, experimental: true };
-		const definitions = await mcpClient.listToolDefinitions(mode);
+		// The two gates are independent: the experimental flag must not smuggle the mutating tools back
+		// into a read-only server.
+		const definitions = await mcpClient.listToolDefinitions({ readonly: true, experimental: true });
 
-		expectGitlensSurface(definitions, [launchpad, openGraph], 'read-only experimental');
+		expectGitlensSurface(definitions, expectedSurface.readonlyExperimental, 'read-only experimental');
 	});
 
 	// ── Declared parameters ──────────────────────────────────────────────────
 
-	test('declares the required parameters of every GitLens tool', async ({ mcpClient }) => {
+	test('declares the parameters of every GitLens tool', async ({ mcpClient }) => {
 		// Experimental mode is the only one that exposes all four tools at once, so assert the whole
 		// registry from a single listing.
 		const definitions = await mcpClient.listToolDefinitions({ experimental: true });
 		expectGitlensSurface(definitions, expectedSurface.experimental, 'experimental');
 
-		for (const [name, required] of Object.entries(expectedRequiredParams)) {
+		for (const [name, params] of Object.entries(expectedParams)) {
+			// Guaranteed by the exact-set assertion above; thrown rather than asserted so the loop body
+			// stays narrowed to a defined definition.
 			const definition = definitions.find(t => t.name === name);
-			expect(definition, `${name} should be published`).toBeDefined();
+			if (definition == null) throw new Error(`${name} is missing from the published tools`);
 
-			expect((definition!.inputSchema?.required ?? []).sort(), `unexpected required params for ${name}`).toEqual(
-				required,
+			expect((definition.inputSchema?.required ?? []).sort(), `unexpected required params for ${name}`).toEqual(
+				params.required,
 			);
-			// The required params must exist as declared properties, otherwise a client can't build a
-			// valid call for them.
-			for (const param of required) {
-				expect(definition!.inputSchema?.properties ?? {}, `${name} should declare "${param}"`).toHaveProperty(
-					param,
-				);
-			}
+			// Exact property set, so a dropped or renamed optional parameter fails too.
+			expect(
+				Object.keys(definition.inputSchema?.properties ?? {}).sort(),
+				`unexpected params for ${name}`,
+			).toEqual([...params.required, ...params.optional].sort());
 		}
 	});
 });

--- a/tests/e2e/specs/mcpSurface.test.ts
+++ b/tests/e2e/specs/mcpSurface.test.ts
@@ -33,7 +33,10 @@ const openGraph = 'gitlens_open_graph';
 const startReview = 'gitlens_start_review';
 const startWork = 'gitlens_start_work';
 
-/** The GitLens-owned tools, sorted, as published in each mode. */
+/**
+ * The GitLens-owned tools as published in each mode. Listing order carries no meaning — the CLI is
+ * free to reorder its registry, so every assertion below sorts both sides and compares sets.
+ */
 const expectedSurface = {
 	default: [launchpad, startReview, startWork],
 	readonly: [launchpad],
@@ -82,7 +85,9 @@ function expectGitlensSurface(definitions: McpToolDefinition[], expected: string
 			.join(', ')}`,
 	).toBeGreaterThan(0);
 
-	expect(published, `unexpected gitlens_* surface in ${mode} mode — check the resolved gk build`).toEqual(expected);
+	expect(published, `unexpected gitlens_* surface in ${mode} mode — check the resolved gk build`).toEqual(
+		[...expected].sort(),
+	);
 }
 
 test.describe('MCP — Surface and Mode Contract', () => {
@@ -133,9 +138,10 @@ test.describe('MCP — Surface and Mode Contract', () => {
 			const definition = definitions.find(t => t.name === name);
 			if (definition == null) throw new Error(`${name} is missing from the published tools`);
 
-			expect((definition.inputSchema?.required ?? []).sort(), `unexpected required params for ${name}`).toEqual(
-				params.required,
-			);
+			expect(
+				[...(definition.inputSchema?.required ?? [])].sort(),
+				`unexpected required params for ${name}`,
+			).toEqual([...params.required].sort());
 			// Exact property set, so a dropped or renamed optional parameter fails too.
 			expect(
 				Object.keys(definition.inputSchema?.properties ?? {}).sort(),

--- a/tests/e2e/specs/mcpSurface.test.ts
+++ b/tests/e2e/specs/mcpSurface.test.ts
@@ -1,0 +1,138 @@
+/**
+ * MCP E2E — Surface and Mode Contract
+ *
+ * Guards the tool surface GitLens owns: which `gitlens_*` tools the bundled MCP server publishes
+ * in each mode, and the parameters they declare. A regression on either side of the boundary — the
+ * extension dropping an IPC route, or the CLI changing its gating — shows up here as a diff in the
+ * published list rather than as a mysterious failure deep in a round-trip test.
+ *
+ * Source of truth (gk CLI `internal/mcp/internal/tools/gitlens.go` + `cmd/gk/mcp/mcp.go`):
+ * - `GetToolset(readOnly)` publishes `gitlens_launchpad` always, `gitlens_start_work` and
+ *   `gitlens_start_review` only when not read-only, and `gitlens_open_graph` only with
+ *   `--experimental`.
+ * - Exactly four tools carry the `gitlens_` prefix, so asserting the *exact* set per mode doubles as
+ *   the rename guard the tracker asks for: a renamed, dropped, or newly added GitLens tool fails
+ *   here and has to be acknowledged in this spec.
+ * - Every mode is a process argument, so each mode is a separate `gk mcp` spawn — the modes cannot
+ *   be switched on a live server.
+ *
+ * Ambient requirement: the `gitlens_*` tools are published only once the CLI has pinged the live
+ * extension and learned its version (`supportsRegisteredTool`), which in turn needs the IPC handlers
+ * registered — i.e. GitLens' AI features enabled (`gitlens.ai.enabled`, on by default). If that
+ * breaks, *all* GitLens tools vanish at once, which `expectGitlensSurface` reports explicitly
+ * instead of letting it read as a gating regression.
+ */
+import type { McpServerMode, McpToolDefinition } from '../fixtures/mcp.js';
+import { expect, mcpTest as test } from '../fixtures/mcp.js';
+
+const launchpad = 'gitlens_launchpad';
+const openGraph = 'gitlens_open_graph';
+const startReview = 'gitlens_start_review';
+const startWork = 'gitlens_start_work';
+
+/** The GitLens-owned tools, sorted, as published in each mode. */
+const expectedSurface = {
+	default: [launchpad, startReview, startWork],
+	readonly: [launchpad],
+	experimental: [launchpad, openGraph, startReview, startWork],
+} satisfies Record<string, string[]>;
+
+/** The parameters each GitLens tool declares as required (`mcp.Required()` in the CLI registry). */
+const expectedRequiredParams: Record<string, string[]> = {
+	[launchpad]: ['directory'],
+	[openGraph]: ['directory'],
+	[startReview]: ['directory', 'pr_url'],
+	[startWork]: ['directory', 'issue_url'],
+};
+
+function gitlensToolNames(definitions: McpToolDefinition[]): string[] {
+	return definitions
+		.filter(t => t.name.startsWith('gitlens_'))
+		.map(t => t.name)
+		.sort();
+}
+
+/**
+ * Asserts the exact set of `gitlens_*` tools for a mode.
+ *
+ * An empty set is called out separately: it means the CLI never resolved the live extension (no IPC
+ * discovery file, handlers not registered, or a version gate), not that mode gating changed.
+ */
+function expectGitlensSurface(definitions: McpToolDefinition[], expected: string[], mode: string): void {
+	const published = gitlensToolNames(definitions);
+
+	expect(
+		published.length,
+		`no gitlens_* tools published in ${mode} mode — the CLI could not resolve the live extension (IPC discovery missing, IPC handlers not registered, or the GitLens version gate rejected it), so mode gating cannot be evaluated. Published tools: ${definitions
+			.map(t => t.name)
+			.sort()
+			.join(', ')}`,
+	).toBeGreaterThan(0);
+
+	expect(published, `unexpected gitlens_* surface in ${mode} mode`).toEqual(expected);
+}
+
+test.describe('MCP — Surface and Mode Contract', () => {
+	test.describe.configure({ mode: 'serial' });
+
+	// ── Mode gating ──────────────────────────────────────────────────────────
+
+	test('publishes the read-write, non-experimental surface by default', async ({ mcpClient }) => {
+		const definitions = await mcpClient.listToolDefinitions();
+
+		expectGitlensSurface(definitions, expectedSurface.default, 'default');
+		// Called out explicitly (though implied by the exact set above): the experimental tool must
+		// stay behind its flag, since it opens UI in the live instance.
+		expect(gitlensToolNames(definitions)).not.toContain(openGraph);
+	});
+
+	test('drops the mutating tools in read-only mode', async ({ mcpClient }) => {
+		const mode: McpServerMode = { readonly: true };
+		const definitions = await mcpClient.listToolDefinitions(mode);
+
+		// Both write-path tools create refs in the working tree (a branch, and a worktree for review),
+		// so read-only mode must not offer them at all.
+		expectGitlensSurface(definitions, expectedSurface.readonly, 'read-only');
+	});
+
+	test('adds gitlens_open_graph with --experimental', async ({ mcpClient }) => {
+		const mode: McpServerMode = { experimental: true };
+		const definitions = await mcpClient.listToolDefinitions(mode);
+
+		expectGitlensSurface(definitions, expectedSurface.experimental, 'experimental');
+	});
+
+	test('keeps read-only gating under --experimental', async ({ mcpClient }) => {
+		// The two flags are independent: the experimental flag must not smuggle the mutating tools
+		// back into a read-only server.
+		const mode: McpServerMode = { readonly: true, experimental: true };
+		const definitions = await mcpClient.listToolDefinitions(mode);
+
+		expectGitlensSurface(definitions, [launchpad, openGraph], 'read-only experimental');
+	});
+
+	// ── Declared parameters ──────────────────────────────────────────────────
+
+	test('declares the required parameters of every GitLens tool', async ({ mcpClient }) => {
+		// Experimental mode is the only one that exposes all four tools at once, so assert the whole
+		// registry from a single listing.
+		const definitions = await mcpClient.listToolDefinitions({ experimental: true });
+		expectGitlensSurface(definitions, expectedSurface.experimental, 'experimental');
+
+		for (const [name, required] of Object.entries(expectedRequiredParams)) {
+			const definition = definitions.find(t => t.name === name);
+			expect(definition, `${name} should be published`).toBeDefined();
+
+			expect((definition!.inputSchema?.required ?? []).sort(), `unexpected required params for ${name}`).toEqual(
+				required,
+			);
+			// The required params must exist as declared properties, otherwise a client can't build a
+			// valid call for them.
+			for (const param of required) {
+				expect(definition!.inputSchema?.properties ?? {}, `${name} should declare "${param}"`).toHaveProperty(
+					param,
+				);
+			}
+		}
+	});
+});


### PR DESCRIPTION
Part of #5106 — implements the **Surface and mode contract** item. Test-only; no product code changes.

## What this guards

GitLens installs the `gk` binary itself and pins no version, so the MCP tool surface the extension was written against can change underneath it on any CLI release. This spec pins that surface: which `gitlens_*` tools the bundled server publishes per mode, and the parameters they declare.

| Mode | Published `gitlens_*` tools |
| --- | --- |
| default | `launchpad`, `start_review`, `start_work` |
| `--readonly` | `launchpad` |
| `--experimental` | `launchpad`, `open_graph`, `start_review`, `start_work` |
| `--readonly --experimental` | `launchpad`, `open_graph` |

The last row is the guard that the two gates stay independent — the experimental flag must not smuggle the mutating tools back into a read-only server.

Parameters are asserted as an **exact property set** per tool, not just the required ones: GitLens reads `instructions` positionally out of the forwarded args (`handleStartWorkCommand` / `handleStartReviewCommand` in `src/env/node/gk/cli/commands.ts`), so a dropped or renamed optional parameter would break that plumbing silently.

Exactly four tools carry the `gitlens_` prefix today, so the exact-set assertions double as the rename guard. That prefix has moved before — v3.1.69's `gitlens_commit_composer` became `git_commit_composer` in v3.1.70 — which is why it is pinned.

## What it does not claim

It does not prove the round-trip into the live extension. Publication is decided at server construction from the CLI's own registry, and the version gate treats an unknown GitLens version as compatible, so a dead extension or missing IPC discovery file still yields the full set. Round-trip coverage stays in `mcpGitlensTools.test.ts`. A failure here therefore points at the resolved `gk` build (or a GitLens version below the registry minimum of v17.10.0), and both the docstring and the failure message say so.

## Helper change

`McpClient` gains a per-call server mode (`--readonly`, `--experimental`) plus `listToolDefinitions()`, so one fixture client can probe every mode without a second fixture — modes are process arguments and cannot be switched on a live server. Flags are passed bare because the CLI derives read-only from the flag being *present* (`cmd.Flags().Changed`), not from its value: `--readonly=false` would still start a read-only server. Existing callers pass no mode, so their spawn arguments are unchanged.

## Validation

- `mcpSurface.test.ts` — 5/5 on `vscode` (Windows).
- Neighbouring MCP specs after the helper refactor (`mcp`, `mcpGitReadTools`, `mcpGitlensTools`) — 34 passed, 2 skipped.
- `pnpm run check` and `pnpm run fmt` clean.
- Full `--project=vscode` run: 193 passed, 3 skipped, and 2 failures in `graphHeader.test.ts:125` / `graphHeaderGitActions.test.ts:140` (the header `Create` readiness probe). Both reproduce identically on `main` at `db581246c` in a clean worktree, so they are pre-existing on the base branch and untouched by this change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
