### PR TITLE
fix(integrations): refresh a per-connection token the provider rejected

### DIFF
--- a/packages/plus/integrations/src/__tests__/rejectedTokenRefresh.test.ts
+++ b/packages/plus/integrations/src/__tests__/rejectedTokenRefresh.test.ts
@@ -1,0 +1,227 @@
+import * as assert from 'node:assert/strict';
+import { suite, test } from 'mocha';
+import type { ProviderAuthenticationSession } from '../authentication/models.js';
+import { GitCloudHostIntegrationId } from '../constants.js';
+import { AuthenticationError } from '../errors.js';
+import { createIntegrationService as createIntegrationManager } from '../integrationService.js';
+import type { ProviderHierarchyResult } from '../providers/models.js';
+import type { ProviderOrganization } from '../results.js';
+import { createFakeRuntime } from './fakeRuntime.js';
+
+/**
+ * A token the provider REJECTS while the backend still believes it is valid — a revoked grant, retired
+ * scopes, an app removed from the org. The refresh used to be purely predictive (`expiresIn < 60`), so this
+ * token was never refreshed: `expiresIn` stayed high, the read kept re-sending the refused token, and the
+ * failure only cleared when the user reconnected by hand.
+ *
+ * These tests pin the observed trigger. They drive the whole chain (read → `AuthenticationError` →
+ * per-connection rejection → forced refresh on the next read) through a fake `fetchGkApi`, so what is
+ * asserted is the actual `POST v1/provider-tokens/tokens/{id}/refresh` reaching the wire — the refresh token
+ * itself never reaches the client, the GK cloud exchanges it server-side.
+ *
+ * The read under test is `getOrganizationsForUserResult`: connection-scoped, and it holds no cache of its
+ * own, so what the assertions see is the auth path rather than a memoized result.
+ */
+
+interface FetchCall {
+	path: string;
+	method: string | undefined;
+}
+
+const NON_EXPIRING_SECONDS = 100_000;
+
+/**
+ * A runtime whose cloud token endpoints answer with a long-lived token, recording every call. `token()`
+ * decides the current token value, so a test can prove the refreshed one replaced it.
+ */
+function createRuntimeWithCloudToken(tokenId: string, token: () => string) {
+	const runtime = createFakeRuntime();
+	const calls: FetchCall[] = [];
+	// `getCloudSession` bails before any cloud call when no GK account is signed in, so the refresh under
+	// test would never be reached.
+	runtime.account.getAccount = async () => ({ id: 'me' });
+	runtime.account.fetchGkApi = (path: string, init?: RequestInit) => {
+		calls.push({ path: path, method: init?.method });
+		if (path === 'v1/provider-tokens') {
+			return Promise.resolve(
+				new Response(
+					JSON.stringify({
+						data: [{ tokenId: tokenId, provider: 'github', type: 'oauth', domain: 'github.com' }],
+					}),
+					{ status: 200 },
+				),
+			);
+		}
+		return Promise.resolve(
+			new Response(
+				JSON.stringify({
+					data: {
+						tokenId: tokenId,
+						accessToken: token(),
+						domain: 'github.com',
+						// Deliberately NOT about to lapse: the whole point is that a purely time-based
+						// refresh cannot see this token is dead.
+						expiresIn: NON_EXPIRING_SECONDS,
+						scopes: 'repo',
+						type: 'oauth',
+					},
+				}),
+				{ status: 200 },
+			),
+		);
+	};
+	return { runtime: runtime, calls: calls };
+}
+
+async function seedConnection(runtime: ReturnType<typeof createFakeRuntime>, tokenId: string, token: string) {
+	await runtime.storage.store('integrations:configured', {
+		github: [{ id: tokenId, cloud: true, integrationId: 'github', scopes: 'repo', primary: true }],
+	});
+	await runtime.storage.storeSecret(
+		`integration.auth.cloud:github|${tokenId}`,
+		JSON.stringify({
+			id: tokenId,
+			accessToken: token,
+			scopes: ['repo'],
+			cloud: true,
+			type: 'oauth',
+			domain: 'github.com',
+			expiresAt: new Date(Date.now() + NON_EXPIRING_SECONDS * 1000),
+		}),
+	);
+}
+
+const authError = () =>
+	new AuthenticationError(
+		{
+			providerId: GitCloudHostIntegrationId.GitHub,
+			microHash: undefined,
+			cloud: true,
+			type: 'oauth',
+			scopes: [],
+		},
+		'token rejected by provider',
+	);
+
+const refreshCalls = (calls: FetchCall[]) =>
+	calls.filter(c => c.path.endsWith('/refresh')).map(c => `${c.method ?? 'GET'} ${c.path}`);
+
+/**
+ * Stubs the provider org read, recording the token each attempt was handed. `rejectWhile` decides which
+ * attempts the provider refuses.
+ */
+function stubOrgRead(integration: unknown, rejectWhile: (attempt: number) => boolean): string[] {
+	const seen: string[] = [];
+	(
+		integration as {
+			getProviderOrganizationsForUser: (
+				session: ProviderAuthenticationSession,
+			) => Promise<ProviderHierarchyResult<ProviderOrganization> | undefined>;
+		}
+	).getProviderOrganizationsForUser = session => {
+		seen.push(session.accessToken);
+		if (rejectWhile(seen.length)) return Promise.reject(authError());
+		return Promise.resolve({ values: [] });
+	};
+	return seen;
+}
+
+suite('rejected-token refresh', () => {
+	test('a per-connection read rejected with an AuthenticationError refreshes that token on the next read', async () => {
+		let token = 'token-stale';
+		const { runtime, calls } = createRuntimeWithCloudToken('sec-tok', () => token);
+		await seedConnection(runtime, 'sec-tok', token);
+		const manager = createIntegrationManager(runtime);
+		const gh = await manager.get(GitCloudHostIntegrationId.GitHub);
+
+		const seen = stubOrgRead(gh, attempt => attempt === 1);
+
+		// First read: the provider refuses the token it was handed. The failure is recovered into `{ error }`
+		// (unchanged behavior); the recovery is what happens on the read that follows.
+		const failed = await gh.getOrganizationsForUserResult('sec-tok');
+		assert.ok(failed?.error != null, 'the rejected read reports its error');
+		assert.deepEqual(refreshCalls(calls), [], 'the failing read itself does not refresh');
+
+		// The cloud now hands back a different token, as a real refresh would.
+		token = 'token-fresh';
+		const recovered = await gh.getOrganizationsForUserResult('sec-tok');
+
+		assert.deepEqual(
+			refreshCalls(calls),
+			['POST v1/provider-tokens/tokens/sec-tok/refresh'],
+			'the next read refreshes the rejected token, scoped to its own connection id',
+		);
+		assert.ok(recovered?.error == null, 'the read that follows the refresh succeeds');
+		assert.deepEqual(seen, ['token-stale', 'token-fresh'], 'the refused token is not sent a second time');
+
+		manager.dispose();
+	});
+
+	test('the refresh is attempted once per rejection, so a token refused again does not loop', async () => {
+		const token = 'token-stale';
+		const { runtime, calls } = createRuntimeWithCloudToken('sec-tok', () => token);
+		await seedConnection(runtime, 'sec-tok', token);
+		const manager = createIntegrationManager(runtime);
+		const gh = await manager.get(GitCloudHostIntegrationId.GitHub);
+
+		const seen = stubOrgRead(gh, () => true);
+
+		// Three reads, every one refused. Only the second may refresh: the first records the rejection, the
+		// second consumes it, and the third must not — a token the provider refuses even after a refresh is
+		// not self-healing, and re-refreshing on every read would hammer the cloud endpoint.
+		for (let i = 0; i < 3; i++) {
+			const result = await gh.getOrganizationsForUserResult('sec-tok');
+			assert.ok(result?.error != null, `read ${i + 1} reports its error`);
+		}
+
+		assert.deepEqual(
+			refreshCalls(calls),
+			['POST v1/provider-tokens/tokens/sec-tok/refresh'],
+			'exactly one refresh across repeated rejections of the same connection',
+		);
+		assert.equal(seen.length, 3, 'every read still attempted the provider');
+
+		manager.dispose();
+	});
+
+	test('a refresh that produced a new token re-arms, so a later rejection can refresh again', async () => {
+		let token = 'token-1';
+		const { runtime, calls } = createRuntimeWithCloudToken('sec-tok', () => token);
+		await seedConnection(runtime, 'sec-tok', token);
+		const manager = createIntegrationManager(runtime);
+		const gh = await manager.get(GitCloudHostIntegrationId.GitHub);
+
+		// Every read is refused, but the cloud hands back a different token each time it is asked — a
+		// connection whose credential really is rotating. The rejection must retire on each new token so a
+		// later failure is still recoverable, rather than latching after the first refresh.
+		const seen = stubOrgRead(gh, () => true);
+
+		await gh.getOrganizationsForUserResult('sec-tok'); // rejects token-1, records it
+		token = 'token-2';
+		await gh.getOrganizationsForUserResult('sec-tok'); // refreshes → token-2, which is then refused
+		token = 'token-3';
+		await gh.getOrganizationsForUserResult('sec-tok'); // token-2's rejection refreshes → token-3
+
+		assert.deepEqual(seen, ['token-1', 'token-2', 'token-3'], 'each read carries the freshly refreshed credential');
+		assert.equal(refreshCalls(calls).length, 2, 'one refresh per distinct rejected token');
+
+		manager.dispose();
+	});
+
+	test('a successful read never refreshes', async () => {
+		const token = 'token-good';
+		const { runtime, calls } = createRuntimeWithCloudToken('sec-tok', () => token);
+		await seedConnection(runtime, 'sec-tok', token);
+		const manager = createIntegrationManager(runtime);
+		const gh = await manager.get(GitCloudHostIntegrationId.GitHub);
+
+		stubOrgRead(gh, () => false);
+
+		const result = await gh.getOrganizationsForUserResult('sec-tok');
+
+		assert.ok(result?.error == null);
+		assert.deepEqual(refreshCalls(calls), [], 'a healthy long-lived token is left alone');
+
+		manager.dispose();
+	});
+});

--- a/packages/plus/integrations/src/authentication/integrationAuthenticationProvider.ts
+++ b/packages/plus/integrations/src/authentication/integrationAuthenticationProvider.ts
@@ -46,11 +46,32 @@ export interface IntegrationAuthenticationProvider extends Disposable {
 		options?: { preserveConfigured?: boolean },
 	): Promise<void>;
 	deleteAllSessions(descriptor?: IntegrationAuthenticationSessionDescriptor): Promise<void>;
+	/**
+	 * Resolves the session for `descriptor`, from storage when it is still usable and from the cloud
+	 * otherwise.
+	 *
+	 * `refreshRejectedToken` marks the stored token as known-refused by the provider (an
+	 * `AuthenticationError` on a previous read), which forces a cloud `/refresh` even when the token's
+	 * expiry still claims it is valid — the case a purely time-based refresh cannot see. The refresh token
+	 * itself never reaches the client: the GK cloud performs the exchange server-side.
+	 */
 	getSession(
 		descriptor: IntegrationAuthenticationSessionDescriptor,
 		options?:
-			| { createIfNeeded?: boolean; forceNewSession?: boolean; sync?: never; source?: Sources }
-			| { createIfNeeded?: never; forceNewSession?: never; sync: boolean; source?: Sources },
+			| {
+					createIfNeeded?: boolean;
+					forceNewSession?: boolean;
+					sync?: never;
+					refreshRejectedToken?: boolean;
+					source?: Sources;
+			  }
+			| {
+					createIfNeeded?: never;
+					forceNewSession?: never;
+					sync: boolean;
+					refreshRejectedToken?: boolean;
+					source?: Sources;
+			  },
 	): Promise<ProviderAuthenticationSession | undefined>;
 	get onDidChange(): Event<void>;
 }
@@ -121,8 +142,20 @@ abstract class IntegrationAuthenticationProviderBase<
 	async getSession(
 		descriptor: IntegrationAuthenticationSessionDescriptor,
 		options?:
-			| { createIfNeeded?: boolean; forceNewSession?: boolean; sync?: never; source?: Sources }
-			| { createIfNeeded?: never; forceNewSession?: never; sync: boolean; source?: Sources },
+			| {
+					createIfNeeded?: boolean;
+					forceNewSession?: boolean;
+					sync?: never;
+					refreshRejectedToken?: boolean;
+					source?: Sources;
+			  }
+			| {
+					createIfNeeded?: never;
+					forceNewSession?: never;
+					sync: boolean;
+					refreshRejectedToken?: boolean;
+					source?: Sources;
+			  },
 	): Promise<ProviderAuthenticationSession | undefined> {
 		let session;
 		let previousToken;
@@ -143,10 +176,15 @@ abstract class IntegrationAuthenticationProviderBase<
 		}
 
 		const isExpiredSession = session?.expiresAt != null && new Date(session.expiresAt).getTime() < Date.now();
-		if (session == null || isExpiredSession) {
+		// A rejected token has to re-resolve even when the stored session looks perfectly healthy: that is
+		// the whole point — the provider refused it while its expiry still says valid. Without this the
+		// stored session short-circuits here and the refresh below is never reached.
+		const refreshRejectedToken = options?.refreshRejectedToken === true && session != null;
+		if (session == null || isExpiredSession || refreshRejectedToken) {
 			session = await this.getNewSession(descriptor, {
 				...options,
 				refreshIfExpired: isExpiredSession,
+				refreshRejectedToken: refreshRejectedToken,
 			});
 
 			if (session != null) {
@@ -169,6 +207,7 @@ abstract class IntegrationAuthenticationProviderBase<
 					forceNewSession?: boolean;
 					sync?: never;
 					refreshIfExpired?: boolean;
+					refreshRejectedToken?: boolean;
 					source?: Sources;
 			  }
 			| {
@@ -176,6 +215,7 @@ abstract class IntegrationAuthenticationProviderBase<
 					forceNewSession?: never;
 					sync: boolean;
 					refreshIfExpired?: boolean;
+					refreshRejectedToken?: boolean;
 					source?: Sources;
 			  },
 	): Promise<ProviderAuthenticationSession | undefined>;
@@ -208,6 +248,7 @@ export class CloudIntegrationAuthenticationProvider<
 					forceNewSession?: boolean;
 					sync?: never;
 					refreshIfExpired?: boolean;
+					refreshRejectedToken?: boolean;
 					source?: Sources;
 			  }
 			| {
@@ -215,6 +256,7 @@ export class CloudIntegrationAuthenticationProvider<
 					forceNewSession?: never;
 					sync: boolean;
 					refreshIfExpired?: boolean;
+					refreshRejectedToken?: boolean;
 					source?: Sources;
 			  },
 	): Promise<ProviderAuthenticationSession | undefined> {
@@ -230,9 +272,15 @@ export class CloudIntegrationAuthenticationProvider<
 		// TODO: This is a stopgap to make sure we're not hammering the api on automatic calls to get the session.
 		// Ultimately we want to timestamp calls to syncCloudIntegrations and use that to determine whether we should
 		// make the call or not.
+		// `refreshRejectedToken` joins the list for the same reason `refreshIfExpired` is on it: both mean the
+		// session in hand is known-unusable, so skipping the cloud round trip would just re-serve it.
 		let session =
-			options?.refreshIfExpired || options?.createIfNeeded || options?.forceNewSession || options?.sync
-				? await this.getCloudSession(descriptor)
+			options?.refreshIfExpired ||
+			options?.refreshRejectedToken ||
+			options?.createIfNeeded ||
+			options?.forceNewSession ||
+			options?.sync
+				? await this.getCloudSession(descriptor, { refreshRejectedToken: options?.refreshRejectedToken })
 				: undefined;
 
 		const shouldCreateSession = options?.createIfNeeded && session == null;
@@ -269,6 +317,7 @@ export class CloudIntegrationAuthenticationProvider<
 
 	private async getCloudSession(
 		descriptor: IntegrationAuthenticationSessionDescriptor,
+		options?: { refreshRejectedToken?: boolean },
 	): Promise<ProviderAuthenticationSession | undefined> {
 		const loggedIn = (await this.authenticationService.ctx.account.getAccount()) != null;
 		if (!loggedIn) return undefined;
@@ -304,7 +353,13 @@ export class CloudIntegrationAuthenticationProvider<
 			session.expiresIn = maxSmallIntegerV8; // maximum expiration length
 		}
 
-		if (session != null && session.expiresIn < 60) {
+		// `expiresIn < 60` is a PREDICTION that the token is about to lapse, and it is the only trigger the
+		// refresh used to have. It cannot see a token the provider has already refused while the backend
+		// still believes it is valid — a revoked grant, retired scopes, an app removed from the org — where
+		// `expiresIn` stays high and the doomed token is re-sent on every read. `refreshRejectedToken` is
+		// the observed counterpart: the caller saw the provider reject this exact token, so refresh it
+		// regardless of what its expiry claims.
+		if (session != null && (session.expiresIn < 60 || options?.refreshRejectedToken)) {
 			session = await cloudIntegrations.getConnectionSession(
 				this.authProviderId,
 				session.accessToken,

--- a/packages/plus/integrations/src/models/gitHostIntegration.ts
+++ b/packages/plus/integrations/src/models/gitHostIntegration.ts
@@ -373,7 +373,10 @@ export abstract class GitHostIntegration<
 			this.resetRequestExceptionCount('getOrganizationsForUser');
 			return { value: result, duration: performance.now() - start };
 		} catch (ex) {
-			this.handleProviderException('getOrganizationsForUser', ex, { scope: scope });
+			this.handleProviderException('getOrganizationsForUser', ex, {
+				scope: scope,
+				connectionId: connectionId,
+			});
 			return { error: toError(ex), duration: performance.now() - start };
 		}
 	}
@@ -409,7 +412,7 @@ export abstract class GitHostIntegration<
 			this.resetRequestExceptionCount('getProjectsForOrg');
 			return { value: result, duration: performance.now() - start };
 		} catch (ex) {
-			this.handleProviderException('getProjectsForOrg', ex, { scope: scope });
+			this.handleProviderException('getProjectsForOrg', ex, { scope: scope, connectionId: connectionId });
 			return { error: toError(ex), duration: performance.now() - start };
 		}
 	}
@@ -446,7 +449,10 @@ export abstract class GitHostIntegration<
 			this.resetRequestExceptionCount('getRepositoriesForOrg');
 			return { value: result, duration: performance.now() - start };
 		} catch (ex) {
-			this.handleProviderException('getRepositoriesForOrg', ex, { scope: scope });
+			this.handleProviderException('getRepositoriesForOrg', ex, {
+				scope: scope,
+				connectionId: options?.connectionId,
+			});
 			return { error: toError(ex), duration: performance.now() - start };
 		}
 	}
@@ -484,7 +490,10 @@ export abstract class GitHostIntegration<
 			this.resetRequestExceptionCount('getRepositoriesForUser');
 			return { value: result, duration: performance.now() - start };
 		} catch (ex) {
-			this.handleProviderException('getRepositoriesForUser', ex, { scope: scope });
+			this.handleProviderException('getRepositoriesForUser', ex, {
+				scope: scope,
+				connectionId: options?.connectionId,
+			});
 			return { error: toError(ex), duration: performance.now() - start };
 		}
 	}
@@ -1414,6 +1423,7 @@ export abstract class GitHostIntegration<
 			this.handleProviderException('searchMyPullRequests', ex, {
 				scope: scope,
 				silent: true,
+				connectionId: connectionId,
 			});
 			return {
 				error: toError(ex),
@@ -1456,7 +1466,10 @@ export abstract class GitHostIntegration<
 			this.resetRequestExceptionCount('getMyPullRequestsForUser');
 			return { value: result, duration: performance.now() - start };
 		} catch (ex) {
-			this.handleProviderException('getMyPullRequestsForUser', ex, { scope: scope });
+			this.handleProviderException('getMyPullRequestsForUser', ex, {
+				scope: scope,
+				connectionId: connectionId,
+			});
 			return { error: toError(ex), duration: performance.now() - start };
 		}
 	}
@@ -1588,7 +1601,7 @@ export abstract class GitHostIntegration<
 			this.resetRequestExceptionCount('searchPullRequests');
 			return prs;
 		} catch (ex) {
-			this.handleProviderException('searchPullRequests', ex, { scope: scope });
+			this.handleProviderException('searchPullRequests', ex, { scope: scope, connectionId: connectionId });
 			return undefined;
 		}
 	}

--- a/packages/plus/integrations/src/models/integration.ts
+++ b/packages/plus/integrations/src/models/integration.ts
@@ -240,15 +240,26 @@ export abstract class IntegrationBase<
 		// A truthy connectionId targets a specific account; an empty string is not a real target, so it falls
 		// through to the primary path below.
 		if (connectionId) {
+			// A read of this connection previously failed with an AuthenticationError, so the token in
+			// storage is known-refused. Ask for a refresh through the GK cloud before reading again, which
+			// is this branch's equivalent of the primary path's `refreshSessionIfExpired`. Claimed here so
+			// the forced refresh runs at most once per rejection.
+			const refreshRejectedToken = this.takeRejectedTokenRefresh(connectionId);
 			// Degrade to "no results" on failure, matching the primary path (whose ensureSession/
 			// refreshSessionIfExpired swallow errors) so read methods keep their never-throws contract.
 			try {
 				const authProvider = await this.authenticationService.get(this.authProvider.id);
 				const session = await authProvider.getSession(
 					{ ...this.authProviderDescriptor, connectionId: connectionId, cloud: true },
-					{ source: source },
+					{ source: source, refreshRejectedToken: refreshRejectedToken },
 				);
-				return session != null && this.isSessionForIntegrationHost(session) ? session : undefined;
+				if (session == null || !this.isSessionForIntegrationHost(session)) return undefined;
+
+				// Record which credential this read carries: the exception handler sees only the error, so
+				// this is what lets it name the token the provider refused. It also retires a rejection the
+				// refresh actually resolved — see `_rejectedTokenByConnection`.
+				this.settleRejectedToken(connectionId, session.accessToken);
+				return session;
 			} catch (ex) {
 				scope?.error(ex);
 				return undefined;
@@ -343,6 +354,53 @@ export abstract class IntegrationBase<
 	requestSessionSyncForUsecase(syncReqUsecase: SyncReqUsecase): void {
 		this._syncRequestsPerFailedUsecase.add(syncReqUsecase);
 	}
+
+	/**
+	 * The token each connection's last read was handed, keyed by connection id. Recorded by
+	 * {@link resolveReadSession} so {@link handleProviderException} — which sees only the error — can name
+	 * the credential the provider actually refused.
+	 */
+	private readonly _lastReadTokenByConnection = new Map<string, string>();
+
+	/**
+	 * Connections whose cloud token the provider rejected with an {@link AuthenticationError}: the token it
+	 * refused, and whether the recovery refresh has already been tried for it. The per-connection
+	 * counterpart of the primary session's expire-and-resync recovery — a rejected token is refreshed
+	 * through the GK cloud's `/refresh` endpoint, which exchanges the refresh token server-side (the client
+	 * never holds one).
+	 *
+	 * The recorded token is what makes this converge. Keyed on the connection alone, the entry would be
+	 * re-armed by the very failure that follows the refresh and the refresh would fire again on every other
+	 * read, forever. Instead {@link resolveReadSession} drops the entry only once the credential actually
+	 * CHANGED (the refresh produced a new token, so the connection is healed and a later rejection may
+	 * refresh again), and a rejection arriving while an entry is already held falls through to
+	 * {@link trackRequestException} — a token still refused after its refresh is not self-healing, so it
+	 * belongs to the failure budget that ends in a reconnect prompt.
+	 */
+	private readonly _rejectedTokenByConnection = new Map<string, { token: string; refreshAttempted: boolean }>();
+
+	/**
+	 * Resolves what a read of `connectionId` should do about a previously rejected token: whether to force
+	 * the cloud refresh, and (afterwards) whether the credential changed. Called by
+	 * {@link resolveReadSession}, which owns the ordering — the decision has to be made before the session
+	 * is resolved and the comparison after.
+	 */
+	private takeRejectedTokenRefresh(connectionId: string): boolean {
+		const rejected = this._rejectedTokenByConnection.get(connectionId);
+		if (rejected == null || rejected.refreshAttempted) return false;
+
+		rejected.refreshAttempted = true;
+		return true;
+	}
+
+	/** Retires the rejection once `token` differs from the one the provider refused. */
+	private settleRejectedToken(connectionId: string, token: string): void {
+		const rejected = this._rejectedTokenByConnection.get(connectionId);
+		if (rejected != null && rejected.token !== token) {
+			this._rejectedTokenByConnection.delete(connectionId);
+		}
+		this._lastReadTokenByConnection.set(connectionId, token);
+	}
 	private static readonly requestExceptionLimit = 5;
 	private requestExceptionCount = 0;
 
@@ -350,6 +408,11 @@ export abstract class IntegrationBase<
 		this.requestExceptionCount = 0;
 		if (syncReqUsecase === 'all') {
 			this._syncRequestsPerFailedUsecase.clear();
+			// 'all' is the whole-integration reset (a disconnect, or a forced re-sync that produced a new
+			// access token). Either way every stored token is replaced or gone, so a rejection recorded
+			// against the tokens that preceded it no longer describes anything.
+			this._rejectedTokenByConnection.clear();
+			this._lastReadTokenByConnection.clear();
 		} else {
 			this._syncRequestsPerFailedUsecase.delete(syncReqUsecase);
 		}
@@ -474,11 +537,37 @@ export abstract class IntegrationBase<
 	protected handleProviderException(
 		syncReqUsecase: SyncReqUsecase,
 		ex: Error,
-		options?: { scope?: ScopedLogger | undefined; silent?: boolean },
+		options?: { scope?: ScopedLogger | undefined; silent?: boolean; connectionId?: string },
 	): void {
 		if (isCancellationError(ex)) return;
 
 		options?.scope?.error(ex);
+
+		// A per-connection (multi-account) read resolved its session through `resolveReadSession`'s
+		// `connectionId` branch, which deliberately never touches the cached primary `_session`. So the
+		// primary-session recovery below cannot apply to it: expiring `_session` would mark a session this
+		// read never used, while the rejected connection kept its stored token and re-sent it on every
+		// later read — a token the provider has already refused (expired scopes, a revoked grant, an
+		// uninstalled app) is not self-healing, so the read failed identically until the user reconnected
+		// by hand. Record the rejection against the connection instead; `resolveReadSession` consumes it
+		// and forces the cloud `/refresh` on the next read of that connection.
+		if (ex instanceof AuthenticationError && options?.connectionId) {
+			const rejectedToken = this._lastReadTokenByConnection.get(options.connectionId);
+			if (rejectedToken != null && !this._rejectedTokenByConnection.has(options.connectionId)) {
+				this._rejectedTokenByConnection.set(options.connectionId, {
+					token: rejectedToken,
+					refreshAttempted: false,
+				});
+				return;
+			}
+
+			// Either the refresh already ran for this connection and its token was refused again, or the
+			// read never resolved a session to attribute. Neither is a stale-token blip, so fall through to
+			// the shared failure budget, which disconnects after `requestExceptionLimit` and surfaces the
+			// reconnect prompt.
+			this.trackRequestException(options);
+			return;
+		}
 
 		if (ex instanceof AuthenticationError && this._session?.cloud) {
 			if (!this.hasSessionSyncRequests()) {
@@ -686,7 +775,7 @@ export abstract class IntegrationBase<
 			this.resetRequestExceptionCount('searchMyIssues');
 			return { value: issues };
 		} catch (ex) {
-			this.handleProviderException('searchMyIssues', ex, { scope: scope });
+			this.handleProviderException('searchMyIssues', ex, { scope: scope, connectionId: connectionId });
 			return { error: toError(ex) };
 		}
 	}
@@ -738,7 +827,7 @@ export abstract class IntegrationBase<
 			this.resetRequestExceptionCount('searchMyIssues');
 			return { value: result };
 		} catch (ex) {
-			this.handleProviderException('searchMyIssues', ex, { scope: scope });
+			this.handleProviderException('searchMyIssues', ex, { scope: scope, connectionId: connectionId });
 			return { error: toError(ex) };
 		}
 	}
@@ -858,7 +947,10 @@ export abstract class IntegrationBase<
 							return undefined;
 						}
 
-						this.handleProviderException('getCurrentAccount', ex, { scope: scope });
+						this.handleProviderException('getCurrentAccount', ex, {
+							scope: scope,
+							connectionId: connectionId,
+						});
 
 						// Invalidate the cache on error, except for auth errors
 						if (!(ex instanceof AuthenticationError)) {

--- a/packages/plus/integrations/src/models/issuesIntegration.ts
+++ b/packages/plus/integrations/src/models/issuesIntegration.ts
@@ -48,7 +48,7 @@ export abstract class IssuesIntegration<
 			this.resetRequestExceptionCount('getAccountForResource');
 			return { value: account };
 		} catch (ex) {
-			this.handleProviderException('getAccountForResource', ex);
+			this.handleProviderException('getAccountForResource', ex, { connectionId: connectionId });
 			return { error: toError(ex) };
 		}
 	}
@@ -80,7 +80,7 @@ export abstract class IssuesIntegration<
 			this.resetRequestExceptionCount('getResourcesForUser');
 			return { value: resources };
 		} catch (ex) {
-			this.handleProviderException('getResourcesForUser', ex);
+			this.handleProviderException('getResourcesForUser', ex, { connectionId: connectionId });
 			return { error: toError(ex) };
 		}
 	}
@@ -108,7 +108,7 @@ export abstract class IssuesIntegration<
 			this.resetRequestExceptionCount('getProjectsForResources');
 			return { value: projects };
 		} catch (ex) {
-			this.handleProviderException('getProjectsForResources', ex);
+			this.handleProviderException('getProjectsForResources', ex, { connectionId: connectionId });
 			return { error: toError(ex) };
 		}
 	}
@@ -161,7 +161,7 @@ export abstract class IssuesIntegration<
 			this.resetRequestExceptionCount('getIssuesForProject');
 			return { value: issues };
 		} catch (ex) {
-			this.handleProviderException('getIssuesForProject', ex);
+			this.handleProviderException('getIssuesForProject', ex, { connectionId: connectionId });
 			return { error: toError(ex) };
 		}
 	}
@@ -188,7 +188,7 @@ export abstract class IssuesIntegration<
 			this.resetRequestExceptionCount('getIssuesForProject');
 			return { value: result };
 		} catch (ex) {
-			this.handleProviderException('getIssuesForProject', ex);
+			this.handleProviderException('getIssuesForProject', ex, { connectionId: connectionId });
 			return { error: toError(ex) };
 		}
 	}


### PR DESCRIPTION
## The bug

A cloud token could be refreshed only by **prediction**. `getCloudSession` asks the GK cloud's `/refresh` endpoint when `expiresIn < 60`:

```ts
// integrationAuthenticationProvider.ts
if (session != null && session.expiresIn < 60) {
    session = await cloudIntegrations.getConnectionSession(id, session.accessToken, connectionId);
}
```

That never fires for a token the provider has already **refused** while the backend still believes it is valid: a revoked grant, retired scopes, an app removed from the org. `expiresIn` stays high, the condition is false, and the doomed token is re-sent on every read. The failure clears only when the user reconnects by hand.

## Why the existing reactive recovery does not cover it

`handleProviderException` does react to an `AuthenticationError` — it expires the cached primary `_session` so the next read re-resolves:

```ts
this._session = { ...this._session, expiresAt: new Date(Date.now() - 1) };
```

But a per-connection (multi-account) read never consults `_session`. `resolveReadSession`'s `connectionId` branch resolves through `authProvider.getSession` and deliberately leaves the primary alone (its own comment: *"WITHOUT disturbing the cached primary `_session`"*). So for any read pinned to a connection, the recovery marked a session the read had not used, while the rejected connection kept its stored token.

The mechanism predates multi-account; it just ended up pointing at the wrong object.

## The fix

Record the rejection **against the connection**, keyed on the token that was refused, and force the refresh on the next read of that connection.

Keying on the token is what makes it converge. Keyed on the connection alone, the entry would be re-armed by the very failure that follows the refresh, and the refresh would fire on every other read forever against a token that will never be accepted. A token still refused after its refresh falls through to `trackRequestException` — the existing failure budget that disconnects after `requestExceptionLimit` and surfaces the reconnect prompt.

**No refresh token is involved on the client.** `/refresh` takes only the access token in hand; the GK cloud performs the OAuth exchange server-side and `ProviderTokensGetResponse` never returns a refresh token. This PR needs no new credential access.

## Scope

- Reads on the **primary-session path are untouched** — their expire-and-resync recovery already works. The change is additive.
- `connectionId` is passed only at the sites that actually resolved a per-connection session (11 of the 26 `handleProviderException` call sites). The other 15 use `this._session!` + `refreshSessionIfExpired` and keep today's behavior byte-for-byte.
- `refreshRejectedToken` is optional throughout, so no existing caller changes.

## Behavior

| Scenario | Before | After |
|---|---|---|
| Token expiring within 60s | refreshed | refreshed (unchanged) |
| Token rejected, expiry still valid | never refreshed, read fails until manual reconnect | refreshed once on the next read |
| Rejected again after its refresh | — | falls through to the failure budget → reconnect prompt |
| Refresh produced a new token | — | rejection retires; a later rejection can refresh again |
| Healthy token | untouched | untouched |

## Tests

Four regression tests in `src/__tests__/rejectedTokenRefresh.test.ts`, driving the whole chain (read → `AuthenticationError` → per-connection rejection → forced refresh) through a fake `fetchGkApi`, so what is asserted is the actual `POST v1/provider-tokens/tokens/{id}/refresh` reaching the wire.

The third test is worth a look: it pins the convergence property above. An earlier draft of this change keyed the rejection on the connection alone and that test caught it firing a refresh every other read indefinitely.

**573 passing, 0 failing** (569 before + 4 new). `tsc -b`, `oxlint` and `oxfmt --check` clean.

One note for anyone extending these tests: the test runner bundles with esbuild, which does **not** typecheck — an earlier revision passed all tests with a broken type-only import that only `tsc -b` caught. Worth running both.

## Context

Found while investigating a Kepler report where GitLab emitted `credentials are either invalid or expired` on every provider read for over three hours straight, never recovering and never disconnecting. It is also the root cause of a misleading "Couldn't refresh — something went wrong" banner there: the unrefreshed token made an org drain fail, which surfaced as a derived `kind: 'other'` truncation warning.

Kepler's own auth-health layer fires a targeted `refresh({providers})` immediately on an auth warning, which reaches `resolveReadSession` with `forceSync` — so with this fix that retry path starts working end to end rather than re-sending the same dead token.
