### PR TITLE
Applies review exclusions while collecting the diff

### DIFF
--- a/src/webviews/plus/graph/__tests__/graphInspectServices.test.ts
+++ b/src/webviews/plus/graph/__tests__/graphInspectServices.test.ts
@@ -14,11 +14,22 @@ import type { GraphInspectService, ScopeSelection } from '../graphService.js';
 // index change that would mark its own result stale (#5605).
 
 type DiffForScopeResult = { diff: string; message: string; context: string } | undefined;
-type GetDiffForScope = (repoPath: string, scope: ScopeSelection, signal?: AbortSignal) => Promise<DiffForScopeResult>;
+type GetDiffForScope = (
+	repoPath: string,
+	scope: ScopeSelection,
+	excluded: Set<string> | undefined,
+	signal?: AbortSignal,
+) => Promise<DiffForScopeResult>;
 
-function invoke(fakeThis: unknown, scope: ScopeSelection, signal?: AbortSignal): Promise<DiffForScopeResult> {
+/** Argument order mirrors `getDiffForScope` itself, so a call here reads the same as the real one. */
+function invoke(
+	fakeThis: unknown,
+	scope: ScopeSelection,
+	excluded?: Set<string>,
+	signal?: AbortSignal,
+): Promise<DiffForScopeResult> {
 	const fn = (GraphInspectServices.prototype as unknown as { getDiffForScope: GetDiffForScope }).getDiffForScope;
-	return fn.call(fakeThis, '/repo', scope, signal);
+	return fn.call(fakeThis, '/repo', scope, excluded, signal);
 }
 
 function wipScope(o: { includeUnstaged?: boolean; includeStaged?: boolean }): ScopeSelection {
@@ -180,6 +191,39 @@ suite('graphInspectServices — getDiffForScope untracked handling (#5586, #5604
 		assert.deepStrictEqual(m.order, ['getUntracked', 'diff:unstaged']);
 	});
 
+	// Fix under test (#5630): the exclusion set is consulted while collecting, so an excluded untracked
+	// path is never staged and its contents are never read into the diff — instead of being staged,
+	// diffed, and then dropped from the assembled text.
+	test('does not stage an excluded untracked path', async () => {
+		const m = createMocks({
+			untracked: ['new.txt', 'nested-repo/'],
+			unstagedDiff: 'diff --git a/new.txt b/new.txt\n',
+		});
+
+		// `nested-repo` without the trailing slash git reports — the shapes have to match normalized.
+		await invoke(m.fakeThis, wipScope({ includeUnstaged: true }), new Set(['nested-repo']));
+
+		sinon.assert.calledOnceWithExactly(m.stageFiles, ['new.txt'], { index: m.tempIndex, intentToAdd: true });
+		// The unexcluded file still needs the scratch index, so the rest of the sequence is unchanged.
+		sinon.assert.calledWithExactly(m.getDiff, uncommitted, undefined, { index: m.tempIndex });
+		assert.deepStrictEqual(m.order, ['getUntracked', 'createIndex', 'stage', 'diff:unstaged', 'dispose']);
+	});
+
+	test('does not create a scratch index when every untracked path is excluded', async () => {
+		const m = createMocks({
+			untracked: ['new.txt', 'nested-repo/'],
+			unstagedDiff: 'diff --git a/tracked.txt b/tracked.txt\n',
+		});
+
+		// Already-normalized, as `getNormalizedExclusions` hands it over.
+		await invoke(m.fakeThis, wipScope({ includeUnstaged: true }), new Set(['new.txt', 'nested-repo']));
+
+		sinon.assert.notCalled(m.createTemporaryIndex);
+		sinon.assert.notCalled(m.stageFiles);
+		sinon.assert.calledWithExactly(m.getDiff, uncommitted, undefined, undefined);
+		assert.deepStrictEqual(m.order, ['getUntracked', 'diff:unstaged']);
+	});
+
 	test('does not touch untracked files for a staged-only scope', async () => {
 		const m = createMocks({ untracked: ['new.txt'], stagedDiff: 'diff --git a/tracked.txt b/tracked.txt\n' });
 
@@ -277,7 +321,7 @@ suite('graphInspectServices — getDiffForScope untracked handling (#5586, #5604
 			disposeError: new Error('EBUSY: temp dir locked'),
 		});
 		await assert.rejects(
-			invoke(c.fakeThis, wipScope({ includeUnstaged: true }), ac.signal),
+			invoke(c.fakeThis, wipScope({ includeUnstaged: true }), undefined, ac.signal),
 			(ex: Error) => !ex.message.includes('EBUSY'),
 			'the cancellation must surface, not the cleanup error',
 		);
@@ -287,7 +331,7 @@ suite('graphInspectServices — getDiffForScope untracked handling (#5586, #5604
 		const ac = new AbortController();
 		const m = createMocks({ untracked: ['new.txt'], unstagedDiff: 'x', abortOnStage: ac });
 
-		await assert.rejects(invoke(m.fakeThis, wipScope({ includeUnstaged: true }), ac.signal));
+		await assert.rejects(invoke(m.fakeThis, wipScope({ includeUnstaged: true }), undefined, ac.signal));
 
 		// Staging into the scratch index ran and the scratch index was disposed, but the abort was honored
 		// before the diff was requested.
@@ -370,11 +414,12 @@ function createReviewFake() {
 	// is a getter over the injected context, so it's fed through `context`.
 	// `buildChangesContext` is shadowed to keep the AI-context gather out of the test.
 	const noopEvent = { subscribe: () => () => {} };
+	const diffCache = new LruMap<string, { diff: string; message: string; context: string }>(4);
 	const fakeThis = Object.assign(Object.create(GraphInspectServices.prototype) as object, {
 		context: { container: container },
 		buildChangesContext: async () => '',
 		_aiCancellations: new Set(),
-		_graphDetailsDiffCache: new LruMap(4),
+		_graphDetailsDiffCache: diffCache,
 		_reviewHistoryCache: new LruMap(4),
 		_composeProgressEvent: noopEvent,
 		_resolveProgressEvent: noopEvent,
@@ -384,7 +429,12 @@ function createReviewFake() {
 		fakeThis,
 	);
 
-	return { graphInspect: graphInspect, reviewChanges: reviewChanges, reviewFocusArea: reviewFocusArea };
+	return {
+		graphInspect: graphInspect,
+		reviewChanges: reviewChanges,
+		reviewFocusArea: reviewFocusArea,
+		diffCache: diffCache,
+	};
 }
 
 function reviewedDiff(stub: sinon.SinonStub): string {
@@ -448,6 +498,32 @@ suite('graphInspectServices — review exclusions across path shapes (#5603)', (
 		const diff = reviewedDiff(m.reviewFocusArea);
 		assert.ok(!diff.includes('nested-repo'), 'the excluded nested repository must not reach the AI');
 		assert.ok(diff.includes('changed.txt'), 'the focus area still covers its included file');
+	});
+
+	// Fix under test (#5630): the diff-cache key is built from the same normalized set the filters
+	// compare, so two spellings of one logical exclusion don't each take a slot in an LRU sized for
+	// only a couple of `excludedFiles` variants — holding byte-identical filtered diffs.
+	test('two spellings of the same exclusion share one diff-cache entry', async () => {
+		const m = createReviewFake();
+		const scope = wipScope({ includeUnstaged: true });
+
+		await m.graphInspect.reviewChanges('/repo', scope, undefined, ['nested-repo/']);
+		const [firstKey] = [...m.diffCache.keys()];
+
+		await m.graphInspect.reviewChanges('/repo', scope, undefined, ['nested-repo']);
+
+		assert.strictEqual(m.diffCache.size, 1, 'the un-normalized spelling should not add a second entry');
+		assert.deepStrictEqual([...m.diffCache.keys()], [firstKey]);
+	});
+
+	test('a genuinely different exclusion set still gets its own diff-cache entry', async () => {
+		const m = createReviewFake();
+		const scope = wipScope({ includeUnstaged: true });
+
+		await m.graphInspect.reviewChanges('/repo', scope, undefined, ['nested-repo/']);
+		await m.graphInspect.reviewChanges('/repo', scope, undefined, ['new.txt']);
+
+		assert.strictEqual(m.diffCache.size, 2);
 	});
 });
 

--- a/src/webviews/plus/graph/graphInspectServices.ts
+++ b/src/webviews/plus/graph/graphInspectServices.ts
@@ -247,7 +247,10 @@ export class GraphInspectServices {
 	);
 	/** Completed exchanges of the active review conversation per diff-cache key (oldest first).
 	 *  Replayed on `mode: 'refine'` requests so the AI sees the prior review as a conversation to
-	 *  follow up on. Kept in lockstep with `_graphDetailsDiffCache` — same keying, same reset. */
+	 *  follow up on. Same keying and same reset as `_graphDetailsDiffCache`, but not the same
+	 *  contents: `reviewFocusArea` populates the diff cache without recording an exchange, so the two
+	 *  can hold different key sets and evict independently. Anything written to the diff cache must
+	 *  therefore already be exclusion-filtered — a refine trusts whatever key it finds there. */
 	private readonly _reviewHistoryCache = new LruMap<string, { instructions?: string; result: AIReviewResult }[]>(
 		GraphInspectServices._diffCacheCap,
 	);
@@ -767,28 +770,19 @@ export class GraphInspectServices {
 							this._graphDetailsDiffCache.delete(diffCacheKey);
 						}
 
+						const excluded = this.getNormalizedExclusions(excludedFiles);
+
 						const cachedData = followUp != null ? this._graphDetailsDiffCache.get(diffCacheKey) : undefined;
-						const data = cachedData ?? (await this.getDiffForScope(repoPath, scope, signal));
+						const data = cachedData ?? (await this.getDiffForScope(repoPath, scope, excluded, signal));
 						if (!data) return { error: { message: 'No changes found.' } };
 
 						if (cachedData == null) {
-							// Filter out user-excluded files before review (cached entries are already filtered).
-							// Normalized on both sides: git reports an untracked directory that is itself a
-							// repository with a trailing slash (`nested-repo/`), which is the path the Files
-							// Changed rows — and so the exclusion set — carry, but staging it intent-to-add lands
-							// it in the diff as a gitlink named without one. An exact compare never matches.
-							const excluded = excludedFiles?.length
-								? new Set(excludedFiles.map(normalizePath))
-								: undefined;
-							if (excluded?.size) {
-								const { filterDiffFiles } = await loadChunk(
-									() => import(/* webpackChunkName: "ai" */ '@gitlens/git/parsers/diffParser.js'),
-								);
-								data.diff = await filterDiffFiles(data.diff, paths =>
-									paths.filter(p => !excluded.has(normalizePath(p))),
-								);
-								signal?.throwIfAborted();
-
+							// Drop anything excluded that still made it into the diff (cached entries are already
+							// filtered). `getDiffForScope` already kept excluded untracked files out of the
+							// collection, so this covers what it can't: tracked working-tree files, and
+							// commit/compare diffs.
+							if (excluded != null) {
+								data.diff = await this.filterExcludedFromDiff(data.diff, excluded, signal);
 								if (!data.diff?.trim()) return { error: { message: 'No changes found.' } };
 							}
 
@@ -904,20 +898,26 @@ export class GraphInspectServices {
 
 						const reviewType = this.getReviewTypeForScope(scope);
 						const diffCacheKey = this.getDiffCacheKey(repoPath, scope, excludedFiles);
+						const excluded = this.getNormalizedExclusions(excludedFiles);
+
 						const cachedData = this._graphDetailsDiffCache.get(diffCacheKey);
-						const data = cachedData ?? (await this.getDiffForScope(repoPath, scope, signal));
+						const data = cachedData ?? (await this.getDiffForScope(repoPath, scope, excluded, signal));
 						if (!data) return { error: { message: 'No changes found for this focus area.' } };
 
 						if (cachedData == null) {
+							// Exclusion-filter before caching, matching what `reviewChanges` stores under this
+							// same key. The focus-area filter below would keep excluded files out of *this*
+							// request's prompt regardless, but a cache entry that still carried them would be
+							// handed to a later `reviewChanges` refine, which trusts cached entries as filtered.
+							data.diff = await this.filterExcludedFromDiff(data.diff, excluded, signal);
 							this._graphDetailsDiffCache.set(diffCacheKey, data);
 						} else {
 							this._graphDetailsDiffCache.touch(diffCacheKey);
 						}
 
 						// Filter diff to only include focus area files, excluding user-excluded files. Both
-						// sides normalized — the focus-area list names diff paths (no trailing slash) while the
-						// exclusion set can carry one; see the `reviewChanges` filter above.
-						const excluded = excludedFiles?.length ? new Set(excludedFiles.map(normalizePath)) : undefined;
+						// sides normalized — the focus-area list names diff paths, so it has to be put in the
+						// same shape as the exclusion set (see `getNormalizedExclusions`) before they can meet.
 						const { filterDiffFiles } = await loadChunk(
 							() => import(/* webpackChunkName: "ai" */ '@gitlens/git/parsers/diffParser.js'),
 						);
@@ -2703,12 +2703,45 @@ export class GraphInspectServices {
 		}
 	}
 
+	/** The user's excluded paths in the one shape everything downstream compares against: normalized,
+	 *  so the `nested-repo/` git reports and the `nested-repo` a diff names are one entry (#5603), and
+	 *  deduped as a result. `undefined` when nothing is excluded. */
+	private getNormalizedExclusions(excludedFiles: readonly string[] | undefined): Set<string> | undefined {
+		if (!excludedFiles?.length) return undefined;
+
+		return new Set(excludedFiles.map(normalizePath));
+	}
+
 	private getDiffCacheKey(repoPath: string, scope: ScopeSelection, excludedFiles?: readonly string[]): string {
+		// Keyed on the normalized set so it matches what the filters compare — two spellings of one
+		// logical exclusion would otherwise each take a slot in an LRU sized for a couple of
+		// `excludedFiles` variants, holding byte-identical filtered diffs.
+		const excluded = this.getNormalizedExclusions(excludedFiles);
 		return JSON.stringify({
 			repoPath: repoPath,
 			scope: scope,
-			excludedFiles: excludedFiles?.toSorted(),
+			excludedFiles: excluded != null ? [...excluded].sort() : undefined,
 		});
+	}
+
+	/** Drops the user's excluded paths from an assembled diff — the backstop for content that can't be
+	 *  kept out of the collection in the first place: tracked working-tree files, and commit/compare
+	 *  diffs. `getDiffForScope` handles untracked files earlier, before they're staged and read.
+	 *  Returns `diff` unchanged when nothing is excluded. */
+	private async filterExcludedFromDiff(
+		diff: string,
+		excluded: Set<string> | undefined,
+		signal?: AbortSignal,
+	): Promise<string> {
+		if (!excluded?.size) return diff;
+
+		const { filterDiffFiles } = await loadChunk(
+			() => import(/* webpackChunkName: "ai" */ '@gitlens/git/parsers/diffParser.js'),
+		);
+		const filtered = await filterDiffFiles(diff, paths => paths.filter(p => !excluded.has(normalizePath(p))));
+		signal?.throwIfAborted();
+
+		return filtered;
 	}
 
 	/** Records a completed review exchange for follow-up (refine) replay — appending to the
@@ -2724,9 +2757,13 @@ export class GraphInspectServices {
 		this._reviewHistoryCache.set(cacheKey, exchanges);
 	}
 
+	/** @param excluded Normalized exclusion set (see `getNormalizedExclusions`). Consulted while
+	 *  *collecting* the diff so excluded untracked content is never staged or read — the assembled diff
+	 *  is still exclusion-filtered by the caller for everything a collection-time filter can't cover. */
 	private async getDiffForScope(
 		repoPath: string,
 		scope: ScopeSelection,
+		excluded: Set<string> | undefined,
 		signal?: AbortSignal,
 	): Promise<{ diff: string; message: string; context: string } | undefined> {
 		const svc = this.container.git.getRepositoryService(repoPath);
@@ -2843,6 +2880,15 @@ export class GraphInspectServices {
 					let untrackedPaths: string[] | undefined;
 					try {
 						untrackedPaths = (await svc.status.getUntrackedFiles(signal)).map(f => f.path);
+						// Drop excluded paths before staging rather than after diffing: the contents of a file
+						// the user explicitly excluded should never be read into memory at all — that's what
+						// the control means — and staging + diffing content guaranteed to be filtered out is
+						// wasted work scaling with the size of what was excluded. It also keeps `git add -N`
+						// off an excluded untracked nested repository, whose `adding embedded git repository`
+						// warning would otherwise be logged on every review.
+						if (excluded?.size) {
+							untrackedPaths = untrackedPaths.filter(p => !excluded.has(normalizePath(p)));
+						}
 					} catch (ex) {
 						// Best-effort: fall back to the plain unstaged diff rather than sinking the whole review.
 						Logger.error(ex, `Failed to enumerate untracked files for review`);


### PR DESCRIPTION
Closes #5630

## What the user saw

Uncheck a file in the Review panel's Files Changed list, start a review of working changes with a scope that includes unstaged changes, and the excluded file was still staged and diffed before being dropped. In the GitLens log you'd see `git add -N -- nested-repo/ new-untracked.txt` naming a path you had just excluded, followed by an unrestricted `git diff`. The entry was correctly absent from the final prompt — the filtering worked — but everything upstream of the filter behaved as if you'd never excluded anything.

Excluding an untracked directory that is itself a git repository made this loud: `git add -N` on it produces git's `warning: adding embedded git repository`, plus its two `hint:` lines, so those appeared in the log on *every* review.

## Why it happened

`getDiffForScope` built the whole working-tree diff and only then handed it to `filterDiffFiles`. In the `includeUnstaged` branch it enumerated every untracked path via `git ls-files --others`, staged all of them intent-to-add into the scratch index, and diffed with no pathspec. The exclusion set was never consulted during any of that — it was applied afterwards, by the callers, on the assembled diff text.

The set was available at the call site the whole time; it is already a parameter of the surrounding `reviewChanges`. It simply wasn't threaded down.

Separately, `getDiffCacheKey` put `excludedFiles?.toSorted()` into the key verbatim while the filters compared `normalizePath`d values (the #5603 fix). So `nested-repo/` and `nested-repo` — the same exclusion after normalization, and the exact pair that motivated #5603 — produced two different keys holding byte-identical filtered content, in an LRU whose own comment notes it budgets for only "a couple of variants from changing `excludedFiles` within a session".

## How it's resolved

The exclusion set is now normalized once, by a new `getNormalizedExclusions`, and threaded into `getDiffForScope` so it can be consulted while collecting rather than after.

| Change | Fixes |
| --- | --- |
| `getDiffForScope` takes the normalized set and filters `untrackedPaths` before `stageFiles` | Excluded untracked content is never staged, never read, never in the diff string |
| Same filter emptying the list short-circuits the scratch index | No `createTemporaryIndex`, no `git add -N`, so no embedded-repo warning for an excluded nested repo |
| `getDiffCacheKey` keys on the normalized set | Two spellings of one exclusion share one LRU entry |
| `filterExcludedFromDiff` extracted from the duplicated inline filter | Single place that owns the post-diff pass; also let the focus-area path reuse it (below) |

The post-diff filter is deliberately kept as the backstop for what a collection-time filter cannot cover: **excluded tracked working-tree files, and commit/compare scopes.** For those, content is still read and then filtered. See "Not covered" below.

Both parts landed in one commit rather than two, because `getDiffForScope` is private with exactly two callers and adding the parameter forces both call sites into the same commit; splitting left one of them passing an `AbortSignal` where a `Set<string>` was expected.

## Beyond the minimal fix

`reviewFocusArea` cached the diff it fetched **without** exclusion-filtering it first, while `reviewChanges` caches the filtered diff under that same key and trusts any cached entry as already filtered. `reviewFocusArea` is also the only writer that populates `_graphDetailsDiffCache` without recording an exchange in `_reviewHistoryCache`, so the two can hold different key sets and evict independently — which is what makes the bad entry reachable, since a refine only reads the diff cache when it finds matching history.

Reaching the unfiltered write needs no eviction: `excludedFiles` is read live from the panel at "analyze area" click time, so toggling a checkbox between the overview and the click is enough for a cache miss. Turning that into a prompt leak additionally needs history for that key to have survived an eviction of its diff entry, which makes it narrow but not unreachable.

`reviewFocusArea` now filters before caching. The `_reviewHistoryCache` doc comment claiming the two caches are "kept in lockstep" is corrected to state the real invariant — anything entering the diff cache must already be filtered.

## Impact

Low, and worth stating precisely: **nothing leaked to the AI provider.** The filter ran before the prompt was built, and I verified via the AI simulator's captured messages that no excluded path reached it. What was wrong is that excluded content was collected into extension memory at all, plus avoidable work and log noise — a gap between what a privacy-facing control implies and what it did. The `reviewFocusArea` cache defect above is the one path that could have put excluded content into a prompt; it needed a specific sequence and I have not reproduced it live, only traced it.

## Tests

Added to `graphInspectServices.test.ts`:

- an excluded untracked path is not passed to `stageFiles`, and the rest of the sequence is unchanged for the file that remains
- when every untracked path is excluded, no scratch index is created and the plain unstaged diff is used
- two spellings of one exclusion share a single diff-cache entry
- a genuinely different exclusion set still gets its own entry

**Not covered:** the `reviewFocusArea` cache-contamination sequence — it needs a multi-step exclusion/eviction dance across two LRUs that the existing prototype-backed fake isn't shaped to drive, and I chose not to add a production seam just to reach it. The fix there is a one-line reuse of the same filter both other paths use.

**Testing caveat, stated plainly:** `pnpm run test` cannot complete in my environment — `vscode-test` downloads VS Code but the extraction is missing `workbench.html` so the host never launches, and mocha isn't resolvable at the repo root so the workspace-package leg errors with "No test files found". Both are environment problems, unrelated to this change. I verified the suite by running the built `out/tests/.../graphInspectServices.test.js` bundle through a throwaway driver supplying mocha's tdd globals: 23 passing, 0 failing. `pnpm run build` and `pnpm run check` are clean on the committed state. **Worth re-running `pnpm run test` normally before merge.**

## Not covered

Excluded **tracked** working-tree files, and commit/compare scopes, are still fully diffed and then filtered. The issue offers "a pathspec-limited diff" as the alternative fix that would close this. I verified it is viable — exclude-only pathspecs work for both files and directories on git 2.55 and need no accompanying positive pathspec, and `getDiff`'s `uris` option preserves the pathspec magic prefix because `hasSchemeRegex` requires a leading letter — but it changes the git invocation on a Pro AI path and I could not exercise the feature end-to-end here, so I left it out rather than ship it unverified. Happy to follow up if wanted.

## Validation

1. In a repo with working changes, create an untracked nested repository (`git init nested-repo`, commit inside it) and a plain untracked file.
2. Open the Review panel on Working Changes with a scope including unstaged changes.
3. Uncheck the `nested-repo` row and start the review.
4. In the GitLens log, `git add -N` should now list only the untracked paths you left checked, and `nested-repo/` should be absent — along with git's `adding embedded git repository` warning and its two hints.
5. Uncheck every untracked row and review again: no `createTemporaryIndex` and no `git add -N` at all, and the review still covers your tracked changes.
6. For the cache: run a review excluding a path with a trailing slash, then again with the same path spelled without one. Both runs should now share one diff-cache entry.

## Related

#5603, #5604, #5605, #5611, #5614 — same feature area; #5630 was found while verifying those on `main`. The scratch-index work from #5614 is what kept this harmless to the repository index.
