### PR TITLE
ci: name pre-release early-exit step for readability

### DIFF
--- a/.github/workflows/cd-pre.yml
+++ b/.github/workflows/cd-pre.yml
@@ -18,7 +18,8 @@ jobs:
               uses: actions/checkout@v4
               with:
                   fetch-depth: 0
-            - id: earlyexit
+            - name: Sync pre branch and detect changes
+              id: earlyexit
               run: |
                   git config user.name github-actions
                   git config user.email github-actions@github.com


### PR DESCRIPTION
## Problem

In `.github/workflows/cd-pre.yml`, the `earlyexit` helper `run` step is unnamed and longer than **300 characters**. In the GitHub Actions UI that collapses into a generic label, which hurts readability when pre-branch sync or change detection fails.

## Changes

Semantics are unchanged: same step `id`, same `GITHUB_OUTPUT` keys, and the same job output wiring (`steps.earlyexit.outputs.status` / `needs.check.outputs.status`).

- Add `name: Sync pre branch and detect changes` to `id: earlyexit`

## Test plan
- [ ] Confirm `publish` still gates on `needs.check.outputs.status == 'changed'`
- [ ] Confirm the step shows the new name in the Actions UI
