### PR TITLE
Adds a promo eyebrow to the Commit Graph header

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,8 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/) and this p
 
 ### Added
 
+- Adds a promo banner to the _Commit Graph_ header during time-limited campaigns &mdash; a centered line above the toolbar row, like the _Home_ view's banner; it shows only promotions with an expiration date (never the evergreen discount), shortens its text as the header narrows, and disappears entirely &mdash; taking no space &mdash; when no campaign is running or the header is too narrow
+
 - Adds an empty state to the _Commit Graph_ when no repository is open &mdash; offers _Open a Folder_, _Clone a Repository_, and _Start a New Project_ actions to get started; in web/virtual environments (e.g. vscode.dev) clone and new-project are replaced by an _Open Remote Repository_ action ([#5408](https://github.com/gitkraken/vscode-gitlens/issues/5408))
 - Adds an untrusted-workspace state to the _Commit Graph_ &mdash; a repository opened in a folder running in Restricted Mode previously showed the no-repository empty state; the graph now shows a _Manage Workspace Trust_ prompt instead, and refreshes to your history as soon as you grant trust
 - Adds a sign-in screen to the _Commit Graph_ for signed-out users &mdash; when no account is connected, the graph is replaced by a _Get Started with GitLens_ screen offering _Create Free Account_ and _Sign In_ actions; when the connected account's email is unverified, it shows a _Verify your email_ prompt with _Resend Email_ and _Synchronize Status_ actions instead

--- a/src/plus/gk/models/promo.ts
+++ b/src/plus/gk/models/promo.ts
@@ -3,7 +3,10 @@ import type { SubscriptionState } from '../../../constants.subscription.js';
 import type { PaidSubscriptionPlanIds } from './subscription.js';
 
 export type PromoKeys = 'pro50' | (string & {});
-export type PromoLocation = 'account' | 'badge' | 'gate' | 'home';
+export type PromoLocationV2 = 'account' | 'badge' | 'gate' | 'home';
+export type PromoLocationV3 = PromoLocationV2 | 'graph';
+export type PromoLocation = PromoLocationV3;
+
 export type PromoPlans = PaidSubscriptionPlanIds;
 
 export interface Promo {
@@ -24,6 +27,7 @@ export interface Promo {
 			};
 			readonly link?: {
 				readonly html: string;
+				readonly compactHtml?: string;
 				readonly title: string;
 				readonly command?: GlExtensionCommands;
 			};

--- a/src/plus/gk/productConfigProvider.ts
+++ b/src/plus/gk/productConfigProvider.ts
@@ -8,7 +8,7 @@ import type { GlExtensionCommands } from '../../constants.commands.js';
 import { SubscriptionState } from '../../constants.subscription.js';
 import type { Container } from '../../container.js';
 import { deviceCohortGroup } from '../../system/-webview/vscode.js';
-import type { Promo, PromoLocation, PromoPlans } from './models/promo.js';
+import type { Promo, PromoLocation, PromoLocationV2, PromoPlans } from './models/promo.js';
 import type { ServerConnection } from './serverConnection.js';
 
 type Config = {
@@ -24,6 +24,7 @@ type ConfigJson = {
 	v?: number;
 	promos?: PromoJson[];
 	promosV2?: PromoV2Json[];
+	promosV2plus?: PromoV2PlusJson[];
 	cli?: {
 		minimumCoreVersion: string;
 		minimumProxyVersion: string;
@@ -35,7 +36,13 @@ type PromoJson = Replace<Promo, 'plan' | 'expiresOn' | 'startsOn', string | unde
 };
 type PromoV2Json = Replace<Promo, 'expiresOn' | 'startsOn', string | undefined> & { v: number | undefined };
 
-const maxKnownPromoVersion = 2;
+/** promo with v=3 is tolerant to adding a new location without bumping a version.
+ * The new location won't break a client that does not support it, the unknown location just gets ignored */
+type PromoV3Json = Replace<PromoV2Json, 'locations', string[] | undefined>;
+type PromoFutureJson = { v: number };
+type PromoV2PlusJson = PromoV2Json | PromoV3Json | PromoFutureJson;
+
+const maxKnownPromoVersion = 3;
 
 const fallbackConfig: Config = {
 	promos: [
@@ -145,11 +152,12 @@ export class ProductConfigProvider {
 		state: SubscriptionState | undefined,
 		plan: PromoPlans,
 		location?: PromoLocation,
+		expiringOnly?: boolean,
 	): Promise<Promo | undefined> {
 		if (state == null) return undefined;
 
 		const promos = await this.getPromos();
-		return getApplicablePromo(promos, state, plan, location);
+		return getApplicablePromo(promos, state, plan, location, expiringOnly);
 	}
 
 	async getCliMinimumVersions(): Promise<{ core: string; proxy: string }> {
@@ -170,7 +178,7 @@ export class ProductConfigProvider {
 }
 
 function createConfigValidator(): Validator<ConfigJson> {
-	const isLocation = Is.Enum<PromoLocation>('account', 'badge', 'gate', 'home');
+	const isLocationV2 = Is.Enum<PromoLocationV2>('account', 'badge', 'gate', 'home');
 	const isState = Is.Enum<SubscriptionState>(
 		SubscriptionState.VerificationRequired,
 		SubscriptionState.Community,
@@ -201,6 +209,7 @@ function createConfigValidator(): Validator<ConfigJson> {
 
 	const isWebviewLink = createValidator({
 		html: Is.String,
+		compactHtml: Is.Optional(Is.String),
 		title: Is.String,
 		command: Is.Optional((value): value is GlExtensionCommands => isCommandPattern(value)),
 	});
@@ -230,7 +239,7 @@ function createConfigValidator(): Validator<ConfigJson> {
 		states: Is.Optional(Is.Array(isState)),
 		expiresOn: Is.Optional(Is.String),
 		startsOn: Is.Optional(Is.String),
-		locations: Is.Optional(Is.Array(isLocation)),
+		locations: Is.Optional(Is.Array(isLocationV2)),
 		content: Is.Optional(isContent),
 		percentile: Is.Optional(Is.Number),
 	});
@@ -243,10 +252,35 @@ function createConfigValidator(): Validator<ConfigJson> {
 		states: Is.Optional(Is.Array(isState)),
 		expiresOn: Is.Optional(Is.String),
 		startsOn: Is.Optional(Is.String),
-		locations: Is.Optional(Is.Array(isLocation)),
+		locations: Is.Optional(Is.Array(isLocationV2)),
 		content: Is.Optional(isContentV2),
 		percentile: Is.Optional(Is.Number),
 	});
+
+	// V3 differs from V2 in exactly one place: `locations` takes any string,
+	// so unknown locations do not break the validation, they are filtered later.
+	const promoV3Validator = createValidator<PromoV3Json>({
+		v: Is.Number,
+		key: Is.String,
+		code: Is.Optional(Is.String),
+		plan: Is.Enum<PromoPlans>('pro', 'advanced', 'teams', 'enterprise'),
+		states: Is.Optional(Is.Array(isState)),
+		expiresOn: Is.Optional(Is.String),
+		startsOn: Is.Optional(Is.String),
+		locations: Is.Optional(Is.Array(Is.String)),
+		content: Is.Optional(isContentV2),
+		percentile: Is.Optional(Is.Number),
+	});
+
+	const promoV2PlusValidator = (data: unknown): data is PromoV2PlusJson => {
+		if (!Is.Object(data)) return false;
+
+		const { v } = data as { v?: unknown };
+		if (!Is.Number(v)) return false;
+		if (v > maxKnownPromoVersion) return true;
+
+		return v === 2 ? promoV2Validator(data) : v === 3 ? promoV3Validator(data) : false;
+	};
 
 	const cliValidator = createValidator({
 		minimumCoreVersion: Is.String,
@@ -259,6 +293,7 @@ function createConfigValidator(): Validator<ConfigJson> {
 		v: Is.Optional(Is.Number),
 		promos: Is.Optional(Is.Array(promoValidator)),
 		promosV2: Is.Optional(Is.Array(promoV2Validator)),
+		promosV2plus: Is.Optional(Is.Array(promoV2PlusValidator)),
 	});
 }
 
@@ -267,11 +302,12 @@ function getApplicablePromo(
 	state: SubscriptionState | undefined,
 	plan: PromoPlans,
 	location?: PromoLocation,
+	expiringOnly?: boolean,
 ): Promo | undefined {
 	if (state == null) return undefined;
 
 	for (const promo of promos) {
-		if (isPromoApplicable(promo, state, plan)) {
+		if (isPromoApplicable(promo, state, plan, expiringOnly)) {
 			if (location == null || promo.locations == null || promo.locations.includes(location)) {
 				return promo;
 			}
@@ -282,29 +318,50 @@ function getApplicablePromo(
 	return undefined;
 }
 
+type KnownPromoJson = PromoJson | PromoV2Json | PromoV3Json;
+const isKnownVersion = (d: PromoJson | PromoV2PlusJson): d is KnownPromoJson =>
+	d.v == null || d.v <= maxKnownPromoVersion;
+const isPromoLocation = Is.Enum<PromoLocation>('account', 'badge', 'gate', 'home', 'graph');
+function filterLocations(locations: string[] | undefined): PromoLocation[] | undefined {
+	return locations?.filter(isPromoLocation);
+}
+
 function getConfig(data: unknown): Config | undefined {
 	const validator = createConfigValidator();
 	if (!validator(data)) return undefined;
 
-	const { promosV2, promos: promosV1, ...rest } = data;
+	const { promosV2, promosV2plus, promos: promosV1, ...rest } = data;
 
-	const promos = (promosV2 ?? promosV1 ?? [])
-		// Filter out promos that we don't know how to handle
-		.filter(d => d.v == null || d.v <= maxKnownPromoVersion)
-		.map(
-			d =>
-				({
-					key: d.key,
-					code: d.code,
-					plan: d.plan ?? 'pro',
-					states: d.states,
-					expiresOn: d.expiresOn == null ? undefined : new Date(d.expiresOn).getTime(),
-					startsOn: d.startsOn == null ? undefined : new Date(d.startsOn).getTime(),
-					locations: d.locations,
-					content: d.content,
-					percentile: d.percentile,
-				}) satisfies Promo,
-		);
+	const given: (PromoJson | PromoV2PlusJson)[] =
+		promosV2plus && promosV2
+			? [...promosV2plus, ...promosV2].reverse()
+			: (promosV2plus ?? promosV2 ?? promosV1 ?? []);
+	// Filter out promos that we don't know how to handle
+	const known: KnownPromoJson[] = given.filter(isKnownVersion);
+	const deduped: KnownPromoJson[] = [];
+	for (const d of known) {
+		const i = deduped.findIndex(x => x.key === d.key);
+		if (i === -1) {
+			deduped.push(d);
+		} else if ((d.v ?? 0) > (deduped[i].v ?? 0)) {
+			deduped[i] = d;
+		}
+	}
+
+	const promos = deduped.reverse().map(
+		d =>
+			({
+				key: d.key,
+				code: d.code,
+				plan: d.plan ?? 'pro',
+				states: d.states,
+				expiresOn: d.expiresOn == null ? undefined : new Date(d.expiresOn).getTime(),
+				startsOn: d.startsOn == null ? undefined : new Date(d.startsOn).getTime(),
+				locations: filterLocations(d.locations),
+				content: d.content,
+				percentile: d.percentile,
+			}) satisfies Promo,
+	);
 
 	const config: Config = {
 		...fallbackConfig,
@@ -314,10 +371,11 @@ function getConfig(data: unknown): Config | undefined {
 	return config;
 }
 
-function isPromoApplicable(promo: Promo, state: SubscriptionState, plan: PromoPlans): boolean {
+function isPromoApplicable(promo: Promo, state: SubscriptionState, plan: PromoPlans, expiringOnly?: boolean): boolean {
 	const now = Date.now();
 
 	return (
+		(!expiringOnly || promo.expiresOn != null) &&
 		(promo.plan == null || promo.plan === plan) &&
 		(promo.states == null || promo.states.includes(state)) &&
 		(promo.expiresOn == null || promo.expiresOn > now) &&

--- a/src/plus/gk/productConfigProvider.ts
+++ b/src/plus/gk/productConfigProvider.ts
@@ -306,18 +306,21 @@ function getApplicablePromo(
 ): Promo | undefined {
 	if (state == null) return undefined;
 
+	// Each location resolves to the first applicable promo that SERVES it — a location miss is not
+	// terminal (this used to `break`). With location-scoped campaigns now a first-class shape (`graph`
+	// exists only on `v: 3` entries), a terminal miss would let a graph-only campaign blank every other
+	// placement — or, ordered the other way, let any concurrent campaign blank the graph. Verified
+	// equivalent on every historical config, where campaigns all carry the same location set.
 	for (const promo of promos) {
-		if (isPromoApplicable(promo, state, plan, expiringOnly)) {
-			// An empty `locations` targets nowhere — either authored as `[]`, or every value was
-			// unrecognized by this client and dropped in `getConfig`. Such a promo must be fully
-			// transparent: neither returned (even for location-less lookups) nor allowed to end the
-			// search below, or a promo aimed at a future surface would blank every current placement.
-			if (promo.locations?.length === 0) continue;
+		if (!isPromoApplicable(promo, state, plan, expiringOnly)) continue;
 
-			if (location == null || promo.locations == null || promo.locations.includes(location)) {
-				return promo;
-			}
-			break;
+		// An empty `locations` targets nowhere — either authored as `[]`, or every value was
+		// unrecognized by this client and dropped in `getConfig`. Such a promo must be fully
+		// transparent, even to location-less lookups.
+		if (promo.locations?.length === 0) continue;
+
+		if (location == null || promo.locations == null || promo.locations.includes(location)) {
+			return promo;
 		}
 	}
 

--- a/src/plus/gk/productConfigProvider.ts
+++ b/src/plus/gk/productConfigProvider.ts
@@ -308,6 +308,12 @@ function getApplicablePromo(
 
 	for (const promo of promos) {
 		if (isPromoApplicable(promo, state, plan, expiringOnly)) {
+			// An empty `locations` targets nowhere — either authored as `[]`, or every value was
+			// unrecognized by this client and dropped in `getConfig`. Such a promo must be fully
+			// transparent: neither returned (even for location-less lookups) nor allowed to end the
+			// search below, or a promo aimed at a future surface would blank every current placement.
+			if (promo.locations?.length === 0) continue;
+
 			if (location == null || promo.locations == null || promo.locations.includes(location)) {
 				return promo;
 			}
@@ -332,11 +338,15 @@ function getConfig(data: unknown): Config | undefined {
 
 	const { promosV2, promosV2plus, promos: promosV1, ...rest } = data;
 
-	const given: (PromoJson | PromoV2PlusJson)[] =
-		promosV2plus && promosV2
-			? [...promosV2plus, ...promosV2].reverse()
-			: (promosV2plus ?? promosV2 ?? promosV1 ?? []);
-	// Filter out promos that we don't know how to handle
+	// `promosV2plus` layers onto `promosV2` and onto nothing else; `promos` is the V1 legacy island.
+	// The list is REVERSED here and reversed back after the dedupe below, so that when one key appears in
+	// both lists the surviving entry keeps the `promosV2` slot (order is priority — an override must not
+	// jump the queue), while keys that exist only in `promosV2plus` end up in front. The two reverses must
+	// stay paired for EVERY path, or single-list configs come out in reverse priority order.
+	const given: (PromoJson | PromoV2PlusJson)[] = (
+		promosV2plus && promosV2 ? [...promosV2plus, ...promosV2] : [...(promosV2plus ?? promosV2 ?? promosV1 ?? [])]
+	).reverse();
+	// Drop promos from a version whose rules we don't have
 	const known: KnownPromoJson[] = given.filter(isKnownVersion);
 	const deduped: KnownPromoJson[] = [];
 	for (const d of known) {

--- a/src/webviews/apps/plus/graph/components/gl-graph-header-promo.ts
+++ b/src/webviews/apps/plus/graph/components/gl-graph-header-promo.ts
@@ -20,9 +20,12 @@ declare global {
 export class GlGraphHeaderPromo extends SignalWatcher(LitElement) {
 	static override styles = [
 		css`
-			/* Hidden by default — "too narrow" */
+			/* Visibility (no promo / too narrow) is owned entirely by the header row this sits in — see
+			   .titlebar__row--promo. This component only swaps which text variant shows: compact by
+			   default, full once the strip can seat it. Splitting the "hidden" state across both layers
+			   left an empty band: the row showed because a promo existed while the content hid itself. */
 			:host {
-				display: none;
+				display: block;
 				min-width: 0;
 				overflow: hidden;
 			}
@@ -35,19 +38,12 @@ export class GlGraphHeaderPromo extends SignalWatcher(LitElement) {
 				color: var(--color-foreground);
 			}
 
-			/* Tight: the shortened text */
-			@container graph-titlebar-promo (min-width: 24rem) {
-				:host {
-					display: block;
-				}
+			gl-promo::part(full) {
+				display: none;
+			}
 
-				gl-promo::part(full) {
-					display: none;
-				}
-
-				gl-promo::part(compact) {
-					display: inline;
-				}
+			gl-promo::part(compact) {
+				display: inline;
 			}
 
 			/* Wide: the full text */
@@ -73,27 +69,51 @@ export class GlGraphHeaderPromo extends SignalWatcher(LitElement) {
 	hasPromo = false;
 
 	private _promo: Promise<Promo | undefined> | undefined;
+	private _pending: Promise<Promo | undefined> | undefined;
 	private _promoFor: Subscription | undefined;
+	private _promoForGeneration: number | undefined;
 
-	/** Re-requested whenever the subscription change */
-	private getPromo(subscription: Subscription | undefined): Promise<Promo | undefined> {
-		if (this._promo == null || this._promoFor !== subscription) {
+	/** Re-requested when the subscription changes OR the promo cache is invalidated. Both keys matter:
+	 * the two arrive as separate messages with no ordering guarantee, so keying on the subscription alone
+	 * can capture a stale cached answer and pin it (see PromosContext.generation).
+	 *
+	 * The served promise (`_promo`) only advances when the request that OWNS the swap resolves. That one
+	 * rule covers two hazards at once: a slower stale response can't overwrite `hasPromo` after a newer
+	 * one (last-issued wins, not last-resolved), and during a refetch the previous content keeps showing
+	 * instead of `<gl-promo>` rendering a pending promise as a blank strip. */
+	private getPromo(subscription: Subscription | undefined, generation: number): Promise<Promo | undefined> {
+		if (this._promo == null || this._promoFor !== subscription || this._promoForGeneration !== generation) {
 			this._promoFor = subscription;
-			this._promo = this.promos.getApplicablePromo(undefined, 'graph', true).then(promo => {
-				this.hasPromo = promo?.content?.webview?.link != null;
-				return promo;
-			});
+			this._promoForGeneration = generation;
+
+			const request: Promise<Promo | undefined> = this.promos
+				.getApplicablePromo(undefined, 'graph', true)
+				.then(promo => {
+					if (this._pending === request) {
+						this._pending = undefined;
+						this._promo = request;
+						this.hasPromo = promo?.content?.webview?.link != null;
+						// The promo may change without `hasPromo` changing (one campaign replacing
+						// another), so an explicit re-render is needed to hand `<gl-promo>` the new promise
+						this.requestUpdate();
+					}
+					return promo;
+				});
+			this._pending = request;
+			// Nothing previous to keep showing on the very first request
+			this._promo ??= request;
 		}
 		return this._promo;
 	}
 
 	override render(): unknown {
-		// Reading the signal here is what subscribes this component to subscription changes
+		// Reading the signals here is what subscribes this component to both of them
 		const subscription = this._subscription?.subscription.get();
+		const generation = this.promos.generation.get();
 
 		return html`<gl-promo
-			.promoPromise=${this.getPromo(subscription)}
-			.source=${{ source: 'graph' } as const}
+			.promoPromise=${this.getPromo(subscription, generation)}
+			.source=${{ source: 'graph-header' } as const}
 			type="link"
 		></gl-promo>`;
 	}

--- a/src/webviews/apps/plus/graph/components/gl-graph-header-promo.ts
+++ b/src/webviews/apps/plus/graph/components/gl-graph-header-promo.ts
@@ -1,0 +1,100 @@
+import { SignalWatcher } from '@lit-labs/signals';
+import { consume } from '@lit/context';
+import { css, html, LitElement } from 'lit';
+import { customElement, property } from 'lit/decorators.js';
+import type { Promo } from '../../../../../plus/gk/models/promo.js';
+import type { Subscription } from '../../../../../plus/gk/models/subscription.js';
+import type { PromosContext } from '../../../shared/contexts/promos.js';
+import { promosContext } from '../../../shared/contexts/promos.js';
+import type { SubscriptionContextState } from '../../../shared/contexts/subscription.js';
+import { subscriptionContext } from '../../../shared/contexts/subscription.js';
+import '../../../shared/components/promo.js';
+
+declare global {
+	interface HTMLElementTagNameMap {
+		'gl-graph-header-promo': GlGraphHeaderPromo;
+	}
+}
+
+@customElement('gl-graph-header-promo')
+export class GlGraphHeaderPromo extends SignalWatcher(LitElement) {
+	static override styles = [
+		css`
+			/* Hidden by default — "too narrow" */
+			:host {
+				display: none;
+				min-width: 0;
+				overflow: hidden;
+			}
+
+			gl-promo::part(link) {
+				color: var(--color-foreground--65);
+			}
+
+			gl-promo::part(link):hover {
+				color: var(--color-foreground);
+			}
+
+			/* Tight: the shortened text */
+			@container graph-titlebar-promo (min-width: 24rem) {
+				:host {
+					display: block;
+				}
+
+				gl-promo::part(full) {
+					display: none;
+				}
+
+				gl-promo::part(compact) {
+					display: inline;
+				}
+			}
+
+			/* Wide: the full text */
+			@container graph-titlebar-promo (min-width: 50rem) {
+				gl-promo::part(full) {
+					display: inline;
+				}
+
+				gl-promo::part(compact) {
+					display: none;
+				}
+			}
+		`,
+	];
+
+	@consume({ context: promosContext })
+	private promos!: PromosContext;
+
+	@consume({ context: subscriptionContext, subscribe: true })
+	private _subscription?: SubscriptionContextState;
+
+	@property({ type: Boolean, reflect: true, attribute: 'has-promo' })
+	hasPromo = false;
+
+	private _promo: Promise<Promo | undefined> | undefined;
+	private _promoFor: Subscription | undefined;
+
+	/** Re-requested whenever the subscription change */
+	private getPromo(subscription: Subscription | undefined): Promise<Promo | undefined> {
+		if (this._promo == null || this._promoFor !== subscription) {
+			this._promoFor = subscription;
+			this._promo = this.promos.getApplicablePromo(undefined, 'graph', true).then(promo => {
+				this.hasPromo = promo?.content?.webview?.link != null;
+				return promo;
+			});
+		}
+		return this._promo;
+	}
+
+	override render(): unknown {
+		// Reading the signal here is what subscribes this component to subscription changes
+		const subscription = this._subscription?.subscription.get();
+
+		return html`<gl-promo
+			.promoPromise=${this.getPromo(subscription)}
+			.source=${{ source: 'graph' } as const}
+			type="link"
+		></gl-promo>`;
+	}
+}

--- a/src/webviews/apps/plus/graph/graph-header.ts
+++ b/src/webviews/apps/plus/graph/graph-header.ts
@@ -82,6 +82,7 @@ import '../../shared/components/search/search-box.js';
 import './actions/gitActionsButtons.js';
 import './components/gl-graph-launchpad-indicator.js';
 import './components/gl-graph-account-indicator.js';
+import './components/gl-graph-header-promo.js';
 
 declare global {
 	interface HTMLElementTagNameMap {
@@ -1011,6 +1012,9 @@ export class GlGraphHeader extends SignalWatcher(LitElement) {
 		return cache(
 			html`<header class="titlebar graph-app__header">
 				<progress-indicator min-visible="300" ?active="${this.graphState.isBusy}"></progress-indicator>
+				<div class="titlebar__row titlebar__row--promo">
+					<gl-graph-header-promo></gl-graph-header-promo>
+				</div>
 				${this.renderTitlebarHeaderRow(repo)} ${this.renderTitlebarSearchRow(repo)}
 			</header>`,
 		);

--- a/src/webviews/apps/plus/graph/styles/header.css.ts
+++ b/src/webviews/apps/plus/graph/styles/header.css.ts
@@ -42,6 +42,17 @@ export const titlebarStyles = css`
 		border-bottom: var(--gl-border-width) solid transparent;
 	}
 
+	.titlebar__row--promo {
+		justify-content: center;
+		container-name: graph-titlebar-promo;
+		container-type: inline-size;
+		overflow: hidden;
+	}
+
+	.titlebar__row--promo:not(:has(gl-graph-header-promo[has-promo])) {
+		display: none;
+	}
+
 	.titlebar__row--filtered {
 		background: color-mix(in srgb, var(--gl-chip-filtered-color) var(--gl-chip-tint-bg), transparent);
 		border-top-color: color-mix(in srgb, var(--gl-chip-filtered-color) var(--gl-chip-tint-border), transparent);

--- a/src/webviews/apps/plus/graph/styles/header.css.ts
+++ b/src/webviews/apps/plus/graph/styles/header.css.ts
@@ -53,6 +53,15 @@ export const titlebarStyles = css`
 		display: none;
 	}
 
+	/* The "too narrow" state must hide the ROW (its borders and the titlebar's row-gap included), and a
+	   container can't gate its own display — so this is a media query. The strip always spans the full
+	   webview width, so the viewport tracks the strip's width to within the header padding. */
+	@media (width <= 250px) {
+		.titlebar__row--promo {
+			display: none;
+		}
+	}
+
 	.titlebar__row--filtered {
 		background: color-mix(in srgb, var(--gl-chip-filtered-color) var(--gl-chip-tint-bg), transparent);
 		border-top-color: color-mix(in srgb, var(--gl-chip-filtered-color) var(--gl-chip-tint-border), transparent);

--- a/src/webviews/apps/shared/components/promo.ts
+++ b/src/webviews/apps/shared/components/promo.ts
@@ -59,6 +59,10 @@ export class GlPromo extends LitElement {
 				color: inherit;
 				text-decoration: underline;
 			}
+
+			.link__compact {
+				display: none;
+			}
 		`,
 	];
 
@@ -116,7 +120,10 @@ export class GlPromo extends LitElement {
 						part="link"
 						href="${this.getCommandUrl(promo)}"
 						title="${ifDefined(content.link.title)}"
-						>${unsafeHTML(content.link.html)}</a
+						><span class="link__full" part="full">${unsafeHTML(content.link.html)}</span
+						><span class="link__compact" part="compact"
+							>${unsafeHTML(content.link.compactHtml ?? content.link.html)}</span
+						></a
 					>`;
 				}
 				break;

--- a/src/webviews/apps/shared/contexts/promos.ts
+++ b/src/webviews/apps/shared/contexts/promos.ts
@@ -1,3 +1,4 @@
+import { signal as litSignal } from '@lit-labs/signals';
 import { createContext } from '@lit/context';
 import type { Promo, PromoLocation, PromoPlans } from '../../../../plus/gk/models/promo.js';
 import { DidChangeSubscription } from '../../../home/protocol.js';
@@ -6,6 +7,7 @@ import { DidChangeNotification } from '../../../plus/timeline/protocol.js';
 import { ApplicablePromoRequest } from '../../../protocol.js';
 import type { Disposable } from '../events.js';
 import type { HostIpc } from '../ipc.js';
+import type { ReadableSignal } from '../state.js';
 
 export class PromosContext implements Disposable {
 	private readonly ipc: HostIpc;
@@ -21,6 +23,7 @@ export class PromosContext implements Disposable {
 					DidChangeNotification.is(msg)
 				) {
 					this._promos.clear();
+					this._generation.set(this._generation.get() + 1);
 				}
 			}),
 		);
@@ -30,6 +33,15 @@ export class PromosContext implements Disposable {
 		`${PromoPlans | undefined}|${PromoLocation | undefined}|${boolean}`,
 		Promise<Promo | undefined>
 	>();
+
+	private readonly _generation = litSignal(0);
+	/** Bumped whenever the cache is invalidated. There's no ordering guarantee between the invalidation
+	 * message and a subscription signal update — a consumer that re-requested on the latter may have hit
+	 * the cache just before it cleared. Keying a memoized promise on this signal as well closes that
+	 * race: whichever of the two lands last triggers one more request against the fresh cache. */
+	get generation(): ReadableSignal<number> {
+		return this._generation;
+	}
 
 	async getApplicablePromo(
 		plan?: PromoPlans,

--- a/src/webviews/apps/shared/contexts/promos.ts
+++ b/src/webviews/apps/shared/contexts/promos.ts
@@ -26,16 +26,29 @@ export class PromosContext implements Disposable {
 		);
 	}
 
-	private _promos = new Map<`${PromoPlans | undefined}|${PromoLocation | undefined}`, Promise<Promo | undefined>>();
+	private _promos = new Map<
+		`${PromoPlans | undefined}|${PromoLocation | undefined}|${boolean}`,
+		Promise<Promo | undefined>
+	>();
 
-	async getApplicablePromo(plan?: PromoPlans, location?: PromoLocation): Promise<Promo | undefined> {
-		const cacheKey = `${plan}|${location}` as const;
+	async getApplicablePromo(
+		plan?: PromoPlans,
+		location?: PromoLocation,
+		expiringOnly: boolean = false,
+	): Promise<Promo | undefined> {
+		const cacheKey = `${plan}|${location}|${expiringOnly}` as const;
 		let promise = this._promos.get(cacheKey);
 		if (promise == null) {
-			promise = this.ipc.sendRequest(ApplicablePromoRequest, { plan: plan, location: location }).then(
-				rsp => rsp.promo,
-				() => undefined,
-			);
+			promise = this.ipc
+				.sendRequest(ApplicablePromoRequest, {
+					plan: plan,
+					location: location,
+					expiringOnly: expiringOnly,
+				})
+				.then(
+					rsp => rsp.promo,
+					() => undefined,
+				);
 			this._promos.set(cacheKey, promise);
 		}
 		const promo = await promise;

--- a/src/webviews/protocol.ts
+++ b/src/webviews/protocol.ts
@@ -37,6 +37,7 @@ export const ExecuteCommand = new IpcCommand<ExecuteCommandParams>('core', 'comm
 export interface ApplicablePromoRequestParams {
 	plan?: PromoPlans;
 	location?: PromoLocation;
+	expiringOnly?: boolean;
 }
 export interface ApplicablePromoResponse {
 	promo: Promo | undefined;

--- a/src/webviews/webviewController.ts
+++ b/src/webviews/webviewController.ts
@@ -822,6 +822,7 @@ export class WebviewController<
 					subscription.state,
 					e.params.plan ?? getSubscriptionNextPaidPlanId(subscription),
 					e.params.location,
+					e.params.expiringOnly,
 				);
 				void this.respond(ApplicablePromoRequest, e, { promo: promo });
 				break;


### PR DESCRIPTION
Closes https://github.com/gitkraken/vscode-gitlens-private/issues/94

## What this adds

A promo eyebrow in the Commit Graph header — its own centered strip above the toolbar row, the way the Home view's eyebrow sits above the account bar.

Per @trevor-polidore's spec on the issue it shows **only time-limited campaigns**, so the evergreen 50%-off default never occupies the header and the placement keeps its urgency. Three states driven by the width of the strip:

| strip width | state |
| --- | --- |
| ≥ 50rem | full text — *"Limited-time: Save 70% on GitLens Pro"* |
| 24–50rem | shortened text — *"Save 70% on Pro"* |
| < 24rem | hidden; the strip collapses to zero height |

The strip also collapses entirely when no campaign is running — which is the normal state, so it costs nothing on a quiet day.

## Config compatibility — the part worth reviewing

The placement needs a new promo location, `graph`. That cannot go into `promosV2`: `createValidator` rejects the **whole config** on a single unknown enum value, so every already-published client would lose all promos and fall back to the hardcoded `pro50`. Bumping a promo's `v` doesn't help either — validation runs before the version filter, and has since `promosV2` was introduced.

The only safe carrier is a **new top-level key**, because unknown keys are ignored by the old validator while unknown enum values are fatal. Hence `promosV2plus`:

- `promosV2` stays exactly as strict as it is today, deliberately. Relaxing it here would let a config that breaks every shipped client keep working in our build, hiding the breakage instead of surfacing it.
- `promosV2plus` carries mixed versions, dispatched per entry on its own `v`: `v: 2` follows V2 rules; `v: 3` is the same except `locations` accepts any string, so a *later* location can ship without another bump; anything newer is accepted as opaque and dropped before it reaches the app.
- It **layers over** `promosV2` rather than replacing it, deduped by `key`, so a campaign only has to be authored twice when it actually needs something old clients can't parse. Ordering is preserved: an override keeps its `promosV2` twin's priority slot, and a key that exists only in `promosV2plus` leads.

Consequence for whoever authors the config: a campaign that should appear in the Graph now needs a `v: 3` twin in `promosV2plus`. That's documented on the `product-json/main` branch — see 36b089b9a, which adds the file-format section to the README and a live `codeflow26` entry using `graph` + the new `compactHtml`.

## Also

- `content.webview.link.compactHtml` — the shortened string. A plain optional field, so it's backward-safe at any version.
- `expiringOnly` on the promo request, folded into the candidate predicate rather than applied to the result, so the evergreen default falls through instead of swallowing a campaign behind it.

## Verification

`pnpm run check` clean. Exercised live against a local `product.json`:

- all three width states, with thresholds measured by forcing the container width (256px → compact, 251px → hidden);
- removing `graph` from the config's locations makes the strip go dark while the Home eyebrow is unaffected — the two placements really are separate;
- the strip appears and disappears across subscription changes (`4 → 6 → 3 → 6 → 4`) with no reload.

27 scenarios covering the parser and selector — version dispatch, merge ordering, base-list selection, `expiringOnly` — pass against an out-of-tree harness. They aren't in the repo: `productConfigProvider.ts` can't be imported by the unit-test harness, since the chain `system/-webview/vscode.ts → command.ts → container.ts → command classes` hits a circular-init crash. Making them real tests means extracting the pure logic into a vscode-free module; happy to do that as a follow-up if you'd like it covered.

## Known limits

- The "too narrow → hidden" state needs a container under 240px. The Graph webview floors at ~300px in the bottom panel, so only the full and compact states are reachable there.
- `getApplicablePromo` still `break`s when the first applicable promo lacks the requested location, so two concurrent campaigns for the same plan where the first isn't authored for the Graph would leave the strip empty. Pre-existing behaviour, unchanged here, and not reachable with today's config (campaign windows don't overlap, and the Pro/Advanced case is separated by plan filtering).
