### PR TITLE
Redesigns the Commit Graph paused-operation bar

### DIFF
--- a/package.json
+++ b/package.json
@@ -6281,6 +6281,16 @@
 				}
 			},
 			{
+				"id": "gitlens.decorations.statusPausedOperationReadyForegroundColor",
+				"description": "Specifies the decoration foreground color of the status when a paused operation has no unresolved conflicts and is ready to continue",
+				"defaults": {
+					"light": "#2da44e",
+					"highContrastLight": "#2da44e",
+					"dark": "#3fb950",
+					"highContrast": "#3fb950"
+				}
+			},
+			{
 				"id": "gitlens.decorations.workspaceRepoMissingForegroundColor",
 				"description": "Specifies the decoration foreground color of workspace repos which are missing a local path",
 				"defaults": {

--- a/packages/git-cli/src/exec/__tests__/gitErrors.test.ts
+++ b/packages/git-cli/src/exec/__tests__/gitErrors.test.ts
@@ -469,6 +469,53 @@ suite('getGitCommandError() Test Suite', () => {
 		assert.strictEqual(captureReason('worktree-delete', ex), 'defaultWorkingTree');
 	});
 
+	// Both routes to `emptyCommit` gate the same UI choice (record the empty commit, or skip it), so
+	// both have to land on that reason rather than falling through to a raw git error.
+	test('maps paused-operation-continue stderr to "emptyCommit" reason (sequencer message)', () => {
+		const ex = makeGitError('The previous cherry-pick is now empty, possibly due to conflict resolution.');
+		assert.strictEqual(captureReason('paused-operation-continue', ex), 'emptyCommit');
+	});
+
+	test('maps paused-operation-continue stderr to "emptyCommit" reason (single revert)', () => {
+		const ex = makeGitError('You are currently reverting commit 5235973.\n\nnothing to commit, working tree clean');
+		assert.strictEqual(captureReason('paused-operation-continue', ex), 'emptyCommit');
+	});
+
+	// The "nothing to commit" route to `emptyCommit` is matched by a broad pattern that also fires on
+	// "no changes added to commit"/"nothing added to commit", which git prints alongside the specific
+	// unmerged/conflict/unstaged messages — so it is mapped LAST. A refusal has to keep reporting the
+	// refusal, or the user gets offered an empty commit for a step that isn't empty.
+	test('a paused-operation-continue refusal still reports conflicts, not "emptyCommit"', () => {
+		const ex = makeGitError(
+			'a.txt: needs merge\nYou must edit all merge conflicts and then\nmark them as resolved using git add',
+		);
+		assert.strictEqual(captureReason('paused-operation-continue', ex), 'conflicts');
+	});
+
+	// Synthetic overlap — not output git was observed to produce, but the invariant the LAST position
+	// buys: whenever a specific reason and the broad "nothing to commit" pattern both match, the
+	// specific one has to win. Fails if the mapping is moved back ahead of the specific reasons.
+	test('a paused-operation-continue error matching both reports the specific one, not "emptyCommit"', () => {
+		const ex = makeGitError(
+			'error: You have unstaged changes.\nno changes added to commit (use "git add" and/or "git commit -a")',
+		);
+		assert.strictEqual(captureReason('paused-operation-continue', ex), 'unstagedChanges');
+	});
+
+	// Guards against narrowing that pattern to the "working tree clean" variant: an empty step with
+	// untracked files present reports this instead, and it must still reach the record-or-skip choice.
+	test('maps paused-operation-continue stderr to "emptyCommit" reason (empty step, untracked files)', () => {
+		const ex = makeGitError(
+			'You are currently reverting commit 5235973.\n\nUntracked files:\n\tnoise.txt\n\nnothing added to commit but untracked files present (use "git add" to track)',
+		);
+		assert.strictEqual(captureReason('paused-operation-continue', ex), 'emptyCommit');
+	});
+
+	test('maps paused-operation-continue stderr to "nothingToContinue" reason', () => {
+		const ex = makeGitError('error: no cherry-pick or revert in progress');
+		assert.strictEqual(captureReason('paused-operation-continue', ex), 'nothingToContinue');
+	});
+
 	test('maps worktree-delete stderr to "locked" reason', () => {
 		const ex = makeGitError(
 			"fatal: cannot remove a locked working tree, lock reason: kepler:task:cb600cca\nuse 'remove -f -f' to override or unlock first",

--- a/packages/git-cli/src/exec/__tests__/gitErrors.test.ts
+++ b/packages/git-cli/src/exec/__tests__/gitErrors.test.ts
@@ -302,9 +302,19 @@ suite('GitErrors Regex Test Suite', () => {
 			assert.ok(GitErrors.cherryPickInProgress.test(stderr));
 		});
 
-		test('cherryPickEmptyPrevious matches "The previous cherry-pick is now empty"', () => {
+		test('previousOperationEmpty matches "The previous cherry-pick is now empty"', () => {
 			const stderr = 'The previous cherry-pick is now empty, possibly due to conflict resolution.';
-			assert.ok(GitErrors.cherryPickEmptyPrevious.test(stderr));
+			assert.ok(GitErrors.previousOperationEmpty.test(stderr));
+		});
+
+		test('previousOperationEmpty matches "The previous revert is now empty"', () => {
+			const stderr = 'The previous revert is now empty, possibly due to conflict resolution.';
+			assert.ok(GitErrors.previousOperationEmpty.test(stderr));
+		});
+
+		test('previousOperationEmpty does not match an unrelated empty-commit message', () => {
+			const stderr = 'nothing to commit, working tree clean';
+			assert.ok(!GitErrors.previousOperationEmpty.test(stderr));
 		});
 
 		test('revertInProgress matches "revert is already in progress"', () => {

--- a/packages/git-cli/src/exec/git.ts
+++ b/packages/git-cli/src/exec/git.ts
@@ -71,7 +71,6 @@ export const GitErrors = {
 	changesWouldBeOverwritten:
 		/Your local changes to the following files would be overwritten|Your local changes would be overwritten|overwritten by checkout/i,
 	cherryPickAborted: /cherry-pick.*aborted/i,
-	cherryPickEmptyPrevious: /The previous cherry-pick is now empty/i,
 	cherryPickInProgress: /cherry-pick is already in progress|You have not concluded your cherry-pick/i,
 	commitChangesFirst: /Please, commit your changes before you can/i,
 	conflict: /^CONFLICT \([^)]+\): \b/m,
@@ -100,6 +99,7 @@ export const GitErrors = {
 	noPausedOperation:
 		/no merge (?:in progress|to abort)|no cherry-pick(?: or revert)? in progress|no rebase in progress/i,
 	permissionDenied: /Permission.*denied/i,
+	previousOperationEmpty: /The previous (?:cherry-pick|revert) is now empty/i,
 	pushRejected: /^error:\s*failed to push some refs to\b/m,
 	pushRejectedRefDoesNotExists: /error:\s*unable to delete '(.*?)': remote ref does not exist/m,
 	rebaseAborted: /Nothing to do|rebase.*aborted/i,
@@ -242,7 +242,7 @@ const errorToReasonMap = new Map<GitCommand, [RegExp, GitCommandToReasonMap[GitC
 			[GitErrors.cherryPickAborted, 'aborted'],
 			[GitErrors.cherryPickInProgress, 'alreadyInProgress'],
 			[GitErrors.conflict, 'conflicts'],
-			[GitErrors.cherryPickEmptyPrevious, 'emptyCommit'],
+			[GitErrors.previousOperationEmpty, 'emptyCommit'],
 			[GitErrors.changesWouldBeOverwritten, 'wouldOverwriteChanges'],
 		],
 	],
@@ -277,7 +277,7 @@ const errorToReasonMap = new Map<GitCommand, [RegExp, GitCommandToReasonMap[GitC
 	[
 		'paused-operation-continue',
 		[
-			[GitErrors.cherryPickEmptyPrevious, 'emptyCommit'],
+			[GitErrors.previousOperationEmpty, 'emptyCommit'],
 			[GitErrors.noPausedOperation, 'nothingToContinue'],
 			[GitErrors.uncommittedChanges, 'uncommittedChanges'],
 			[GitErrors.unmergedFiles, 'unmergedFiles'],

--- a/packages/git-cli/src/exec/git.ts
+++ b/packages/git-cli/src/exec/git.ts
@@ -284,6 +284,16 @@ const errorToReasonMap = new Map<GitCommand, [RegExp, GitCommandToReasonMap[GitC
 			[GitErrors.unresolvedConflicts, 'conflicts'],
 			[GitErrors.unstagedChanges, 'unstagedChanges'],
 			[GitErrors.changesWouldBeOverwritten, 'wouldOverwriteChanges'],
+			// A single (non-sequencer) revert resolved to a no-op never gets git's "previous revert is now
+			// empty" message — its `--continue` falls through to the commit, which reports having nothing to
+			// commit. Mid-paused-op that means the step became empty, so it earns the same choice.
+			//
+			// Kept LAST because the pattern is deliberately broad: it also matches "no changes added to
+			// commit" and "nothing added to commit", which appear alongside the more specific unmerged /
+			// conflict / unstaged messages. Matching first would shadow those. It isn't narrowed to the
+			// "working tree clean" variant because an empty step with untracked files present instead reports
+			// "nothing added to commit but untracked files present".
+			[GitErrors.nothingToCommit, 'emptyCommit'],
 		],
 	],
 	[

--- a/packages/git-cli/src/providers/__tests__/integration/pausedOperations.test.ts
+++ b/packages/git-cli/src/providers/__tests__/integration/pausedOperations.test.ts
@@ -6,6 +6,53 @@ import { PausedOperationContinueError } from '@gitlens/git/errors.js';
 import type { TestRepo } from './helpers.js';
 import { addCommit, createTestRepo } from './helpers.js';
 
+/** Builds `feature` and `main` edits of README.md that conflict with each other. */
+function setupDivergedBranches(r: TestRepo): void {
+	execFileSync('git', ['checkout', '-b', 'feature'], { cwd: r.path, stdio: 'pipe' });
+	addCommit(r.path, 'README.md', '# Test Repository\nfeature edit\n', 'Feature edit README');
+	execFileSync('git', ['checkout', 'main'], { cwd: r.path, stdio: 'pipe' });
+	addCommit(r.path, 'README.md', '# Test Repository\nmain edit\n', 'Main edit README');
+}
+
+/** Cherry-picks `feature`'s commit onto `main`, pausing on the README.md conflict. */
+function setupConflictedCherryPick(r: TestRepo): void {
+	setupDivergedBranches(r);
+
+	try {
+		execFileSync('git', ['cherry-pick', 'feature'], { cwd: r.path, stdio: 'pipe' });
+		assert.fail('Expected the cherry-pick to pause on a conflict');
+	} catch {
+		// Expected: the cherry-pick pauses on the README.md conflict
+	}
+}
+
+/** Reverts `main`'s last commit, pausing on the README.md conflict a later edit creates. */
+function setupConflictedRevert(r: TestRepo): void {
+	addCommit(r.path, 'README.md', '# Test Repository\nalpha\n', 'Add alpha');
+	const target = execFileSync('git', ['rev-parse', 'HEAD'], { cwd: r.path, encoding: 'utf-8' }).trim();
+	addCommit(r.path, 'README.md', '# Test Repository\nbeta\n', 'Replace alpha with beta');
+
+	try {
+		execFileSync('git', ['revert', '--no-edit', target], { cwd: r.path, stdio: 'pipe' });
+		assert.fail('Expected the revert to pause on a conflict');
+	} catch {
+		// Expected: the revert pauses on the README.md conflict
+	}
+}
+
+function resolveReadme(r: TestRepo, content: string): void {
+	writeFileSync(join(r.path, 'README.md'), content);
+	execFileSync('git', ['add', 'README.md'], { cwd: r.path, stdio: 'pipe' });
+}
+
+function getCommitCount(r: TestRepo): number {
+	return Number(execFileSync('git', ['rev-list', '--count', 'HEAD'], { cwd: r.path, encoding: 'utf-8' }).trim());
+}
+
+function getSubject(r: TestRepo, rev = 'HEAD'): string {
+	return execFileSync('git', ['log', '--format=%s', '-1', rev], { cwd: r.path, encoding: 'utf-8' }).trim();
+}
+
 /**
  * Starts a rebase of `feature` onto `main` that pauses with a content conflict in README.md,
  * then resolves and stages the conflict, leaving the repo ready for `rebase --continue`.
@@ -72,4 +119,112 @@ suite('PausedOperationsGitSubProvider.continuePausedOperation', () => {
 			}
 		},
 	);
+
+	test('with allowEmpty records the empty commit and concludes the cherry-pick', async () => {
+		const r = createTestRepo();
+		try {
+			setupConflictedCherryPick(r);
+			// Resolving to main's own content leaves the pick with nothing to apply
+			resolveReadme(r, '# Test Repository\nmain edit\n');
+
+			await assert.rejects(
+				r.provider.pausedOps.continuePausedOperation(r.path, { messageEditor: 'true' }),
+				(ex: unknown) => PausedOperationContinueError.is(ex, 'emptyCommit'),
+			);
+
+			const before = getCommitCount(r);
+			await r.provider.pausedOps.continuePausedOperation(r.path, { allowEmpty: true, messageEditor: 'true' });
+
+			assert.strictEqual(getCommitCount(r), before + 1, 'Expected the empty commit to be recorded');
+			assert.strictEqual(getSubject(r), 'Feature edit README');
+
+			const diff = execFileSync('git', ['diff', '--name-only', 'HEAD~1', 'HEAD'], {
+				cwd: r.path,
+				encoding: 'utf-8',
+			}).trim();
+			assert.strictEqual(diff, '', 'Expected the recorded commit to be empty');
+
+			const status = await r.provider.pausedOps.getPausedOperationStatus(r.path, { force: true });
+			assert.strictEqual(status, undefined, 'Expected the cherry-pick to be finished');
+		} finally {
+			r.cleanup();
+		}
+	});
+
+	test('completes a conflicted revert headlessly', async () => {
+		const r = createTestRepo();
+		try {
+			// Force any editor invocation to fail, so success proves the editor was suppressed
+			execFileSync('git', ['config', 'core.editor', 'false'], { cwd: r.path, stdio: 'pipe' });
+			setupConflictedRevert(r);
+			resolveReadme(r, '# Test Repository\nresolved\n');
+
+			await r.provider.pausedOps.continuePausedOperation(r.path, { messageEditor: 'true' });
+
+			assert.strictEqual(getSubject(r), 'Revert "Add alpha"');
+
+			const status = await r.provider.pausedOps.getPausedOperationStatus(r.path, { force: true });
+			assert.strictEqual(status, undefined, 'Expected the revert to be finished');
+		} finally {
+			r.cleanup();
+		}
+	});
+});
+
+suite('PausedOperationsGitSubProvider.getPausedOperationStatus', () => {
+	test('a paused cherry-pick names the commit it is applying', async () => {
+		const r = createTestRepo();
+		try {
+			setupConflictedCherryPick(r);
+
+			const status = await r.provider.pausedOps.getPausedOperationStatus(r.path, { force: true });
+			assert.ok(status?.type === 'cherry-pick');
+			assert.strictEqual(status.incoming.message, 'Feature edit README');
+			assert.strictEqual(status.HEAD.message, 'Feature edit README');
+		} finally {
+			r.cleanup();
+		}
+	});
+
+	test('a paused revert names the commit it is reverting', async () => {
+		const r = createTestRepo();
+		try {
+			setupConflictedRevert(r);
+
+			const status = await r.provider.pausedOps.getPausedOperationStatus(r.path, { force: true });
+			assert.ok(status?.type === 'revert');
+			assert.strictEqual(status.incoming.message, 'Add alpha');
+		} finally {
+			r.cleanup();
+		}
+	});
+
+	// Once a conflicted step is committed by hand, CHERRY_PICK_HEAD is gone and only `sequencer/todo`
+	// describes the run — the subject has to come off the todo line itself.
+	test('a sequencer-driven cherry-pick names the commit from its todo line', async () => {
+		const r = createTestRepo();
+		try {
+			execFileSync('git', ['checkout', '-b', 'feature'], { cwd: r.path, stdio: 'pipe' });
+			addCommit(r.path, 'README.md', '# Test Repository\nfeature one\n', 'Feature commit one');
+			addCommit(r.path, 'README.md', '# Test Repository\nfeature two\n', 'Feature commit two');
+			execFileSync('git', ['checkout', 'main'], { cwd: r.path, stdio: 'pipe' });
+			addCommit(r.path, 'README.md', '# Test Repository\nmain edit\n', 'Main edit README');
+
+			try {
+				execFileSync('git', ['cherry-pick', 'feature~1', 'feature'], { cwd: r.path, stdio: 'pipe' });
+				assert.fail('Expected the cherry-pick to pause on a conflict');
+			} catch {
+				// Expected: the first pick conflicts
+			}
+
+			resolveReadme(r, '# Test Repository\nresolved\n');
+			execFileSync('git', ['commit', '--no-edit'], { cwd: r.path, stdio: 'pipe' });
+
+			const status = await r.provider.pausedOps.getPausedOperationStatus(r.path, { force: true });
+			assert.ok(status?.type === 'cherry-pick');
+			assert.strictEqual(status.incoming.message, 'Feature commit one');
+		} finally {
+			r.cleanup();
+		}
+	});
 });

--- a/packages/git-cli/src/providers/__tests__/integration/pausedOperations.test.ts
+++ b/packages/git-cli/src/providers/__tests__/integration/pausedOperations.test.ts
@@ -123,6 +123,9 @@ suite('PausedOperationsGitSubProvider.continuePausedOperation', () => {
 	test('with allowEmpty records the empty commit and concludes the cherry-pick', async () => {
 		const r = createTestRepo();
 		try {
+			// The allowEmpty commit passes no `core.editor`/`GIT_EDITOR` of its own — it relies solely on
+			// `--no-edit`. Force any editor invocation to fail so a regression that drops it can't pass.
+			execFileSync('git', ['config', 'core.editor', 'false'], { cwd: r.path, stdio: 'pipe' });
 			setupConflictedCherryPick(r);
 			// Resolving to main's own content leaves the pick with nothing to apply
 			resolveReadme(r, '# Test Repository\nmain edit\n');
@@ -146,6 +149,38 @@ suite('PausedOperationsGitSubProvider.continuePausedOperation', () => {
 
 			const status = await r.provider.pausedOps.getPausedOperationStatus(r.path, { force: true });
 			assert.strictEqual(status, undefined, 'Expected the cherry-pick to be finished');
+		} finally {
+			r.cleanup();
+		}
+	});
+
+	test('with allowEmpty records the empty commit and concludes the revert', async () => {
+		const r = createTestRepo();
+		try {
+			execFileSync('git', ['config', 'core.editor', 'false'], { cwd: r.path, stdio: 'pipe' });
+			setupConflictedRevert(r);
+			// Resolving to HEAD's own content leaves the revert with nothing to apply
+			resolveReadme(r, '# Test Repository\nbeta\n');
+
+			await assert.rejects(
+				r.provider.pausedOps.continuePausedOperation(r.path, { messageEditor: 'true' }),
+				(ex: unknown) => PausedOperationContinueError.is(ex, 'emptyCommit'),
+			);
+
+			const before = getCommitCount(r);
+			await r.provider.pausedOps.continuePausedOperation(r.path, { allowEmpty: true, messageEditor: 'true' });
+
+			assert.strictEqual(getCommitCount(r), before + 1, 'Expected the empty commit to be recorded');
+			assert.strictEqual(getSubject(r), 'Revert "Add alpha"');
+
+			const diff = execFileSync('git', ['diff', '--name-only', 'HEAD~1', 'HEAD'], {
+				cwd: r.path,
+				encoding: 'utf-8',
+			}).trim();
+			assert.strictEqual(diff, '', 'Expected the recorded commit to be empty');
+
+			const status = await r.provider.pausedOps.getPausedOperationStatus(r.path, { force: true });
+			assert.strictEqual(status, undefined, 'Expected the revert to be finished');
 		} finally {
 			r.cleanup();
 		}

--- a/packages/git-cli/src/providers/__tests__/integration/pausedOperations.test.ts
+++ b/packages/git-cli/src/providers/__tests__/integration/pausedOperations.test.ts
@@ -75,7 +75,59 @@ function setupConflictedRebase(r: TestRepo): void {
 	execFileSync('git', ['add', 'README.md'], { cwd: r.path, stdio: 'pipe' });
 }
 
+/**
+ * Starts a rebase of `feature` (two commits, both editing README.md) onto `main`, pausing on the
+ * first step's conflict — so skipping or continuing step 1 lands on step 2's conflict.
+ */
+function setupTwoStepConflictedRebase(r: TestRepo): void {
+	execFileSync('git', ['checkout', '-b', 'feature'], { cwd: r.path, stdio: 'pipe' });
+	addCommit(r.path, 'README.md', '# Test Repository\nfeature one\n', 'Feature commit one');
+	addCommit(r.path, 'README.md', '# Test Repository\nfeature two\n', 'Feature commit two');
+	execFileSync('git', ['checkout', 'main'], { cwd: r.path, stdio: 'pipe' });
+	addCommit(r.path, 'README.md', '# Test Repository\nmain edit\n', 'Main edit README');
+	execFileSync('git', ['checkout', 'feature'], { cwd: r.path, stdio: 'pipe' });
+
+	try {
+		execFileSync('git', ['rebase', 'main'], { cwd: r.path, stdio: 'pipe' });
+		assert.fail('Expected the rebase to pause on a conflict');
+	} catch {
+		// Expected: the rebase pauses on the first step's README.md conflict
+	}
+}
+
 suite('PausedOperationsGitSubProvider.continuePausedOperation', () => {
+	// `--skip`/`--continue` drive the WHOLE rebase, so a LATER step's conflict exits the command
+	// non-zero even though this step did what was asked — and git words it identically to a refusal.
+	// Consumers therefore can't trust the reason alone; they have to compare state. Locking that in:
+	// the throw and the advance must BOTH happen, so anything reporting "cannot skip" has to check.
+	test('a skip that lands on the next step conflicts still advances, despite rejecting', async () => {
+		const r = createTestRepo();
+		try {
+			setupTwoStepConflictedRebase(r);
+
+			const before = await r.provider.pausedOps.getPausedOperationStatus(r.path, { force: true });
+			assert.ok(before?.type === 'rebase');
+			assert.strictEqual(before.steps.current.number, 1);
+
+			await assert.rejects(
+				r.provider.pausedOps.continuePausedOperation(r.path, { skip: true }),
+				(ex: unknown) => PausedOperationContinueError.is(ex, 'conflicts'),
+				'Expected the skip to report unresolved conflicts',
+			);
+
+			const after = await r.provider.pausedOps.getPausedOperationStatus(r.path, { force: true });
+			assert.ok(after?.type === 'rebase', 'Expected the rebase to still be paused, on the NEXT step');
+			assert.strictEqual(after.steps.current.number, 2, 'Expected the skip to have advanced a step');
+			assert.notStrictEqual(
+				after.steps.current.commit?.ref,
+				before.steps.current.commit?.ref,
+				'Expected the paused commit to have moved on',
+			);
+		} finally {
+			r.cleanup();
+		}
+	});
+
 	test('with messageEditor completes a conflicted rebase headlessly and preserves the commit message', async () => {
 		const r = createTestRepo();
 		try {

--- a/packages/git-cli/src/providers/pausedOperations.ts
+++ b/packages/git-cli/src/providers/pausedOperations.ts
@@ -24,7 +24,7 @@ import type { CliGitProviderInternal } from '../cliGitProvider.js';
 import type { Git } from '../exec/git.js';
 import { getGitCommandError } from '../exec/git.js';
 
-const todoCommitRegex = /^(?:p(?:ick)?|revert)\s+([a-f0-9]+)/i;
+const todoCommitRegex = /^(?:p(?:ick)?|revert)\s+([a-f0-9]+)(?:\s+(.+))?$/i;
 
 type Operation = 'cherry-pick' | 'merge' | 'rebase-apply' | 'rebase-merge' | 'revert' | 'sequencer';
 
@@ -134,22 +134,25 @@ export class PausedOperationsGitSubProvider implements GitPausedOperationsSubPro
 						return undefined;
 					}
 
-					const [branchResult, mergeBaseResult] = await Promise.allSettled([
+					const [branchResult, mergeBaseResult, messageResult] = await Promise.allSettled([
 						this.provider.branches.getCurrentBranchReference(repoPath, cancellation),
 						this.provider.refs.getMergeBase(repoPath, 'CHERRY_PICK_HEAD', 'HEAD', undefined, cancellation),
+						this.getCommitMessage(repoPath, cherryPickHead, cancellation),
 					]);
 					if (cancellation?.aborted) throw new CancellationError();
 
 					const current = getSettledValue(branchResult)!;
 					const mergeBase = getSettledValue(mergeBaseResult);
+					// Names the commit being applied, so consumers can say which one a skip would drop
+					const message = getSettledValue(messageResult);
 
 					return {
 						type: 'cherry-pick',
 						repoPath: repoPath,
 						mergeBase: mergeBase,
-						HEAD: createReference(cherryPickHead, repoPath, { refType: 'revision' }),
+						HEAD: createReference(cherryPickHead, repoPath, { refType: 'revision', message: message }),
 						current: current,
-						incoming: createReference(cherryPickHead, repoPath, { refType: 'revision' }),
+						incoming: createReference(cherryPickHead, repoPath, { refType: 'revision', message: message }),
 					} satisfies GitCherryPickStatus;
 				}
 				case 'merge': {
@@ -222,22 +225,25 @@ export class PausedOperationsGitSubProvider implements GitPausedOperationsSubPro
 						return undefined;
 					}
 
-					const [branchResult, mergeBaseResult] = await Promise.allSettled([
+					const [branchResult, mergeBaseResult, messageResult] = await Promise.allSettled([
 						this.provider.branches.getCurrentBranchReference(repoPath, cancellation),
 						this.provider.refs.getMergeBase(repoPath, 'REVERT_HEAD', 'HEAD', undefined, cancellation),
+						this.getCommitMessage(repoPath, revertHead, cancellation),
 					]);
 					if (cancellation?.aborted) throw new CancellationError();
 
 					const current = getSettledValue(branchResult)!;
 					const mergeBase = getSettledValue(mergeBaseResult);
+					// Names the commit being reverted, so consumers can say which one a skip would drop
+					const message = getSettledValue(messageResult);
 
 					return {
 						type: 'revert',
 						repoPath: repoPath,
 						mergeBase: mergeBase,
-						HEAD: createReference(revertHead, repoPath, { refType: 'revision' }),
+						HEAD: createReference(revertHead, repoPath, { refType: 'revision', message: message }),
 						current: current,
-						incoming: createReference(revertHead, repoPath, { refType: 'revision' }),
+						incoming: createReference(revertHead, repoPath, { refType: 'revision', message: message }),
 					} satisfies GitRevertStatus;
 				}
 				case 'rebase-apply':
@@ -407,6 +413,10 @@ export class PausedOperationsGitSubProvider implements GitPausedOperationsSubPro
 						return undefined;
 					}
 
+					// The todo line carries only the commit's SUBJECT (the other producers carry the full
+					// message) — good enough to name the commit a skip would drop, without another git call
+					const message = match?.[2]?.trim() || undefined;
+
 					const [branchResult, mergeBaseResult] = await Promise.allSettled([
 						this.provider.branches.getCurrentBranchReference(repoPath, cancellation),
 						this.provider.refs.getMergeBase(repoPath, currentCommitSha, 'HEAD', undefined, cancellation),
@@ -421,9 +431,15 @@ export class PausedOperationsGitSubProvider implements GitPausedOperationsSubPro
 							type: 'cherry-pick',
 							repoPath: repoPath,
 							mergeBase: mergeBase,
-							HEAD: createReference(currentCommitSha, repoPath, { refType: 'revision' }),
+							HEAD: createReference(currentCommitSha, repoPath, {
+								refType: 'revision',
+								message: message,
+							}),
 							current: current,
-							incoming: createReference(currentCommitSha, repoPath, { refType: 'revision' }),
+							incoming: createReference(currentCommitSha, repoPath, {
+								refType: 'revision',
+								message: message,
+							}),
 						} satisfies GitCherryPickStatus;
 					}
 
@@ -431,15 +447,45 @@ export class PausedOperationsGitSubProvider implements GitPausedOperationsSubPro
 						type: 'revert',
 						repoPath: repoPath,
 						mergeBase: mergeBase,
-						HEAD: createReference(currentCommitSha, repoPath, { refType: 'revision' }),
+						HEAD: createReference(currentCommitSha, repoPath, { refType: 'revision', message: message }),
 						current: current,
-						incoming: createReference(currentCommitSha, repoPath, { refType: 'revision' }),
+						incoming: createReference(currentCommitSha, repoPath, {
+							refType: 'revision',
+							message: message,
+						}),
 					} satisfies GitRevertStatus;
 				}
 			}
 		});
 
 		return status;
+	}
+
+	/** Memoized per repo by sha — forced status re-reads on FS noise (every file save while resolving
+	 *  conflicts) would otherwise re-spawn `git log` for an unchanging commit. */
+	private readonly _commitMessageCache = new Map<string, { sha: string; message: string | undefined }>();
+
+	private async getCommitMessage(
+		repoPath: string,
+		sha: string,
+		cancellation?: AbortSignal,
+	): Promise<string | undefined> {
+		const cached = this._commitMessageCache.get(repoPath);
+		if (cached?.sha === sha) return cached.message;
+
+		const result = await this.git.run(
+			{ cwd: repoPath, cancellation: cancellation, errors: 'ignore' },
+			'log',
+			'-1',
+			'--format=%B',
+			sha,
+		);
+		const message = result.stdout.trim() || undefined;
+		// Don't cache a miss — a transient failure would otherwise stick for the operation's lifetime
+		if (message != null) {
+			this._commitMessageCache.set(repoPath, { sha: sha, message: message });
+		}
+		return message;
 	}
 
 	private async readDotGitFile(
@@ -511,7 +557,7 @@ export class PausedOperationsGitSubProvider implements GitPausedOperationsSubPro
 	@debug()
 	async continuePausedOperation(
 		repoPath: string,
-		options?: { skip?: boolean; messageEditor?: string },
+		options?: { allowEmpty?: boolean; skip?: boolean; messageEditor?: string },
 	): Promise<void> {
 		const scope = getScopedLogger();
 
@@ -534,7 +580,35 @@ export class PausedOperationsGitSubProvider implements GitPausedOperationsSubPro
 			env = { GIT_EDITOR: options.messageEditor };
 		}
 
+		let mutated = false;
 		try {
+			if (options?.allowEmpty) {
+				const commitArgs = ['commit', '--allow-empty', '--no-edit'];
+				try {
+					// Git won't record the empty commit on its own; making it explicitly (`--no-edit` reuses the
+					// message git already prepared) is what lets the operation move past it.
+					await this.git.run({ cwd: repoPath, errors: 'throw' }, ...commitArgs);
+					mutated = true;
+				} catch (ex) {
+					scope?.error(ex);
+					// Same reason taxonomy, but attributed to the commit that actually failed
+					throw getGitCommandError(
+						'paused-operation-continue',
+						ex,
+						reason =>
+							new PausedOperationContinueError(
+								{
+									reason: reason,
+									operation: status,
+									skip: false,
+									gitCommand: { repoPath: repoPath, args: commitArgs },
+								},
+								ex,
+							),
+					);
+				}
+			}
+
 			await this.git.run(
 				{
 					cwd: repoPath,
@@ -550,11 +624,11 @@ export class PausedOperationsGitSubProvider implements GitPausedOperationsSubPro
 				},
 				...args,
 			);
-			this.context.hooks?.cache?.onReset?.(repoPath, 'branches', 'status');
-			this.context.hooks?.repository?.onChanged?.(repoPath, ['head', 'heads', 'index']);
+			mutated = true;
 		} catch (ex) {
-			scope?.error(ex);
-			throw getGitCommandError(
+			if (PausedOperationContinueError.is(ex)) throw ex;
+
+			const error = getGitCommandError(
 				'paused-operation-continue',
 				ex,
 				reason =>
@@ -568,6 +642,20 @@ export class PausedOperationsGitSubProvider implements GitPausedOperationsSubPro
 						ex,
 					),
 			);
+
+			// An empty commit concludes a single-commit cherry-pick/revert outright, leaving its
+			// `--continue` nothing to continue — the operation finished either way.
+			if (!options?.allowEmpty || !PausedOperationContinueError.is(error, 'nothingToContinue')) {
+				scope?.error(ex);
+				throw error;
+			}
+		} finally {
+			// The repo can mutate even when a later step throws (the empty commit landing before its
+			// `--continue` fails) — notify on mutation, not on method success.
+			if (mutated) {
+				this.context.hooks?.cache?.onReset?.(repoPath, 'branches', 'status');
+				this.context.hooks?.repository?.onChanged?.(repoPath, ['head', 'heads', 'index']);
+			}
 		}
 	}
 }

--- a/packages/git-cli/src/providers/pausedOperations.ts
+++ b/packages/git-cli/src/providers/pausedOperations.ts
@@ -580,7 +580,6 @@ export class PausedOperationsGitSubProvider implements GitPausedOperationsSubPro
 			env = { GIT_EDITOR: options.messageEditor };
 		}
 
-		let mutated = false;
 		try {
 			if (options?.allowEmpty) {
 				const commitArgs = ['commit', '--allow-empty', '--no-edit'];
@@ -588,7 +587,6 @@ export class PausedOperationsGitSubProvider implements GitPausedOperationsSubPro
 					// Git won't record the empty commit on its own; making it explicitly (`--no-edit` reuses the
 					// message git already prepared) is what lets the operation move past it.
 					await this.git.run({ cwd: repoPath, errors: 'throw' }, ...commitArgs);
-					mutated = true;
 				} catch (ex) {
 					scope?.error(ex);
 					// Same reason taxonomy, but attributed to the commit that actually failed
@@ -624,7 +622,6 @@ export class PausedOperationsGitSubProvider implements GitPausedOperationsSubPro
 				},
 				...args,
 			);
-			mutated = true;
 		} catch (ex) {
 			if (PausedOperationContinueError.is(ex)) throw ex;
 
@@ -650,12 +647,13 @@ export class PausedOperationsGitSubProvider implements GitPausedOperationsSubPro
 				throw error;
 			}
 		} finally {
-			// The repo can mutate even when a later step throws (the empty commit landing before its
-			// `--continue` fails) — notify on mutation, not on method success.
-			if (mutated) {
-				this.context.hooks?.cache?.onReset?.(repoPath, 'branches', 'status');
-				this.context.hooks?.repository?.onChanged?.(repoPath, ['head', 'heads', 'index']);
-			}
+			// Notify unconditionally rather than only on success: a throwing `--continue` can still have
+			// mutated the repo (committing the resolved step, then stopping on the NEXT step's conflict or
+			// empty commit), and the error alone can't distinguish that from a no-op failure. Invalidating
+			// after a genuine no-op only costs a re-read; not invalidating after a real advance leaves
+			// consumers rendering a stale step.
+			this.context.hooks?.cache?.onReset?.(repoPath, 'branches', 'status');
+			this.context.hooks?.repository?.onChanged?.(repoPath, ['head', 'heads', 'index']);
 		}
 	}
 }

--- a/packages/git/src/providers/pausedOperations.ts
+++ b/packages/git/src/providers/pausedOperations.ts
@@ -10,6 +10,8 @@ export interface GitPausedOperationsSubProvider {
 	continuePausedOperation(
 		repoPath: string,
 		options?: {
+			/** Records the empty commit the operation refused to create, then concludes it (cherry-pick/revert) */
+			allowEmpty?: boolean;
 			skip?: boolean;
 			/** Editor command used if the operation needs to edit a commit message (e.g. `true` to keep the original message without opening an editor) */
 			messageEditor?: string;

--- a/packages/git/src/utils/pausedOperationStatus.utils.ts
+++ b/packages/git/src/utils/pausedOperationStatus.utils.ts
@@ -23,29 +23,57 @@ export function getConflictCurrentRef(status: GitPausedOperationStatus): GitRefe
 	return status.current;
 }
 
+/** `name` is the Title Case form for buttons/actions; `prose` is the sentence form ("Cherry-pick paused"). */
 export const pausedOperationStatusStringsByType = {
 	'cherry-pick': {
+		name: 'Cherry Pick',
+		prose: 'Cherry-pick',
 		label: 'Cherry picking',
 		conflicts: 'Resolve conflicts to continue cherry picking',
 		directionality: 'into',
 	},
 	merge: {
+		name: 'Merge',
+		prose: 'Merge',
 		label: 'Merging',
 		conflicts: 'Resolve conflicts to continue merging',
 		directionality: 'into',
 	},
 	rebase: {
+		name: 'Rebase',
+		prose: 'Rebase',
 		label: 'Rebasing',
 		conflicts: 'Resolve conflicts to continue rebasing',
 		directionality: 'onto',
 		pending: 'Pending rebase of',
 	},
 	revert: {
+		name: 'Revert',
+		prose: 'Revert',
 		label: 'Reverting',
 		conflicts: 'Resolve conflicts to continue reverting',
 		directionality: 'in',
 	},
 } as const;
+
+export type PausedOperationVariant = 'conflicts' | 'pending' | 'ready';
+
+/** Codicon per variant — shared so the bar and the WIP badge can't drift. */
+export const pausedOperationVariantIcons: Record<PausedOperationVariant, string> = {
+	conflicts: 'warning',
+	pending: 'circle-outline',
+	ready: 'check',
+};
+
+/** Unresolved conflicts outrank a rebase that hasn't reached its first step — neither can continue, but only conflicts are actionable. */
+export function getPausedOperationVariant(
+	status: GitPausedOperationStatus,
+	hasConflicts: boolean,
+): PausedOperationVariant {
+	if (hasConflicts) return 'conflicts';
+	if (status.type === 'rebase' && status.steps.total === 0) return 'pending';
+	return 'ready';
+}
 
 /**
  * Resolves the correct file paths for each side of a merge conflict diff when the file may have been renamed.

--- a/src/git/actions/pausedOperation.ts
+++ b/src/git/actions/pausedOperation.ts
@@ -88,13 +88,45 @@ async function continuePausedOperationCore(
 		}
 
 		if (PausedOperationContinueError.is(ex, 'conflicts') || PausedOperationContinueError.is(ex, 'unmergedFiles')) {
-			void window.showWarningMessage(ex.message);
+			// `<op> --continue`/`--skip` drives the WHOLE operation, so a LATER step's conflict exits the
+			// command non-zero even though this step did exactly what was asked — and git reports it with the
+			// same "CONFLICT"/"could not apply" text as a refusal, so the reason can't tell them apart. Ask
+			// the repo instead: warn only when nothing actually moved, otherwise the operation advanced and
+			// simply stopped again further along, which the paused-op surface already shows.
+			if (!(await hasPausedOperationProgressed(svc, ex.details.operation))) {
+				void window.showWarningMessage(ex.message);
+			}
 			void showPausedOperationStatus(container, svc.path, { source: source });
 			return;
 		}
 
 		void showGitErrorMessage(ex);
 	}
+}
+
+/**
+ * Whether the paused operation moved since `before` was captured — it finished, changed kind, or
+ * advanced onto a different commit. Compares state rather than error text, which varies by git
+ * version and locale.
+ */
+async function hasPausedOperationProgressed(
+	svc: GitRepositoryService,
+	before: GitPausedOperationStatus,
+): Promise<boolean> {
+	// Force a fresh read: the failing command just mutated the repo, so a cached status is exactly
+	// the pre-command one we're comparing against
+	const after = await svc.pausedOps?.getPausedOperationStatus?.({ force: true });
+	if (after == null || after.type !== before.type) return true;
+
+	if (after.type === 'rebase' && before.type === 'rebase') {
+		// The apply backend can't report step numbers, so fall back to the commit being applied
+		return (
+			after.steps.current.number !== before.steps.current.number ||
+			after.steps.current.commit?.ref !== before.steps.current.commit?.ref
+		);
+	}
+
+	return after.HEAD.ref !== before.HEAD.ref;
 }
 
 export interface ShowPausedOperationStatusOptions {

--- a/src/git/actions/pausedOperation.ts
+++ b/src/git/actions/pausedOperation.ts
@@ -27,7 +27,7 @@ export async function continuePausedOperation(
 	svc: GitRepositoryService,
 	source?: Source,
 ): Promise<void> {
-	return continuePausedOperationCore(container, svc, false, source);
+	return continuePausedOperationCore(container, svc, undefined, source);
 }
 
 export async function skipPausedOperation(
@@ -35,17 +35,17 @@ export async function skipPausedOperation(
 	svc: GitRepositoryService,
 	source?: Source,
 ): Promise<void> {
-	return continuePausedOperationCore(container, svc, true, source);
+	return continuePausedOperationCore(container, svc, { skip: true }, source);
 }
 
 async function continuePausedOperationCore(
 	container: Container,
 	svc: GitRepositoryService,
-	skip: boolean = false,
+	options?: { allowEmpty?: boolean; skip?: boolean },
 	source?: Source,
 ): Promise<void> {
 	try {
-		return await svc.pausedOps?.continuePausedOperation?.(skip ? { skip: true } : undefined);
+		return await svc.pausedOps?.continuePausedOperation?.(options);
 	} catch (ex) {
 		if (PausedOperationContinueError.is(ex, 'emptyCommit')) {
 			// Use the operation status from the error - it's already accurate
@@ -55,19 +55,22 @@ async function continuePausedOperationCore(
 
 			const pausedAt = getReferenceLabel(operation.incoming, { icon: false, label: true, quoted: true });
 
+			const emptyCommitItem = { title: 'Continue with Empty Commit' };
 			const skipItem = { title: 'Skip' };
 			const cancelItem = { title: 'Cancel', isCloseAffordance: true };
 
-			// TODO@eamodio: We should offer a continue with allowing an empty commit option
-
 			const result = await window.showInformationMessage(
-				`The ${operation.type} operation cannot be continued because ${pausedAt} resulted in an empty commit.\n\nDo you want to skip ${pausedAt}?`,
+				`The ${operation.type} operation cannot be continued because ${pausedAt} resulted in an empty commit.\n\nDo you want to record ${pausedAt} as an empty commit, or skip it?`,
 				{ modal: true },
+				emptyCommitItem,
 				skipItem,
 				cancelItem,
 			);
+			if (result === emptyCommitItem) {
+				return void continuePausedOperationCore(container, svc, { allowEmpty: true }, source);
+			}
 			if (result === skipItem) {
-				return void continuePausedOperationCore(container, svc, true, source);
+				return void continuePausedOperationCore(container, svc, { skip: true }, source);
 			}
 
 			void showPausedOperationStatus(container, svc.path, { source: source });

--- a/src/webviews/apps/commitDetails/components/gl-details-wip-panel.ts
+++ b/src/webviews/apps/commitDetails/components/gl-details-wip-panel.ts
@@ -649,6 +649,7 @@ export class GlDetailsWipPanel extends GlDetailsBase {
 		return html`<div class="paused-op">
 			<gl-merge-rebase-status
 				?conflicts=${this.wip?.changes?.hasConflicts ?? false}
+				.conflictsCount=${this.wip?.stats?.conflictsCount}
 				.pausedOpStatus=${pausedOpStatus}
 			></gl-merge-rebase-status>
 		</div>`;

--- a/src/webviews/apps/plus/graph/components/gl-details-wip-header.ts
+++ b/src/webviews/apps/plus/graph/components/gl-details-wip-header.ts
@@ -420,6 +420,7 @@ export class GlDetailsWipHeader extends LitElement {
 				?has-staged-changes=${this.wip?.changes?.files?.some(f => f.staged) ?? false}
 				?ai-resolve=${this.aiEnabled}
 				?ai-resume=${this.aiEnabled}
+				?ai-active=${this.wip?.changes?.aiRebaseActive ?? false}
 				?readonly=${this.activeMode != null}
 				.pausedOpStatus=${pausedOpStatus}
 			></gl-merge-rebase-status>

--- a/src/webviews/apps/plus/graph/components/gl-details-wip-header.ts
+++ b/src/webviews/apps/plus/graph/components/gl-details-wip-header.ts
@@ -416,6 +416,7 @@ export class GlDetailsWipHeader extends LitElement {
 		return html`<div slot="secondary" class="graph-details-header__paused-op">
 			<gl-merge-rebase-status
 				?conflicts=${this.wip?.changes?.hasConflicts ?? false}
+				.conflictsCount=${this.wip?.stats?.conflictsCount}
 				?has-staged-changes=${this.wip?.changes?.files?.some(f => f.staged) ?? false}
 				?ai-resolve=${this.aiEnabled}
 				?ai-resume=${this.aiEnabled}

--- a/src/webviews/apps/plus/home/components/active-work.ts
+++ b/src/webviews/apps/plus/home/components/active-work.ts
@@ -569,6 +569,7 @@ export class GlActiveBranchCard extends GlBranchCardBase {
 
 		return html`<gl-merge-rebase-status
 			?conflicts=${wip.hasConflicts}
+			.conflictsCount=${wip.conflictsCount}
 			.pausedOpStatus=${wip.pausedOpStatus}
 		></gl-merge-rebase-status>`;
 	}

--- a/src/webviews/apps/plus/shared/components/__tests__/merge-rebase-status.utils.test.ts
+++ b/src/webviews/apps/plus/shared/components/__tests__/merge-rebase-status.utils.test.ts
@@ -15,9 +15,10 @@ import {
 	getPausedOperationBarActionLabel,
 	getPausedOperationBarIconTooltip,
 	getPausedOperationBarLabel,
+	getPausedOperationSkipDetail,
 	getPausedOperationSkipLabel,
 	getPausedOperationSkipRef,
-	getPausedOperationStepTooltip,
+	getPausedOperationStepTooltipParts,
 	isPausedOperationStepped,
 } from '../merge-rebase-status.utils.js';
 
@@ -242,28 +243,10 @@ suite('getPausedOperationSkipRef', () => {
 });
 
 suite('getPausedOperationSkipLabel', () => {
-	test('skip names its victim', () => {
-		assert.strictEqual(
-			getPausedOperationSkipLabel(createCherryPick('Fix parser edge case')),
-			'Skip a1b2c3d "Fix parser edge case"',
-		);
-	});
-
-	test('only the subject line is used', () => {
-		assert.strictEqual(
-			getPausedOperationSkipLabel(createRevert('Add telemetry\n\nWith a long body that is not a subject')),
-			'Skip a1b2c3d "Add telemetry"',
-		);
-	});
-
-	test('a long subject is elided', () => {
-		const subject = 'A'.repeat(80);
-		const label = getPausedOperationSkipLabel(createCherryPick(subject));
-		assert.strictEqual(label, `Skip a1b2c3d "${'A'.repeat(49)}…"`);
-	});
-
-	test('without a subject it falls back to the sha', () => {
-		assert.strictEqual(getPausedOperationSkipLabel(createCherryPick()), 'Skip a1b2c3d');
+	test('a rebase skips its paused commit; a cherry-pick/revert skips the commit', () => {
+		assert.strictEqual(getPausedOperationSkipLabel(createRebase()), 'Skip Paused Commit');
+		assert.strictEqual(getPausedOperationSkipLabel(createCherryPick()), 'Skip Commit');
+		assert.strictEqual(getPausedOperationSkipLabel(createRevert()), 'Skip Commit');
 	});
 
 	test('without a commit at all it falls back to plain Skip', () => {
@@ -272,22 +255,55 @@ suite('getPausedOperationSkipLabel', () => {
 	});
 });
 
-suite('getPausedOperationStepTooltip', () => {
-	test('names the paused-on commit and what is left', () => {
+suite('getPausedOperationSkipDetail', () => {
+	test('names the victim', () => {
 		assert.strictEqual(
-			getPausedOperationStepTooltip(createRebase({ message: 'Fix parser edge case' })),
-			'0f1e2d3 "Fix parser edge case" — 4 remaining',
+			getPausedOperationSkipDetail(createCherryPick('Fix parser edge case')),
+			'a1b2c3d "Fix parser edge case"',
 		);
 	});
 
-	test('a final step has nothing remaining', () => {
+	test('only the subject line is used', () => {
 		assert.strictEqual(
-			getPausedOperationStepTooltip(createRebase({ current: 7, total: 7, message: 'Last one' })),
-			'0f1e2d3 "Last one" — 0 remaining',
+			getPausedOperationSkipDetail(createRevert('Add telemetry\n\nWith a long body that is not a subject')),
+			'a1b2c3d "Add telemetry"',
 		);
 	});
 
-	test('without a commit it still reports what is left', () => {
-		assert.strictEqual(getPausedOperationStepTooltip(createRebase({ noCommit: true })), '4 remaining');
+	test('a long subject is elided', () => {
+		const subject = 'A'.repeat(80);
+		assert.strictEqual(getPausedOperationSkipDetail(createCherryPick(subject)), `a1b2c3d "${'A'.repeat(49)}…"`);
+	});
+
+	test('without a subject it falls back to the sha', () => {
+		assert.strictEqual(getPausedOperationSkipDetail(createCherryPick()), 'a1b2c3d');
+	});
+
+	test('without a commit there is no detail', () => {
+		assert.strictEqual(getPausedOperationSkipDetail(createRebase({ noCommit: true })), undefined);
+		assert.strictEqual(getPausedOperationSkipDetail(createMerge()), undefined);
+	});
+});
+
+suite('getPausedOperationStepTooltipParts', () => {
+	test('states where the rebase is paused and the commit subject', () => {
+		assert.deepStrictEqual(getPausedOperationStepTooltipParts(createRebase({ message: 'Fix parser edge case' })), {
+			detail: 'Rebase paused at 0f1e2d3 (step 3 of 7)',
+			subject: '"Fix parser edge case"',
+		});
+	});
+
+	test('without a subject only the detail remains', () => {
+		assert.deepStrictEqual(getPausedOperationStepTooltipParts(createRebase()), {
+			detail: 'Rebase paused at 0f1e2d3 (step 3 of 7)',
+			subject: undefined,
+		});
+	});
+
+	test('without a commit the position still reads', () => {
+		assert.deepStrictEqual(getPausedOperationStepTooltipParts(createRebase({ noCommit: true })), {
+			detail: 'Rebase paused (step 3 of 7)',
+			subject: undefined,
+		});
 	});
 });

--- a/src/webviews/apps/plus/shared/components/__tests__/merge-rebase-status.utils.test.ts
+++ b/src/webviews/apps/plus/shared/components/__tests__/merge-rebase-status.utils.test.ts
@@ -1,0 +1,293 @@
+import * as assert from 'assert';
+import type {
+	GitCherryPickStatus,
+	GitMergeStatus,
+	GitRebaseStatus,
+	GitRevertStatus,
+} from '@gitlens/git/models/pausedOperationStatus.js';
+import {
+	getPausedOperationVariant,
+	pausedOperationVariantIcons,
+} from '@gitlens/git/utils/pausedOperationStatus.utils.js';
+import { createReference } from '@gitlens/git/utils/reference.utils.js';
+import {
+	getPausedOperationAbortLabel,
+	getPausedOperationBarActionLabel,
+	getPausedOperationBarIconTooltip,
+	getPausedOperationBarLabel,
+	getPausedOperationSkipLabel,
+	getPausedOperationSkipRef,
+	getPausedOperationStepTooltip,
+	isPausedOperationStepped,
+} from '../merge-rebase-status.utils.js';
+
+const repoPath = '/repo';
+const incomingSha = 'a1b2c3d4e5f60718293a4b5c6d7e8f9012345678';
+const stepSha = '0f1e2d3c4b5a69788796a5b4c3d2e1f001234567';
+
+function createMerge(): GitMergeStatus {
+	return {
+		type: 'merge',
+		repoPath: repoPath,
+		mergeBase: undefined,
+		HEAD: createReference(incomingSha, repoPath, { refType: 'revision' }),
+		current: createReference('main', repoPath, { refType: 'branch', name: 'main', remote: false }),
+		incoming: createReference('feature', repoPath, { refType: 'branch', name: 'feature', remote: false }),
+	};
+}
+
+function createRebase(options?: {
+	current?: number;
+	total?: number;
+	message?: string;
+	noCommit?: boolean;
+}): GitRebaseStatus {
+	return {
+		type: 'rebase',
+		repoPath: repoPath,
+		mergeBase: undefined,
+		HEAD: createReference(stepSha, repoPath, { refType: 'revision' }),
+		onto: createReference(incomingSha, repoPath, { refType: 'revision' }),
+		source: createReference(incomingSha, repoPath, { refType: 'revision' }),
+		current: createReference('main', repoPath, { refType: 'branch', name: 'main', remote: false }),
+		incoming: createReference('feature', repoPath, { refType: 'branch', name: 'feature', remote: false }),
+		steps: {
+			current: {
+				number: options?.current ?? 3,
+				commit: options?.noCommit
+					? undefined
+					: createReference(stepSha, repoPath, { refType: 'revision', message: options?.message }),
+			},
+			total: options?.total ?? 7,
+		},
+		hasStarted: true,
+		isPaused: true,
+		isInteractive: false,
+	};
+}
+
+function createCherryPick(message?: string): GitCherryPickStatus {
+	return {
+		type: 'cherry-pick',
+		repoPath: repoPath,
+		mergeBase: undefined,
+		HEAD: createReference(incomingSha, repoPath, { refType: 'revision', message: message }),
+		current: createReference('main', repoPath, { refType: 'branch', name: 'main', remote: false }),
+		incoming: createReference(incomingSha, repoPath, { refType: 'revision', message: message }),
+	};
+}
+
+function createRevert(message?: string): GitRevertStatus {
+	return {
+		type: 'revert',
+		repoPath: repoPath,
+		mergeBase: undefined,
+		HEAD: createReference(incomingSha, repoPath, { refType: 'revision', message: message }),
+		current: createReference('main', repoPath, { refType: 'branch', name: 'main', remote: false }),
+		incoming: createReference(incomingSha, repoPath, { refType: 'revision', message: message }),
+	};
+}
+
+suite('getPausedOperationVariant', () => {
+	test('conflicts win over a rebase that has not started', () => {
+		assert.strictEqual(getPausedOperationVariant(createRebase({ current: 0, total: 0 }), true), 'conflicts');
+	});
+
+	test('a rebase with no steps yet is pending', () => {
+		assert.strictEqual(getPausedOperationVariant(createRebase({ current: 0, total: 0 }), false), 'pending');
+	});
+
+	test('a started rebase without conflicts is ready', () => {
+		assert.strictEqual(getPausedOperationVariant(createRebase(), false), 'ready');
+	});
+
+	test('non-rebase operations are never pending', () => {
+		assert.strictEqual(getPausedOperationVariant(createMerge(), false), 'ready');
+		assert.strictEqual(getPausedOperationVariant(createCherryPick(), false), 'ready');
+		assert.strictEqual(getPausedOperationVariant(createRevert(), false), 'ready');
+	});
+});
+
+suite('isPausedOperationStepped', () => {
+	test('a started rebase is stepped whether or not it has conflicts', () => {
+		assert.strictEqual(isPausedOperationStepped(createRebase(), 'ready'), true);
+		assert.strictEqual(isPausedOperationStepped(createRebase(), 'conflicts'), true);
+	});
+
+	test('a pending rebase is not stepped', () => {
+		assert.strictEqual(isPausedOperationStepped(createRebase({ current: 0, total: 0 }), 'pending'), false);
+	});
+
+	test('non-rebase operations are never stepped', () => {
+		assert.strictEqual(isPausedOperationStepped(createMerge(), 'conflicts'), false);
+		assert.strictEqual(isPausedOperationStepped(createCherryPick(), 'ready'), false);
+	});
+});
+
+suite('getPausedOperationBarLabel', () => {
+	test('conflicts name the paused operation', () => {
+		assert.strictEqual(getPausedOperationBarLabel(createMerge(), 'conflicts'), 'Merge paused');
+		assert.strictEqual(getPausedOperationBarLabel(createRebase(), 'conflicts'), 'Rebase paused');
+		assert.strictEqual(getPausedOperationBarLabel(createCherryPick(), 'conflicts'), 'Cherry-pick paused');
+		assert.strictEqual(getPausedOperationBarLabel(createRevert(), 'conflicts'), 'Revert paused');
+	});
+
+	test('ready is verb-led', () => {
+		assert.strictEqual(getPausedOperationBarLabel(createMerge(), 'ready'), 'Merging');
+		assert.strictEqual(getPausedOperationBarLabel(createRebase(), 'ready'), 'Rebasing');
+		assert.strictEqual(getPausedOperationBarLabel(createCherryPick(), 'ready'), 'Cherry picking');
+		assert.strictEqual(getPausedOperationBarLabel(createRevert(), 'ready'), 'Reverting');
+	});
+
+	test('a pending rebase reads into its refs', () => {
+		assert.strictEqual(
+			getPausedOperationBarLabel(createRebase({ current: 0, total: 0 }), 'pending'),
+			'Pending rebase of',
+		);
+	});
+});
+
+suite('getPausedOperationBarActionLabel', () => {
+	test('the conflict count rides on the button', () => {
+		assert.strictEqual(getPausedOperationBarActionLabel(createMerge(), 'conflicts', 3), 'Resolve 3 Conflicts');
+	});
+
+	test('a single conflict is not pluralized', () => {
+		assert.strictEqual(getPausedOperationBarActionLabel(createMerge(), 'conflicts', 1), 'Resolve 1 Conflict');
+	});
+
+	test('a host without a count still gets an actionable label', () => {
+		assert.strictEqual(
+			getPausedOperationBarActionLabel(createMerge(), 'conflicts', undefined),
+			'Resolve Conflicts',
+		);
+	});
+
+	test('continue names the operation', () => {
+		assert.strictEqual(getPausedOperationBarActionLabel(createMerge(), 'ready', undefined), 'Continue Merge');
+		assert.strictEqual(
+			getPausedOperationBarActionLabel(createCherryPick(), 'ready', undefined),
+			'Continue Cherry Pick',
+		);
+		assert.strictEqual(getPausedOperationBarActionLabel(createRevert(), 'ready', undefined), 'Continue Revert');
+		assert.strictEqual(
+			getPausedOperationBarActionLabel(createRebase({ current: 0, total: 0 }), 'pending', undefined),
+			'Continue Rebase',
+		);
+	});
+});
+
+suite('pausedOperationVariantIcons', () => {
+	test('each variant gets its own icon', () => {
+		assert.strictEqual(pausedOperationVariantIcons.conflicts, 'warning');
+		assert.strictEqual(pausedOperationVariantIcons.pending, 'circle-outline');
+		assert.strictEqual(pausedOperationVariantIcons.ready, 'check');
+	});
+});
+
+suite('getPausedOperationBarIconTooltip', () => {
+	test('conflicts restate the count in plain words', () => {
+		assert.strictEqual(
+			getPausedOperationBarIconTooltip(createMerge(), 'conflicts', 2),
+			'2 conflicting files must be resolved before the merge can continue',
+		);
+		assert.strictEqual(
+			getPausedOperationBarIconTooltip(createRebase(), 'conflicts', 1),
+			'1 conflicting file must be resolved before the rebase can continue',
+		);
+	});
+
+	test('a countless host drops the number, not the sentence', () => {
+		assert.strictEqual(
+			getPausedOperationBarIconTooltip(createCherryPick(), 'conflicts', undefined),
+			'Conflicting files must be resolved before the cherry-pick can continue',
+		);
+	});
+
+	test('ready spells out that nothing is blocking', () => {
+		assert.strictEqual(
+			getPausedOperationBarIconTooltip(createMerge(), 'ready', undefined),
+			'No unresolved conflicts — ready to continue',
+		);
+	});
+
+	test('pending has nothing to explain', () => {
+		assert.strictEqual(
+			getPausedOperationBarIconTooltip(createRebase({ current: 0, total: 0 }), 'pending', undefined),
+			undefined,
+		);
+	});
+});
+
+suite('getPausedOperationAbortLabel', () => {
+	test('abort names the operation', () => {
+		assert.strictEqual(getPausedOperationAbortLabel(createMerge()), 'Abort Merge');
+		assert.strictEqual(getPausedOperationAbortLabel(createCherryPick()), 'Abort Cherry Pick');
+	});
+});
+
+suite('getPausedOperationSkipRef', () => {
+	test('a merge has nothing to skip', () => {
+		assert.strictEqual(getPausedOperationSkipRef(createMerge()), undefined);
+	});
+
+	test('a rebase skips its current step', () => {
+		assert.strictEqual(getPausedOperationSkipRef(createRebase())?.ref, stepSha);
+	});
+
+	test('a cherry-pick/revert skips the commit it is applying', () => {
+		assert.strictEqual(getPausedOperationSkipRef(createCherryPick())?.ref, incomingSha);
+		assert.strictEqual(getPausedOperationSkipRef(createRevert())?.ref, incomingSha);
+	});
+});
+
+suite('getPausedOperationSkipLabel', () => {
+	test('skip names its victim', () => {
+		assert.strictEqual(
+			getPausedOperationSkipLabel(createCherryPick('Fix parser edge case')),
+			'Skip a1b2c3d "Fix parser edge case"',
+		);
+	});
+
+	test('only the subject line is used', () => {
+		assert.strictEqual(
+			getPausedOperationSkipLabel(createRevert('Add telemetry\n\nWith a long body that is not a subject')),
+			'Skip a1b2c3d "Add telemetry"',
+		);
+	});
+
+	test('a long subject is elided', () => {
+		const subject = 'A'.repeat(80);
+		const label = getPausedOperationSkipLabel(createCherryPick(subject));
+		assert.strictEqual(label, `Skip a1b2c3d "${'A'.repeat(49)}…"`);
+	});
+
+	test('without a subject it falls back to the sha', () => {
+		assert.strictEqual(getPausedOperationSkipLabel(createCherryPick()), 'Skip a1b2c3d');
+	});
+
+	test('without a commit at all it falls back to plain Skip', () => {
+		assert.strictEqual(getPausedOperationSkipLabel(createRebase({ noCommit: true })), 'Skip');
+		assert.strictEqual(getPausedOperationSkipLabel(createMerge()), 'Skip');
+	});
+});
+
+suite('getPausedOperationStepTooltip', () => {
+	test('names the paused-on commit and what is left', () => {
+		assert.strictEqual(
+			getPausedOperationStepTooltip(createRebase({ message: 'Fix parser edge case' })),
+			'0f1e2d3 "Fix parser edge case" — 4 remaining',
+		);
+	});
+
+	test('a final step has nothing remaining', () => {
+		assert.strictEqual(
+			getPausedOperationStepTooltip(createRebase({ current: 7, total: 7, message: 'Last one' })),
+			'0f1e2d3 "Last one" — 0 remaining',
+		);
+	});
+
+	test('without a commit it still reports what is left', () => {
+		assert.strictEqual(getPausedOperationStepTooltip(createRebase({ noCommit: true })), '4 remaining');
+	});
+});

--- a/src/webviews/apps/plus/shared/components/merge-rebase-status.ts
+++ b/src/webviews/apps/plus/shared/components/merge-rebase-status.ts
@@ -253,18 +253,41 @@ export class GlMergeConflictWarning extends LitElement {
 	@property({ type: Object })
 	pausedOpStatus?: GitPausedOperationStatus;
 
-	/** Set when Continue is clicked; the command runs out of band, so only a fresh `pausedOpStatus`
-	 *  clears it. Git blocked on a commit-message editor pushes nothing, so the spinner holding is
-	 *  correct — it's waiting on the user. */
+	/** Set when Continue is clicked; the command runs out of band, so a fresh `pausedOpStatus` clears it. */
 	@state()
 	private _continuing = false;
 
+	/** A continue can fail without moving the repo (an empty commit the user then cancels out of,
+	 *  unstaged changes, unmerged files), and a host that re-sends an unchanged `pausedOpStatus` by
+	 *  reference won't register as a change either — so the fresh-status reset alone can strand the
+	 *  primary action in a disabled spinner with nothing else to click. Restore it after a wait long
+	 *  enough that no ordinary continue trips it.
+	 *
+	 *  Note this is only a backstop: measured live, the reset almost always comes from the status
+	 *  instead — even a continue still blocked on the commit-message editor churns `COMMIT_EDITMSG`
+	 *  and the index, which lands a fresh status and clears the busy state early. So the spinner is
+	 *  not a reliable "still running" indicator; re-clicking is harmless (the runner dedups the
+	 *  in-flight command), but the bar can't currently distinguish waiting from finished. */
+	private static readonly continuingWatchdogMs = 30000;
+	private _continuingTimer: ReturnType<typeof setTimeout> | undefined;
+
+	override disconnectedCallback(): void {
+		this.clearContinuing();
+		super.disconnectedCallback?.();
+	}
+
 	protected override willUpdate(changedProperties: PropertyValues<this>): void {
 		if (changedProperties.has('pausedOpStatus')) {
-			this._continuing = false;
+			this.clearContinuing();
 		}
 
 		super.willUpdate(changedProperties);
+	}
+
+	private clearContinuing(): void {
+		clearTimeout(this._continuingTimer);
+		this._continuingTimer = undefined;
+		this._continuing = false;
 	}
 
 	private get onSkipUrl() {
@@ -419,8 +442,18 @@ export class GlMergeConflictWarning extends LitElement {
 	};
 
 	/** Presentation only — the href's navigation still fires the command. */
-	private onContinue = (): void => {
+	private onContinue = (e: Event): void => {
+		// The button keeps its href while busy so `gl-button` reuses its inner anchor — dropping the href
+		// swaps that anchor for a `<button>`, which discards keyboard focus. So the repeat activation is
+		// cancelled here instead: `disabled` stops the pointer, and Enter on a focused link fires a click
+		// we can preventDefault.
+		if (this._continuing) {
+			e.preventDefault();
+			return;
+		}
+
 		this._continuing = true;
+		this._continuingTimer = setTimeout(() => this.clearContinuing(), GlMergeConflictWarning.continuingWatchdogMs);
 	};
 
 	private renderActions(status: GitPausedOperationStatus, variant: PausedOperationVariant) {
@@ -496,24 +529,28 @@ export class GlMergeConflictWarning extends LitElement {
 	 *  longer excluded — `revert --continue` is supported end to end. */
 	private renderPrimaryAction(status: GitPausedOperationStatus, variant: PausedOperationVariant, aiPrimary: boolean) {
 		if (variant !== 'conflicts') {
-			// No href while waiting — disabled stops the pointer, but a link still navigates on Enter.
-			if (this._continuing) {
-				const waiting = aiPrimary
+			const continuing = this._continuing;
+			const label = continuing
+				? aiPrimary
 					? 'Continuing Automatic Rebase…'
-					: `Continuing ${pausedOperationStatusStringsByType[status.type].name}…`;
-				return html`<gl-button density="compact" disabled
-					><code-icon icon="loading" modifier="spin" slot="prefix"></code-icon>${waiting}</gl-button
-				>`;
-			}
+					: `Continuing ${pausedOperationStatusStringsByType[status.type].name}…`
+				: aiPrimary
+					? 'Continue Automatic Rebase'
+					: getPausedOperationBarActionLabel(status, variant, this.conflictsCount);
 
-			if (aiPrimary) {
-				return html`<gl-button density="compact" href=${this.onContinueWithAiUrl} @click=${this.onContinue}
-					>Continue Automatic Rebase</gl-button
-				>`;
-			}
-
-			return html`<gl-button density="compact" href=${this.onContinueUrl} @click=${this.onContinue}
-				>${getPausedOperationBarActionLabel(status, variant, this.conflictsCount)}</gl-button
+			// One template across both states, and the href kept even while busy, so Lit reuses the button
+			// AND `gl-button` reuses its inner anchor (no href swaps that anchor for a `<button>`, which
+			// discards keyboard focus). `disabled` stops the pointer and drops it from the tab order without
+			// blurring it; `onContinue` cancels the repeat navigation. `aria-busy` carries the state change.
+			return html`<gl-button
+				density="compact"
+				?disabled=${continuing}
+				aria-busy=${continuing ? 'true' : nothing}
+				href=${aiPrimary ? this.onContinueWithAiUrl : this.onContinueUrl}
+				@click=${this.onContinue}
+				>${
+					continuing ? html`<code-icon icon="loading" modifier="spin" slot="prefix"></code-icon>` : nothing
+				}${label}</gl-button
 			>`;
 		}
 

--- a/src/webviews/apps/plus/shared/components/merge-rebase-status.ts
+++ b/src/webviews/apps/plus/shared/components/merge-rebase-status.ts
@@ -232,6 +232,12 @@ export class GlMergeConflictWarning extends LitElement {
 	@property({ type: Boolean, attribute: 'ai-resume' })
 	aiResume = false;
 
+	/** An automatic rebase session owns this paused rebase — continue continues in the vein it started:
+	 *  the primary action resumes the automatic run and the manual continue demotes to a secondary.
+	 *  Only meaningful alongside `ai-resume`. */
+	@property({ type: Boolean, attribute: 'ai-active' })
+	aiActive = false;
+
 	/** Whether the working tree has anything staged. Mirrors the takeover loop's own
 	 *  `hasStagedChanges()` gate, so the "Continue using Automatic Rebase" affordance matches what a takeover would
 	 *  actually do on a rebase paused without conflicts. */
@@ -419,21 +425,33 @@ export class GlMergeConflictWarning extends LitElement {
 
 	private renderActions(status: GitPausedOperationStatus, variant: PausedOperationVariant) {
 		const type = status.type;
-		// "Continue using Automatic Rebase" mirrors the takeover loop's own gate (`resumingThisStep ||
+		// The AI continue mirrors the takeover loop's own gate (`resumingThisStep ||
 		// hasStagedChanges()`): with conflicts it resolves them, and with a staged resolution it
 		// continues and keeps resolving the REMAINING steps — so hiding it once the user stages an
 		// escalated step would strand them on plain "Continue", which ends automation for the rest of
 		// the run. Still hidden for a genuine non-conflict stop (an interactive edit/break with nothing
 		// staged), where a takeover has nothing to continue and would only escalate.
 		const aiRebase = type === 'rebase' && this.aiResume && (this.conflicts || this.hasStagedChanges);
+		// Continue continues in the vein the rebase started: with an automatic session active the
+		// primary resumes it, and the manual continue becomes the secondary instead of the sparkle.
+		const aiPrimary = type === 'rebase' && this.aiResume && this.aiActive && variant !== 'conflicts';
 
 		return html`<action-nav class="actions">
-			${this.renderPrimaryAction(status, variant)}
+			${this.renderPrimaryAction(status, variant, aiPrimary)}
 			${when(
-				aiRebase,
+				aiPrimary,
 				() =>
 					html`<action-item
-						label="Continue using Automatic Rebase"
+						label="Continue Rebase Manually"
+						href=${this.onContinueUrl}
+						icon="gl-continue"
+					></action-item>`,
+			)}
+			${when(
+				aiRebase && !aiPrimary,
+				() =>
+					html`<action-item
+						label=${this.aiActive ? 'Continue Automatic Rebase' : 'Continue using Automatic Rebase'}
 						href=${this.onContinueWithAiUrl}
 						icon="gl-continue-sparkle"
 					></action-item>`,
@@ -476,21 +494,30 @@ export class GlMergeConflictWarning extends LitElement {
 	/** One obvious next step per state. Continue renders only in ready/pending, which structurally keeps
 	 *  a conflicted rebase from offering a `--continue` that can't succeed; a revert's continue is no
 	 *  longer excluded — `revert --continue` is supported end to end. */
-	private renderPrimaryAction(status: GitPausedOperationStatus, variant: PausedOperationVariant) {
-		const label = getPausedOperationBarActionLabel(status, variant, this.conflictsCount);
+	private renderPrimaryAction(status: GitPausedOperationStatus, variant: PausedOperationVariant, aiPrimary: boolean) {
 		if (variant !== 'conflicts') {
 			// No href while waiting — disabled stops the pointer, but a link still navigates on Enter.
 			if (this._continuing) {
-				const waiting = `Continuing ${pausedOperationStatusStringsByType[status.type].name}…`;
+				const waiting = aiPrimary
+					? 'Continuing Automatic Rebase…'
+					: `Continuing ${pausedOperationStatusStringsByType[status.type].name}…`;
 				return html`<gl-button density="compact" disabled
 					><code-icon icon="loading" modifier="spin" slot="prefix"></code-icon>${waiting}</gl-button
 				>`;
 			}
 
+			if (aiPrimary) {
+				return html`<gl-button density="compact" href=${this.onContinueWithAiUrl} @click=${this.onContinue}
+					>Continue Automatic Rebase</gl-button
+				>`;
+			}
+
 			return html`<gl-button density="compact" href=${this.onContinueUrl} @click=${this.onContinue}
-				>${label}</gl-button
+				>${getPausedOperationBarActionLabel(status, variant, this.conflictsCount)}</gl-button
 			>`;
 		}
+
+		const label = getPausedOperationBarActionLabel(status, variant, this.conflictsCount);
 
 		// With AI resolve available (graph host), the action enters Resolve Conflicts mode.
 		// Elsewhere it falls back to revealing the conflicts in the tree / rebase editor.

--- a/src/webviews/apps/plus/shared/components/merge-rebase-status.ts
+++ b/src/webviews/apps/plus/shared/components/merge-rebase-status.ts
@@ -1,80 +1,149 @@
 import { consume } from '@lit/context';
+import type { PropertyValues } from 'lit';
 import { css, html, LitElement, nothing } from 'lit';
-import { customElement, property } from 'lit/decorators.js';
+import { customElement, property, state } from 'lit/decorators.js';
 import { when } from 'lit/directives/when.js';
-import type { GitPausedOperation, GitPausedOperationStatus } from '@gitlens/git/models/pausedOperationStatus.js';
+import type { GitPausedOperationStatus, GitRebaseStatus } from '@gitlens/git/models/pausedOperationStatus.js';
 import type { GitReference } from '@gitlens/git/models/reference.js';
-import { pausedOperationStatusStringsByType } from '@gitlens/git/utils/pausedOperationStatus.utils.js';
+import type { PausedOperationVariant } from '@gitlens/git/utils/pausedOperationStatus.utils.js';
+import {
+	getConflictCurrentRef,
+	getPausedOperationVariant,
+	pausedOperationStatusStringsByType,
+	pausedOperationVariantIcons,
+} from '@gitlens/git/utils/pausedOperationStatus.utils.js';
 import type { ContinueRebaseWithAiCommandArgs } from '../../../../../commands/autoRebase.js';
 import { createCommandLink } from '../../../../../system/commands.js';
 import type { ShowInCommitGraphCommandArgs } from '../../../../plus/graph/registration.js';
 import type { WebviewContext } from '../../../shared/contexts/webview.js';
 import { webviewContext } from '../../../shared/contexts/webview.js';
+import {
+	getPausedOperationAbortLabel,
+	getPausedOperationBarActionLabel,
+	getPausedOperationBarIconTooltip,
+	getPausedOperationBarLabel,
+	getPausedOperationSkipLabel,
+	getPausedOperationStepTooltip,
+	isPausedOperationStepped,
+} from './merge-rebase-status.utils.js';
 import '../../../shared/components/actions/action-item.js';
 import '../../../shared/components/actions/action-nav.js';
 import '../../../shared/components/branch-name.js';
+import '../../../shared/components/button.js';
 import '../../../shared/components/code-icon.js';
 import '../../../shared/components/commit-sha.js';
 import '../../../shared/components/overlays/tooltip.js';
-
-/** Names the operation in the "Continue" action so it reads distinctly from the AI "Continue
- *  Automatic Rebase" action sitting next to it on a paused rebase. */
-const continueLabelsByType: Record<GitPausedOperation, string> = {
-	'cherry-pick': 'Continue Cherry Pick',
-	merge: 'Continue Merge',
-	rebase: 'Continue Rebase',
-	revert: 'Continue Revert',
-};
 
 @customElement('gl-merge-rebase-status')
 export class GlMergeConflictWarning extends LitElement {
 	static override styles = [
 		css`
 			.status {
+				/* The strip's background is a fixed decoration color, not a theme color, so its chips can't
+				   derive from the theme either. Lightening reads on all four variants where a currentColor
+				   tint muddied the amber/green fills, so chips/pills/buttons are white overlays carrying
+				   dark ink whatever the strip's own text color is. */
+				--gl-paused-op-chip: rgb(255 255 255 / 0.45);
+				--gl-paused-op-chip-hover: rgb(255 255 255 / 0.6);
+				--gl-paused-op-ink: #1a1a1a;
 				--action-item-foreground: #000;
-				/* Blend the action hover/active states into the banner instead of the generic
-				   grey toolbar hover. currentColor tracks --action-item-foreground, so the
-				   conflicts variant (white foreground) tints correctly without redeclaring. */
-				--action-item-hover-background: color-mix(in srgb, currentColor 12%, transparent);
-				--action-item-active-background: color-mix(in srgb, currentColor 22%, transparent);
+				--action-item-hover-background: var(--gl-paused-op-chip);
+				--action-item-active-background: var(--gl-paused-op-chip-hover);
 
 				box-sizing: border-box;
+				container-type: inline-size;
 				display: flex;
 				gap: var(--gl-space-6);
 				align-items: center;
 				width: 100%;
 				max-width: 100%;
-				padding: 0.1rem 0.4rem;
+				min-height: 2.4rem;
+				padding: 0.2rem 0.4rem 0.2rem 0.6rem;
 				margin-block: 0;
 				color: #000;
 				background-color: var(--vscode-gitlens-decorations\\.statusMergingOrRebasingForegroundColor);
 				border-radius: var(--gl-radius-sm);
 			}
 
-			:host([conflicts]) .status {
+			.status[data-variant='conflicts'] {
 				--action-item-foreground: #fff;
 
 				color: #fff;
 				background-color: var(--vscode-gitlens-decorations\\.statusMergingOrRebasingConflictForegroundColor);
 			}
 
+			.status[data-variant='ready'] {
+				--action-item-foreground: #06150a;
+
+				color: #06150a;
+				background-color: var(--vscode-gitlens-decorations\\.statusPausedOperationReadyForegroundColor);
+			}
+
+			/* The light theme's green is dark enough to carry white text; dark's is not. */
+			:host-context(.vscode-light) .status[data-variant='ready'],
+			:host-context(.vscode-high-contrast-light) .status[data-variant='ready'] {
+				--action-item-foreground: #fff;
+
+				color: #fff;
+			}
+
 			.label {
+				display: flex;
 				flex: 1;
+				gap: var(--gl-space-4);
+				align-items: center;
 				min-width: 0;
 				overflow: hidden;
-				text-overflow: ellipsis;
 				white-space: nowrap;
 			}
 
+			/* The phrase never shrinks — width pressure goes to the refs, which shrink and (stepped) drop. */
+			.label__text {
+				flex: none;
+			}
+
+			.label__text--emphasized {
+				font-weight: 600;
+			}
+
+			.separator {
+				flex: none;
+				opacity: 0.55;
+			}
+
+			.refs {
+				display: inline-flex;
+				flex: 0 1 auto;
+				gap: var(--gl-space-4);
+				align-items: center;
+				min-width: 0;
+				overflow: hidden;
+			}
+
+			/* Refs absorb all the shrink, ellipsizing well past the chips' resting minimum. */
+			.refs .chip {
+				min-width: 0;
+			}
+
+			/* Under width pressure the refs are the first thing to go: the branch row directly below the
+			   strip already names the branch and the paused-at pill's hover carries the rest, so the
+			   phrase and the actions never lose room. Only stripped when a step pill is competing for it.
+			   The threshold is where the chips stop being able to NAME their refs — slivers are worse
+			   than absence. */
+			@container (max-width: 52rem) {
+				.status--stepped .refs {
+					display: none;
+				}
+			}
+
 			.icon,
-			.steps,
 			.actions {
 				flex: none;
 			}
 
-			/* Read-only (mode) banner: baseline-align so the "(N/M)" step counter lines up with the
+			/* Read-only (mode) banner: baseline-align so the "at 3/7" step counter lines up with the
 			   status text. The branch-name chips inflate the label's line-box, so plain center-alignment
-			   leaves the counter sitting too low. Keep the warning icon centered. */
+			   leaves the counter sitting too low. Keep the leading icon centered. */
 			:host([readonly]) .status {
 				align-items: baseline;
 			}
@@ -83,37 +152,51 @@ export class GlMergeConflictWarning extends LitElement {
 				align-self: center;
 			}
 
-			.md-code {
-				padding: 0 var(--gl-space-4) var(--gl-space-2);
-				font-family: var(--vscode-editor-font-family);
-				background: var(--vscode-textCodeBlock-background);
-				border-radius: var(--gl-radius-sm);
-			}
-
 			gl-commit-sha::part(label) {
 				font-weight: bold;
 			}
 
-			.link {
-				color: inherit;
-				text-decoration: underline dotted;
-				text-underline-offset: 0.3rem;
-				opacity: 0.9;
+			/* The ref chips wrap atomic inline-level components, which text-decoration can't reach, so the
+			   clickable affordance is the fill rather than an underline. */
+			.chip {
+				display: inline-flex;
+				flex: 0 1 auto;
+				align-items: center;
+				min-width: 4ch;
+				padding: 0 var(--gl-space-4);
+				overflow: hidden;
+				color: var(--gl-paused-op-ink);
+				text-decoration: none;
+				cursor: pointer;
+				background-color: var(--gl-paused-op-chip);
+				border-radius: var(--gl-radius-xs);
 
 				&:hover {
-					text-decoration: none;
-					opacity: 1;
+					background-color: var(--gl-paused-op-chip-hover);
 				}
 			}
 
-			.link--conflicts {
-				margin-left: var(--gl-space-10);
+			/* The step counter is short and load-bearing — it never shrinks with the refs. */
+			.steps {
+				flex: none;
+				min-width: auto;
+				font-variant-numeric: tabular-nums;
 			}
 
-			.ref-link {
-				color: inherit;
-				text-decoration: none !important;
-				cursor: pointer;
+			.actions gl-button {
+				--button-background: var(--gl-paused-op-chip);
+				--button-hover-background: var(--gl-paused-op-chip-hover);
+				--button-foreground: var(--gl-paused-op-ink);
+				--button-border: color-mix(in srgb, currentColor 40%, transparent);
+				--button-compact-padding: 0.1rem var(--gl-space-8);
+
+				margin-right: var(--gl-space-2);
+				font-weight: 600;
+				white-space: nowrap;
+			}
+
+			.actions action-item:is(:hover, :focus-within) {
+				--action-item-foreground: var(--gl-paused-op-ink);
 			}
 		`,
 	];
@@ -121,8 +204,12 @@ export class GlMergeConflictWarning extends LitElement {
 	@consume({ context: webviewContext })
 	private _webview!: WebviewContext;
 
-	@property({ type: Boolean, reflect: true })
+	@property({ type: Boolean })
 	conflicts = false;
+
+	/** How many files are conflicted, when the host knows — rides on the Resolve action's label. */
+	@property({ type: Number, attribute: 'conflicts-count' })
+	conflictsCount?: number;
 
 	/** Opt-in for routing the conflicts status text into Resolve Conflicts mode (fires
 	 *  `ai-resolve-conflicts`). Only hosts that can handle the event (the graph WIP details) should
@@ -149,6 +236,20 @@ export class GlMergeConflictWarning extends LitElement {
 
 	@property({ type: Object })
 	pausedOpStatus?: GitPausedOperationStatus;
+
+	/** Set when Continue is clicked; the command runs out of band, so only a fresh `pausedOpStatus`
+	 *  clears it. Git blocked on a commit-message editor pushes nothing, so the spinner holding is
+	 *  correct — it's waiting on the user. */
+	@state()
+	private _continuing = false;
+
+	protected override willUpdate(changedProperties: PropertyValues<this>): void {
+		if (changedProperties.has('pausedOpStatus')) {
+			this._continuing = false;
+		}
+
+		super.willUpdate(changedProperties);
+	}
 
 	private get onSkipUrl() {
 		return this.createPausedOperationCommandLink('skip');
@@ -184,55 +285,76 @@ export class GlMergeConflictWarning extends LitElement {
 	}
 
 	override render(): unknown {
-		if (this.pausedOpStatus == null) return nothing;
+		const status = this.pausedOpStatus;
+		if (status == null) return nothing;
+
+		const variant = getPausedOperationVariant(status, this.conflicts);
+		// One predicate drives both the CSS gate (refs drop at narrow widths) and the step-pill render.
+		const stepped = isPausedOperationStepped(status, variant) ? status : undefined;
 
 		return html`
-			<span class="status" part="base">
-				<code-icon icon="warning" class="icon"></code-icon>
-				${this.renderStatus(this.pausedOpStatus)}${this.renderActions()}
+			<span class="status ${stepped != null ? 'status--stepped' : ''}" part="base" data-variant=${variant}>
+				${this.renderIcon(status, variant)}${this.renderLabel(status, variant, stepped)}${
+					// Read-only keeps the variant's copy and tint — only the affordances go away.
+					this.readOnly ? nothing : this.renderActions(status, variant)
+				}
 			</span>
 		`;
 	}
 
-	private renderStatus(pausedOpStatus: GitPausedOperationStatus) {
-		if (pausedOpStatus.type !== 'rebase') {
-			const strings = pausedOperationStatusStringsByType[pausedOpStatus.type];
-			const label = this.conflicts ? strings.conflicts : strings.label;
-			return html`<span class="label"
-				>${this.renderConflictsLink(label)} ${this.renderReference(pausedOpStatus.incoming)}
-				${strings.directionality} ${this.renderReference(pausedOpStatus.current)}</span
-			>`;
-		}
+	private renderIcon(status: GitPausedOperationStatus, variant: PausedOperationVariant) {
+		const icon = html`<code-icon icon=${pausedOperationVariantIcons[variant]} class="icon"></code-icon>`;
 
-		const started = pausedOpStatus.steps.total > 0;
-		const strings = pausedOperationStatusStringsByType[pausedOpStatus.type];
-		const label = this.conflicts ? strings.conflicts : started ? strings.label : strings.pending;
-		return html`<span class="label"
-				>${this.renderConflictsLink(label)} ${this.renderReference(pausedOpStatus.incoming)}
-				${strings.directionality} ${this.renderReference(pausedOpStatus.current ?? pausedOpStatus.onto)}</span
-			>${
-				started
-					? html`<span class="steps"
-							>(${pausedOpStatus.steps.current.number}/${pausedOpStatus.steps.total})</span
-						>`
-					: nothing
-			}`;
+		const tooltip = getPausedOperationBarIconTooltip(status, variant, this.conflictsCount);
+		if (tooltip == null) return icon;
+
+		return html`<gl-tooltip content=${tooltip}>${icon}</gl-tooltip>`;
 	}
 
-	private renderConflictsLink(label: string) {
-		if (!this.conflicts || this.readOnly) return label;
+	private renderLabel(
+		status: GitPausedOperationStatus,
+		variant: PausedOperationVariant,
+		stepped: GitRebaseStatus | undefined,
+	) {
+		const label = getPausedOperationBarLabel(status, variant);
 
-		// With AI resolve available (graph host), clicking the status text enters Resolve Conflicts mode.
-		// Elsewhere it falls back to revealing the conflicts in the tree / rebase editor.
-		if (this.aiResolve) {
-			return html`<gl-tooltip content="Resolve Conflicts">
-				<a href="#" class="link" @click=${this.onResolveWithAI}>${label}</a>
-			</gl-tooltip>`;
+		return html`<span class="label"
+			><span class="label__text ${variant === 'conflicts' ? 'label__text--emphasized' : ''}">${label}</span
+			>${stepped != null ? this.renderStep(stepped) : nothing}${this.renderRefs(
+				status,
+				// The pending phrase reads straight into its refs ("Pending rebase of <feature> onto <main>").
+				variant !== 'pending',
+			)}</span
+		>`;
+	}
+
+	/** The step counter IS the paused-on commit — clicking it jumps to that commit, hovering it names it. */
+	private renderStep(status: GitRebaseStatus) {
+		const steps = `${status.steps.current.number}/${status.steps.total}`;
+		const at = html`<span class="label__text">at</span>`;
+
+		const commit = status.steps.current.commit;
+		if (this.readOnly || commit == null) {
+			return html`${at}<span class="steps">${steps}</span>`;
 		}
 
-		return html`<gl-tooltip content="Show Conflicts">
-			<a href="${this.onShowConflictsUrl}" class="link">${label}</a>
-		</gl-tooltip>`;
+		return html`${at}<gl-tooltip
+				><a href=${this.createJumpUrl(commit)} class="steps chip">${steps}</a
+				><span slot="content"
+					>${getPausedOperationStepTooltip(status)}<br />${this.getJumpLabel(false)}</span
+				></gl-tooltip
+			>`;
+	}
+
+	private renderRefs(status: GitPausedOperationStatus, separator: boolean) {
+		const strings = pausedOperationStatusStringsByType[status.type];
+		// Never null in practice: `current` is required on non-rebase models, `onto` on rebase.
+		const current = getConflictCurrentRef(status)!;
+
+		// The leading separator lives inside the group so nothing dangles when it drops at narrow widths.
+		return html`<span class="refs"
+			>${separator ? html`<span class="separator">·</span>` : nothing}${this.renderReference(status.incoming)}<span>${strings.directionality}</span>${this.renderReference(current)}</span
+		>`;
 	}
 
 	private renderReference(ref: GitReference) {
@@ -244,21 +366,22 @@ export class GlMergeConflictWarning extends LitElement {
 		// Read-only: plain ref text, no jump-to-branch/commit link or tooltip.
 		if (this.readOnly) return content;
 
+		return html`<gl-tooltip content=${this.getJumpLabel(isBranch)}>
+			<a href=${this.createJumpUrl(ref)} class="chip">${content}</a>
+		</gl-tooltip>`;
+	}
+
+	private getJumpLabel(isBranch: boolean): string {
 		const webviewId = this._webview.webviewId;
 		const isInGraph = webviewId === 'gitlens.graph' || webviewId === 'gitlens.views.graph';
 
-		const tooltip = isInGraph
+		return isInGraph
 			? isBranch
 				? 'Jump to Branch'
 				: 'Jump to Commit'
 			: isBranch
 				? 'Open Branch in Commit Graph'
 				: 'Open Commit in Commit Graph';
-		const jumpUrl = this.createJumpUrl(ref);
-
-		return html`<gl-tooltip content=${tooltip}>
-			<a href=${jumpUrl} class="ref-link">${content}</a>
-		</gl-tooltip>`;
 	}
 
 	private createJumpUrl(ref: GitReference): string {
@@ -273,37 +396,30 @@ export class GlMergeConflictWarning extends LitElement {
 		this.dispatchEvent(new CustomEvent('ai-resolve-conflicts', { bubbles: true, composed: true }));
 	};
 
-	private renderActions() {
-		if (this.pausedOpStatus == null || this.readOnly) return nothing;
+	/** Presentation only — the href's navigation still fires the command. */
+	private onContinue = (): void => {
+		this._continuing = true;
+	};
 
-		const status = this.pausedOpStatus.type;
+	private renderActions(status: GitPausedOperationStatus, variant: PausedOperationVariant) {
+		const type = status.type;
 		// "Continue Automatic Rebase" mirrors the takeover loop's own gate (`resumingThisStep ||
 		// hasStagedChanges()`): with conflicts it resolves them, and with a staged resolution it
 		// continues and keeps resolving the REMAINING steps — so hiding it once the user stages an
 		// escalated step would strand them on plain "Continue", which ends automation for the rest of
 		// the run. Still hidden for a genuine non-conflict stop (an interactive edit/break with nothing
 		// staged), where a takeover has nothing to continue and would only escalate.
-		const aiRebase = status === 'rebase' && this.aiResume && (this.conflicts || this.hasStagedChanges);
-		// Plain `<op> --continue` is valid once a rebase has no unresolved conflicts.
-		const canContinue = status !== 'revert' && !(status === 'rebase' && this.conflicts);
+		const aiRebase = type === 'rebase' && this.aiResume && (this.conflicts || this.hasStagedChanges);
 
 		return html`<action-nav class="actions">
+			${this.renderPrimaryAction(status, variant)}
 			${when(
-				status === 'rebase',
+				type === 'rebase',
 				() =>
 					html`<action-item
 						label="Open in Rebase Editor"
 						href=${this.onOpenEditorUrl}
 						icon="edit"
-					></action-item>`,
-			)}
-			${when(
-				canContinue,
-				() =>
-					html`<action-item
-						label=${continueLabelsByType[status]}
-						icon="gl-continue"
-						href=${this.onContinueUrl}
 					></action-item>`,
 			)}
 			${when(
@@ -316,10 +432,47 @@ export class GlMergeConflictWarning extends LitElement {
 					></action-item>`,
 			)}
 			${when(
-				status !== 'merge',
-				() => html`<action-item label="Skip" icon="gl-skip" href=${this.onSkipUrl}></action-item>`,
+				type !== 'merge',
+				() =>
+					html`<action-item
+						label=${getPausedOperationSkipLabel(status)}
+						icon="gl-skip"
+						href=${this.onSkipUrl}
+					></action-item>`,
 			)}
-			<action-item label="Abort" href=${this.onAbortUrl} icon="gl-abort"></action-item>
+			<action-item
+				label=${getPausedOperationAbortLabel(status)}
+				href=${this.onAbortUrl}
+				icon="gl-abort"
+			></action-item>
 		</action-nav>`;
+	}
+
+	/** One obvious next step per state. Continue renders only in ready/pending, which structurally keeps
+	 *  a conflicted rebase from offering a `--continue` that can't succeed; a revert's continue is no
+	 *  longer excluded — `revert --continue` is supported end to end. */
+	private renderPrimaryAction(status: GitPausedOperationStatus, variant: PausedOperationVariant) {
+		const label = getPausedOperationBarActionLabel(status, variant, this.conflictsCount);
+		if (variant !== 'conflicts') {
+			// No href while waiting — disabled stops the pointer, but a link still navigates on Enter.
+			if (this._continuing) {
+				const waiting = `Continuing ${pausedOperationStatusStringsByType[status.type].name}…`;
+				return html`<gl-button density="compact" disabled
+					><code-icon icon="loading" modifier="spin" slot="prefix"></code-icon>${waiting}</gl-button
+				>`;
+			}
+
+			return html`<gl-button density="compact" href=${this.onContinueUrl} @click=${this.onContinue}
+				>${label}</gl-button
+			>`;
+		}
+
+		// With AI resolve available (graph host), the action enters Resolve Conflicts mode.
+		// Elsewhere it falls back to revealing the conflicts in the tree / rebase editor.
+		if (this.aiResolve) {
+			return html`<gl-button density="compact" @click=${this.onResolveWithAI}>${label}</gl-button>`;
+		}
+
+		return html`<gl-button density="compact" href=${this.onShowConflictsUrl}>${label}</gl-button>`;
 	}
 }

--- a/src/webviews/apps/plus/shared/components/merge-rebase-status.ts
+++ b/src/webviews/apps/plus/shared/components/merge-rebase-status.ts
@@ -18,12 +18,14 @@ import type { ShowInCommitGraphCommandArgs } from '../../../../plus/graph/regist
 import type { WebviewContext } from '../../../shared/contexts/webview.js';
 import { webviewContext } from '../../../shared/contexts/webview.js';
 import {
+	describePausedOperationCommit,
 	getPausedOperationAbortLabel,
 	getPausedOperationBarActionLabel,
 	getPausedOperationBarIconTooltip,
 	getPausedOperationBarLabel,
+	getPausedOperationSkipDetail,
 	getPausedOperationSkipLabel,
-	getPausedOperationStepTooltip,
+	getPausedOperationStepTooltipParts,
 	isPausedOperationStepped,
 } from './merge-rebase-status.utils.js';
 import '../../../shared/components/actions/action-item.js';
@@ -198,6 +200,14 @@ export class GlMergeConflictWarning extends LitElement {
 			.actions action-item:is(:hover, :focus-within) {
 				--action-item-foreground: var(--gl-paused-op-ink);
 			}
+
+			/* Tooltip structure shared with the graph header: action line, rule, identifying detail */
+			hr {
+				margin: var(--gl-space-8) 0;
+				border: none;
+				border-top: var(--gl-border-width) solid var(--vscode-widget-border, var(--vscode-foreground));
+				opacity: 0.4;
+			}
 		`,
 	];
 
@@ -223,7 +233,7 @@ export class GlMergeConflictWarning extends LitElement {
 	aiResume = false;
 
 	/** Whether the working tree has anything staged. Mirrors the takeover loop's own
-	 *  `hasStagedChanges()` gate, so the "Continue Automatic Rebase" affordance matches what a takeover would
+	 *  `hasStagedChanges()` gate, so the "Continue using Automatic Rebase" affordance matches what a takeover would
 	 *  actually do on a rebase paused without conflicts. */
 	@property({ type: Boolean, attribute: 'has-staged-changes' })
 	hasStagedChanges = false;
@@ -338,10 +348,13 @@ export class GlMergeConflictWarning extends LitElement {
 			return html`${at}<span class="steps">${steps}</span>`;
 		}
 
+		const parts = getPausedOperationStepTooltipParts(status);
 		return html`${at}<gl-tooltip
 				><a href=${this.createJumpUrl(commit)} class="steps chip">${steps}</a
 				><span slot="content"
-					>${getPausedOperationStepTooltip(status)}<br />${this.getJumpLabel(false)}</span
+					>${this.getJumpLabel('paused-commit')}
+					<hr />
+					${parts.detail}${parts.subject ? html`<br />${parts.subject}` : nothing}</span
 				></gl-tooltip
 			>`;
 	}
@@ -366,22 +379,25 @@ export class GlMergeConflictWarning extends LitElement {
 		// Read-only: plain ref text, no jump-to-branch/commit link or tooltip.
 		if (this.readOnly) return content;
 
-		return html`<gl-tooltip content=${this.getJumpLabel(isBranch)}>
+		// The detail line carries the untruncated identity, since the chip itself may be squeezed
+		const detail = ref.refType === 'revision' ? (describePausedOperationCommit(ref) ?? ref.ref) : ref.name;
+
+		return html`<gl-tooltip>
 			<a href=${this.createJumpUrl(ref)} class="chip">${content}</a>
+			<span slot="content"
+				>${this.getJumpLabel(isBranch ? 'branch' : 'commit')}
+				<hr />
+				${detail}</span
+			>
 		</gl-tooltip>`;
 	}
 
-	private getJumpLabel(isBranch: boolean): string {
+	private getJumpLabel(kind: 'branch' | 'commit' | 'paused-commit'): string {
 		const webviewId = this._webview.webviewId;
 		const isInGraph = webviewId === 'gitlens.graph' || webviewId === 'gitlens.views.graph';
 
-		return isInGraph
-			? isBranch
-				? 'Jump to Branch'
-				: 'Jump to Commit'
-			: isBranch
-				? 'Open Branch in Commit Graph'
-				: 'Open Commit in Commit Graph';
+		const noun = kind === 'branch' ? 'Branch' : kind === 'commit' ? 'Commit' : 'Paused Commit';
+		return isInGraph ? `Jump to ${noun}` : `Open ${noun} in Commit Graph`;
 	}
 
 	private createJumpUrl(ref: GitReference): string {
@@ -403,7 +419,7 @@ export class GlMergeConflictWarning extends LitElement {
 
 	private renderActions(status: GitPausedOperationStatus, variant: PausedOperationVariant) {
 		const type = status.type;
-		// "Continue Automatic Rebase" mirrors the takeover loop's own gate (`resumingThisStep ||
+		// "Continue using Automatic Rebase" mirrors the takeover loop's own gate (`resumingThisStep ||
 		// hasStagedChanges()`): with conflicts it resolves them, and with a staged resolution it
 		// continues and keeps resolving the REMAINING steps — so hiding it once the user stages an
 		// escalated step would strand them on plain "Continue", which ends automation for the rest of
@@ -414,6 +430,15 @@ export class GlMergeConflictWarning extends LitElement {
 		return html`<action-nav class="actions">
 			${this.renderPrimaryAction(status, variant)}
 			${when(
+				aiRebase,
+				() =>
+					html`<action-item
+						label="Continue using Automatic Rebase"
+						href=${this.onContinueWithAiUrl}
+						icon="gl-continue-sparkle"
+					></action-item>`,
+			)}
+			${when(
 				type === 'rebase',
 				() =>
 					html`<action-item
@@ -422,30 +447,30 @@ export class GlMergeConflictWarning extends LitElement {
 						icon="edit"
 					></action-item>`,
 			)}
-			${when(
-				aiRebase,
-				() =>
-					html`<action-item
-						label="Continue Automatic Rebase"
-						href=${this.onContinueWithAiUrl}
-						icon="gl-continue-sparkle"
-					></action-item>`,
-			)}
-			${when(
-				type !== 'merge',
-				() =>
-					html`<action-item
-						label=${getPausedOperationSkipLabel(status)}
-						icon="gl-skip"
-						href=${this.onSkipUrl}
-					></action-item>`,
-			)}
+			${when(type !== 'merge', () => this.renderSkipAction(status))}
 			<action-item
 				label=${getPausedOperationAbortLabel(status)}
 				href=${this.onAbortUrl}
 				icon="gl-abort"
 			></action-item>
 		</action-nav>`;
+	}
+
+	private renderSkipAction(status: GitPausedOperationStatus) {
+		const label = getPausedOperationSkipLabel(status);
+		const detail = getPausedOperationSkipDetail(status);
+
+		return html`<action-item label=${label} icon="gl-skip" href=${this.onSkipUrl}
+			>${
+				detail != null
+					? html`<span slot="tooltip"
+							>${label}
+							<hr />
+							${detail}</span
+						>`
+					: nothing
+			}</action-item
+		>`;
 	}
 
 	/** One obvious next step per state. Continue renders only in ready/pending, which structurally keeps

--- a/src/webviews/apps/plus/shared/components/merge-rebase-status.utils.ts
+++ b/src/webviews/apps/plus/shared/components/merge-rebase-status.utils.ts
@@ -70,19 +70,34 @@ export function getPausedOperationSkipRef(status: GitPausedOperationStatus): Git
 	return status.type === 'rebase' ? status.steps.current.commit : status.incoming;
 }
 
+/** The Skip action's title; the victim rides in the tooltip detail, not the label. */
 export function getPausedOperationSkipLabel(status: GitPausedOperationStatus): string {
-	const described = describeCommit(getPausedOperationSkipRef(status));
-	return described != null ? `Skip ${described}` : 'Skip';
+	if (getPausedOperationSkipRef(status) == null) return 'Skip';
+	return status.type === 'rebase' ? 'Skip Paused Commit' : 'Skip Commit';
 }
 
-/** The paused-at pill's hover: the commit the step counter stands in for, plus how much is left. */
-export function getPausedOperationStepTooltip(status: GitRebaseStatus): string {
-	const remaining = `${Math.max(0, status.steps.total - status.steps.current.number)} remaining`;
-	const described = describeCommit(status.steps.current.commit);
-	return described != null ? `${described} — ${remaining}` : remaining;
+/** The Skip tooltip's detail line — names the commit a skip would drop. */
+export function getPausedOperationSkipDetail(status: GitPausedOperationStatus): string | undefined {
+	return describePausedOperationCommit(getPausedOperationSkipRef(status));
 }
 
-function describeCommit(ref: GitRevisionReference | undefined): string | undefined {
+/** The paused-at pill's tooltip: where the operation stands, plus the paused-on commit's subject. */
+export function getPausedOperationStepTooltipParts(status: GitRebaseStatus): {
+	detail: string;
+	subject: string | undefined;
+} {
+	const step = `step ${status.steps.current.number} of ${status.steps.total}`;
+	const sha = shortenRevision(status.steps.current.commit?.ref);
+
+	const { summary } = splitCommitMessage(status.steps.current.commit?.message);
+	return {
+		detail: sha ? `Rebase paused at ${sha} (${step})` : `Rebase paused (${step})`,
+		subject: summary ? `"${truncate(summary, maxSubjectLength)}"` : undefined,
+	};
+}
+
+/** `<shortSha> "<subject>"` when the message is known, the sha alone otherwise. */
+export function describePausedOperationCommit(ref: GitRevisionReference | undefined): string | undefined {
 	if (!ref?.ref) return undefined;
 
 	const sha = shortenRevision(ref.ref);

--- a/src/webviews/apps/plus/shared/components/merge-rebase-status.utils.ts
+++ b/src/webviews/apps/plus/shared/components/merge-rebase-status.utils.ts
@@ -1,0 +1,93 @@
+import type { GitPausedOperationStatus, GitRebaseStatus } from '@gitlens/git/models/pausedOperationStatus.js';
+import type { GitRevisionReference } from '@gitlens/git/models/reference.js';
+import { splitCommitMessage } from '@gitlens/git/utils/commit.utils.js';
+import type { PausedOperationVariant } from '@gitlens/git/utils/pausedOperationStatus.utils.js';
+import { pausedOperationStatusStringsByType } from '@gitlens/git/utils/pausedOperationStatus.utils.js';
+import { shortenRevision } from '@gitlens/git/utils/revision.utils.js';
+import { pluralize, truncate } from '@gitlens/utils/string.js';
+
+/** Longest commit subject a tooltip carries before it's elided. */
+const maxSubjectLength = 50;
+
+/** True when the strip shows the "at <m/t>" step context — also gates which strips drop their refs at narrow widths. */
+export function isPausedOperationStepped(
+	status: GitPausedOperationStatus,
+	variant: PausedOperationVariant,
+): status is GitRebaseStatus {
+	return status.type === 'rebase' && variant !== 'pending';
+}
+
+/** The strip's leading phrase; the paused-at pill and the refs are appended to it by the caller. */
+export function getPausedOperationBarLabel(status: GitPausedOperationStatus, variant: PausedOperationVariant): string {
+	const strings = pausedOperationStatusStringsByType[status.type];
+	if (variant === 'conflicts') return `${strings.prose} paused`;
+	if (variant === 'pending' && status.type === 'rebase') {
+		return pausedOperationStatusStringsByType.rebase.pending;
+	}
+	return strings.label;
+}
+
+/** The primary action's label — the conflict count rides on the button, where it's acted on. */
+export function getPausedOperationBarActionLabel(
+	status: GitPausedOperationStatus,
+	variant: PausedOperationVariant,
+	conflictsCount: number | undefined,
+): string {
+	if (variant === 'conflicts') {
+		// Hosts that don't carry a count still get an actionable label.
+		return conflictsCount == null ? 'Resolve Conflicts' : `Resolve ${pluralize('Conflict', conflictsCount)}`;
+	}
+	return `Continue ${pausedOperationStatusStringsByType[status.type].name}`;
+}
+
+/** Plain-words restatement of the state for label-only scanners, carried on the leading icon. */
+export function getPausedOperationBarIconTooltip(
+	status: GitPausedOperationStatus,
+	variant: PausedOperationVariant,
+	conflictsCount: number | undefined,
+): string | undefined {
+	switch (variant) {
+		case 'conflicts': {
+			const name = pausedOperationStatusStringsByType[status.type].prose.toLowerCase();
+			return conflictsCount == null
+				? `Conflicting files must be resolved before the ${name} can continue`
+				: `${pluralize('conflicting file', conflictsCount)} must be resolved before the ${name} can continue`;
+		}
+		case 'pending':
+			return undefined;
+		case 'ready':
+			return 'No unresolved conflicts — ready to continue';
+	}
+}
+
+export function getPausedOperationAbortLabel(status: GitPausedOperationStatus): string {
+	return `Abort ${pausedOperationStatusStringsByType[status.type].name}`;
+}
+
+/** The commit a skip drops: the rebase's current step, or the single commit a cherry-pick/revert applies. */
+export function getPausedOperationSkipRef(status: GitPausedOperationStatus): GitRevisionReference | undefined {
+	if (status.type === 'merge') return undefined;
+	return status.type === 'rebase' ? status.steps.current.commit : status.incoming;
+}
+
+export function getPausedOperationSkipLabel(status: GitPausedOperationStatus): string {
+	const described = describeCommit(getPausedOperationSkipRef(status));
+	return described != null ? `Skip ${described}` : 'Skip';
+}
+
+/** The paused-at pill's hover: the commit the step counter stands in for, plus how much is left. */
+export function getPausedOperationStepTooltip(status: GitRebaseStatus): string {
+	const remaining = `${Math.max(0, status.steps.total - status.steps.current.number)} remaining`;
+	const described = describeCommit(status.steps.current.commit);
+	return described != null ? `${described} — ${remaining}` : remaining;
+}
+
+function describeCommit(ref: GitRevisionReference | undefined): string | undefined {
+	if (!ref?.ref) return undefined;
+
+	const sha = shortenRevision(ref.ref);
+	if (!sha) return undefined;
+
+	const { summary } = splitCommitMessage(ref.message);
+	return summary ? `${sha} "${truncate(summary, maxSubjectLength)}"` : sha;
+}

--- a/src/webviews/apps/shared/components/actions/action-item.ts
+++ b/src/webviews/apps/shared/components/actions/action-item.ts
@@ -151,8 +151,12 @@ export class ActionItem extends LitElement {
 	}
 
 	override render(): unknown {
+		// A slotted `tooltip` supersedes the label-derived string, for consumers needing rich content
+		const richTooltip = this.querySelector('[slot="tooltip"]') != null;
+
 		return html`
-			<gl-tooltip content="${this.effectiveTooltip ?? nothing}">
+			<gl-tooltip content="${richTooltip ? nothing : (this.effectiveTooltip ?? nothing)}">
+				${richTooltip ? html`<span slot="content"><slot name="tooltip"></slot></span>` : nothing}
 				<a
 					role="${!this.effectiveHref ? 'button' : nothing}"
 					type="${!this.effectiveHref ? 'button' : nothing}"

--- a/src/webviews/apps/shared/components/commit/wip-stats.ts
+++ b/src/webviews/apps/shared/components/commit/wip-stats.ts
@@ -1,7 +1,11 @@
 import { css, html, LitElement, nothing } from 'lit';
 import { customElement, property } from 'lit/decorators.js';
 import type { GitPausedOperationStatus } from '@gitlens/git/models/pausedOperationStatus.js';
-import { pausedOperationStatusStringsByType } from '@gitlens/git/utils/pausedOperationStatus.utils.js';
+import {
+	getPausedOperationVariant,
+	pausedOperationStatusStringsByType,
+	pausedOperationVariantIcons,
+} from '@gitlens/git/utils/pausedOperationStatus.utils.js';
 import { pluralize } from '@gitlens/utils/string.js';
 import { baseStyles as pillStyles } from '../pills/pill.css.js';
 import './commit-stats.js';
@@ -84,6 +88,17 @@ export class GlWipStats extends LitElement {
 			.paused-op-badge--conflicts {
 				color: #fff;
 				background-color: var(--vscode-gitlens-decorations\\.statusMergingOrRebasingConflictForegroundColor);
+			}
+
+			.paused-op-badge--ready {
+				color: #06150a;
+				background-color: var(--vscode-gitlens-decorations\\.statusPausedOperationReadyForegroundColor);
+			}
+
+			/* The light theme's green is dark enough to carry white text; dark's is not. */
+			:host-context(.vscode-light) .paused-op-badge--ready,
+			:host-context(.vscode-high-contrast-light) .paused-op-badge--ready {
+				color: #fff;
 			}
 		`,
 	];
@@ -173,22 +188,26 @@ export class GlWipStats extends LitElement {
 	}
 
 	private renderPausedOp(pausedOp: GitPausedOperationStatus) {
+		// Mirrors the paused-operation bar's state set so the header badge and the bar can't disagree
+		const variant = getPausedOperationVariant(pausedOp, this.hasConflicts);
 		const opStrings = pausedOperationStatusStringsByType[pausedOp.type];
-		const label = this.hasConflicts ? pluralize('conflict', this.conflictsCount ?? 1) : opStrings.label;
+		const label = variant === 'conflicts' ? pluralize('conflict', this.conflictsCount ?? 1) : opStrings.label;
 
 		const badge = html`<span
-			class="paused-op-badge${this.hasConflicts ? ' paused-op-badge--conflicts' : ''}"
+			class="paused-op-badge${variant === 'conflicts' ? ' paused-op-badge--conflicts' : ''}${
+				variant === 'ready' ? ' paused-op-badge--ready' : ''
+			}"
 			aria-label=${label}
 		>
-			<code-icon icon="warning"></code-icon>
+			<code-icon icon=${pausedOperationVariantIcons[variant]}></code-icon>
 			${label}
 		</span>`;
 
 		if (this.noTooltip) return badge;
 
-		return html`<gl-tooltip placement="bottom"
-			>${badge}<span slot="content">${opStrings.label} in progress</span></gl-tooltip
-		>`;
+		const tooltip =
+			variant === 'ready' ? `${opStrings.label} — ready to continue` : `${opStrings.label} in progress`;
+		return html`<gl-tooltip placement="bottom">${badge}<span slot="content">${tooltip}</span></gl-tooltip>`;
 	}
 }
 

--- a/src/webviews/home/homeWebview.ts
+++ b/src/webviews/home/homeWebview.ts
@@ -623,8 +623,6 @@ export class HomeWebviewProvider implements WebviewProvider<State, State, HomeWe
 	@command('gitlens.pausedOperation.continue:')
 	@debug({ args: pausedOpArgs => ({ pausedOpArgs: pausedOpArgs.type }) })
 	private async continuePausedOperation(pausedOpArgs: GitPausedOperationStatus) {
-		if (pausedOpArgs.type === 'revert') return;
-
 		await continuePausedOperation(this.container, this.container.git.getRepositoryService(pausedOpArgs.repoPath), {
 			source: 'home',
 		});

--- a/src/webviews/plus/graph/graphCommands.ts
+++ b/src/webviews/plus/graph/graphCommands.ts
@@ -986,9 +986,6 @@ export class GraphCommands {
 		if (repoPath == null) return;
 
 		const svc = this.container.git.getRepositoryService(repoPath);
-		const type = pausedOpArgs?.type ?? (await svc.pausedOps?.getPausedOperationStatus?.())?.type;
-		if (type == null || type === 'revert') return;
-
 		await continuePausedOperation(this.container, svc, { source: 'graph' });
 	}
 

--- a/src/webviews/plus/graph/graphWebview.ts
+++ b/src/webviews/plus/graph/graphWebview.ts
@@ -554,6 +554,12 @@ export class GraphWebviewProvider implements WebviewProvider<State, State, Graph
 			this.container.usage.onDidChange(this.onUsageChanged, this),
 			onDidChangeContext(this.onContextChanged, this),
 			this.container.subscription.onDidChangeFeaturePreview(this.onFeaturePreviewChanged, this),
+			// The bar's primary continue swaps between automatic/manual with the session
+			this.container.autoRebase.onDidChange(e => {
+				if (e.repoPath === this.repository?.path) {
+					void this._wip.notifyDidChangeWorkingTree();
+				}
+			}),
 			this.container.git.onDidChangeRepositories(async e => {
 				if (this._etag !== this.container.git.etag) {
 					if (this._discovering != null) {

--- a/src/webviews/plus/graph/graphWipService.ts
+++ b/src/webviews/plus/graph/graphWipService.ts
@@ -1169,6 +1169,10 @@ export class GraphWipService {
 					files: files,
 					hasConflicts: status.hasConflicts,
 					pausedOpStatus: pausedOpStatus,
+					aiRebaseActive:
+						pausedOpStatus?.type === 'rebase' && this.container.autoRebase.getSession(repo.path) != null
+							? true
+							: undefined,
 				},
 				repositoryCount: this.container.git.openRepositoryCount,
 				revision: revision,

--- a/src/webviews/rpc/services/types.ts
+++ b/src/webviews/rpc/services/types.ts
@@ -365,6 +365,9 @@ export interface WipChange {
 	files: WipFileChange[];
 	hasConflicts?: boolean;
 	pausedOpStatus?: GitPausedOperationStatus;
+	/** An automatic (AI) rebase session owns the paused rebase, so continuing should resume that run
+	 *  rather than issue a plain `--continue` */
+	aiRebaseActive?: boolean;
 }
 
 // ============================================================


### PR DESCRIPTION
Rebuilds the Commit Graph's paused-operation bar around one obvious next action per state, enriches its tooltips so every ref and action names the commit it acts on, and fixes a set of continue-flow defects found along the way.

Closes #5648

## What changed

**One state, one primary action.** The bar now resolves to a `conflicts` / `pending` / `ready` variant (shared `getPausedOperationVariant`, so the strip and the WIP header badge can't disagree) and renders a single primary button per state. Conflicts get "Resolve N Conflicts"; ready/pending get "Continue \<Operation\>". This structurally removes the old offer to `--continue` a conflicted rebase, which could never succeed.

**`revert --continue` works end to end.** The `type === 'revert'` early-returns in the Home and Graph continue commands are gone, and an empty revert now offers "Continue with Empty Commit / Skip / Cancel" like a cherry-pick.

**Continue in the vein it started.** With an automatic (AI) rebase session owning the paused rebase, the primary action resumes that run and the manual continue demotes to a secondary.

**Richer tooltips.** The step pill, ref chips and Skip action carry an action line, a rule, then identifying detail, so the full sha + subject survive a truncated chip. `action-item` gained a rich-tooltip slot following the existing `gl-button` pattern.

**Continue-flow fixes** (detail in #5648, "Also in scope"): the busy state can no longer dead-end; `nothing to commit` maps to `emptyCommit` for `paused-operation-continue`; cache invalidation after `--continue` is unconditional; and keyboard focus survives activating Continue.

**Also fixes a pre-existing misreport** (present on `main`, but this branch's unconditional cache invalidation makes it obvious): `--continue`/`--skip` drive the whole operation, so a later step's conflict exits the command non-zero even though the requested step succeeded — and git words it identically to a refusal. Skipping a paused commit therefore warned "Cannot skip the rebase operation as there are unresolved conflicts" while the rebase had moved on. The warning is now gated on whether the operation actually moved, comparing state rather than error text. The provider still throws, since `autoRebaseCore`'s loop documents and depends on that behaviour.

## Verification

Build, lint and typecheck clean. `packages/git-cli`: 439 unit + 191 integration passing, including new coverage for the revert `allowEmpty` path, editor suppression during the allow-empty commit, and the `paused-operation-continue` reason mappings. 44 new unit tests for the bar's label/tooltip helpers.

Exercised against a live instance across every variant — rebase (`conflicts`/`ready`/`pending`), cherry-pick, revert, merge — verifying handlers produce their intended outcome, not just that they fire. No console errors in any state. Confirmed by measurement: tooltips are not clipped or mispositioned by the strip's `container-type: inline-size`; the refs container query drops correctly either side of its threshold; focus is retained on the reused inner anchor (`tabindex="-1"`, `aria-busy="true"`); and the empty-revert path reaches the record-or-skip dialog in 9ms.
