### PR TITLE
Fix comparison diffs always opening at the top of the file

### DIFF
--- a/src/views/nodes/resultsFileNode.ts
+++ b/src/views/nodes/resultsFileNode.ts
@@ -10,7 +10,6 @@ import { StatusFileFormatter } from '../../git/formatters/statusFormatter.js';
 import { GitUri } from '../../git/gitUri.js';
 import { createCommand } from '../../system/-webview/command.js';
 import { relativeDir } from '../../system/-webview/path.js';
-import { editorLineToDiffRange } from '../../system/-webview/vscode/range.js';
 import type { View } from '../viewBase.js';
 import { getFileTooltipMarkdown } from './abstract/viewFileNode.js';
 import type { ViewNode } from './abstract/viewNode.js';
@@ -140,7 +139,6 @@ export class ResultsFileNode extends ViewRefFileNode<'results-file', View, State
 			repoPath: this.uri.repoPath!,
 
 			fromComparison: true,
-			range: editorLineToDiffRange(0),
 			showOptions: { preserveFocus: true, preview: true },
 		});
 	}


### PR DESCRIPTION
## Problem
Every file opened from a Search & Compare comparison result opens at the very top instead of the first difference. This is very annoying when reviewing differences.

## Solution
Suggested by Claude Code: Dropping the hardcoded range restores the default reveal-first-change behavior for comparison diffs.

ResultsFileNode.getCommand() hardcoded range: editorLineToDiffRange(0). That range flows into DiffWithCommand as an explicit editor selection, which causes vscode.diff() to place the cursor at the very top of the file instead of letting the diff editor reveal the first change, as it does for every other diff entry point.