### PR TITLE
Add upgrade toast for v19

### DIFF
--- a/src/messages.ts
+++ b/src/messages.ts
@@ -309,9 +309,14 @@ export async function showWhatsNewMessage(majorVersion: string): Promise<void> {
 	const confirm = { title: 'OK', isCloseAffordance: true };
 	const releaseNotes = { title: 'View Release Notes' };
 	const openWalkthrough = { title: 'Open Walkthrough' };
+	const openGraph = { title: 'Show Commit Graph' };
 
 	let message: string;
 	switch (majorVersion) {
+		case '19':
+			message =
+				'GitLens upgraded to 19 — the Commit Graph now lives in the GitLens panel, sitting right beside your work to carry every change from task to merge with AI Review, Compose, and Resolve.';
+			break;
 		case '18':
 			message =
 				'GitLens upgraded to 18 — the Commit Graph is all new with agent integration, multi-worktree WIP rows, AI-powered Review and Compose modes, and more.';
@@ -325,7 +330,7 @@ export async function showWhatsNewMessage(majorVersion: string): Promise<void> {
 			break;
 	}
 
-	const actions: MessageItem[] = [releaseNotes];
+	const actions: MessageItem[] = majorVersion === '19' ? [openGraph, releaseNotes] : [releaseNotes];
 	if (majorVersion === '18') {
 		actions.push(openWalkthrough);
 	}
@@ -337,6 +342,8 @@ export async function showWhatsNewMessage(majorVersion: string): Promise<void> {
 		void openUrl(urls.releaseNotes);
 	} else if (result === openWalkthrough) {
 		void executeCommand('gitlens.showWelcomeView', { mode: 'graph' });
+	} else if (result === openGraph) {
+		void executeCommand('gitlens.showGraphView');
 	}
 }
 

--- a/src/messages.ts
+++ b/src/messages.ts
@@ -315,7 +315,7 @@ export async function showWhatsNewMessage(majorVersion: string): Promise<void> {
 	switch (majorVersion) {
 		case '19':
 			message =
-				'GitLens upgraded to 19 — the Commit Graph now lives in the GitLens panel, sitting right beside your work to carry every change from task to merge with AI Review, Compose, and Resolve.';
+				'GitLens 19 is here — the Commit Graph has been rebuilt from the ground up: dramatically faster, lighter, now the heart of GitLens, with new and enhanced workflows from code to merge.';
 			break;
 		case '18':
 			message =


### PR DESCRIPTION

---
# Description

Adds upgrade toast for version 19.0, offering an option to open the Commit Graph in the GitLens panel.

# Checklist

- [x] I have followed the guidelines in the Contributing document
- [x] My changes follow the coding style of this project
- [x] My changes build without any errors or warnings
- [x] My changes have been formatted and linted
- [x] My changes include any required corresponding changes to the documentation (including CHANGELOG.md and README.md)
- [x] My changes have been rebased and squashed to the minimal number (typically 1) of relevant commits
- [x] My changes have a descriptive commit message with a short title, including a `Fixes $XXX -` or `Closes #XXX -` prefix to auto-close the issue that your PR addresses
