### PR TITLE
Fixes paused-operation bar and automatic rebase issues

### DIFF
--- a/packages/git-cli/src/providers/pausedOperations.ts
+++ b/packages/git-cli/src/providers/pausedOperations.ts
@@ -533,7 +533,9 @@ export class PausedOperationsGitSubProvider implements GitPausedOperationsSubPro
 		const args = [status.type, options?.quit ? '--quit' : '--abort'];
 
 		try {
-			await this.git.run({ cwd: repoPath, errors: 'throw' }, ...args);
+			// Unbounded like the operations it undoes — an abort of a large rebase can outrun the default
+			// command timeout, and being SIGTERM'd partway through would leave the repo mid-abort.
+			await this.git.run({ cwd: repoPath, errors: 'throw', timeout: 0 }, ...args);
 			this.context.hooks?.cache?.onReset?.(repoPath, 'branches', 'status');
 			this.context.hooks?.repository?.onChanged?.(repoPath, ['head', 'heads', 'index']);
 		} catch (ex) {
@@ -613,6 +615,10 @@ export class PausedOperationsGitSubProvider implements GitPausedOperationsSubPro
 					errors: 'throw',
 					configs: configs,
 					env: env,
+					// A `--continue` that opens the commit-message editor blocks for as long as the user leaves
+					// that tab open, which is unbounded — the default `advanced.git.timeout` would SIGTERM it
+					// mid-operation. The start paths (merge/rebase/revert) opt out for the same reason.
+					timeout: 0,
 					// The runner dedups in-flight commands by args only — it ignores per-call `configs`/`env`.
 					// A headless continue (with `GIT_EDITOR`) and a plain `--continue` would therefore collapse
 					// into one execution, so the plain one could silently run headless (auto-accepting a commit

--- a/src/constants.telemetry.ts
+++ b/src/constants.telemetry.ts
@@ -1022,6 +1022,8 @@ interface AutoRebaseStepResolvedEvent {
 interface AutoRebaseCompletedEvent extends AutoRebaseLifecycleEvent {
 	/** Total conflicted files resolved across the run */
 	'files.count': number;
+	/** Steps whose commit git dropped for being empty — the resolution left nothing to commit */
+	'steps.emptied.count': number;
 	/** What happened to the autostash at the end of the run */
 	autostash: 'none' | 'reapplied' | 'left-in-stash';
 }

--- a/src/git/actions/pausedOperation.ts
+++ b/src/git/actions/pausedOperation.ts
@@ -1,13 +1,15 @@
-import { window } from 'vscode';
+import { EventEmitter, Uri, window } from 'vscode';
 import { PausedOperationAbortError, PausedOperationContinueError } from '@gitlens/git/errors.js';
 import type { GitPausedOperationStatus } from '@gitlens/git/models/pausedOperationStatus.js';
 import { uncommitted } from '@gitlens/git/models/revision.js';
+import { pausedOperationStatusStringsByType } from '@gitlens/git/utils/pausedOperationStatus.utils.js';
 import { getReferenceLabel } from '@gitlens/git/utils/reference.utils.js';
 import type { Source } from '../../constants.telemetry.js';
 import type { Container } from '../../container.js';
 import { showGitErrorMessage } from '../../messages.js';
 import { arePlusFeaturesEnabled } from '../../plus/gk/utils/-webview/plus.utils.js';
 import { executeCommand } from '../../system/-webview/command.js';
+import { isDescendant } from '../../system/-webview/path.js';
 import type { GitRepositoryService } from '../gitRepositoryService.js';
 import { openRebaseEditor } from '../utils/-webview/rebase.utils.js';
 
@@ -22,12 +24,26 @@ export async function abortPausedOperation(svc: GitRepositoryService, options?: 
 	}
 }
 
+/** Repos with a continue/skip in flight. `<op> --continue` can block indefinitely — git opens
+ *  `COMMIT_EDITMSG` and waits for the tab to be closed — and the git runner dedups the still-running
+ *  command by args, so a second invocation would silently ride the first and appear to do nothing. */
+const continuingRepos = new Set<string>();
+
+const _onDidChangeContinuing = new EventEmitter<string>();
+/** Fires with the repo path whenever a continue/skip starts or settles. */
+export const onDidChangeContinuingPausedOperation = _onDidChangeContinuing.event;
+
+/** Whether a continue/skip is still running for `repoPath` — the paused-op bar's busy state. */
+export function isContinuingPausedOperation(repoPath: string): boolean {
+	return continuingRepos.has(repoPath);
+}
+
 export async function continuePausedOperation(
 	container: Container,
 	svc: GitRepositoryService,
 	source?: Source,
 ): Promise<void> {
-	return continuePausedOperationCore(container, svc, undefined, source);
+	return runContinue(container, svc, undefined, source);
 }
 
 export async function skipPausedOperation(
@@ -35,7 +51,70 @@ export async function skipPausedOperation(
 	svc: GitRepositoryService,
 	source?: Source,
 ): Promise<void> {
-	return continuePausedOperationCore(container, svc, { skip: true }, source);
+	return runContinue(container, svc, { skip: true }, source);
+}
+
+/** Guards the user-initiated entry points so a repeat click reports the wait instead of vanishing into
+ *  the runner's dedup. The inner retries (`allowEmpty`/`skip` after the empty-commit prompt) run under
+ *  the same flag — they're the same continue, still in flight. */
+async function runContinue(
+	container: Container,
+	svc: GitRepositoryService,
+	options?: { skip?: boolean },
+	source?: Source,
+): Promise<void> {
+	if (continuingRepos.has(svc.path)) {
+		void showAlreadyContinuing(svc);
+		return;
+	}
+
+	continuingRepos.add(svc.path);
+	_onDidChangeContinuing.fire(svc.path);
+	try {
+		await continuePausedOperationCore(container, svc, options, source);
+	} finally {
+		continuingRepos.delete(svc.path);
+		_onDidChangeContinuing.fire(svc.path);
+	}
+}
+
+/** The open commit-message document git is blocked on — `<gitdir>/COMMIT_EDITMSG` for this repo. */
+function findCommitMessageUri(repoPath: string): Uri | undefined {
+	for (const group of window.tabGroups.all) {
+		for (const tab of group.tabs) {
+			const input: unknown = tab.input;
+			if (input == null || typeof input !== 'object' || !('uri' in input)) continue;
+
+			const { uri } = input;
+			if (!(uri instanceof Uri) || !uri.path.endsWith('COMMIT_EDITMSG')) continue;
+			if (isDescendant(uri, repoPath)) return uri;
+		}
+	}
+
+	return undefined;
+}
+
+async function showAlreadyContinuing(svc: GitRepositoryService): Promise<void> {
+	const status = await svc.pausedOps?.getPausedOperationStatus?.();
+	const name = (status != null ? pausedOperationStatusStringsByType[status.type].prose : 'operation').toLowerCase();
+
+	if (findCommitMessageUri(svc.path) == null) {
+		void window.showInformationMessage(`The ${name} is already continuing — waiting for it to finish.`);
+		return;
+	}
+
+	const showItem = { title: 'Show Commit Message' };
+	const result = await window.showInformationMessage(
+		`The ${name} is waiting for you to save and close the commit message before it can finish.`,
+		showItem,
+	);
+	if (result !== showItem) return;
+
+	// Re-find it: the user may have closed it while the notification was up, which unblocks git anyway.
+	const uri = findCommitMessageUri(svc.path);
+	if (uri != null) {
+		void window.showTextDocument(uri, { preview: false });
+	}
 }
 
 async function continuePausedOperationCore(

--- a/src/plus/coretools/conflict/__tests__/autoRebaseCore.test.ts
+++ b/src/plus/coretools/conflict/__tests__/autoRebaseCore.test.ts
@@ -99,6 +99,7 @@ function makePorts(repo: FakeRepo, overrides?: Partial<AutoRebaseLoopPorts>): Au
 			return Promise.resolve();
 		},
 		hasStagedChanges: () => Promise.resolve(false),
+		willCommitBeEmpty: () => Promise.resolve(false),
 		continueOperation: options => {
 			repo.continues.push(options ?? {});
 			if (repo.step < repo.total) {
@@ -453,6 +454,60 @@ suite('coretools/conflict/autoRebaseCore', () => {
 		assert.strictEqual(session.steps.length, 1);
 		assert.strictEqual(session.steps[0].kind, 'empty-skipped');
 		assert.strictEqual(attempts, 2);
+	});
+
+	test('records a dropped commit when git empties it silently and exits 0 (real git behavior)', async () => {
+		// A rebase `--continue` whose index matches HEAD drops the commit and reports success — no
+		// `emptyCommit` error is ever raised, so the emptiness has to be detected before continuing.
+		const repo = makeRepo({ 1: ['a.txt'] });
+		const session = makeSession();
+
+		const result = await run(session, makePorts(repo, { willCommitBeEmpty: () => Promise.resolve(true) }));
+
+		assert.strictEqual(result.type, 'completed');
+		assert.strictEqual(session.steps.length, 1);
+		assert.strictEqual(session.steps[0].kind, 'empty-skipped');
+		// Plain `--continue`, never `--skip`: a mis-detection must not discard real staged content.
+		assert.deepStrictEqual(repo.continues, [{}]);
+	});
+
+	test('records a dropped commit even when the continue reports a LATER step conflict', async () => {
+		// One `--continue` drives the whole rebase: this step's commit can be dropped as empty and the
+		// command still exit non-zero for a later step's conflict. The drop must not go unrecorded.
+		const repo = makeRepo({ 1: ['a.txt'], 3: ['a.txt'] }, 3);
+		const session = makeSession();
+
+		const ports = makePorts(repo, { willCommitBeEmpty: () => Promise.resolve(repo.step === 1) });
+		ports.continueOperation = () => {
+			repo.continues.push({});
+			if (repo.step === 1) {
+				repo.step = 3;
+				throw new PausedOperationContinueError({
+					reason: 'conflicts',
+					operation: makeStatus(3, 3),
+					skip: false,
+					gitCommand: { repoPath: '/repo', args: ['rebase', '--continue'] },
+				});
+			}
+
+			repo.done = true;
+			return Promise.resolve();
+		};
+
+		const result = await run(session, ports);
+
+		assert.strictEqual(result.type, 'completed');
+		assert.strictEqual(session.steps[0].kind, 'empty-skipped');
+	});
+
+	test('leaves a non-empty step recorded as resolved', async () => {
+		const repo = makeRepo({ 1: ['a.txt'] });
+		const session = makeSession();
+
+		const result = await run(session, makePorts(repo, { willCommitBeEmpty: () => Promise.resolve(false) }));
+
+		assert.strictEqual(result.type, 'completed');
+		assert.strictEqual(session.steps[0].kind, 'conflicts');
 	});
 
 	test('keeps going when a continue "fails" because a LATER step conflicted (real git behavior)', async () => {

--- a/src/plus/coretools/conflict/__tests__/autoRebaseService.test.ts
+++ b/src/plus/coretools/conflict/__tests__/autoRebaseService.test.ts
@@ -77,7 +77,12 @@ function makeFakes(record: StoredAutoRebaseUndo | undefined, repo: Partial<FakeR
 		},
 		git: { getRepositoryService: () => svc },
 		telemetry: { sendEvent: () => {} },
-		ai: { enabled: true, allowed: true, flushBYOKUsage: () => Promise.resolve() },
+		ai: {
+			enabled: true,
+			allowed: true,
+			flushBYOKUsage: () => Promise.resolve(),
+			getModel: () => Promise.resolve({ id: 'test-model', provider: { id: 'test' } }),
+		},
 	} as unknown as Container;
 
 	return { service: new AutoRebaseService(container), state: state, storage: storage };
@@ -288,7 +293,12 @@ function makeTakeoverFakes(headSha: string) {
 		},
 		git: { getRepositoryService: () => svc },
 		telemetry: { sendEvent: () => {} },
-		ai: { enabled: true, allowed: true, flushBYOKUsage: () => Promise.resolve() },
+		ai: {
+			enabled: true,
+			allowed: true,
+			flushBYOKUsage: () => Promise.resolve(),
+			getModel: () => Promise.resolve({ id: 'test-model', provider: { id: 'test' } }),
+		},
 	} as unknown as Container;
 
 	service = new AutoRebaseService(container);
@@ -343,7 +353,12 @@ function makeResumeFakes() {
 		},
 		git: { getRepositoryService: () => svc },
 		telemetry: { sendEvent: (name: string) => void events.push(name) },
-		ai: { enabled: true, allowed: true, flushBYOKUsage: () => Promise.resolve() },
+		ai: {
+			enabled: true,
+			allowed: true,
+			flushBYOKUsage: () => Promise.resolve(),
+			getModel: () => Promise.resolve({ id: 'test-model', provider: { id: 'test' } }),
+		},
 	} as unknown as Container;
 
 	const service = new AutoRebaseService(container);

--- a/src/plus/coretools/conflict/autoRebaseCore.ts
+++ b/src/plus/coretools/conflict/autoRebaseCore.ts
@@ -45,6 +45,8 @@ export interface AutoRebaseLoopPorts {
 	/** Whether the index has staged changes — distinguishes a resolved-and-staged pause (continue)
 	 *  from a genuine non-conflict stop like an interactive `edit`/`break` (escalate) */
 	hasStagedChanges(): Promise<boolean>;
+	/** Whether the index matches HEAD, so the step's commit would be empty and git will drop it */
+	willCommitBeEmpty(): Promise<boolean>;
 	/** Continue (or skip) the paused operation headlessly; throws {@link PausedOperationContinueError} */
 	continueOperation(options?: { skip?: boolean }): Promise<void>;
 	/** Minimum confidence required to auto-apply — read per step so it's live-tunable mid-run */
@@ -104,6 +106,20 @@ export async function runAutoRebaseLoop(
 		stepNumber: number | undefined,
 		recordedStep?: AutoRebaseStepRecord,
 	): Promise<AutoRebaseLoopResult | undefined> => {
+		// A resolution that keeps the current side can leave the index matching HEAD. Git then drops the
+		// commit and still reports success (`--continue` exits 0, "Successfully rebased"), so this is the
+		// only moment the drop is observable. Probe rather than skip: `--continue` commits real content if
+		// this is ever wrong, where a `--skip` would discard it.
+		const willBeEmpty = recordedStep != null && (await ports.willCommitBeEmpty());
+		// Only once the operation has actually moved past this step is the drop a fact rather than a
+		// prediction. Idempotent, since the `emptyCommit` path below records the same thing itself.
+		const recordEmptied = (): void => {
+			if (!willBeEmpty || recordedStep == null || recordedStep.kind === 'empty-skipped') return;
+
+			recordedStep.kind = 'empty-skipped';
+			onDidChange();
+		};
+
 		try {
 			await ports.continueOperation();
 		} catch (ex) {
@@ -135,6 +151,8 @@ export async function runAutoRebaseLoop(
 					return undefined;
 				case 'conflicts':
 				case 'unmergedFiles':
+					// The operation advanced and stopped again further along, so this step is behind us.
+					recordEmptied();
 					return undefined;
 				default:
 					return escalate({
@@ -144,6 +162,10 @@ export async function runAutoRebaseLoop(
 					});
 			}
 		}
+
+		// The continue succeeded, so the step is behind us either way.
+		recordEmptied();
+
 		return undefined;
 	};
 

--- a/src/plus/coretools/conflict/autoRebaseService.ts
+++ b/src/plus/coretools/conflict/autoRebaseService.ts
@@ -1,5 +1,6 @@
 import type { Disposable, Event } from 'vscode';
 import { CancellationTokenSource, EventEmitter } from 'vscode';
+import type { AIModel } from '@gitlens/ai/models/model.js';
 import { PausedOperationAbortError } from '@gitlens/git/errors.js';
 import { uuid } from '@gitlens/utils/crypto.js';
 import { wait } from '@gitlens/utils/promise.js';
@@ -96,7 +97,7 @@ export class AutoRebaseService implements Disposable {
 	 * an operation already in progress, …).
 	 */
 	async start(svc: GitRepositoryService, options: AutoRebaseStartOptions): Promise<AutoRebaseSession> {
-		const integration = await this.ensureAvailable(svc);
+		const { integration, model } = await this.ensureAvailable(svc, options.source);
 
 		const existing = await svc.pausedOps?.getPausedOperationStatus?.({ force: true });
 		if (existing != null) {
@@ -150,7 +151,7 @@ export class AutoRebaseService implements Disposable {
 			if (!result.conflicted) {
 				await this.finalize(svc, active);
 			} else {
-				await this.runLoop(svc, active, integration, options.source);
+				await this.runLoop(svc, active, integration, options.source, model);
 			}
 		} catch (ex) {
 			this.fail(active, ex);
@@ -160,7 +161,7 @@ export class AutoRebaseService implements Disposable {
 
 	/** Takes over an existing paused rebase and automates its remaining steps. */
 	async takeover(svc: GitRepositoryService, source: Source): Promise<AutoRebaseSession> {
-		const integration = await this.ensureAvailable(svc);
+		const { integration, model } = await this.ensureAvailable(svc, source);
 
 		const status = await svc.pausedOps?.getPausedOperationStatus?.({ force: true });
 		if (status?.type !== 'rebase') {
@@ -175,7 +176,7 @@ export class AutoRebaseService implements Disposable {
 		// takeover session, so the end-of-run summary spans the whole rebase.
 		const existing = this._sessions.get(svc.path);
 		if (existing?.session.phase === 'escalated') {
-			return this.resumeEscalatedSession(svc, existing, integration, source);
+			return this.resumeEscalatedSession(svc, existing, integration, source, model);
 		}
 
 		// The rebase we're taking over may have already autostashed before we arrived — record whether
@@ -209,7 +210,7 @@ export class AutoRebaseService implements Disposable {
 		const active = this.trackSession(session, source);
 
 		try {
-			await this.runLoop(svc, active, integration, source);
+			await this.runLoop(svc, active, integration, source, model);
 		} catch (ex) {
 			this.fail(active, ex);
 		}
@@ -228,6 +229,7 @@ export class AutoRebaseService implements Disposable {
 		active: ActiveAutoRebase,
 		integration: ConflictToolsIntegration,
 		source: Source,
+		model: AIModel,
 	): Promise<AutoRebaseSession> {
 		const { session } = active;
 
@@ -244,7 +246,7 @@ export class AutoRebaseService implements Disposable {
 		this.fireChange(session);
 
 		try {
-			await this.runLoop(svc, active, integration, source);
+			await this.runLoop(svc, active, integration, source, model);
 		} catch (ex) {
 			this.fail(active, ex);
 		}
@@ -422,6 +424,7 @@ export class AutoRebaseService implements Disposable {
 		active: ActiveAutoRebase,
 		integration: ConflictToolsIntegration,
 		source: Source,
+		model: AIModel,
 	): Promise<void> {
 		const signal = toAbortSignal(active.cts.token)!;
 		const ports: AutoRebaseLoopPorts = {
@@ -438,6 +441,8 @@ export class AutoRebaseService implements Disposable {
 						signal: signal,
 						onProgress: args.onProgress,
 						conversationId: active.session.id,
+						// Resolved pre-flight, so no request can stop to ask for one mid-run.
+						model: model,
 					},
 					{ source: source.source, detail: 'autoRebase' },
 				),
@@ -687,7 +692,10 @@ export class AutoRebaseService implements Disposable {
 		);
 	}
 
-	private async ensureAvailable(svc: GitRepositoryService): Promise<ConflictToolsIntegration> {
+	private async ensureAvailable(
+		svc: GitRepositoryService,
+		source: Source,
+	): Promise<{ integration: ConflictToolsIntegration; model: AIModel }> {
 		if (!this.container.ai.allowed) {
 			throw new Error('AI features are disabled.');
 		}
@@ -702,7 +710,18 @@ export class AutoRebaseService implements Disposable {
 			throw new Error('An automatic rebase is already running for this repository.');
 		}
 
-		return integration;
+		// Resolve the model BEFORE anything starts. Left to `sendRequest`, this resolves lazily inside the
+		// run — the picker (or a sign-in/API-key prompt) then opens behind a progress panel already claiming
+		// "Analyzing <file>…", which is indistinguishable from a stall. Answering it here means the run
+		// either starts with a model in hand or never starts at all, and the branch is untouched either way.
+		const model = await this.container.ai.getModel({ scope: 'resolve' }, source);
+		if (model == null) {
+			// Dismissing the picker is a refusal to start, handled like the other pre-flight refusals: the
+			// caller surfaces this message and the repository is never touched.
+			throw new Error('Automatic rebase needs an AI model — none was selected.');
+		}
+
+		return { integration: integration, model: model };
 	}
 
 	private getIntegration(): Promise<ConflictToolsIntegration | undefined> {

--- a/src/plus/coretools/conflict/autoRebaseService.ts
+++ b/src/plus/coretools/conflict/autoRebaseService.ts
@@ -444,6 +444,9 @@ export class AutoRebaseService implements Disposable {
 			applyResolutions: resolutions => integration.applyBatch({ svc: svc, resolutions: resolutions }),
 			stageFiles: paths => svc.staging!.stageFiles(paths),
 			hasStagedChanges: async () => (await svc.status?.getStatus?.())?.files.some(f => f.staged) ?? false,
+			// `git diff --quiet --staged` — index against HEAD, which is what git itself commits.
+			willCommitBeEmpty: async () =>
+				!(await svc.status.hasWorkingChanges({ staged: true, unstaged: false, untracked: false })),
 			continueOperation: options => svc.pausedOps!.continuePausedOperation({ ...options, messageEditor: 'true' }),
 			getConfidenceThreshold: () => configuration.get('ai.autoRebase.confidenceThreshold'),
 			delay: wait,
@@ -600,6 +603,7 @@ export class AutoRebaseService implements Disposable {
 			{
 				...this.lifecycleData(session),
 				'files.count': session.steps.reduce((sum, s) => sum + s.files.length, 0),
+				'steps.emptied.count': session.steps.reduce((n, s) => (s.kind === 'empty-skipped' ? n + 1 : n), 0),
 				autostash: autostash,
 			},
 			active.source,

--- a/src/plus/coretools/conflict/integration.ts
+++ b/src/plus/coretools/conflict/integration.ts
@@ -2,6 +2,7 @@ import { promises as fs } from 'node:fs';
 import { isAbsolute, join } from 'node:path';
 import { applyResolutions, defaultVerifier, extractConflict, resolveConflict } from '@gitkraken/conflict-tools';
 import { CancellationTokenSource } from 'vscode';
+import type { AIModel } from '@gitlens/ai/models/model.js';
 import type { AIChatMessage, AIChatMessageRole, AIProviderResponse } from '@gitlens/ai/models/provider.js';
 import type { Source } from '../../../constants.telemetry.js';
 import type { Container } from '../../../container.js';
@@ -35,6 +36,9 @@ export interface ResolveSingleArgs {
 	/** Session-scoped conversation ID forwarded with every AI request so the backend charges its
 	 *  flat per-feature fee once per resolution session instead of once per request. */
 	conversationId?: string;
+	/** Model resolved up front by the caller. Passing it keeps `sendRequest` from resolving one lazily,
+	 *  which can open the model picker mid-request — see {@link ResolveAllParallelArgs.model}. */
+	model?: AIModel;
 }
 
 export interface ExtractArgs {
@@ -64,6 +68,10 @@ export interface ResolveAllParallelArgs {
 	/** Session-scoped conversation ID forwarded with every AI request so the backend charges its
 	 *  flat per-feature fee once per resolution session instead of once per request. */
 	conversationId?: string;
+	/** Model resolved up front by the caller. Without it `sendRequest` resolves one per request, and a
+	 *  non-silent resolve can show the model picker — so files resolving in parallel would each race to
+	 *  open a picker VS Code can only show one of, cancelling the rest as "the AI couldn't resolve". */
+	model?: AIModel;
 }
 
 /** Default max in-flight AI resolutions for the parallel batch path — balances throughput against
@@ -91,7 +99,7 @@ export class ConflictToolsIntegration {
 
 	async resolveSingle(args: ResolveSingleArgs, telemetrySource: Source): Promise<Resolution> {
 		const git = createConflictGitPort(args.svc);
-		const model = createAiModelPort(this.container, telemetrySource, args.conversationId);
+		const model = createAiModelPort(this.container, telemetrySource, args.conversationId, args.model);
 		return resolveConflict(args.conflict, args.context ?? {}, {
 			git: git,
 			model: model,
@@ -120,7 +128,7 @@ export class ConflictToolsIntegration {
 	 */
 	async resolveAllParallel(args: ResolveAllParallelArgs, telemetrySource: Source): Promise<StepResult> {
 		const git = createConflictGitPort(args.svc);
-		const model = createAiModelPort(this.container, telemetrySource, args.conversationId);
+		const model = createAiModelPort(this.container, telemetrySource, args.conversationId, args.model);
 		const entries = [...args.entries];
 		const resolutions: Resolution[] = [];
 		const errors: { filePath: string; error: Error }[] = [];
@@ -375,7 +383,12 @@ function createConflictGitPort(
 	};
 }
 
-function createAiModelPort(container: Container, source: Source, conversationId?: string): ConflictModelPort {
+function createAiModelPort(
+	container: Container,
+	source: Source,
+	conversationId?: string,
+	resolvedModel?: AIModel,
+): ConflictModelPort {
 	return {
 		generate: async (params: ConflictModelParams): Promise<ConflictModelResult> => {
 			const cancellationSource = new CancellationTokenSource();
@@ -430,7 +443,7 @@ function createAiModelPort(container: Container, source: Source, conversationId?
 
 				const result = await container.ai.sendRequest(
 					'conflict-resolution',
-					undefined,
+					resolvedModel,
 					// biome-ignore lint/suspicious/noExplicitAny: AIRequestProvider telemetry type is deeply private; we supply the minimum shape
 					provider as any,
 					source,

--- a/src/webviews/apps/commitDetails/components/gl-details-wip-panel.ts
+++ b/src/webviews/apps/commitDetails/components/gl-details-wip-panel.ts
@@ -650,6 +650,7 @@ export class GlDetailsWipPanel extends GlDetailsBase {
 			<gl-merge-rebase-status
 				?conflicts=${this.wip?.changes?.hasConflicts ?? false}
 				.conflictsCount=${this.wip?.stats?.conflictsCount}
+				?continuing=${this.wip?.changes?.pausedOpContinuing ?? false}
 				.pausedOpStatus=${pausedOpStatus}
 			></gl-merge-rebase-status>
 		</div>`;

--- a/src/webviews/apps/plus/graph/components/gl-details-resolve-mode-panel.ts
+++ b/src/webviews/apps/plus/graph/components/gl-details-resolve-mode-panel.ts
@@ -94,9 +94,20 @@ function kindDisplay(kind: ConflictKind | undefined, status?: GitFileConflictSta
 /** Conflicted files across a run's recorded steps — the unit users count, where a step is one rebase
  *  pause that can carry several files. `aiOnly` drops `manual` steps (the user resolved those after an
  *  escalation, so they aren't AI's work); `empty-skipped` steps still count, since AI did resolve their
- *  files and the commit only turned out empty afterwards. */
+ *  files and the commit only turned out empty afterwards — {@link describeEmptySkipped} is what tells
+ *  the user those commits are gone, so the file count alone never reads as a clean run. */
 function countResolvedFiles(steps: readonly AutoRebaseSummaryStep[], options?: { aiOnly?: boolean }): number {
 	return steps.reduce((count, s) => (options?.aiOnly && s.kind === 'manual' ? count : count + s.files.length), 0);
+}
+
+/** Names the commits git dropped for being empty, so a completed run can't report them as kept. A step
+ *  legitimately empties whenever its changes are already upstream, so this states the fact without
+ *  calling it a loss. */
+function describeEmptySkipped(steps: readonly AutoRebaseSummaryStep[]): string | undefined {
+	const count = steps.reduce((n, s) => (s.kind === 'empty-skipped' ? n + 1 : n), 0);
+	if (count === 0) return undefined;
+
+	return `${pluralize('commit', count)} became empty and ${count === 1 ? 'was' : 'were'} skipped.`;
 }
 
 /** Drop the trailing action hint ("… — choose a side to keep") from a conflict description — the row's
@@ -888,15 +899,23 @@ export class GlDetailsResolveModePanel extends LitElement {
 		// Only AI's own resolutions earn the "with AI" credit — a run that escalated and was finished by
 		// hand has `manual` steps, and claiming those would overstate what automation did.
 		const resolvedByAi = countResolvedFiles(run.steps, { aiOnly: true });
+		// Git drops a step whose resolution left nothing to commit — a completed run has to say so here,
+		// where the eye lands, not only on the step row further down.
+		const emptied = describeEmptySkipped(run.steps);
 		const outcome =
 			run.phase === 'completed'
-				? resolvedByAi > 0
-					? `Rebase completed — ${pluralize('conflicted file', resolvedByAi)} resolved with AI.`
-					: run.steps.length > 0
-						? 'Rebase completed — you resolved every conflict.'
-						: // Like the cancelled message below, only reachable for a render or two before the
-							// mode exit lands (see `auto-rebase-exit`).
-							'Rebase completed — no conflicts.'
+				? [
+						resolvedByAi > 0
+							? `Rebase completed — ${pluralize('conflicted file', resolvedByAi)} resolved with AI.`
+							: run.steps.length > 0
+								? 'Rebase completed — you resolved every conflict.'
+								: // Like the cancelled message below, only reachable for a render or two before the
+									// mode exit lands (see `auto-rebase-exit`).
+									'Rebase completed — no conflicts.',
+						emptied,
+					]
+						.filter(Boolean)
+						.join(' ')
 				: run.phase === 'aborted'
 					? // A cancelled run leaves the mode (see `auto-rebase-exit`), so this is only reachable for
 						// the render or two before that lands — kept accurate rather than removed so a missed

--- a/src/webviews/apps/plus/graph/components/gl-details-wip-header.ts
+++ b/src/webviews/apps/plus/graph/components/gl-details-wip-header.ts
@@ -421,6 +421,7 @@ export class GlDetailsWipHeader extends LitElement {
 				?ai-resolve=${this.aiEnabled}
 				?ai-resume=${this.aiEnabled}
 				?ai-active=${this.wip?.changes?.aiRebaseActive ?? false}
+				?continuing=${this.wip?.changes?.pausedOpContinuing ?? false}
 				?readonly=${this.activeMode != null}
 				.pausedOpStatus=${pausedOpStatus}
 			></gl-merge-rebase-status>

--- a/src/webviews/apps/plus/graph/components/gl-rebase-summary-sheet.ts
+++ b/src/webviews/apps/plus/graph/components/gl-rebase-summary-sheet.ts
@@ -357,6 +357,7 @@ export class GlRebaseSummarySheet extends LitElement {
 	}
 
 	private renderOverview(summary: AutoRebaseSummary, fileCount: number): unknown {
+		const emptiedCount = summary.steps.reduce((n, s) => (s.kind === 'empty-skipped' ? n + 1 : n), 0);
 		const outcomeLabel =
 			summary.outcome === 'completed'
 				? 'completed'
@@ -381,6 +382,10 @@ export class GlRebaseSummarySheet extends LitElement {
 						? html` · ${pluralize('conflicted file', fileCount)} resolved across
 							${pluralize('step', summary.steps.length)}`
 						: nothing
+				}${
+					// Steps git dropped for being empty aren't commits on the branch — the counts above would
+					// otherwise read as "every step landed".
+					emptiedCount > 0 ? html` · ${pluralize('commit', emptiedCount)} skipped as empty` : nothing
 				}
 			</div>
 			${

--- a/src/webviews/apps/plus/shared/components/__tests__/merge-rebase-status.utils.test.ts
+++ b/src/webviews/apps/plus/shared/components/__tests__/merge-rebase-status.utils.test.ts
@@ -15,6 +15,7 @@ import {
 	getPausedOperationBarActionLabel,
 	getPausedOperationBarIconTooltip,
 	getPausedOperationBarLabel,
+	getPausedOperationBarRefsSummary,
 	getPausedOperationSkipDetail,
 	getPausedOperationSkipLabel,
 	getPausedOperationSkipRef,
@@ -186,33 +187,45 @@ suite('pausedOperationVariantIcons', () => {
 	});
 });
 
+suite('getPausedOperationBarRefsSummary', () => {
+	test('branch operands are named, in the operation’s own direction', () => {
+		assert.strictEqual(getPausedOperationBarRefsSummary(createMerge()), 'Merging feature into main');
+		assert.strictEqual(getPausedOperationBarRefsSummary(createRebase()), 'Rebasing feature onto main');
+	});
+
+	test('a revision operand is shortened', () => {
+		assert.strictEqual(getPausedOperationBarRefsSummary(createCherryPick()), 'Cherry picking a1b2c3d into main');
+		assert.strictEqual(getPausedOperationBarRefsSummary(createRevert()), 'Reverting a1b2c3d in main');
+	});
+});
+
 suite('getPausedOperationBarIconTooltip', () => {
-	test('conflicts restate the count in plain words', () => {
+	test('conflicts restate the count in plain words, led by the operands', () => {
 		assert.strictEqual(
 			getPausedOperationBarIconTooltip(createMerge(), 'conflicts', 2),
-			'2 conflicting files must be resolved before the merge can continue',
+			'Merging feature into main. 2 conflicting files must be resolved before the merge can continue',
 		);
 		assert.strictEqual(
 			getPausedOperationBarIconTooltip(createRebase(), 'conflicts', 1),
-			'1 conflicting file must be resolved before the rebase can continue',
+			'Rebasing feature onto main. 1 conflicting file must be resolved before the rebase can continue',
 		);
 	});
 
 	test('a countless host drops the number, not the sentence', () => {
 		assert.strictEqual(
 			getPausedOperationBarIconTooltip(createCherryPick(), 'conflicts', undefined),
-			'Conflicting files must be resolved before the cherry-pick can continue',
+			'Cherry picking a1b2c3d into main. Conflicting files must be resolved before the cherry-pick can continue',
 		);
 	});
 
 	test('ready spells out that nothing is blocking', () => {
 		assert.strictEqual(
 			getPausedOperationBarIconTooltip(createMerge(), 'ready', undefined),
-			'No unresolved conflicts — ready to continue',
+			'Merging feature into main. No unresolved conflicts — ready to continue',
 		);
 	});
 
-	test('pending has nothing to explain', () => {
+	test('pending has nothing to explain — its own label already names the refs', () => {
 		assert.strictEqual(
 			getPausedOperationBarIconTooltip(createRebase({ current: 0, total: 0 }), 'pending', undefined),
 			undefined,

--- a/src/webviews/apps/plus/shared/components/__tests__/merge-rebase-status.utils.test.ts
+++ b/src/webviews/apps/plus/shared/components/__tests__/merge-rebase-status.utils.test.ts
@@ -141,10 +141,10 @@ suite('getPausedOperationBarLabel', () => {
 		assert.strictEqual(getPausedOperationBarLabel(createRevert(), 'ready'), 'Reverting');
 	});
 
-	test('a pending rebase reads into its refs', () => {
+	test('a pending rebase stands alone, since its refs can shed', () => {
 		assert.strictEqual(
 			getPausedOperationBarLabel(createRebase({ current: 0, total: 0 }), 'pending'),
-			'Pending rebase of',
+			'Pending rebase',
 		);
 	});
 });
@@ -225,10 +225,10 @@ suite('getPausedOperationBarIconTooltip', () => {
 		);
 	});
 
-	test('pending has nothing to explain — its own label already names the refs', () => {
+	test('pending names its operands too, since its refs shed like every other variant', () => {
 		assert.strictEqual(
 			getPausedOperationBarIconTooltip(createRebase({ current: 0, total: 0 }), 'pending', undefined),
-			undefined,
+			'Rebasing feature onto main. The rebase hasn’t reached its first step',
 		);
 	});
 });

--- a/src/webviews/apps/plus/shared/components/merge-rebase-status.ts
+++ b/src/webviews/apps/plus/shared/components/merge-rebase-status.ts
@@ -125,16 +125,16 @@ export class GlMergeConflictWarning extends LitElement {
 			/* Under width pressure the refs are the first thing to go: the branch row directly below the
 			   strip already names the branch, and the leading icon's hover names the operands, so the
 			   phrase and the actions never lose room. The threshold is where the chips stop being able to
-			   NAME their refs — slivers are worse than absence. Every variant sheds except pending, whose
-			   phrase reads straight into its refs ("Pending rebase of <feature> onto <main>"). */
+			   NAME their refs — slivers are worse than absence. Every variant sheds, including pending,
+			   whose leading "of" rides inside the group so its phrase still reads once they're gone. */
 			@container (max-width: 52rem) {
-				.status--sheddable .refs {
+				.refs {
 					display: none;
 				}
 
 				/* Refs gone, the phrase is the only thing left that can absorb the squeeze — ellipsize it
 				   rather than let the label's overflow clip it mid-word. */
-				.status--sheddable .label__phrase {
+				.label__phrase {
 					flex: 0 1 auto;
 					min-width: 0;
 					overflow: hidden;
@@ -341,11 +341,9 @@ export class GlMergeConflictWarning extends LitElement {
 
 		const variant = getPausedOperationVariant(status, this.conflicts);
 		const stepped = isPausedOperationStepped(status, variant) ? status : undefined;
-		// Pending is the one variant whose phrase reads into its refs, so it's the one that can't shed them.
-		const sheddable = variant !== 'pending';
 
 		return html`
-			<span class="status ${sheddable ? 'status--sheddable' : ''}" part="base" data-variant=${variant}>
+			<span class="status" part="base" data-variant=${variant}>
 				${this.renderIcon(status, variant)}${this.renderLabel(status, variant, stepped)}${
 					// Read-only keeps the variant's copy and tint — only the affordances go away.
 					this.readOnly ? nothing : this.renderActions(status, variant)
@@ -375,8 +373,9 @@ export class GlMergeConflictWarning extends LitElement {
 				>${label}</span
 			>${stepped != null ? this.renderStep(stepped) : nothing}${this.renderRefs(
 				status,
-				// The pending phrase reads straight into its refs ("Pending rebase of <feature> onto <main>").
-				variant !== 'pending',
+				// Pending's phrase reads straight into its refs ("Pending rebase" + "of <feature> onto <main>"),
+				// so it leads with that "of" where every other variant leads with a separator.
+				variant === 'pending' ? 'of' : '·',
 			)}</span
 		>`;
 	}
@@ -402,14 +401,17 @@ export class GlMergeConflictWarning extends LitElement {
 			>`;
 	}
 
-	private renderRefs(status: GitPausedOperationStatus, separator: boolean) {
+	private renderRefs(status: GitPausedOperationStatus, lead: '·' | 'of') {
 		const strings = pausedOperationStatusStringsByType[status.type];
 		// Never null in practice: `current` is required on non-rebase models, `onto` on rebase.
 		const current = getConflictCurrentRef(status)!;
 
-		// The leading separator lives inside the group so nothing dangles when it drops at narrow widths.
+		// The leading token lives inside the group so nothing dangles when it drops at narrow widths —
+		// neither a separator nor the preposition the pending phrase would otherwise trail off with.
 		return html`<span class="refs"
-			>${separator ? html`<span class="separator">·</span>` : nothing}${this.renderReference(status.incoming)}<span>${strings.directionality}</span>${this.renderReference(current)}</span
+			>${
+				lead === '·' ? html`<span class="separator">·</span>` : html`<span class="label__text">of</span>`
+			}${this.renderReference(status.incoming)}<span>${strings.directionality}</span>${this.renderReference(current)}</span
 		>`;
 	}
 

--- a/src/webviews/apps/plus/shared/components/merge-rebase-status.ts
+++ b/src/webviews/apps/plus/shared/components/merge-rebase-status.ts
@@ -99,7 +99,7 @@ export class GlMergeConflictWarning extends LitElement {
 				white-space: nowrap;
 			}
 
-			/* The phrase never shrinks — width pressure goes to the refs, which shrink and (stepped) drop. */
+			/* The phrase never shrinks — width pressure goes to the refs, which shrink and then drop. */
 			.label__text {
 				flex: none;
 			}
@@ -122,19 +122,23 @@ export class GlMergeConflictWarning extends LitElement {
 				overflow: hidden;
 			}
 
-			/* Refs absorb all the shrink, ellipsizing well past the chips' resting minimum. */
-			.refs .chip {
-				min-width: 0;
-			}
-
 			/* Under width pressure the refs are the first thing to go: the branch row directly below the
-			   strip already names the branch and the paused-at pill's hover carries the rest, so the
-			   phrase and the actions never lose room. Only stripped when a step pill is competing for it.
-			   The threshold is where the chips stop being able to NAME their refs — slivers are worse
-			   than absence. */
+			   strip already names the branch, and the leading icon's hover names the operands, so the
+			   phrase and the actions never lose room. The threshold is where the chips stop being able to
+			   NAME their refs — slivers are worse than absence. Every variant sheds except pending, whose
+			   phrase reads straight into its refs ("Pending rebase of <feature> onto <main>"). */
 			@container (max-width: 52rem) {
-				.status--stepped .refs {
+				.status--sheddable .refs {
 					display: none;
+				}
+
+				/* Refs gone, the phrase is the only thing left that can absorb the squeeze — ellipsize it
+				   rather than let the label's overflow clip it mid-word. */
+				.status--sheddable .label__phrase {
+					flex: 0 1 auto;
+					min-width: 0;
+					overflow: hidden;
+					text-overflow: ellipsis;
 				}
 			}
 
@@ -164,7 +168,7 @@ export class GlMergeConflictWarning extends LitElement {
 				display: inline-flex;
 				flex: 0 1 auto;
 				align-items: center;
-				min-width: 4ch;
+				min-width: 0;
 				padding: 0 var(--gl-space-4);
 				overflow: hidden;
 				color: var(--gl-paused-op-ink);
@@ -328,11 +332,12 @@ export class GlMergeConflictWarning extends LitElement {
 		if (status == null) return nothing;
 
 		const variant = getPausedOperationVariant(status, this.conflicts);
-		// One predicate drives both the CSS gate (refs drop at narrow widths) and the step-pill render.
 		const stepped = isPausedOperationStepped(status, variant) ? status : undefined;
+		// Pending is the one variant whose phrase reads into its refs, so it's the one that can't shed them.
+		const sheddable = variant !== 'pending';
 
 		return html`
-			<span class="status ${stepped != null ? 'status--stepped' : ''}" part="base" data-variant=${variant}>
+			<span class="status ${sheddable ? 'status--sheddable' : ''}" part="base" data-variant=${variant}>
 				${this.renderIcon(status, variant)}${this.renderLabel(status, variant, stepped)}${
 					// Read-only keeps the variant's copy and tint — only the affordances go away.
 					this.readOnly ? nothing : this.renderActions(status, variant)
@@ -358,7 +363,8 @@ export class GlMergeConflictWarning extends LitElement {
 		const label = getPausedOperationBarLabel(status, variant);
 
 		return html`<span class="label"
-			><span class="label__text ${variant === 'conflicts' ? 'label__text--emphasized' : ''}">${label}</span
+			><span class="label__text label__phrase ${variant === 'conflicts' ? 'label__text--emphasized' : ''}"
+				>${label}</span
 			>${stepped != null ? this.renderStep(stepped) : nothing}${this.renderRefs(
 				status,
 				// The pending phrase reads straight into its refs ("Pending rebase of <feature> onto <main>").

--- a/src/webviews/apps/plus/shared/components/merge-rebase-status.ts
+++ b/src/webviews/apps/plus/shared/components/merge-rebase-status.ts
@@ -257,22 +257,22 @@ export class GlMergeConflictWarning extends LitElement {
 	@property({ type: Object })
 	pausedOpStatus?: GitPausedOperationStatus;
 
-	/** Set when Continue is clicked; the command runs out of band, so a fresh `pausedOpStatus` clears it. */
+	/** The host reports a continue/skip still running for this repo. `<op> --continue` blocks for as long
+	 *  as git's commit-message tab stays open — unbounded — so only the host can say when it ends; a
+	 *  timer here could only guess, and guessing wrong re-enables an action whose click can do nothing.
+	 *  Hosts that don't report it leave the busy state to the fresh-status reset below. */
+	@property({ type: Boolean, attribute: 'continuing' })
+	continuing = false;
+
+	/** Set when Continue is clicked, so the action goes busy before the host's first update lands. */
 	@state()
 	private _continuing = false;
 
-	/** A continue can fail without moving the repo (an empty commit the user then cancels out of,
-	 *  unstaged changes, unmerged files), and a host that re-sends an unchanged `pausedOpStatus` by
-	 *  reference won't register as a change either — so the fresh-status reset alone can strand the
-	 *  primary action in a disabled spinner with nothing else to click. Restore it after a wait long
-	 *  enough that no ordinary continue trips it.
-	 *
-	 *  Note this is only a backstop: measured live, the reset almost always comes from the status
-	 *  instead — even a continue still blocked on the commit-message editor churns `COMMIT_EDITMSG`
-	 *  and the index, which lands a fresh status and clears the busy state early. So the spinner is
-	 *  not a reliable "still running" indicator; re-clicking is harmless (the runner dedups the
-	 *  in-flight command), but the bar can't currently distinguish waiting from finished. */
-	private static readonly continuingWatchdogMs = 30000;
+	/** Last-resort backstop for hosts that report neither `continuing` nor a fresh `pausedOpStatus` after a
+	 *  continue settles — without it the action could strand disabled with nothing left to click. Long
+	 *  enough that it can't cut short a real wait on the commit-message tab, and it never overrides a host
+	 *  that says the command is still running. */
+	private static readonly continuingBackstopMs = 300000;
 	private _continuingTimer: ReturnType<typeof setTimeout> | undefined;
 
 	override disconnectedCallback(): void {
@@ -281,7 +281,10 @@ export class GlMergeConflictWarning extends LitElement {
 	}
 
 	protected override willUpdate(changedProperties: PropertyValues<this>): void {
-		if (changedProperties.has('pausedOpStatus')) {
+		// Drop the optimistic state once the host reports the command settled — including a continue that
+		// failed without moving the repo, so the action can't strand disabled. Hosts that don't report
+		// `continuing` at all fall back to a fresh status as the settle signal.
+		if (!this.continuing && (changedProperties.has('continuing') || changedProperties.has('pausedOpStatus'))) {
 			this.clearContinuing();
 		}
 
@@ -292,6 +295,11 @@ export class GlMergeConflictWarning extends LitElement {
 		clearTimeout(this._continuingTimer);
 		this._continuingTimer = undefined;
 		this._continuing = false;
+	}
+
+	/** Busy while either the click's optimistic state or the host's in-flight report holds. */
+	private get isContinuing(): boolean {
+		return this.continuing || this._continuing;
 	}
 
 	private get onSkipUrl() {
@@ -453,13 +461,18 @@ export class GlMergeConflictWarning extends LitElement {
 		// swaps that anchor for a `<button>`, which discards keyboard focus. So the repeat activation is
 		// cancelled here instead: `disabled` stops the pointer, and Enter on a focused link fires a click
 		// we can preventDefault.
-		if (this._continuing) {
+		if (this.isContinuing) {
 			e.preventDefault();
 			return;
 		}
 
 		this._continuing = true;
-		this._continuingTimer = setTimeout(() => this.clearContinuing(), GlMergeConflictWarning.continuingWatchdogMs);
+		this._continuingTimer = setTimeout(() => {
+			// A host reporting an in-flight command outranks the backstop — its `continuing` clears this.
+			if (this.continuing) return;
+
+			this.clearContinuing();
+		}, GlMergeConflictWarning.continuingBackstopMs);
 	};
 
 	private renderActions(status: GitPausedOperationStatus, variant: PausedOperationVariant) {
@@ -535,7 +548,7 @@ export class GlMergeConflictWarning extends LitElement {
 	 *  longer excluded — `revert --continue` is supported end to end. */
 	private renderPrimaryAction(status: GitPausedOperationStatus, variant: PausedOperationVariant, aiPrimary: boolean) {
 		if (variant !== 'conflicts') {
-			const continuing = this._continuing;
+			const continuing = this.isContinuing;
 			const label = continuing
 				? aiPrimary
 					? 'Continuing Automatic Rebase…'
@@ -548,7 +561,7 @@ export class GlMergeConflictWarning extends LitElement {
 			// AND `gl-button` reuses its inner anchor (no href swaps that anchor for a `<button>`, which
 			// discards keyboard focus). `disabled` stops the pointer and drops it from the tab order without
 			// blurring it; `onContinue` cancels the repeat navigation. `aria-busy` carries the state change.
-			return html`<gl-button
+			const button = html`<gl-button
 				density="compact"
 				?disabled=${continuing}
 				aria-busy=${continuing ? 'true' : nothing}
@@ -557,6 +570,15 @@ export class GlMergeConflictWarning extends LitElement {
 				>${
 					continuing ? html`<code-icon icon="loading" modifier="spin" slot="prefix"></code-icon>` : nothing
 				}${label}</gl-button
+			>`;
+
+			// A disabled action can't explain itself, and the commonest reason a continue runs long is git
+			// waiting on a commit-message tab the user can't see from here — so name it while busy.
+			if (!continuing) return button;
+
+			return html`<gl-tooltip
+				content="Waiting for Git to finish. If a commit message tab is open, save and close it to continue."
+				>${button}</gl-tooltip
 			>`;
 		}
 

--- a/src/webviews/apps/plus/shared/components/merge-rebase-status.utils.ts
+++ b/src/webviews/apps/plus/shared/components/merge-rebase-status.utils.ts
@@ -24,9 +24,9 @@ export function isPausedOperationStepped(
 export function getPausedOperationBarLabel(status: GitPausedOperationStatus, variant: PausedOperationVariant): string {
 	const strings = pausedOperationStatusStringsByType[status.type];
 	if (variant === 'conflicts') return `${strings.prose} paused`;
-	if (variant === 'pending' && status.type === 'rebase') {
-		return pausedOperationStatusStringsByType.rebase.pending;
-	}
+	// The shared `pending` string trails a preposition for callers that append a ref inline (the tree
+	// view). The bar's refs can shed, so it carries that "of" inside the refs group instead.
+	if (variant === 'pending' && status.type === 'rebase') return 'Pending rebase';
 	return strings.label;
 }
 
@@ -67,11 +67,10 @@ export function getPausedOperationBarIconTooltip(
 	variant: PausedOperationVariant,
 	conflictsCount: number | undefined,
 ): string | undefined {
-	// The pending phrase reads into its refs, which never shed — restating them would only echo the label.
-	if (variant === 'pending') return undefined;
-
 	let state;
-	if (variant === 'conflicts') {
+	if (variant === 'pending') {
+		state = 'The rebase hasn’t reached its first step';
+	} else if (variant === 'conflicts') {
 		const name = pausedOperationStatusStringsByType[status.type].prose.toLowerCase();
 		state =
 			conflictsCount == null

--- a/src/webviews/apps/plus/shared/components/merge-rebase-status.utils.ts
+++ b/src/webviews/apps/plus/shared/components/merge-rebase-status.utils.ts
@@ -1,15 +1,18 @@
 import type { GitPausedOperationStatus, GitRebaseStatus } from '@gitlens/git/models/pausedOperationStatus.js';
-import type { GitRevisionReference } from '@gitlens/git/models/reference.js';
+import type { GitReference, GitRevisionReference } from '@gitlens/git/models/reference.js';
 import { splitCommitMessage } from '@gitlens/git/utils/commit.utils.js';
 import type { PausedOperationVariant } from '@gitlens/git/utils/pausedOperationStatus.utils.js';
-import { pausedOperationStatusStringsByType } from '@gitlens/git/utils/pausedOperationStatus.utils.js';
+import {
+	getConflictCurrentRef,
+	pausedOperationStatusStringsByType,
+} from '@gitlens/git/utils/pausedOperationStatus.utils.js';
 import { shortenRevision } from '@gitlens/git/utils/revision.utils.js';
 import { pluralize, truncate } from '@gitlens/utils/string.js';
 
 /** Longest commit subject a tooltip carries before it's elided. */
 const maxSubjectLength = 50;
 
-/** True when the strip shows the "at <m/t>" step context — also gates which strips drop their refs at narrow widths. */
+/** True when the strip shows the "at <m/t>" step context. */
 export function isPausedOperationStepped(
 	status: GitPausedOperationStatus,
 	variant: PausedOperationVariant,
@@ -40,24 +43,46 @@ export function getPausedOperationBarActionLabel(
 	return `Continue ${pausedOperationStatusStringsByType[status.type].name}`;
 }
 
-/** Plain-words restatement of the state for label-only scanners, carried on the leading icon. */
+/** `Merging feature into main` — names the operands the ref chips carry, so the identity survives the
+ *  narrow-width shed. Undefined when either side can't be named. */
+export function getPausedOperationBarRefsSummary(status: GitPausedOperationStatus): string | undefined {
+	const current = nameRef(getConflictCurrentRef(status));
+	const incoming = nameRef(status.incoming);
+	if (current == null || incoming == null) return undefined;
+
+	const strings = pausedOperationStatusStringsByType[status.type];
+	return `${strings.label} ${incoming} ${strings.directionality} ${current}`;
+}
+
+function nameRef(ref: GitReference | undefined): string | undefined {
+	if (ref == null) return undefined;
+
+	return ref.refType === 'branch' ? ref.name : shortenRevision(ref.ref) || undefined;
+}
+
+/** Plain-words restatement of the state for label-only scanners, carried on the leading icon. Leads with
+ *  the operands, which are the only place they're named once the refs shed at narrow widths. */
 export function getPausedOperationBarIconTooltip(
 	status: GitPausedOperationStatus,
 	variant: PausedOperationVariant,
 	conflictsCount: number | undefined,
 ): string | undefined {
-	switch (variant) {
-		case 'conflicts': {
-			const name = pausedOperationStatusStringsByType[status.type].prose.toLowerCase();
-			return conflictsCount == null
+	// The pending phrase reads into its refs, which never shed — restating them would only echo the label.
+	if (variant === 'pending') return undefined;
+
+	let state;
+	if (variant === 'conflicts') {
+		const name = pausedOperationStatusStringsByType[status.type].prose.toLowerCase();
+		state =
+			conflictsCount == null
 				? `Conflicting files must be resolved before the ${name} can continue`
 				: `${pluralize('conflicting file', conflictsCount)} must be resolved before the ${name} can continue`;
-		}
-		case 'pending':
-			return undefined;
-		case 'ready':
-			return 'No unresolved conflicts — ready to continue';
+	} else {
+		state = 'No unresolved conflicts — ready to continue';
 	}
+
+	const refs = getPausedOperationBarRefsSummary(status);
+	return refs == null ? state : `${refs}. ${state}`;
 }
 
 export function getPausedOperationAbortLabel(status: GitPausedOperationStatus): string {

--- a/src/webviews/plus/graph/graphWebview.ts
+++ b/src/webviews/plus/graph/graphWebview.ts
@@ -68,6 +68,7 @@ import type { Container } from '../../../container.js';
 import type { FeaturePreview } from '../../../features.js';
 import { getFeaturePreviewStatus } from '../../../features.js';
 import { openCommitChanges, openCommitChangesWithWorking, undoCommit } from '../../../git/actions/commit.js';
+import { onDidChangeContinuingPausedOperation } from '../../../git/actions/pausedOperation.js';
 import * as RepoActions from '../../../git/actions/repository.js';
 import * as StashActions from '../../../git/actions/stash.js';
 import { CommitFormatter } from '../../../git/formatters/commitFormatter.js';
@@ -561,6 +562,13 @@ export class GraphWebviewProvider implements WebviewProvider<State, State, Graph
 			// The bar's primary continue swaps between automatic/manual with the session
 			this.container.autoRebase.onDidChange(e => {
 				if (e.repoPath === this.repository?.path) {
+					void this._wip.notifyDidChangeWorkingTree();
+				}
+			}),
+			// A continue can block indefinitely on git's commit-message tab, so the bar's busy state comes
+			// from here rather than a timer that could only guess when the command ended
+			onDidChangeContinuingPausedOperation(repoPath => {
+				if (repoPath === this.repository?.path) {
 					void this._wip.notifyDidChangeWorkingTree();
 				}
 			}),

--- a/src/webviews/plus/graph/graphWipService.ts
+++ b/src/webviews/plus/graph/graphWipService.ts
@@ -22,6 +22,7 @@ import { getSettledValue } from '@gitlens/utils/promise.js';
 import { PromiseCache } from '@gitlens/utils/promiseCache.js';
 import type { StoredGraphWipDraft } from '../../../constants.storage.js';
 import type { Container } from '../../../container.js';
+import { isContinuingPausedOperation } from '../../../git/actions/pausedOperation.js';
 import { CommitFormatter } from '../../../git/formatters/commitFormatter.js';
 import type { GlRepository } from '../../../git/models/repository.js';
 import { getBranchRemote } from '../../../git/utils/-webview/branch.utils.js';
@@ -1198,6 +1199,10 @@ export class GraphWipService {
 						pausedOpStatus?.type === 'rebase' && this.container.autoRebase.getSession(repo.path) != null
 							? true
 							: undefined,
+					// Flipping this is also what gets the settle past the notification's content dedup: a
+					// continue that failed without moving the repo produces an otherwise identical payload.
+					pausedOpContinuing:
+						pausedOpStatus != null && isContinuingPausedOperation(repo.path) ? true : undefined,
 				},
 				repositoryCount: this.container.git.openRepositoryCount,
 				revision: revision,

--- a/src/webviews/rpc/services/types.ts
+++ b/src/webviews/rpc/services/types.ts
@@ -368,6 +368,9 @@ export interface WipChange {
 	/** An automatic (AI) rebase session owns the paused rebase, so continuing should resume that run
 	 *  rather than issue a plain `--continue` */
 	aiRebaseActive?: boolean;
+	/** A continue/skip is still running. `<op> --continue` blocks for as long as git's commit-message tab
+	 *  stays open, so only the host knows when it ends — the bar can't time it. */
+	pausedOpContinuing?: boolean;
 }
 
 // ============================================================


### PR DESCRIPTION
Fixes four issues filed 2026-08-05 against `main` @ `4b7c5fb52`, found while live-verifying #5450 and #5648. All four were validated against the code before any change — every core claim held, with refinements noted per commit.

Closes #5655, closes #5656, closes #5661, closes #5662.

## #5655 — Ref chips collapsed to slivers in narrow placements

The container query that sheds the bar's refs was scoped to `.status--stepped`, a class only a *started rebase* ever gets — so a paused merge, cherry-pick or revert never shed: chips shrank to 8px of bare padding while the separator kept its full width.

Shedding is now driven for every variant. The follow-up commit closes a hole the first pass introduced: exempting the `pending` variant (whose phrase reads into its refs) left it rendering the exact 8px artifact the issue is about, so its leading "of" moved inside the refs group to leave with them.

Also fixes the read-only variant, which had no chip wrapper and collapsed to nothing.

## #5656 — Continue dead-ended on the commit-message tab

`<op> --continue` opens `COMMIT_EDITMSG` and blocks until the tab closes — unbounded. The bar guessed with a 30s watchdog, re-enabled the action while git was still blocked, and the next click vanished into the git runner's dedup of the still-running command.

Replaced with a host-reported in-flight state (`Wip.changes` carries `pausedOpContinuing`). A repeat invocation now reports the wait and offers to focus the tab; the busy action explains itself on hover. Also disables the command timeout for continue/skip/abort, matching the merge/rebase/revert start paths — the default 60s `advanced.git.timeout` was SIGTERM-ing a continue legitimately waiting on the editor.

## #5661 — Completed rebase reported commits it had dropped

When a resolution keeps the current side the step's commit can end up empty; git drops it and still exits 0 with "Successfully rebased" (verified against git 2.55). The existing `empty-skipped` handling only fired off a non-zero exit, so it was unreachable for rebase — its integration coverage is cherry-pick and revert only.

Now probes the index against HEAD before continuing and records the step as `empty-skipped`, reusing the machinery already in place. Deliberately keeps a plain `--continue` rather than `--skip`: if the probe is ever wrong, `--continue` commits the real content where `--skip` would discard it, so a mis-detection stays cosmetic instead of destructive. The completion line and summary report skipped commits instead of counting them as steps that landed.

## #5662 — Automatic rebase stalled on the AI model picker

The model resolved lazily per AI request *inside* the run, so the picker opened behind a Resolve panel already claiming "Analyzing <file>…". Worse, five files resolve in parallel and the non-silent resolve bypasses the dedupe cache, so each raced to open its own picker — losers were hidden, resolved as cancelled, and surfaced as "The AI couldn't resolve \<file\>", blaming the model for an unanswered prompt.

The model is now resolved once pre-flight, before any session or progress state exists; dismissing it refuses the start with the branch untouched. Threading the resolved model through also removes the parallel-picker race.

Note the reported precondition is narrower than "no model configured": a verified account with GitKraken AI org-enabled resolves a fallback silently, so the picker only appears when no usable fallback resolves.

## Verification

Types, lint (`oxlint --type-aware`) and unit tests pass; each commit type-checks standalone.

**Live-verified** (`/live-exercise`, real fixtures, measured not eyeballed):

- **#5655** — merge @177px, rebase 1/3 @241px, Home card @135px, pending @265px: refs either fully absent or ≥51px legible, **no width produces a sliver**; separator never dangles; rebase step counter preserved; operands preserved in the leading-icon tooltip. Threshold behaves as designed (~520px).
- **#5656** — end-to-end: continue → git blocks on `COMMIT_EDITMSG` → bar stays busy **past 40s** (old watchdog gave up at 30) → repeat invocation reports instead of vanishing → closing the tab lands the merge immediately → bar releases and is actionable again on the next paused op.

## Known pre-existing issue (not addressed)

At very narrow widths the bar names nothing: measured at 241px the fixed-width actions take 207px and the label gets **0**, so the phrase *and* step counter clip away entirely, leaving only an icon and "Resolve 1 Conflict" (in Home, actions 191px overflow a 135px bar). Driven by `.actions { flex: none }` + `.label { flex: 1; min-width: 0 }` — untouched by this branch, so pre-existing per branch-ownership rules. It does cap how much of #5655's intent lands at the widths the issue is about.
