### PR TITLE
Fixes the wrong change types and inflated line counts a two-pass review's first pass ranks from

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -59,6 +59,7 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/) and this p
 - Fixes searching by author `@username` in GitHub virtual repositories dropping the first character of the username
 - Fixes searching by author or committer `@me` in GitHub virtual repositories skipping the filter entirely for accounts without a display name
 - Fixes the _Commit Graph_'s search history reading and saving under the first-opened repository after switching repositories in a multi-repo workspace
+- Fixes the _Commit Graph_'s _Review_ mode choosing focus areas from wrong file details on large change sets &mdash; newly added files counted as modified, and changed-line counts included unchanged context ([#5658](https://github.com/gitkraken/vscode-gitlens/issues/5658))
 
 ## [19.0.1] - 2026-08-13
 

--- a/packages/git-cli/src/parsers/__tests__/diffParser.test.ts
+++ b/packages/git-cli/src/parsers/__tests__/diffParser.test.ts
@@ -309,9 +309,9 @@ suite('countDiffInsertionsAndDeletions Test Suite', () => {
 		assert.strictEqual(parsed.files.length, 1);
 
 		const { insertions, deletions } = countDiffInsertionsAndDeletions(parsed.files[0]);
-		// previous: 3 lines (deletions context), current: 4 lines (insertions context)
-		assert.strictEqual(insertions, 4, 'Should count current lines as insertions');
-		assert.strictEqual(deletions, 3, 'Should count previous lines as deletions');
+		// One added line, three unchanged context lines that must not be counted
+		assert.strictEqual(insertions, 1, 'Should count only added lines as insertions');
+		assert.strictEqual(deletions, 0, 'Should not count context lines as deletions');
 	});
 
 	test('returns zeros for file without hunks', () => {
@@ -345,9 +345,8 @@ rename to new.ts`;
 		assert.strictEqual(parsed.files.length, 1);
 
 		const { insertions, deletions } = countDiffInsertionsAndDeletions(parsed.files[0]);
-		// First hunk: prev 2, curr 3
-		// Second hunk: prev 3, curr 2
-		assert.strictEqual(insertions, 5, 'Should sum current lines from all hunks');
-		assert.strictEqual(deletions, 5, 'Should sum previous lines from all hunks');
+		// First hunk: one added line; second hunk: one removed line
+		assert.strictEqual(insertions, 1, 'Should sum added lines from all hunks');
+		assert.strictEqual(deletions, 1, 'Should sum removed lines from all hunks');
 	});
 });

--- a/packages/git/src/parsers/__tests__/diffParser.test.ts
+++ b/packages/git/src/parsers/__tests__/diffParser.test.ts
@@ -761,7 +761,7 @@ suite('Diff Parser Test Suite', () => {
 	});
 
 	suite('countDiffInsertionsAndDeletions', () => {
-		test('counts insertions and deletions from hunks', () => {
+		test('counts insertions and deletions from hunks, excluding context lines', () => {
 			const data = [
 				'diff --git a/src/foo.ts b/src/foo.ts',
 				'index abc1234..def5678 100644',
@@ -777,8 +777,140 @@ suite('Diff Parser Test Suite', () => {
 			const result = parseGitDiff(data);
 			const counts = countDiffInsertionsAndDeletions(result.files[0]);
 
-			assert.strictEqual(counts.insertions, 4);
+			assert.strictEqual(counts.insertions, 1);
+			assert.strictEqual(counts.deletions, 0);
+		});
+
+		test('counts an asymmetric change block', () => {
+			const data = [
+				'diff --git a/src/foo.ts b/src/foo.ts',
+				'index abc1234..def5678 100644',
+				'--- a/src/foo.ts',
+				'+++ b/src/foo.ts',
+				'@@ -1,5 +1,3 @@',
+				' line1',
+				'-old1',
+				'-old2',
+				'-old3',
+				'+new1',
+				' line5',
+			].join('\n');
+
+			const result = parseGitDiff(data);
+			const counts = countDiffInsertionsAndDeletions(result.files[0]);
+
+			assert.strictEqual(counts.insertions, 1);
 			assert.strictEqual(counts.deletions, 3);
+		});
+
+		test('counts an added file with no deletions', () => {
+			const data = [
+				'diff --git a/new.txt b/new.txt',
+				'new file mode 100644',
+				'index 0000000..abc1234',
+				'--- /dev/null',
+				'+++ b/new.txt',
+				'@@ -0,0 +1 @@',
+				'+hello',
+			].join('\n');
+
+			const result = parseGitDiff(data);
+			assert.strictEqual(result.files[0].status, GitFileIndexStatus.Added);
+
+			const counts = countDiffInsertionsAndDeletions(result.files[0]);
+
+			assert.strictEqual(counts.insertions, 1);
+			assert.strictEqual(counts.deletions, 0);
+		});
+
+		test('counts a deleted file with no insertions', () => {
+			const data = [
+				'diff --git a/gone.txt b/gone.txt',
+				'deleted file mode 100644',
+				'index abc1234..0000000',
+				'--- a/gone.txt',
+				'+++ /dev/null',
+				'@@ -1,2 +0,0 @@',
+				'-line1',
+				'-line2',
+			].join('\n');
+
+			const result = parseGitDiff(data);
+			assert.strictEqual(result.files[0].status, GitFileIndexStatus.Deleted);
+
+			const counts = countDiffInsertionsAndDeletions(result.files[0]);
+
+			assert.strictEqual(counts.insertions, 0);
+			assert.strictEqual(counts.deletions, 2);
+		});
+
+		test('ignores the no-newline marker', () => {
+			const data = [
+				'diff --git a/src/foo.ts b/src/foo.ts',
+				'index abc1234..def5678 100644',
+				'--- a/src/foo.ts',
+				'+++ b/src/foo.ts',
+				'@@ -1 +1 @@',
+				'-old',
+				'\\ No newline at end of file',
+				'+new',
+				'\\ No newline at end of file',
+			].join('\n');
+
+			const result = parseGitDiff(data);
+			const counts = countDiffInsertionsAndDeletions(result.files[0]);
+
+			assert.strictEqual(counts.insertions, 1);
+			assert.strictEqual(counts.deletions, 1);
+		});
+
+		test('returns zeros for a pure rename and for a binary file', () => {
+			const rename = [
+				'diff --git a/old.ts b/new.ts',
+				'similarity index 100%',
+				'rename from old.ts',
+				'rename to new.ts',
+			].join('\n');
+
+			let result = parseGitDiff(rename);
+			assert.strictEqual(result.files[0].status, GitFileIndexStatus.Renamed);
+			assert.deepStrictEqual(countDiffInsertionsAndDeletions(result.files[0]), {
+				insertions: 0,
+				deletions: 0,
+			});
+
+			const binary = [
+				'diff --git a/logo.png b/logo.png',
+				'index abc1234..def5678 100644',
+				'Binary files a/logo.png and b/logo.png differ',
+			].join('\n');
+
+			result = parseGitDiff(binary);
+			assert.strictEqual(result.files[0].metadata.binary, true);
+			assert.deepStrictEqual(countDiffInsertionsAndDeletions(result.files[0]), {
+				insertions: 0,
+				deletions: 0,
+			});
+		});
+
+		test('counts annotated diff content (as sent to the AI)', () => {
+			const data = [
+				'diff --git a/src/foo.ts b/src/foo.ts',
+				'index abc1234..def5678 100644',
+				'--- a/src/foo.ts',
+				'+++ b/src/foo.ts',
+				'@@ -1,3 +1,3 @@',
+				' [    1] line1',
+				'-[     ] old',
+				'+[    2] new',
+				' [    3] line3',
+			].join('\n');
+
+			const result = parseGitDiff(data);
+			const counts = countDiffInsertionsAndDeletions(result.files[0]);
+
+			assert.strictEqual(counts.insertions, 1);
+			assert.strictEqual(counts.deletions, 1);
 		});
 	});
 

--- a/packages/git/src/parsers/diffParser.ts
+++ b/packages/git/src/parsers/diffParser.ts
@@ -219,18 +219,41 @@ export async function filterDiffFiles(
 		.join('');
 }
 
-/** Counts insertions and deletions from a parsed diff file */
+/**
+ * Counts the added and removed lines of a parsed diff file, matching what `git diff --numstat`
+ * reports for it. Binary files and files without content changes (pure renames, mode changes)
+ * count as 0/0.
+ */
 export function countDiffInsertionsAndDeletions(file: ParsedGitDiffFile): { insertions: number; deletions: number } {
 	let insertions = 0;
 	let deletions = 0;
 	for (const hunk of file.hunks) {
-		insertions += hunk.current.count;
-		deletions += hunk.previous.count;
+		// Counted off the hunk's raw content rather than its header counts (which include unchanged
+		// context) or `hunk.lines` (which merges a removed/added pair into one `changed` entry and
+		// lets a following context line overwrite the tail of an asymmetric block). Scanned in place
+		// rather than split into lines: splitting a multi-megabyte diff allocates a string per line
+		// for a single pass that only ever looks at each line's first character.
+		const { content } = hunk;
+		for (let start = 0; start < content.length;) {
+			const marker = content[start];
+			if (marker === '+') {
+				insertions++;
+			} else if (marker === '-') {
+				deletions++;
+			}
+
+			const end = content.indexOf('\n', start);
+			if (end === -1) break;
+
+			start = end + 1;
+		}
 	}
 	return { insertions: insertions, deletions: deletions };
 }
 
-/** Counts approximate number of changed lines in a diff file */
+/** Counts the approximate number of changed lines in a diff file — the size of both sides of its
+ *  hunks, unchanged context included. Suitable for relative sizing, not for reporting a line count
+ *  to the user; use {@link countDiffInsertionsAndDeletions} for that. */
 export function countDiffLines(file: ParsedGitDiffFile): number {
 	let count = 0;
 	for (const hunk of file.hunks) {

--- a/src/webviews/plus/graph/__tests__/graphInspectServices.test.ts
+++ b/src/webviews/plus/graph/__tests__/graphInspectServices.test.ts
@@ -375,9 +375,9 @@ const diffWithNestedRepoGitlink = [
 
 type CreateServices = () => { graphInspect: GraphInspectService };
 
-function createReviewFake() {
+function createReviewFake(diff: string = diffWithNestedRepoGitlink) {
 	const getDiff = sinon.stub();
-	getDiff.withArgs(uncommitted).resolves({ contents: diffWithNestedRepoGitlink });
+	getDiff.withArgs(uncommitted).resolves({ contents: diff });
 	getDiff.withArgs(uncommittedStaged).resolves(undefined);
 
 	// Mirrors the scratch-index staging the review performs (#5604/#5605) so these tests run the same
@@ -399,14 +399,18 @@ function createReviewFake() {
 
 	const reviewChanges = sinon.stub().returns({ promise: Promise.resolve({ result: { mode: 'single-pass' } }) });
 	const reviewFocusArea = sinon.stub().returns({ promise: Promise.resolve({ result: {} }) });
+	const reviewOverview = sinon
+		.stub()
+		.returns({ promise: Promise.resolve({ result: { mode: 'two-pass', focusAreas: [] } }) });
 
 	const container = {
 		git: { getRepositoryService: () => svc },
 		ai: {
-			// No model → the conservative single-pass threshold, which this small diff clears, so the
-			// assertions can read the diff straight off the single-pass request.
+			// No model → the conservative single-pass (8000-token) threshold. `diffWithNestedRepoGitlink`
+			// clears it, so the existing single-pass assertions can read the diff straight off that
+			// request; the two-pass manifest tests below pass a diff sized to exceed it instead.
 			getModel: async () => undefined,
-			actions: { reviewChanges: reviewChanges, reviewFocusArea: reviewFocusArea },
+			actions: { reviewChanges: reviewChanges, reviewFocusArea: reviewFocusArea, reviewOverview: reviewOverview },
 		},
 	} as unknown as Container;
 
@@ -434,6 +438,7 @@ function createReviewFake() {
 		graphInspect: graphInspect,
 		reviewChanges: reviewChanges,
 		reviewFocusArea: reviewFocusArea,
+		reviewOverview: reviewOverview,
 		diffCache: diffCache,
 	};
 }
@@ -525,6 +530,123 @@ suite('graphInspectServices — review exclusions across path shapes (#5603)', (
 		await m.graphInspect.reviewChanges('/repo', scope, undefined, ['new.txt']);
 
 		assert.strictEqual(m.diffCache.size, 2);
+	});
+});
+
+// Fix under test (#5658): pass 1 of a two-pass review sees nothing but the JSON file manifest built
+// here, so every field on it has to be trustworthy — a hardcoded `status: 'M'` or hunk-header-inflated
+// line counts fed pass 1 wrong data with nothing to catch it. This diff is padded well past
+// `shouldUseSinglePass`'s ~22400-character (8000-token) fallback threshold so `reviewChanges` takes the
+// two-pass branch and the manifest actually gets built.
+
+/** One context line long enough that a handful of them, repeated, push the whole diff past the
+ *  single-pass token threshold without needing hundreds of lines to do it. */
+const paddingContextLines = Array.from({ length: 12 }, (_, i) => ` context padding line ${i} ${'x'.repeat(2000)}`);
+
+/** A diff with one file of each shape the manifest has to get right: a plain modification (with
+ *  padding context so the diff clears the two-pass threshold), a new file, a rename with content
+ *  changes, and a binary file. */
+const diffForTwoPassManifest = [
+	'diff --git a/modified.txt b/modified.txt',
+	'index 1111111..2222222 100644',
+	'--- a/modified.txt',
+	'+++ b/modified.txt',
+	'@@ -1,15 +1,16 @@',
+	...paddingContextLines,
+	'-removed line one',
+	'-removed line two',
+	'+added line one',
+	'+added line two',
+	'+added line three',
+	' trailing context line',
+	'diff --git a/added.txt b/added.txt',
+	'new file mode 100644',
+	'index 0000000..3333333',
+	'--- /dev/null',
+	'+++ b/added.txt',
+	'@@ -0,0 +1,4 @@',
+	'+added file line one',
+	'+added file line two',
+	'+added file line three',
+	'+added file line four',
+	'diff --git a/renamed_old.txt b/renamed_new.txt',
+	'similarity index 80%',
+	'rename from renamed_old.txt',
+	'rename to renamed_new.txt',
+	'index 4444444..5555555 100644',
+	'--- a/renamed_old.txt',
+	'+++ b/renamed_new.txt',
+	'@@ -1,3 +1,3 @@',
+	' unchanged line',
+	'-old content',
+	'+new content',
+	' trailing line',
+	'diff --git a/binary.png b/binary.png',
+	'index 6666666..7777777 100644',
+	'Binary files a/binary.png and b/binary.png differ',
+	'',
+].join('\n');
+
+interface ManifestFile {
+	path: string;
+	status: string;
+	additions: number;
+	deletions: number;
+}
+
+function reviewedManifest(stub: sinon.SinonStub): ManifestFile[] {
+	assert.ok(stub.called, 'the pass-1 review-overview action should have been invoked');
+	const files = (stub.firstCall.args[0] as { files: string }).files;
+	return JSON.parse(files) as ManifestFile[];
+}
+
+suite('graphInspectServices — two-pass file manifest (#5658)', () => {
+	test('reports real per-file status and changed-line counts — not a blanket "M" or inflated counts', async () => {
+		const m = createReviewFake(diffForTwoPassManifest);
+
+		const result = await m.graphInspect.reviewChanges(
+			'/repo',
+			wipScope({ includeUnstaged: true }),
+			undefined,
+			undefined,
+		);
+
+		assert.ok(!('error' in result), `review should not have errored: ${JSON.stringify(result)}`);
+		// Confirms the diff was actually large enough to take the two-pass branch, rather than the
+		// assertions below silently reading stale (unset) stub state.
+		sinon.assert.notCalled(m.reviewChanges);
+		sinon.assert.calledOnce(m.reviewOverview);
+
+		const files = reviewedManifest(m.reviewOverview);
+		const byPath = new Map(files.map(f => [f.path, f]));
+
+		const modified = byPath.get('modified.txt');
+		assert.ok(modified, 'modified.txt should be in the manifest');
+		assert.strictEqual(modified.status, 'M');
+		assert.strictEqual(modified.additions, 3, 'only the 3 real `+` lines, not the 16-line hunk header count');
+		assert.strictEqual(modified.deletions, 2, 'only the 2 real `-` lines, not the padding context lines');
+
+		const added = byPath.get('added.txt');
+		assert.ok(added, 'added.txt should be in the manifest');
+		assert.strictEqual(
+			added.status,
+			'A',
+			'a new file must not read as a blanket "M" against a nonexistent prior version',
+		);
+		assert.strictEqual(added.additions, 4);
+		assert.strictEqual(added.deletions, 0, 'the `-0,0` hunk header must not be read as a phantom deletion');
+
+		const renamed = byPath.get('renamed_new.txt');
+		assert.ok(renamed, 'renamed_new.txt should be in the manifest, keyed by its new path');
+		assert.strictEqual(renamed.status, 'R');
+		assert.strictEqual(renamed.additions, 1);
+		assert.strictEqual(renamed.deletions, 1);
+
+		const binary = byPath.get('binary.png');
+		assert.ok(binary, 'binary.png should be in the manifest');
+		assert.strictEqual(binary.status, 'M');
+		assert.strictEqual(binary.additions, 0, 'a binary file has no line-based hunks to count');
+		assert.strictEqual(binary.deletions, 0);
 	});
 });
 

--- a/src/webviews/plus/graph/graphInspectServices.ts
+++ b/src/webviews/plus/graph/graphInspectServices.ts
@@ -845,10 +845,20 @@ export class GraphInspectServices {
 							() => import(/* webpackChunkName: "ai" */ '@gitlens/git/parsers/diffParser.js'),
 						);
 						signal?.throwIfAborted();
+						// Pass 1 has nothing but this manifest to rank focus areas from — no diff content — so
+						// every field has to be what git would report: the parsed status per file (not a blanket
+						// "modified", which reads an added file as having a previous version to compare against),
+						// and changed-line counts that exclude unchanged context (see
+						// `countDiffInsertionsAndDeletions`).
 						const parsed = parseGitDiff(data.diff);
 						const parsedFiles = parsed.files.map(f => {
 							const { insertions, deletions } = countDiffInsertionsAndDeletions(f);
-							return { path: f.path, status: 'M', additions: insertions, deletions: deletions };
+							return {
+								path: f.path,
+								status: f.status,
+								additions: insertions,
+								deletions: deletions,
+							};
 						});
 						const fileManifest = JSON.stringify(parsedFiles);
 


### PR DESCRIPTION
Closes #5658

## What the user saw

The first pass of a two-pass review ranks focus areas from a JSON file manifest alone — no diff content, only paths, change types and line counts. Every file in that manifest read as modified, including newly added ones, and the counts overstated what actually changed. On a working-changes review of one modified tracked file plus one new untracked file:

```json
[{"path":"file1.txt","status":"M","additions":6006,"deletions":4},
 {"path":"new-untracked-5630.txt","status":"M","additions":1,"deletions":1}]
```

Git reported `+6004/-1` for the first file, and the second was a new one-line file with nothing deleted.

## Why it happened

Two independent causes, both in how the manifest was assembled.

**The counts came from the hunk headers.** `countDiffInsertionsAndDeletions` summed `hunk.current.count` and `hunk.previous.count` — the totals in `@@ -a,b +c,d @@`, which count *every* line on each side, unchanged context included. A hunk carrying three context lines around one edit therefore reported four additions. Scaled up, a file with a few thousand added lines overstated its additions by however much context its hunks happened to carry.

The same arithmetic produced the phantom deletion. A new file's header is `@@ -0,0 +1 @@`, and `parseHunkHeaderPart` computes its count as `Number(countS) || 1` — so the zero on the old side became a **1**, and an added file was credited with a deletion that does not exist.

**The status was hardcoded.** The manifest built each entry as `{ path, status: 'M', additions, deletions }`. `parseGitDiff` had already determined the real per-file status and it was simply discarded, so an added, deleted, renamed or copied file all reported as modified — which, as the issue notes, invites pass 1 to phrase findings as though a previous version existed to compare against.

## How it's resolved

| Change | Symptom it fixes |
| --- | --- |
| `countDiffInsertionsAndDeletions` counts lines in each hunk's content that begin with `+`/`-` | Context-inflated counts, and the phantom deletion on added files |
| The manifest emits `f.status` instead of `'M'` | Every file reading as modified |

Nothing else changes shape — the manifest still carries exactly `path`, `status`, `additions`, `deletions`, and the pass-1 prompt is untouched. The status letters the manifest now emits (`A`/`M`/`D`/`R`/`C`/`T` from `GitFileIndexStatus`) are the ones git itself uses, and the template already tells the model to rank from "change types and line counts".

Counting off each hunk's content rather than the parsed `hunk.lines` map is deliberate: that map is keyed by file line number and merges a removed/added pair into one `changed` entry, so on an asymmetric block a following context line overwrites the tail of it. Counted from the map, a 3-removed/1-added block reports `+1/-2` where git reports `+1/-3`.

The content is scanned in place rather than split into lines, since splitting a multi-megabyte diff allocates a string per line for a single pass that only ever looks at each line's first character. Measured on a 576 KB, 97-file diff that is ~0.40 ms versus ~0.76 ms and allocates nothing. Neither number is material — this runs once per review, after a `parseGitDiff` it can never skip (~6 ms for the same diff) and before a request that takes seconds — it is just the cheaper option where it costs nothing.

`countDiffLines` is deliberately left alone. Its only caller compares magnitudes against thresholds (`>500`, `>200`, `<50`) that were tuned to context-inclusive numbers, so "fixing" it would silently retune truncation scoring rather than repair anything. Its doc comment now says so.

The other existing caller of the corrected helper, `createFallbackDiffSummary`, prints `+N/-M` per file and inherits the fix. Its numbers shift, correctly — nothing re-parses them, and since accurate counts are at most the old inflated ones, its character-budget check cannot newly fail.

## Behavior changes

**Focus-area ranking will differ for large change sets.** The counts feed the pass-1 ranking, so correcting them changes which areas come back and in what order. That is the point of the fix, but it is a visible change in output, not only a repaired input.

**Pass 2 is unaffected** — it works from real diff content, so its findings and line citations are unchanged either way.

One pre-existing wrinkle that truthful statuses make visible, disclosed so it can be judged rather than discovered: `getDiffForScope` concatenates the unstaged, staged and per-commit diffs, and `parseGitDiff` emits one entry per `diff --git` boundary with no dedup by path. A file touched in both an included commit and the working tree therefore yields two manifest entries. Previously both read `M`; now one can read `A` and the other `M` for the same path. Each entry is individually accurate for its slice, and the duplication mechanism is untouched here. Closing it properly means either deduping by path — which requires deciding what a single status means for a file added in a commit and then modified unstaged — or labelling each entry with its source, so it is left for a follow-up rather than decided incidentally in a bug fix.

## Tests

- 7 new cases in `packages/git/src/parsers/__tests__/diffParser.test.ts` covering the shapes most likely to expose an off-by-one: asymmetric change blocks, added and deleted files, pure renames and binary files (both `0/0`), the `\ No newline at end of file` marker, and an annotated diff, since the manifest parses the `[NNNNN]`-annotated text rather than raw git output.
- Two pre-existing assertions in each diffParser suite encoded the buggy header-count expectations (`4/3` and `5/5`) and were retargeted to what git reports.
- A manifest-level regression test in `src/webviews/plus/graph/__tests__/graphInspectServices.test.ts` forces the two-pass path and asserts the manifest across a modified, added, renamed and binary file together — the rename reports its new path with status `R`, the added file `A` with no deletions, and the binary file `M` with `0/0`.

**Not covered, stated plainly:** the manifest-level test has never been executed locally — `vscode-test` will not run while other VS Code instances are open, so it is type-checked and linted only and CI is its first real run. The parser suites do run (53 and 20 passing).

Separately worth knowing: `pnpm run test:packages` reports success while running zero tests on Windows — the recursive filter matches no projects and the packages' own single-quoted globs reach `cmd` literally. I ran the suites directly instead and left the scripts alone.

## Validation

1. In a scratch repository, commit a file, then add a few thousand lines to it and delete one. Add one new untracked file with a single line.
2. `git add -N <untracked>` (what the review does internally so untracked files appear in the unstaged diff), then capture `git diff`.
3. Compare the manifest built from that diff against `git diff --numstat` and `git diff --name-status`.

Run against that tree, the old code produces:

```json
[{"path":"file1.txt","status":"M","additions":6007,"deletions":4},
 {"path":"new-untracked-5658.txt","status":"M","additions":1,"deletions":1}]
```

reproducing the issue, including the bogus `1/1`. This branch produces:

```json
[{"path":"file1.txt","status":"M","additions":6004,"deletions":1},
 {"path":"new-untracked-5658.txt","status":"A","additions":1,"deletions":0}]
```

matching git exactly.

Also verified against a real 97-file commit in this repository (83 modified, 6 renamed, 6 deleted, 2 added): every count matches `git diff --numstat` and every status matches `--name-status`.

The issue also suggests eyeballing a couple of real reviews before and after, since the ranking shifts. **That has not been done** — it needs a live instance and real model calls.

## Related

- #5630 — adjacent, not the cause; that change moved when exclusions are applied and did not touch how the manifest is built.
- Not fixed here: under `diff.noprefix=true`, `diffRegex` fails to match and `parseGitDiff` silently skips the file, dropping it from the manifest entirely. Every git invocation forces `diff.mnemonicPrefix=false` and `core.quotepath=false` but not `diff.noprefix=false`. The regex and that loop are unchanged by this branch, so it does not own the problem, but a silently omitted file is worth its own issue.
