### PR TITLE
Fixes an automatic rebase asking for AI before refusing

### DIFF
--- a/src/plus/coretools/conflict/__tests__/autoRebaseService.test.ts
+++ b/src/plus/coretools/conflict/__tests__/autoRebaseService.test.ts
@@ -432,3 +432,94 @@ suite('coretools/conflict/AutoRebaseService late cancel', () => {
 		assert.strictEqual(storage.has('autoRebase:undo:/repo'), false);
 	});
 });
+
+/**
+ * Harness for the pre-flight ordering: `calls` records the model resolve and the rebase itself, so a
+ * test can assert both whether the user was asked about AI at all and that the ask precedes anything
+ * that would show progress. `pausedOp` sets what the pre-flight status read finds.
+ */
+function makePreflightFakes(pausedOp?: GitPausedOperationStatus) {
+	const calls: string[] = [];
+	const storage = new Map<string, unknown>();
+
+	const svc = {
+		path: '/repo',
+		pausedOps: { getPausedOperationStatus: () => Promise.resolve(pausedOp) },
+		branches: { getBranch: () => Promise.resolve({ name: 'feature' }) },
+		revision: { resolveRevision: () => Promise.resolve({ sha: 'post', revision: 'post' }) },
+		status: { getStatus: () => Promise.resolve({ hasChanges: false, files: [] }) },
+		ops: {
+			rebase: () => {
+				calls.push('rebase');
+				return Promise.resolve({ conflicted: false });
+			},
+			reset: () => Promise.resolve(),
+		},
+		staging: { stageFiles: () => Promise.resolve() },
+		createUnsafeGit: () => undefined,
+	};
+
+	const container = {
+		storage: {
+			getWorkspace: (key: string) => storage.get(key),
+			storeWorkspace: (key: string, value: unknown) => {
+				storage.set(key, value);
+				return Promise.resolve();
+			},
+			deleteWorkspace: (key: string) => {
+				storage.delete(key);
+				return Promise.resolve();
+			},
+		},
+		git: { getRepositoryService: () => svc },
+		telemetry: { sendEvent: () => {} },
+		ai: {
+			enabled: true,
+			allowed: true,
+			flushBYOKUsage: () => Promise.resolve(),
+			getModel: () => {
+				calls.push('getModel');
+				return Promise.resolve({ id: 'test-model', provider: { id: 'test' } });
+			},
+		},
+	} as unknown as Container;
+
+	const service = new AutoRebaseService(container);
+	// Stub the lazily node-imported integration — no run gets far enough to use it
+	(service as unknown as { _integration: Promise<unknown> })._integration = Promise.resolve({});
+
+	return { service: service, calls: calls, svc: svc as unknown as GitRepositoryService };
+}
+
+suite('coretools/conflict/AutoRebaseService pre-flight ordering', () => {
+	test('a start refused for an operation already in progress never asks about AI', async () => {
+		const { service, calls, svc } = makePreflightFakes({ type: 'merge' } as unknown as GitPausedOperationStatus);
+
+		await assert.rejects(
+			service.start(svc, { upstream: 'main', source: { source: 'commandPalette' } }),
+			/A merge is already in progress\./,
+		);
+
+		// The refusal was knowable without AI, so no provider/model decision may have been spent on it
+		assert.deepStrictEqual(calls, []);
+	});
+
+	test('a takeover refused for having no rebase to take over never asks about AI', async () => {
+		const { service, calls, svc } = makePreflightFakes(undefined);
+
+		await assert.rejects(service.takeover(svc, { source: 'commandPalette' }), /No rebase is in progress\./);
+
+		assert.deepStrictEqual(calls, []);
+	});
+
+	test('a start that proceeds resolves the model before the rebase begins', async () => {
+		const { service, calls, svc } = makePreflightFakes(undefined);
+
+		const session = await service.start(svc, { upstream: 'main', source: { source: 'commandPalette' } });
+
+		// Guards the ordering the other direction: a model resolved lazily inside the run would open its
+		// picker behind a panel already showing progress, which reads as a stall (#5662)
+		assert.strictEqual(session.phase, 'completed');
+		assert.deepStrictEqual(calls, ['getModel', 'rebase']);
+	});
+});

--- a/src/plus/coretools/conflict/autoRebaseService.ts
+++ b/src/plus/coretools/conflict/autoRebaseService.ts
@@ -97,7 +97,7 @@ export class AutoRebaseService implements Disposable {
 	 * an operation already in progress, …).
 	 */
 	async start(svc: GitRepositoryService, options: AutoRebaseStartOptions): Promise<AutoRebaseSession> {
-		const { integration, model } = await this.ensureAvailable(svc, options.source);
+		const integration = await this.ensureAvailable(svc);
 
 		const existing = await svc.pausedOps?.getPausedOperationStatus?.({ force: true });
 		if (existing != null) {
@@ -107,6 +107,9 @@ export class AutoRebaseService implements Disposable {
 					: `A ${existing.type} is already in progress.`,
 			);
 		}
+
+		// Every refusal above is knowable without AI, so the model is resolved only once they've passed
+		const model = await this.ensureModel(options.source);
 
 		const [branch, headRev, status, stashMessages] = await Promise.all([
 			options.branch ?? svc.branches.getBranch().then(b => b?.name),
@@ -161,7 +164,7 @@ export class AutoRebaseService implements Disposable {
 
 	/** Takes over an existing paused rebase and automates its remaining steps. */
 	async takeover(svc: GitRepositoryService, source: Source): Promise<AutoRebaseSession> {
-		const { integration, model } = await this.ensureAvailable(svc, source);
+		const integration = await this.ensureAvailable(svc);
 
 		const status = await svc.pausedOps?.getPausedOperationStatus?.({ force: true });
 		if (status?.type !== 'rebase') {
@@ -170,6 +173,9 @@ export class AutoRebaseService implements Disposable {
 		if (!status.isPaused) {
 			throw new Error('The rebase is not paused.');
 		}
+
+		// There's a rebase to take over, so it's worth asking for a model (see `ensureModel`)
+		const model = await this.ensureModel(source);
 
 		// Resume our own escalated run in place — reuse the existing session (id, preRun, and the
 		// steps already recorded before the escalation) instead of discarding them via a fresh
@@ -692,10 +698,12 @@ export class AutoRebaseService implements Disposable {
 		);
 	}
 
-	private async ensureAvailable(
-		svc: GitRepositoryService,
-		source: Source,
-	): Promise<{ integration: ConflictToolsIntegration; model: AIModel }> {
+	/**
+	 * The pre-flight checks that can refuse without asking the user anything — all silent, so a
+	 * caller can run them (and its own paused-operation checks) before {@link ensureModel} spends a
+	 * decision on a start that was never going to happen.
+	 */
+	private async ensureAvailable(svc: GitRepositoryService): Promise<ConflictToolsIntegration> {
 		if (!this.container.ai.allowed) {
 			throw new Error('AI features are disabled.');
 		}
@@ -710,10 +718,22 @@ export class AutoRebaseService implements Disposable {
 			throw new Error('An automatic rebase is already running for this repository.');
 		}
 
-		// Resolve the model BEFORE anything starts. Left to `sendRequest`, this resolves lazily inside the
-		// run — the picker (or a sign-in/API-key prompt) then opens behind a progress panel already claiming
-		// "Analyzing <file>…", which is indistinguishable from a stall. Answering it here means the run
-		// either starts with a model in hand or never starts at all, and the branch is untouched either way.
+		return integration;
+	}
+
+	/**
+	 * Resolves the model the run will use, prompting if nothing is configured. Callers must invoke
+	 * this in the window between their own silent refusals and `trackSession()`:
+	 * - AFTER every refusal that doesn't need AI (an operation already in progress, …), so we never
+	 *   ask which provider to trust only to then report an obstacle that was knowable up front.
+	 * - BEFORE anything shows progress. Left to `sendRequest`, this resolves lazily inside the run,
+	 *   and the picker (or a sign-in/API-key prompt) opens behind a panel already claiming
+	 *   "Analyzing <file>…", which is indistinguishable from a stall.
+	 *
+	 * So the run either starts with a model in hand or never starts at all, and the branch is
+	 * untouched either way.
+	 */
+	private async ensureModel(source: Source): Promise<AIModel> {
 		const model = await this.container.ai.getModel({ scope: 'resolve' }, source);
 		if (model == null) {
 			// Dismissing the picker is a refusal to start, handled like the other pre-flight refusals: the
@@ -721,7 +741,7 @@ export class AutoRebaseService implements Disposable {
 			throw new Error('Automatic rebase needs an AI model — none was selected.');
 		}
 
-		return { integration: integration, model: model };
+		return model;
 	}
 
 	private getIntegration(): Promise<ConflictToolsIntegration | undefined> {


### PR DESCRIPTION
Fixes #5670.

## Problem

Resolving the AI model up front (2c9c4b70b, #5662) put it ahead of the pre-flight checks that need no AI at all. With a merge already paused in the repository, **Automatic Rebase** asked which provider and which model to use, and only then reported "A merge is already in progress."

Nothing is damaged — the paused merge is untouched and no rebase starts — but the user spends a decision about which AI vendor to trust in order to be told about an obstacle that was knowable before any prompt. It lands on the first automatic rebase of a session, which is exactly when the person is least sure what the prompt is for.

`takeover()` had the same ordering, so **Continue Automatic Rebase** on a repo with nothing paused also prompted before saying "No rebase is in progress."

## Fix

The two orderings don't compete. Progress starts at `trackSession()`, and the paused-operation checks already sit well upstream of it, so there's an existing window between them for the model resolve.

- Splits `ensureAvailable` into the silent checks (AI allowed, environment, run already active) and a new `ensureModel`, so callers can refuse before anything is asked
- `start()` and `takeover()` resolve the model after their own paused-operation checks, still before `trackSession` — so the prompt is never behind a spinner, which is what #5662 required. `ensureModel`'s doc comment states both halves of the rule so neither failure is reintroduced
- Keeps the environment check ahead of the paused-op reads: `svc.pausedOps?.` is optional-chained, so the reverse order would skip the refusal and report the wrong message on a host without paused-operation support

Refusal messages, the `takeover` status-read count, and all call sites are unchanged. The escalated-resume path stays downstream of the status checks and still receives a resolved model.

No CHANGELOG entry — the misordering only ever existed in pre-release builds.

## Tests

Three new `pre-flight ordering` tests whose harness records `getModel` and `ops.rebase` calls, so "was the user prompted?" is directly assertable:

1. `start` with a paused merge rejects with "A merge is already in progress." and `getModel` is never called (regression test for #5670)
2. `takeover` with nothing paused rejects with "No rebase is in progress." and `getModel` is never called
3. A proceeding `start` records `['getModel', 'rebase']` in that order — the guard against sliding back into #5662

## Verification

Full unit suite green (1961), `pnpm run check` clean. Verified live against a build, in a repo with a paused merge:

- **Control** (nothing paused): "Select AI Provider for Resolving Conflicts" opens and waits — confirming the prompt genuinely appears in this configuration, so its later absence means something
- **#5670** (merge paused): "A merge is already in progress." with the quick-pick widget hidden — no AI prompt. Repo verified untouched afterward: same unmerged files, same `MERGE_HEAD`, no rebase started
- **Takeover** (nothing paused): "No rebase is in progress.", no AI prompt
- **#5662 invariant**: while the prompt was open, no webviews were open at all — no Resolve panel, nothing showing progress. Dismissing gave "Automatic rebase needs an AI model — none was selected." with the branch untouched
- Re-confirmed with a second AI configuration (`gitlens.ai.model` set to an unresolvable model, which reaches the model picker by a different path)