### PR TITLE
MCP E2E: write-path validation and failure paths

### DIFF
--- a/tests/e2e/specs/mcpGitlensWritePath.test.ts
+++ b/tests/e2e/specs/mcpGitlensWritePath.test.ts
@@ -1,0 +1,173 @@
+/**
+ * MCP E2E — GitLens write-path tools, failure and validation paths
+ *
+ * `gitlens_start_work` and `gitlens_start_review` are the two mutating GitLens tools: they create a
+ * branch (and, for review, a worktree) through the live extension host. Their happy paths need a
+ * connected hosting integration and live issue/PR URLs, so they are covered separately and skip
+ * without credentials. What is coverable hermetically — and what breaks most often — is everything
+ * before that: argument validation, and what a caller sees when the request cannot be honoured.
+ *
+ * Where each failure is decided, read from source on both sides:
+ * - **Missing `directory` / `issue_url` / `pr_url`** never leaves the CLI. `startWorkHandler` and
+ *   `startReviewHandler` return `textResponse(..., true)`, which is the `{ data: { message, error } }`
+ *   envelope with the protocol-level error flag left unset — the same shape `gitlens_open_graph` uses
+ *   for its own validation refusals.
+ * - **A GitLens-side refusal** does leave the CLI: `runLaunchpadWorkflow` POSTs `{ cwd, args }` to the
+ *   route (unlike `/graph`, these tools really do forward their arguments), and
+ *   `parseGitlensCommandResponse` turns any `stderr` the extension returns into a JSON-RPC error
+ *   carrying that text verbatim.
+ * - **Not hanging is the point.** The extension's handlers `await` a deferred the Start Work / Start
+ *   Review wizard settles, and the wizard cancels it in a `finally`. A caller that never gets an
+ *   answer means that path was escaped without settling — which from the agent's side is
+ *   indistinguishable from a dead extension, so it is asserted explicitly rather than left to a
+ *   timeout.
+ *
+ * Note what is NOT reachable here: GitLens' own `No issue identifier provided` / `No Pull Request
+ * provided` guards fire only on empty `args`, and the CLI rejects an empty URL before it ever builds
+ * a request — so those strings cannot be observed through MCP, and the CLI's own wording is what a
+ * client sees.
+ */
+import { existsSync, readdirSync } from 'node:fs';
+import path from 'node:path';
+import { MaxTimeout } from '../baseTest.js';
+import type { McpMessage } from '../fixtures/mcp.js';
+import { expect, mcpTest as test } from '../fixtures/mcp.js';
+
+type ToolResult = { content?: { text?: string }[]; isError?: boolean };
+type RefusalPayload = { message?: string; error?: boolean };
+
+const startWork = 'gitlens_start_work';
+const startReview = 'gitlens_start_review';
+
+/** Not a URL any provider can resolve, and not empty — so it reaches the extension. */
+const malformedUrl = 'not-a-url';
+
+/**
+ * Asserts a CLI-side validation refusal and returns its payload.
+ *
+ * These arrive as a normal result: the CLI reports them through the `{ data }` envelope and leaves
+ * `isError` unset, so a client that switches on the protocol flag would read them as success. That
+ * is worth pinning precisely because it is the surprising half of the contract.
+ */
+function expectValidationRefusal(response: McpMessage): RefusalPayload {
+	expect(
+		response.error,
+		`expected a payload refusal, got a JSON-RPC error: ${JSON.stringify(response.error)}`,
+	).toBeUndefined();
+
+	const result = response.result as ToolResult | undefined;
+	expect(result?.isError, 'the CLI reports validation refusals in the payload, not via isError').toBeFalsy();
+
+	const text = result?.content?.[0]?.text;
+	expect(text, 'refusal should carry text content').toBeTruthy();
+
+	const parsed = JSON.parse(text!) as { data?: RefusalPayload };
+	expect(parsed).toHaveProperty('data');
+
+	return parsed.data ?? {};
+}
+
+/** Local branches in the worker's workspace repository — the invariant a failed call must not move. */
+function localBranches(workspacePath: string): string[] {
+	const headsDir = path.join(workspacePath, '.git', 'refs', 'heads');
+	return existsSync(headsDir) ? readdirSync(headsDir) : [];
+}
+
+test.describe('MCP — GitLens write path (validation and failure)', () => {
+	test.describe.configure({ mode: 'serial' });
+
+	// These tools drive a wizard that can surface a quick pick. Leaving one open would poison every
+	// later spec in this worker, so each case starts and ends from a clean UI.
+	test.beforeEach(async ({ vscode }) => {
+		await vscode.gitlens.resetUI();
+	});
+
+	test.afterAll(async ({ vscode }) => {
+		await vscode.gitlens.resetUI();
+	});
+
+	test('gitlens_start_work refuses a missing issue_url in the payload', async ({ mcpClient, vscode }) => {
+		const payload = expectValidationRefusal(
+			await mcpClient.callTool(startWork, { directory: vscode.electron.workspacePath }),
+		);
+
+		expect(payload).toEqual({ message: "missing 'issue_url' parameter", error: true });
+	});
+
+	test('gitlens_start_review refuses a missing pr_url in the payload', async ({ mcpClient, vscode }) => {
+		const payload = expectValidationRefusal(
+			await mcpClient.callTool(startReview, { directory: vscode.electron.workspacePath }),
+		);
+
+		expect(payload).toEqual({ message: "missing 'pr_url' parameter", error: true });
+	});
+
+	test('gitlens_start_work refuses a missing directory in the payload', async ({ mcpClient }) => {
+		// `directory` is checked before the URL, so this stays a CLI-side refusal even with a URL given.
+		const payload = expectValidationRefusal(
+			await mcpClient.callTool(startWork, { issue_url: 'https://github.com/o/r/issues/1' }),
+		);
+
+		expect(payload).toEqual({ message: "missing 'directory' parameter", error: true });
+	});
+
+	/**
+	 * Known broken, measured rather than assumed: with no hosting integration connected — the state
+	 * every agent-driven and CI run is in — the Start Work wizard falls back to an interactive step
+	 * ("Start Work — Connect an Integration") despite `useDefaults`, and the MCP call is never
+	 * answered. The deferred the IPC handler awaits is only settled in the wizard's `finally`, which a
+	 * suspended picker never reaches, so the CLI waits out its 10-minute HTTP budget and the client
+	 * gives up at 30s. Verified live: after 8s the quick pick is on screen and the call is still
+	 * pending.
+	 *
+	 * Left as `fixme` rather than run: the two cases would burn 30s each and, worse, leave a modal
+	 * picker open in a worker-scoped instance every later spec shares. They flip on the moment the
+	 * wizard reports instead of prompting.
+	 */
+	test.fixme('gitlens_start_work answers a malformed issue URL instead of hanging', async ({ mcpClient, vscode }) => {
+		const workspacePath = vscode.electron.workspacePath;
+		const before = localBranches(workspacePath);
+
+		const response = await mcpClient.callTool(startWork, {
+			directory: workspacePath,
+			issue_url: malformedUrl,
+		});
+
+		// The wizard cannot resolve the issue, so the extension must report that rather than leave the
+		// caller waiting. The text is the extension's (relayed verbatim by the proxy); only the fact
+		// that an answer arrived — and that it is a refusal — is asserted, since the wording belongs to
+		// whichever step gave up.
+		expect(
+			response.error,
+			`expected the extension to answer a malformed URL; response=${JSON.stringify(response)}`,
+		).toBeDefined();
+
+		// A wizard that escaped without settling its deferred would leave a picker on screen and the
+		// call unanswered; assert the UI is clear so a future regression names that rather than showing
+		// up as an unrelated failure in the next spec.
+		await expect(vscode.page.locator('.quick-input-widget')).toBeHidden({ timeout: MaxTimeout });
+		expect(localBranches(workspacePath), 'a failed start-work must not leave a branch behind').toEqual(before);
+	});
+
+	/** Same defect as above, through the review wizard. */
+	test.fixme('gitlens_start_review answers a malformed PR URL instead of hanging', async ({ mcpClient, vscode }) => {
+		const workspacePath = vscode.electron.workspacePath;
+		const before = localBranches(workspacePath);
+
+		const response = await mcpClient.callTool(startReview, {
+			directory: workspacePath,
+			pr_url: malformedUrl,
+		});
+
+		expect(
+			response.error,
+			`expected the extension to answer a malformed URL; response=${JSON.stringify(response)}`,
+		).toBeDefined();
+
+		await expect(vscode.page.locator('.quick-input-widget')).toBeHidden({ timeout: MaxTimeout });
+		expect(
+			localBranches(workspacePath),
+			'a failed start-review must not leave a branch or worktree behind',
+		).toEqual(before);
+	});
+});

--- a/tests/e2e/specs/mcpGitlensWritePath.test.ts
+++ b/tests/e2e/specs/mcpGitlensWritePath.test.ts
@@ -112,7 +112,7 @@ test.describe('MCP — GitLens write path (validation and failure)', () => {
 	});
 
 	/**
-	 * Known broken, measured rather than assumed: with no hosting integration connected — the state
+	 * Known broken — #5679, measured rather than assumed: with no hosting integration connected — the state
 	 * every agent-driven and CI run is in — the Start Work wizard falls back to an interactive step
 	 * ("Start Work — Connect an Integration") despite `useDefaults`, and the MCP call is never
 	 * answered. The deferred the IPC handler awaits is only settled in the wizard's `finally`, which a
@@ -149,7 +149,7 @@ test.describe('MCP — GitLens write path (validation and failure)', () => {
 		expect(localBranches(workspacePath), 'a failed start-work must not leave a branch behind').toEqual(before);
 	});
 
-	/** Same defect as above, through the review wizard. */
+	/** Same defect as above (#5679), through the review wizard. */
 	test.fixme('gitlens_start_review answers a malformed PR URL instead of hanging', async ({ mcpClient, vscode }) => {
 		const workspacePath = vscode.electron.workspacePath;
 		const before = localBranches(workspacePath);


### PR DESCRIPTION
Covers the validation and failure side of `gitlens_start_work` and `gitlens_start_review` — the block tracked in #5106. Their happy paths need a connected hosting integration and live issue/PR URLs, so they stay in the credential-gated block; everything before that is hermetic and is what breaks most often.

Three cases, each pinned to its exact shape:

- `gitlens_start_work` without `issue_url`
- `gitlens_start_review` without `pr_url`
- `gitlens_start_work` without `directory` — checked first, so it stays a CLI-side refusal even when a URL is supplied

All three arrive as **ordinary results**: the CLI reports them through the `{ data }` envelope and leaves the protocol-level error flag unset, so a client switching on that flag would read a refusal as success. That is the surprising half of the contract and the reason to pin it rather than assert "it failed".

The spec also records what is *not* reachable through MCP, while it is fresh: GitLens' own `No issue identifier provided` and `No Pull Request provided` guards fire only on empty args, and the CLI rejects an empty URL before it ever builds a request. Those strings cannot be observed from a client, so the wording a client sees is the CLI's. The tracker's checkbox asked for the GitLens strings; that expectation was wrong, not the implementation.

## The two `fixme` cases are a measured defect, not a placeholder

"A malformed URL is answered rather than left hanging" does not hold today, and the cause is not the URL.

With no hosting integration connected — the state of every CI run and every fresh profile — the Start Work wizard falls back to an interactive step despite `useDefaults: true`:

> **Start Work ᴘʀᴏ • Connect an Integration** — "Connect an integration to accelerate your work" / Cancel

and the call is never answered. The deferred the IPC handler awaits is settled only in the wizard's `finally`, which a generator suspended on a picker never reaches. Verified live: eight seconds in, the quick pick is on screen and the call is still pending. The client gives up at 30s; the CLI would wait out its ten-minute HTTP budget.

From an agent's side — and MCP has no other kind of caller — that is indistinguishable from a dead extension: no error, no explanation, and a modal picker left open in the user's editor that nothing will close.

Running the cases would burn that timeout twice per run and, worse, leave that picker open in the worker-scoped instance every later spec shares, so they are `fixme` with the measurement written next to them. They flip on the moment the wizard reports instead of prompting. Filed as #5679 after checking both sides: the bundled CLI cannot prevent it — its capability gate is derived from the GitLens version rather than from integration state, so at call time it cannot know the wizard will prompt, and once the request is sent it can only wait. The cases reference the issue, so whoever fixes it finds the coverage waiting.

## Validation

- `mcpGitlensWritePath.test.ts` — 3 passed, 2 fixme
- whole MCP family — 45 passed / 4 skipped
- `pnpm run check` — clean

Windows, `--project=vscode`.

Refs #5106

🤖 Generated with [Claude Code](https://claude.com/claude-code)

