### PR TITLE
Adds a one-time out-of-window Pro trial auto-reset on Graph open

### DIFF
--- a/docs/telemetry-events.md
+++ b/docs/telemetry-events.md
@@ -6846,6 +6846,17 @@ or
 
 ```typescript
 {
+  // One-time out-of-window trial reset, attempted from Graph state builds; `failed` may repeat within a session (retries), paid accounts emit no event
+  'action': 'auto-reset-trial',
+  // `refused` = the reset 409'd an account the eligibility check approved (e.g. paid-org members); `failed-shape` = the eligibility payload no longer matches what the client reads
+  'outcome': 'reset' | 'not-eligible' | 'refused' | 'failed' | 'failed-shape'
+}
+```
+
+or
+
+```typescript
+{
   'action': 'start-preview-trial:graph',
   'day': number,
   [`day.${number}.startedOn`]: string,

--- a/src/commands/resets.ts
+++ b/src/commands/resets.ts
@@ -2,6 +2,7 @@ import type { MessageItem } from 'vscode';
 import { window } from 'vscode';
 import { resetApprovedAvatarTemplates, resetAvatarCache } from '../avatars.js';
 import type { Container } from '../container.js';
+import { clearTrialResetSessionAttempts } from '../plus/gk/trialAutoReset.js';
 import type { QuickPickItemOfT } from '../quickpicks/items/common.js';
 import { createQuickPickSeparator } from '../quickpicks/items/common.js';
 import { settingsMigrations } from '../settingsMigrations.js';
@@ -320,6 +321,8 @@ export class ResetCommand extends GlCommandBase {
 					switch (reset) {
 						case 'subscription':
 							await this.container.storage.delete('premium:subscription');
+							await this.container.storage.deleteWithPrefix('plus:trialReset');
+							clearTrialResetSessionAttempts();
 							break;
 						case 'previews':
 							await this.container.storage.deleteWithPrefix('plus:preview');

--- a/src/constants.storage.ts
+++ b/src/constants.storage.ts
@@ -130,6 +130,7 @@ interface GlobalStorageCore {
 }
 
 type GlobalStorageDynamic = Record<`plus:preview:${FeaturePreviews}:usages`, StoredFeaturePreviewUsagePeriod[]> &
+	Record<`plus:trialReset:${string}:attempted`, boolean> &
 	Record<
 		`plus:organization:${string}:settings`,
 		Stored<(OrganizationSettings & { lastValidatedAt: number }) | undefined>

--- a/src/constants.telemetry.ts
+++ b/src/constants.telemetry.ts
@@ -2892,6 +2892,12 @@ type SubscriptionActionEventData =
 			action: 'visibility';
 			visible: boolean;
 	  }
+	| {
+			/** One-time out-of-window trial reset, attempted from Graph state builds; `failed` may repeat within a session (retries), paid accounts emit no event */
+			action: 'auto-reset-trial';
+			/** `refused` = the reset 409'd an account the eligibility check approved (e.g. paid-org members); `failed-shape` = the eligibility payload no longer matches what the client reads */
+			outcome: 'reset' | 'not-eligible' | 'refused' | 'failed' | 'failed-shape';
+	  }
 	| FeaturePreviewActionEventData;
 
 export interface SubscriptionEventDataWithPrevious

--- a/src/plus/gk/__tests__/trialAutoReset.test.ts
+++ b/src/plus/gk/__tests__/trialAutoReset.test.ts
@@ -1,0 +1,374 @@
+import * as assert from 'assert';
+import { CancellationError } from '@gitlens/utils/cancellation.js';
+import { SubscriptionState } from '../../../constants.subscription.js';
+import type { Container } from '../../../container.js';
+import { RequestsAreBlockedTemporarilyError } from '../../../errors.js';
+import type { Subscription } from '../models/subscription.js';
+import type { ServerConnection } from '../serverConnection.js';
+import type { TrialResetHost } from '../trialAutoReset.js';
+import { autoResetTrialIfEligible, clearTrialResetSessionAttempts } from '../trialAutoReset.js';
+
+suite('Trial Auto Reset Test Suite', () => {
+	suite('autoResetTrialIfEligible', () => {
+		setup(() => clearTrialResetSessionAttempts());
+
+		function fakeSubscription(accountId: string, state: SubscriptionState, planId = 'community-with-account') {
+			return {
+				account: { id: accountId, name: 'Test', email: 'test@test', verified: true },
+				plan: { actual: { id: planId }, effective: { id: planId } },
+				state: state,
+			} as unknown as Subscription;
+		}
+
+		type Call = { path: string; method: string | undefined };
+
+		function createWorld(options: {
+			subscription: Subscription;
+			responses?: Record<string, { status: number; body?: unknown } | Error>;
+			session?: null;
+			/** Simulates an account switch between the subscription read and the session resolve */
+			sessionAccountId?: string;
+			/** What the subscription becomes after `refreshSubscription` */
+			refreshedSubscription?: Subscription;
+		}) {
+			const world = {
+				subscription: options.subscription,
+				calls: [] as Call[],
+				events: [] as unknown[],
+				log: [] as string[],
+				stored: new Map<string, unknown>(),
+			};
+
+			const container = {
+				storage: {
+					get: (key: string, defaultValue?: unknown) => world.stored.get(key) ?? defaultValue,
+					store: (key: string, value: unknown) => {
+						world.stored.set(key, value);
+						world.log.push('store');
+						return Promise.resolve();
+					},
+				},
+				telemetry: {
+					enabled: true,
+					sendEvent: (_name: string, data: unknown) => world.events.push(data),
+				},
+			} as unknown as Container;
+
+			const connection = {
+				fetchGkApi: (path: string, init?: { method?: string }) => {
+					world.calls.push({ path: path, method: init?.method });
+					world.log.push(`fetch:${path}`);
+					const rsp = options.responses?.[path];
+					if (rsp == null) throw new Error(`Unexpected request: ${path}`);
+					if (rsp instanceof Error) throw rsp;
+					return Promise.resolve({
+						ok: rsp.status >= 200 && rsp.status < 300,
+						status: rsp.status,
+						statusText: String(rsp.status),
+						json: () => Promise.resolve(rsp.body ?? {}),
+					} as Response);
+				},
+			} as unknown as ServerConnection;
+
+			const host: TrialResetHost = {
+				getSubscription: () => Promise.resolve(world.subscription),
+				ensureSession: () =>
+					options.session === null
+						? Promise.resolve(undefined)
+						: Promise.resolve({
+								account: { id: options.sessionAccountId ?? options.subscription.account?.id },
+							} as never),
+				refreshSubscription: () => {
+					world.log.push('refresh');
+					if (options.refreshedSubscription != null) {
+						world.subscription = options.refreshedSubscription;
+					}
+					return Promise.resolve();
+				},
+				notifyReset: () => {
+					world.log.push('notify');
+				},
+			};
+
+			return {
+				world: world,
+				run: () => autoResetTrialIfEligible(container, connection, host, { source: 'graph' }),
+			};
+		}
+
+		const eligible = { status: 200, body: { canResetTrial: true } };
+		const notEligible = { status: 200, body: { canResetTrial: false } };
+
+		test('skips everything when the account already settled its attempt', async () => {
+			const { world, run } = createWorld({
+				subscription: fakeSubscription('settled-1', SubscriptionState.TrialExpired),
+			});
+			world.stored.set('plus:trialReset:settled-1:attempted', true);
+
+			await run();
+			assert.deepStrictEqual(world.calls, []);
+			assert.deepStrictEqual(world.events, []);
+		});
+
+		test('settles paid accounts without any requests', async () => {
+			const { world, run } = createWorld({
+				subscription: fakeSubscription('paid-1', SubscriptionState.Paid, 'pro'),
+			});
+
+			await run();
+			assert.deepStrictEqual(world.calls, []);
+			assert.deepStrictEqual(world.events, []);
+			assert.strictEqual(world.stored.get('plus:trialReset:paid-1:attempted'), true);
+		});
+
+		test('waits out an active trial, then resets once it lapses', async () => {
+			const { world, run } = createWorld({
+				subscription: fakeSubscription('waiter-1', SubscriptionState.Trial),
+				responses: {
+					'user/trial-eligibility': eligible,
+					'user/reactivate-trial': { status: 200 },
+				},
+			});
+
+			// Active trial: no requests, nothing settled — the attempt stays open
+			await run();
+			assert.strictEqual(world.calls.length, 0);
+			assert.strictEqual(world.stored.size, 0);
+
+			// Trial lapsed: eligibility → reset → settle BEFORE the refresh (a failed check-in must not
+			// leave the attempt open after a successful server-side reset)
+			world.subscription = fakeSubscription('waiter-1', SubscriptionState.TrialExpired);
+			await run();
+			assert.deepStrictEqual(
+				world.calls.map(c => c.path),
+				['user/trial-eligibility', 'user/reactivate-trial'],
+			);
+			assert.strictEqual(world.stored.get('plus:trialReset:waiter-1:attempted'), true);
+			assert.ok(world.log.indexOf('store') < world.log.indexOf('refresh'));
+			assert.deepStrictEqual(world.events, [{ action: 'auto-reset-trial', outcome: 'reset' }]);
+		});
+
+		test('notifies the user once the refreshed subscription shows the new trial', async () => {
+			const { world, run } = createWorld({
+				subscription: fakeSubscription('toast-1', SubscriptionState.TrialExpired),
+				refreshedSubscription: fakeSubscription('toast-1', SubscriptionState.Trial),
+				responses: {
+					'user/trial-eligibility': eligible,
+					'user/reactivate-trial': { status: 200 },
+				},
+			});
+
+			await run();
+			assert.ok(world.log.includes('notify'));
+		});
+
+		test('skips the notification when the post-reset refresh does not land, but still settles', async () => {
+			const { world, run } = createWorld({
+				subscription: fakeSubscription('toast-2', SubscriptionState.TrialExpired),
+				responses: {
+					'user/trial-eligibility': eligible,
+					'user/reactivate-trial': { status: 200 },
+				},
+			});
+
+			await run();
+			assert.ok(!world.log.includes('notify'));
+			assert.strictEqual(world.stored.get('plus:trialReset:toast-2:attempted'), true);
+			assert.deepStrictEqual(world.events, [{ action: 'auto-reset-trial', outcome: 'reset' }]);
+		});
+
+		test('settles when the server says the account may not reset', async () => {
+			const { world, run } = createWorld({
+				subscription: fakeSubscription('declined-1', SubscriptionState.TrialExpired),
+				responses: { 'user/trial-eligibility': notEligible },
+			});
+
+			await run();
+			assert.strictEqual(world.stored.get('plus:trialReset:declined-1:attempted'), true);
+			assert.deepStrictEqual(world.events, [{ action: 'auto-reset-trial', outcome: 'not-eligible' }]);
+		});
+
+		test('settles a 409 refusal without refreshing the subscription', async () => {
+			const { world, run } = createWorld({
+				subscription: fakeSubscription('refused-1', SubscriptionState.TrialExpired),
+				responses: {
+					'user/trial-eligibility': eligible,
+					'user/reactivate-trial': { status: 409 },
+				},
+			});
+
+			await run();
+			assert.strictEqual(world.stored.get('plus:trialReset:refused-1:attempted'), true);
+			assert.ok(!world.log.includes('refresh'));
+			assert.deepStrictEqual(world.events, [{ action: 'auto-reset-trial', outcome: 'refused' }]);
+		});
+
+		test('does not settle when the reset itself fails with a server error', async () => {
+			const { world, run } = createWorld({
+				subscription: fakeSubscription('reset-500', SubscriptionState.TrialExpired),
+				responses: {
+					'user/trial-eligibility': eligible,
+					'user/reactivate-trial': { status: 500 },
+				},
+			});
+
+			await run();
+			assert.strictEqual(world.stored.size, 0);
+			assert.deepStrictEqual(world.events, [{ action: 'auto-reset-trial', outcome: 'failed' }]);
+		});
+
+		test('does not settle on a server error and backs off before retrying', async () => {
+			const { world, run } = createWorld({
+				subscription: fakeSubscription('flaky-1', SubscriptionState.TrialExpired),
+				responses: { 'user/trial-eligibility': { status: 500 } },
+			});
+
+			await run();
+			assert.strictEqual(world.stored.size, 0);
+			assert.deepStrictEqual(world.events, [{ action: 'auto-reset-trial', outcome: 'failed' }]);
+
+			// Within the cooldown the guard stops repeated requests (every state rebuild calls this,
+			// and 5 failed GK requests trip the global request blocker)
+			await run();
+			assert.strictEqual(world.calls.length, 1);
+			assert.strictEqual(world.events.length, 1);
+		});
+
+		test('refreshes instead of settling when the server sees a trial the client does not', async () => {
+			const { world, run } = createWorld({
+				subscription: fakeSubscription('stale-1', SubscriptionState.TrialExpired),
+				responses: {
+					'user/trial-eligibility': {
+						status: 200,
+						body: {
+							canResetTrial: false,
+							trialEnd: new Date(Date.now() + 7 * 24 * 60 * 60 * 1000).toISOString(),
+						},
+					},
+				},
+			});
+
+			await run();
+			assert.ok(world.log.includes('refresh'));
+			assert.strictEqual(world.stored.size, 0);
+			assert.deepStrictEqual(world.events, []);
+		});
+
+		test('fails open on an unrecognized eligibility payload instead of settling', async () => {
+			const { world, run } = createWorld({
+				subscription: fakeSubscription('reshaped-1', SubscriptionState.TrialExpired),
+				responses: { 'user/trial-eligibility': { status: 200, body: { data: { canResetTrial: false } } } },
+			});
+
+			await run();
+			assert.strictEqual(world.stored.size, 0);
+			assert.deepStrictEqual(world.events, [{ action: 'auto-reset-trial', outcome: 'failed-shape' }]);
+		});
+
+		test('fails open on an unparseable trialEnd instead of settling', async () => {
+			const { world, run } = createWorld({
+				subscription: fakeSubscription('reshaped-2', SubscriptionState.TrialExpired),
+				responses: {
+					'user/trial-eligibility': { status: 200, body: { canResetTrial: false, trialEnd: 'whenever' } },
+				},
+			});
+
+			await run();
+			assert.strictEqual(world.stored.size, 0);
+			assert.deepStrictEqual(world.events, [{ action: 'auto-reset-trial', outcome: 'failed-shape' }]);
+		});
+
+		test('skips unverified accounts without requests or settling', async () => {
+			const subscription = fakeSubscription('unverified-1', SubscriptionState.TrialExpired);
+			(subscription.account as { verified: boolean }).verified = false;
+			const { world, run } = createWorld({ subscription: subscription });
+
+			await run();
+			assert.strictEqual(world.calls.length, 0);
+			assert.strictEqual(world.stored.size, 0);
+			assert.deepStrictEqual(world.events, []);
+		});
+
+		test('bails when the session belongs to another account', async () => {
+			const { world, run } = createWorld({
+				subscription: fakeSubscription('switched-from', SubscriptionState.TrialExpired),
+				sessionAccountId: 'switched-to',
+				responses: {
+					'user/trial-eligibility': eligible,
+					'user/reactivate-trial': { status: 200 },
+				},
+			});
+
+			await run();
+			assert.strictEqual(world.calls.length, 0);
+			assert.strictEqual(world.stored.size, 0);
+			assert.deepStrictEqual(world.events, []);
+		});
+
+		test('stays quiet when no session is available', async () => {
+			const { world, run } = createWorld({
+				subscription: fakeSubscription('signed-out-1', SubscriptionState.TrialExpired),
+				session: null,
+			});
+
+			await run();
+			assert.strictEqual(world.calls.length, 0);
+			assert.strictEqual(world.stored.size, 0);
+			assert.deepStrictEqual(world.events, []);
+		});
+
+		test('stays quiet when GK requests are blocked', async () => {
+			const { world, run } = createWorld({
+				subscription: fakeSubscription('blocked-1', SubscriptionState.TrialExpired),
+				responses: { 'user/trial-eligibility': new RequestsAreBlockedTemporarilyError() },
+			});
+
+			await run();
+			assert.strictEqual(world.stored.size, 0);
+			assert.deepStrictEqual(world.events, []);
+		});
+
+		test('stays quiet when the eligibility request times out', async () => {
+			const { world, run } = createWorld({
+				subscription: fakeSubscription('cancelled-1', SubscriptionState.TrialExpired),
+				responses: { 'user/trial-eligibility': new CancellationError(new Error('timeout')) },
+			});
+
+			await run();
+			assert.strictEqual(world.stored.size, 0);
+			assert.deepStrictEqual(world.events, []);
+		});
+
+		test('keeps each account on its own attempt budget', async () => {
+			const failing = { 'user/trial-eligibility': { status: 500 } };
+			const a = createWorld({
+				subscription: fakeSubscription('acct-a', SubscriptionState.TrialExpired),
+				responses: failing,
+			});
+			await a.run();
+			assert.strictEqual(a.world.calls.length, 1);
+
+			// Within A's cooldown, B must still get its own check
+			const b = createWorld({
+				subscription: fakeSubscription('acct-b', SubscriptionState.TrialExpired),
+				responses: failing,
+			});
+			await b.run();
+			assert.strictEqual(b.world.calls.length, 1);
+		});
+
+		test('stays quiet when the reset request itself is blocked', async () => {
+			const { world, run } = createWorld({
+				subscription: fakeSubscription('blocked-2', SubscriptionState.TrialExpired),
+				responses: {
+					'user/trial-eligibility': eligible,
+					'user/reactivate-trial': new RequestsAreBlockedTemporarilyError(),
+				},
+			});
+
+			await run();
+			assert.strictEqual(world.stored.size, 0);
+			assert.deepStrictEqual(world.events, []);
+		});
+	});
+});

--- a/src/plus/gk/subscriptionService.ts
+++ b/src/plus/gk/subscriptionService.ts
@@ -75,7 +75,8 @@ import type { Organization } from './models/organization.js';
 import type { Promo } from './models/promo.js';
 import type { PaidSubscriptionPlanIds, Subscription, SubscriptionUpgradeCommandArgs } from './models/subscription.js';
 import type { ServerConnection } from './serverConnection.js';
-import { ensurePlusFeaturesEnabled } from './utils/-webview/plus.utils.js';
+import { autoResetTrialIfEligible } from './trialAutoReset.js';
+import { arePlusFeaturesEnabled, ensurePlusFeaturesEnabled } from './utils/-webview/plus.utils.js';
 import { getConfiguredActiveOrganizationId, updateActiveOrganizationId } from './utils/-webview/subscription.utils.js';
 import { getSubscriptionFromCheckIn } from './utils/checkin.utils.js';
 import {
@@ -752,6 +753,30 @@ export class SubscriptionService implements Disposable {
 			scope?.error(ex);
 			debugger;
 		}
+	}
+
+	/**
+	 * Attempts the one-time out-of-window Pro trial reset.
+	 * Remove along with the promo.
+	 */
+	@gate(() => '')
+	@debug()
+	async autoResetTrialIfEligible(source: Source): Promise<void> {
+		// Silent check on purpose — never prompt from this background path
+		if (!arePlusFeaturesEnabled()) return;
+
+		return autoResetTrialIfEligible(
+			this.container,
+			this.connection,
+			{
+				getSubscription: () => this.getSubscription(),
+				ensureSession: () => this.ensureSession(false, source),
+				refreshSubscription: async session => {
+					await this.checkInAndValidate(session, source, { force: true });
+				},
+			},
+			source,
+		);
 	}
 
 	@debug()

--- a/src/plus/gk/trialAutoReset.ts
+++ b/src/plus/gk/trialAutoReset.ts
@@ -1,6 +1,6 @@
-// One-time, out-of-window Pro trial reset. `canResetTrial` is true only between `trialEnd` and
-// `nextOptInDate` — never during an active trial — so active trials are skipped without settling and
-// re-checked on later Graph opens. Attempts are tracked per account.
+// One-time, out-of-window Pro trial reset. The server owns eligibility (`canResetTrial`) — the client
+// never predicts it or schedules around a trial's end. Active trials are skipped without settling and
+// re-checked whenever the Graph rebuilds; every other answer is final. Attempts are tracked per account.
 //
 // Launch promo — to remove: this file + test, `SubscriptionService.autoResetTrialIfEligible` and its
 // `graphWebview.getState` call site, the `plus:trialReset:${string}:attempted` storage key (incl. its

--- a/src/plus/gk/trialAutoReset.ts
+++ b/src/plus/gk/trialAutoReset.ts
@@ -1,0 +1,247 @@
+// One-time, out-of-window Pro trial reset. `canResetTrial` is true only between `trialEnd` and
+// `nextOptInDate` — never during an active trial — so active trials are skipped without settling and
+// re-checked on later Graph opens. Attempts are tracked per account.
+//
+// Launch promo — to remove: this file + test, `SubscriptionService.autoResetTrialIfEligible` and its
+// `graphWebview.getState` call site, the `plus:trialReset:${string}:attempted` storage key (incl. its
+// entry in `Storage.reset`'s exclude list and the debug reset in `resets.ts`), and the
+// `auto-reset-trial` telemetry action (re-run `pnpm run generate:docs:telemetry` after).
+// Keep the Graph's Pro-access-flip rebuild in `graphWebview.onSubscriptionChanged` — it is not
+// promo-specific (it also covers upgrades and manual reactivation).
+
+import type { AuthenticationSession, MessageItem } from 'vscode';
+import { window } from 'vscode';
+import { isCancellationError } from '@gitlens/utils/cancellation.js';
+import { Logger } from '@gitlens/utils/logger.js';
+import { pluralize } from '@gitlens/utils/string.js';
+import { urls } from '../../constants.js';
+import type { Source } from '../../constants.telemetry.js';
+import type { Container } from '../../container.js';
+import { AuthenticationRequiredError, RequestsAreBlockedTemporarilyError } from '../../errors.js';
+import { openUrl } from '../../system/-webview/vscode/uris.js';
+import type { Subscription } from './models/subscription.js';
+import type { ServerConnection } from './serverConnection.js';
+import { getSubscriptionTimeRemaining, isSubscriptionPaid, isSubscriptionTrial } from './utils/subscription.utils.js';
+
+type TrialResetStep =
+	/** Paid plan — the reset would change nothing for them; settled by design rather than re-checked. */
+	| 'paid'
+	/** The server answered, and this account may not reset early. */
+	| 'not-eligible'
+	/** The reset went through. */
+	| 'reset'
+	/** Eligibility approved the account but the reset 409'd — the backend excludes some accounts for
+	 *  reasons the client cannot see (e.g. paid-org members). Kept as its own telemetry outcome so a
+	 *  systematic disagreement between the two stays visible. */
+	| 'refused'
+	/** Offline or server error — nothing was decided; retry later. */
+	| 'failed'
+	/** The eligibility payload no longer matches what the client reads — the promo is off for everyone
+	 *  until it's fixed, so it stays out of the generic `failed` bucket. */
+	| 'failed-shape';
+
+/** `GET user/trial-eligibility` — only `canResetTrial` gates the reset; the rest is for diagnostics. */
+type TrialEligibility = {
+	canResetTrial?: boolean;
+	isExtendedReset?: boolean;
+	resetCount?: number;
+	resetLimit?: number;
+	nextOptInDate?: string;
+	trialEnd?: string;
+};
+
+export type TrialResetHost = {
+	getSubscription(): Promise<Subscription>;
+	ensureSession(): Promise<AuthenticationSession | undefined>;
+	/** Forces a check-in so the reset trial's new dates land in the stored subscription. */
+	refreshSubscription(session: AuthenticationSession): Promise<void>;
+	/** Tells the user their trial is back — called only when the client actually sees the new trial.
+	 *  Defaults to the reactivation toast; overridable for tests. */
+	notifyReset?(subscription: Subscription): void;
+};
+
+type SessionAttempt = { at: number; count: number };
+
+/** Attempts per account — a transient failure retries after a cooldown and gives up for the session
+ *  after a few tries, staying clear of the global GK request blocker. */
+const sessionAttempts = new Map<string, SessionAttempt>();
+const attemptCooldownMs = 5 * 60 * 1000;
+const maxAttemptsPerSession = 3;
+
+/** Lets the debug `Reset > Subscription` command re-arm the flow without a window reload. */
+export function clearTrialResetSessionAttempts(): void {
+	sessionAttempts.clear();
+}
+
+/** Assumes a single-flight caller — invoke only via the `@gate`d `SubscriptionService.autoResetTrialIfEligible`. */
+export async function autoResetTrialIfEligible(
+	container: Container,
+	connection: ServerConnection,
+	host: TrialResetHost,
+	source: Source,
+): Promise<void> {
+	const subscription = await host.getSubscription();
+
+	if (subscription.account == null || subscription.account.verified === false) return;
+
+	const accountId = subscription.account.id;
+	if (container.storage.get(`plus:trialReset:${accountId}:attempted`, false)) return;
+
+	if (isSubscriptionPaid(subscription)) {
+		await settle(container, source, accountId, 'paid');
+		return;
+	}
+
+	if (isSubscriptionTrial(subscription)) return;
+
+	const attempt = sessionAttempts.get(accountId);
+	if (attempt != null && (attempt.count >= maxAttemptsPerSession || Date.now() - attempt.at < attemptCooldownMs)) {
+		return;
+	}
+
+	// Signed out or the session lapsed — skip quietly and re-check on a later state build. A switch
+	// to another account while awaiting above would reset that account's trial under this one's flag
+	const session = await host.ensureSession();
+	if (session == null || session.account.id !== accountId) return;
+
+	sessionAttempts.set(accountId, { at: Date.now(), count: (attempt?.count ?? 0) + 1 });
+
+	let eligibility: TrialEligibility;
+	try {
+		// Pinned to the captured session so an account switch mid-flight can't reset the wrong account
+		const rsp = await connection.fetchGkApi(
+			'user/trial-eligibility',
+			{ method: 'GET' },
+			{ token: session.accessToken },
+		);
+		if (!rsp.ok) {
+			Logger.warn(`Unable to check Pro trial reset eligibility: (${rsp.status}) ${rsp.statusText}`);
+			await settle(container, source, accountId, 'failed');
+			return;
+		}
+
+		eligibility = (await rsp.json()) as TrialEligibility;
+	} catch (ex) {
+		if (handledAsTransient(ex, accountId, attempt)) return;
+
+		Logger.error(ex, 'Unable to check Pro trial reset eligibility');
+		await settle(container, source, accountId, 'failed');
+		return;
+	}
+
+	// Fail open on an unrecognized shape — settling on it would permanently kill the promo for
+	// everyone if the endpoint's payload ever changes. Its own outcome so a contract break is
+	// distinguishable from an outage in telemetry.
+	const trialEnd = eligibility.trialEnd != null ? new Date(eligibility.trialEnd) : undefined;
+	if (typeof eligibility.canResetTrial !== 'boolean' || (trialEnd != null && isNaN(trialEnd.getTime()))) {
+		Logger.warn('Unable to check Pro trial reset eligibility: unrecognized response shape');
+		await settle(container, source, accountId, 'failed-shape');
+		return;
+	}
+
+	if (!eligibility.canResetTrial) {
+		// The server sees an active trial the client doesn't (a reset POST that timed out after
+		// succeeding, or a trial started from another GK app) — refresh instead of settling on
+		// stale state; once that trial lapses a re-check settles honestly
+		if (trialEnd != null && trialEnd > new Date()) {
+			try {
+				await host.refreshSubscription(session);
+			} catch (ex) {
+				Logger.error(ex, 'Unable to refresh the stale subscription');
+			}
+			return;
+		}
+
+		Logger.debug(
+			`Pro trial reset unavailable: extended=${eligibility.isExtendedReset}, resets=${eligibility.resetCount}/${eligibility.resetLimit}, nextOptInDate=${eligibility.nextOptInDate}`,
+		);
+		await settle(container, source, accountId, 'not-eligible');
+		return;
+	}
+
+	try {
+		const rsp = await connection.fetchGkApi(
+			'user/reactivate-trial',
+			{ method: 'POST', body: JSON.stringify({ client: 'gitlens' }) },
+			{ token: session.accessToken },
+		);
+		if (!rsp.ok) {
+			if (rsp.status === 409) {
+				Logger.warn(
+					'Pro trial reset was refused (409) despite a positive eligibility check — expected for accounts the backend excludes for reasons the client cannot see (e.g. paid-org members)',
+				);
+				await settle(container, source, accountId, 'refused');
+			} else {
+				Logger.warn(`Unable to reset Pro trial: (${rsp.status}) ${rsp.statusText}`);
+				await settle(container, source, accountId, 'failed');
+			}
+			return;
+		}
+	} catch (ex) {
+		if (handledAsTransient(ex, accountId, attempt)) return;
+
+		Logger.error(ex, 'Unable to reset Pro trial');
+		await settle(container, source, accountId, 'failed');
+		return;
+	}
+
+	Logger.debug(`Pro trial reset performed: extended=${eligibility.isExtendedReset}`);
+	await settle(container, source, accountId, 'reset');
+
+	try {
+		await host.refreshSubscription(session);
+	} catch (ex) {
+		// The trial is already reset server-side; without this check-in the new dates just show up on the next one.
+		Logger.error(ex, 'Unable to refresh the subscription after resetting the Pro trial');
+	}
+
+	// Only celebrate when the client actually sees the new trial — a failed check-in above would
+	// pair a success toast with a still-gated UI; the next check-in surfaces the dates silently
+	const refreshed = await host.getSubscription();
+	if (isSubscriptionTrial(refreshed)) {
+		(host.notifyReset ?? showTrialResetMessage)(refreshed);
+	}
+}
+
+function showTrialResetMessage(subscription: Subscription): void {
+	const remaining = getSubscriptionTimeRemaining(subscription, 'days') ?? 0;
+	const message = `Your GitLens Pro trial has been reactivated! Experience all the new Pro features for another ${pluralize(
+		'day',
+		remaining,
+	)}.`;
+
+	const learn: MessageItem = { title: "See What's New" };
+	void window.showInformationMessage(message, learn).then(result => {
+		if (result === learn) {
+			void openUrl(urls.releaseNotes);
+		}
+	});
+}
+
+/** Expected states rather than errors — no telemetry. Blocked and unauthenticated requests never leave
+ *  the client, so they keep the cooldown without spending a try; a timed-out one did go out and counts. */
+function handledAsTransient(ex: unknown, accountId: string, attempt: SessionAttempt | undefined): boolean {
+	if (ex instanceof RequestsAreBlockedTemporarilyError || ex instanceof AuthenticationRequiredError) {
+		sessionAttempts.set(accountId, { at: Date.now(), count: attempt?.count ?? 0 });
+		return true;
+	}
+
+	return isCancellationError(ex);
+}
+
+async function settle(container: Container, source: Source, accountId: string, step: TrialResetStep): Promise<void> {
+	// Every definitive step ends the account's one-time attempt; only failures retry later
+	const settled = step !== 'failed' && step !== 'failed-shape';
+	const outcome = step === 'paid' ? undefined : step;
+
+	if (outcome != null && container.telemetry.enabled) {
+		container.telemetry.sendEvent('subscription/action', { action: 'auto-reset-trial', outcome: outcome }, source);
+	}
+
+	if (settled) {
+		// Swallow storage failures — on the reset path a throw here would skip the refresh + message
+		await container.storage
+			.store(`plus:trialReset:${accountId}:attempted`, true)
+			.catch((ex: unknown) => Logger.error(ex, 'Unable to persist the Pro trial reset attempt'));
+	}
+}

--- a/src/system/-webview/storage.ts
+++ b/src/system/-webview/storage.ts
@@ -109,7 +109,7 @@ export class Storage implements Disposable {
 
 	@trace({ onlyExit: { after: 250 } })
 	async reset(): Promise<void> {
-		return this.deleteWithPrefixCore(undefined, /^(premium:subscription|plus:preview:.*)$/);
+		return this.deleteWithPrefixCore(undefined, /^(premium:subscription|plus:preview:.*|plus:trialReset:.*)$/);
 	}
 
 	@trace({ args: (key: keyof GlobalStorage) => ({ key: key }), onlyExit: { after: 250 } })

--- a/src/webviews/plus/graph/graphWebview.ts
+++ b/src/webviews/plus/graph/graphWebview.ts
@@ -4186,6 +4186,9 @@ export class GraphWebviewProvider implements WebviewProvider<State, State, Graph
 			};
 		}
 
+		// Runs on every state build, not just opens — its own guards make repeats cheap no-ops
+		void this.container.subscription.autoResetTrialIfEligible({ source: 'graph' });
+
 		if (this.container.git.repositoryCount === 0) {
 			this._wip.updateWorkingTreeBadge(undefined);
 			return {

--- a/src/webviews/plus/graph/graphWebview.ts
+++ b/src/webviews/plus/graph/graphWebview.ts
@@ -98,7 +98,10 @@ import type { OnboardingChangeEvent } from '../../../onboarding/onboardingServic
 import type { UsageChangeEvent } from '../../../onboarding/usageTracker.js';
 import type { FeaturePreviewChangeEvent, SubscriptionChangeEvent } from '../../../plus/gk/subscriptionService.js';
 import { isHooksBannerEnabled, isMcpBannerEnabled } from '../../../plus/gk/utils/-webview/mcp.utils.js';
-import { isAccountAccessRequired } from '../../../plus/gk/utils/subscription.utils.js';
+import {
+	isAccountAccessRequired,
+	isSubscriptionTrialOrPaidFromState,
+} from '../../../plus/gk/utils/subscription.utils.js';
 import { showComparisonPicker } from '../../../quickpicks/comparisonPicker.js';
 import { showContributorsPicker } from '../../../quickpicks/contributorsPicker.js';
 import { showReferencePicker2 } from '../../../quickpicks/referencePicker.js';
@@ -2206,6 +2209,20 @@ export class GraphWebviewProvider implements WebviewProvider<State, State, Graph
 		//  - on entering the access screen, cancels any in-flight full-path `getState` (whose stale
 		//    signed-in state would otherwise overwrite the signed-out one) and clears a stale badge.
 		if (wasAccountAccessRequired !== this._accountAccessRequired && this.host.ready) {
+			this._data.updateState(true);
+			return;
+		}
+
+		// A Pro-access flip (upgrade, manual reactivation, or the trial auto-reset — which is kicked
+		// off from `getState` itself) makes any in-flight state build stale: its `allowed`/
+		// `subscription` snapshot would re-gate the Graph when it ships, so a full rebuild follows
+		// (superseding it via the coalesced-run refire, not cancelling it). Deliberately fires in
+		// both directions, even with no build in flight — a re-gate needs fresh state too.
+		if (
+			isSubscriptionTrialOrPaidFromState(e.previous.state) !==
+				isSubscriptionTrialOrPaidFromState(e.current.state) &&
+			this.host.ready
+		) {
 			this._data.updateState(true);
 			return;
 		}


### PR DESCRIPTION
Implements gitkraken/vscode-gitlens-private#97 (milestone 18.4).

When a signed-in user opens the Commit Graph, GitLens asks the server (`GET user/trial-eligibility`) whether the account may reset its Pro trial outside the standard 90-day window, and if so performs the reset (`POST user/reactivate-trial`), refreshes the subscription, and shows a reactivation toast.

**Behavior**
- Gated on the server's `canResetTrial` — never on local subscription state. Active trials are skipped without settling and re-checked once they lapse (the server never approves a reset during an active trial).
- One attempt per account **per machine** — the `plus:trialReset:${accountId}:attempted` flag is deliberately excluded from settings sync and from `Storage.reset`.
- Paid accounts settle immediately without any requests; a 409 from reactivation (paid-org members) settles as `refused`.
- The toast only fires once the client actually sees the new trial, so a failed post-reset check-in can't pair a success message with a still-gated UI — mirrors the guard on the manual reactivation flow.
- Fails open: server errors and unrecognized payload shapes never consume the attempt. Retries are capped at 3 per session with a 5-minute cooldown; a request that never leaves the client (blocked or unauthenticated) keeps the cooldown without spending a try, while a wire timeout counts against the budget.
- Both requests are pinned to the captured session token, so an account switch mid-flight can't reset the wrong account.
- Telemetry: `subscription/action` with `action: 'auto-reset-trial'` and `outcome: reset | not-eligible | refused | failed | failed-shape`. `failed-shape` is kept separate so a broken payload contract — which disables the promo for everyone — isn't read as an ordinary outage.

**Removal** — this is a launch promo; `src/plus/gk/trialAutoReset.ts` starts with a checklist of everything to delete when it ends, including the one piece that stays (the Graph's Pro-access-flip rebuild, which also covers upgrades and manual reactivation).

Verified live end-to-end on a test account against dev-api: eligibility → reset → fresh 14-day trial → Graph un-gated without reload → toast; repeat opens are no-ops (`resetCount 1/1`). Covered by 18 behavioral unit tests. No CHANGELOG entry on purpose — the promo is silent and is deleted wholesale when it ends.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
