### PR TITLE
Fixes css template minifier dropping semicolons after interpolations

### DIFF
--- a/scripts/webpack-template-minifier.mjs
+++ b/scripts/webpack-template-minifier.mjs
@@ -1,4 +1,5 @@
 import { defaultMinifyOptions, defaultStrategy, minifyHTMLLiterals } from 'minify-html-literals';
+import postcss from 'postcss';
 import { createCssProcessor } from './css-minify-preset.mjs';
 
 /**
@@ -33,6 +34,33 @@ import { createCssProcessor } from './css-minify-preset.mjs';
  */
 
 let processor;
+
+/**
+ * The library's `${…}` stand-in is `@TEMPLATE_EXPRESSION…();` — the trailing `;` is part of the
+ * split token. When an interpolation ends a declaration (`--x: ${val};`), cssnano collapses the
+ * placeholder's own `;` into the declaration separator, and the split-by-placeholder step then
+ * consumes that separator — fusing the NEXT declaration into this value. A custom property eats
+ * whatever follows silently, since almost any token stream is a valid custom-property value.
+ *
+ * The library guards against exactly this, but only via a clean-css `transform` hook
+ * (`adjustMinifyCSSOptions`) that redirecting `minifyCSS` to cssnano bypasses. Mirror it here: a
+ * second parse over cssnano's output re-appends `;` to any declaration value that ends with the
+ * placeholder, so the split eats the restored one and the real separator survives. Parse-level on
+ * purpose — placeholders in mid-value positions (`var(--x, ${fallback})`) keep their `();` inside
+ * the parens, and a string-level replace could not tell the two apart.
+ */
+const placeholderValueSuffix = /@TEMPLATE_EXPRESSION_*\(\)$/;
+const semicolonRestorer = postcss([
+	{
+		postcssPlugin: 'restore-template-expression-semicolons',
+		Declaration(decl) {
+			const value = decl.value.trimEnd();
+			if (placeholderValueSuffix.test(value)) {
+				decl.value = `${value};`;
+			}
+		},
+	},
+]);
 
 /** @this {import('webpack').LoaderContext<unknown>} */
 export default function templateMinifierLoader(source) {
@@ -94,7 +122,14 @@ export default function templateMinifierLoader(source) {
 
 	processor ??= createCssProcessor();
 
-	Promise.all(stylesheets.map(css => processor.process(css, { from: undefined }).then(r => [css, r.css])))
+	Promise.all(
+		stylesheets.map(css =>
+			processor
+				.process(css, { from: undefined })
+				.then(r => semicolonRestorer.process(r.css, { from: undefined }))
+				.then(r => [css, r.css]),
+		),
+	)
 		.then(entries => {
 			const minified = new Map(entries);
 			const result = minifyHTMLLiterals(source, {


### PR DESCRIPTION
Fixes #5685

### What the user saw

In production builds, the scope/commit picker in the Commit Graph's **compose** and **review** modes could not be scrolled: no scrollbar thumb ever appeared and the mouse wheel did nothing, leaving everything past the first few rows unreachable. Dev builds were unaffected, which is what made this so hard to pin down — F5 and local inspection always looked fine. The picker's state colors (the amber/teal timeline dots) were also silently broken in the same builds, for the same reason.

### Why it happened

Production webview builds minify the CSS inside `` css`…` `` tagged templates via `scripts/webpack-template-minifier.mjs`, which drives `minify-html-literals` but redirects its CSS minification from the bundled clean-css 4.x to cssnano (clean-css predates native nesting, `@container`, and `@layer`, and silently drops them).

`minify-html-literals` stands in for each `${…}` interpolation with the placeholder `@TEMPLATE_EXPRESSION();` — the trailing semicolon is part of the split token. When an interpolation ends a declaration (`--x: ${val};`), the minifier collapses the placeholder's own `;` and the declaration separator into one semicolon, and the split-by-placeholder step then consumes that lone survivor — fusing the *next* declaration into the interpolated value. When that value belongs to a custom property the fusion is silent, since almost any token stream is a valid custom-property value.

The library guards against exactly this, but only via a clean-css `transform` hook (`adjustMinifyCSSOptions`) that the cssnano redirect bypasses.

`gl-commits-scope-pane.css.ts` is the one stylesheet in the repo with the vulnerable shape — six interpolated custom properties followed by `display: flex` on `:host`. Shipped builds produced:

```css
:host{--details-scope-pane-uncommitted-color:var(…)--details-scope-pane-unpushed-color:var(…)…--details-scope-pane-bg-color:var(…)display:flex;flex:1;min-height:0;overflow:hidden}
```

— one giant custom-property declaration swallowing the other five custom properties *and* `display: flex`. Without `display: flex` the host stopped constraining the inner `.details-scope-pane`, which grew to its full content height (no overflow → no scrollbar, nothing for the wheel to scroll) and was clipped by the host's `overflow: hidden`.

### How it's resolved

The loader now mirrors the library's clean-css hook on the cssnano path: a second postcss pass over cssnano's output re-appends `;` to any declaration value that ends with the placeholder, so the split consumes the restored semicolon and the real declaration separator survives. The pass is parse-level on purpose — placeholders in mid-value positions (`var(--x, ${fallback})`) legitimately keep their `();` inside parentheses, and a string-level replacement cannot tell the two apart.

### Tests

Build scripts have no unit-test harness, so no automated test is added. The fixed loader was run directly (production mode, mocked loader context) against every `css.ts` stylesheet in the repo — all 59 minify without warnings, adjacent interpolated declarations stay separated, and the same harness against the old pipeline reproduces the fused output.

### Validation

1. `pnpm run bundle` (or package a VSIX) — dev builds skip the loader entirely, so `pnpm run build` cannot exercise this.
2. Inspect `dist/webviews/graph.js`: in the scope-pane `:host` rule, each `--details-scope-pane-*` custom property ends with `;` and `display:flex` is a standalone declaration again.
3. Run the production build, open the Commit Graph on a branch with more commits than fit the picker, and enter compose or review mode: the scope picker scrolls with the wheel, shows a scrollbar thumb on hover, and the timeline dots show their amber/teal state colors.
