### PR TITLE
Restores the interrupted comparison itself after signing back in

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -61,6 +61,7 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/) and this p
 
 ### Fixed
 
+- Fixes signing back in after a sign-out interrupted a _Commit Graph_ comparison reopening the comparison on different references &mdash; the interrupted comparison's own references are now carried across the sign-in instead of the default current-branch-versus-working-tree shape ([#5671](https://github.com/gitkraken/vscode-gitlens/issues/5671))
 - Fixes rows in the _Commit Graph_ side bar panels nudging their trailing decorations to the left on hover
 - Fixes AI conflict resolution failing outright when the AI backend won't accept tool calls &mdash; it now falls back to resolving without consulting the repository, as it already did for AI providers that can't carry tool calls at all, instead of failing the whole operation. Errors forwarded from an AI provider also now carry that provider's own message, rather than only the backend's generic "upstream AI provider error"
 - Fixes an automatic rebase freezing mid-step when AI becomes unavailable &mdash; running out of AI credits (or hitting a rate limit, or going offline) showed a notification and left the run spinning on its last message indefinitely, because the notification had to be clicked before the request could fail &mdash; and _Cancel Rebase_ did nothing until it was. The run now stops promptly, leaves the rebase paused at the step it reached with its conflicts intact, and reports that AI became unavailable rather than blaming the file it was working on

--- a/src/webviews/apps/plus/graph/components/__tests__/detailsState.test.ts
+++ b/src/webviews/apps/plus/graph/components/__tests__/detailsState.test.ts
@@ -1,7 +1,12 @@
 import * as assert from 'assert';
 import { uncommitted } from '@gitlens/git/models/revision.js';
 import type { DetailsState } from '../detailsState.js';
-import { createDetailsState, getActiveTaskAction } from '../detailsState.js';
+import {
+	createDetailsState,
+	getActiveTaskAction,
+	getOpenComparison,
+	shouldRestoreCapturedComparison,
+} from '../detailsState.js';
 
 function enterMode(
 	state: DetailsState,
@@ -70,11 +75,90 @@ suite('getActiveTaskAction — the account-gate task capture (#5534)', () => {
 	test('an open compare (sheet or panel form) captures open-compare', () => {
 		const sheet = createDetailsState();
 		sheet.compareSheetOpen.set(true);
-		assert.deepStrictEqual(getActiveTaskAction(sheet), { action: 'open-compare' });
+		assert.deepStrictEqual(getActiveTaskAction(sheet), {
+			action: 'open-compare',
+			compare: undefined,
+			compareGraphRepoPath: undefined,
+		});
 
 		const panel = createDetailsState();
 		panel.compareAsPanel.set(true);
-		assert.deepStrictEqual(getActiveTaskAction(panel), { action: 'open-compare' });
+		assert.deepStrictEqual(getActiveTaskAction(panel), {
+			action: 'open-compare',
+			compare: undefined,
+			compareGraphRepoPath: undefined,
+		});
+	});
+
+	test('an open compare carries its refs against its birth-record repo, so the restore reopens the SAME comparison', () => {
+		const state = createDetailsState();
+		state.compareSheetOpen.set(true);
+		state.branchCompareLeftRef.set('main');
+		state.branchCompareLeftRefType.set('branch');
+		state.branchCompareRightRef.set('feature');
+		state.branchCompareRightRefType.set('branch');
+		state.branchCompareIncludeWorkingTree.set(false);
+		state.branchCompareGraphRepoPath.set('/repo');
+
+		// Selection has wandered to a secondary worktree; the captured refs must still target the
+		// birth-record repo (`/repo`), not the passed selection path.
+		assert.deepStrictEqual(getActiveTaskAction(state, '/repo/worktrees/feature'), {
+			action: 'open-compare',
+			compare: {
+				repoPath: '/repo',
+				leftRef: 'main',
+				leftRefType: 'branch',
+				rightRef: 'feature',
+				rightRefType: 'branch',
+				includeWorkingTree: false,
+			},
+			compareGraphRepoPath: '/repo',
+		});
+	});
+
+	test('the passed selection path backs the refs only when there is no birth record', () => {
+		const state = createDetailsState();
+		state.compareSheetOpen.set(true);
+		state.branchCompareRightRef.set('feature');
+		state.branchCompareRightRefType.set('branch');
+
+		assert.strictEqual(getActiveTaskAction(state, '/repo')?.compare?.repoPath, '/repo');
+	});
+
+	test('a compare without a right ref falls back to the ref-less capture (default-shape restore)', () => {
+		const state = createDetailsState();
+		state.compareSheetOpen.set(true);
+		state.branchCompareLeftRef.set('main');
+
+		assert.deepStrictEqual(getActiveTaskAction(state, '/repo'), {
+			action: 'open-compare',
+			compare: undefined,
+			compareGraphRepoPath: undefined,
+		});
+	});
+
+	test('a compare without a repo path cannot be restored by refs — ref-less capture', () => {
+		const state = createDetailsState();
+		state.compareAsPanel.set(true);
+		state.branchCompareRightRef.set('feature');
+
+		assert.deepStrictEqual(getActiveTaskAction(state), {
+			action: 'open-compare',
+			compare: undefined,
+			compareGraphRepoPath: undefined,
+		});
+	});
+
+	test('an empty-string repo path counts as no repo path — ref-less capture', () => {
+		const state = createDetailsState();
+		state.compareSheetOpen.set(true);
+		state.branchCompareRightRef.set('feature');
+
+		assert.deepStrictEqual(getActiveTaskAction(state, ''), {
+			action: 'open-compare',
+			compare: undefined,
+			compareGraphRepoPath: undefined,
+		});
 	});
 
 	test('an active mode wins over a coexisting open compare', () => {
@@ -83,5 +167,63 @@ suite('getActiveTaskAction — the account-gate task capture (#5534)', () => {
 		enterMode(state, 'review', 'wip', '/repo', uncommitted);
 
 		assert.strictEqual(getActiveTaskAction(state)?.action, 'enter-review');
+	});
+});
+
+suite('getOpenComparison — the live-comparison probe (#5671)', () => {
+	test('no open comparison probes as undefined', () => {
+		assert.strictEqual(getOpenComparison(createDetailsState(), '/repo'), undefined);
+	});
+
+	test('an open comparison is visible even while a mode sits on top of it', () => {
+		const state = createDetailsState();
+		state.compareSheetOpen.set(true);
+		state.branchCompareRightRef.set('feature');
+		state.branchCompareGraphRepoPath.set('/repo');
+		enterMode(state, 'review', 'wip', '/repo', uncommitted);
+
+		assert.strictEqual(getActiveTaskAction(state, '/repo')?.action, 'enter-review');
+		assert.deepStrictEqual(getOpenComparison(state, '/repo'), {
+			compare: {
+				repoPath: '/repo',
+				leftRef: undefined,
+				leftRefType: undefined,
+				rightRef: 'feature',
+				rightRefType: undefined,
+				includeWorkingTree: false,
+			},
+			graphRepoPath: '/repo',
+		});
+	});
+});
+
+suite('shouldRestoreCapturedComparison — the restore guards (#5671)', () => {
+	const refs = { repoPath: '/repo', leftRef: 'main', rightRef: 'feature' };
+	const noLive = undefined;
+	const liveWithRefs = { compare: { repoPath: '/repo', rightRef: 'other' }, graphRepoPath: '/repo' };
+	const liveRefless = { compare: undefined, graphRepoPath: '/repo' };
+
+	test('a witnessed family mismatch restores nothing, refs or not', () => {
+		assert.strictEqual(shouldRestoreCapturedComparison(refs, '/a', '/b', noLive), false);
+		assert.strictEqual(shouldRestoreCapturedComparison(undefined, '/a', '/b', noLive), false);
+	});
+
+	test('an unknown family on either side cannot witness a switch — the capture proceeds', () => {
+		assert.strictEqual(shouldRestoreCapturedComparison(refs, undefined, '/b', noLive), true);
+		assert.strictEqual(shouldRestoreCapturedComparison(refs, '/a', undefined, noLive), true);
+	});
+
+	test('an open ref-carrying live comparison always wins over the capture', () => {
+		assert.strictEqual(shouldRestoreCapturedComparison(refs, '/a', '/a', liveWithRefs), false);
+	});
+
+	test('a ref-less live comparison yields only to captured refs (same comparison mid-init)', () => {
+		assert.strictEqual(shouldRestoreCapturedComparison(refs, '/a', '/a', liveRefless), true);
+		assert.strictEqual(shouldRestoreCapturedComparison(undefined, '/a', '/a', liveRefless), false);
+	});
+
+	test('matching families with no live comparison restore', () => {
+		assert.strictEqual(shouldRestoreCapturedComparison(refs, '/a', '/a', noLive), true);
+		assert.strictEqual(shouldRestoreCapturedComparison(undefined, '/a', '/a', noLive), true);
 	});
 });

--- a/src/webviews/apps/plus/graph/components/__tests__/detailsWorkflowController.test.ts
+++ b/src/webviews/apps/plus/graph/components/__tests__/detailsWorkflowController.test.ts
@@ -1384,6 +1384,19 @@ suite('DetailsWorkflowController.compare lifecycle', () => {
 		assert.strictEqual(state.branchCompareRightRef.get(), 'feature');
 	});
 
+	test('openCompare records the GRAPH repo as the birth record — not the selection — and closeCompare clears it', () => {
+		const { state, controller } = setup({ repoPath: '/A/wt', graphRepoPath: '/A' });
+
+		controller.openCompare(
+			{ sha: uncommitted, shas: undefined, repoPath: '/A/wt' },
+			{ leftRef: 'main', leftRefType: 'branch', rightRef: 'feature', rightRefType: 'branch' },
+		);
+		assert.strictEqual(state.branchCompareGraphRepoPath.get(), '/A');
+
+		controller.closeCompare();
+		assert.strictEqual(state.branchCompareGraphRepoPath.get(), undefined);
+	});
+
 	test('openCompare while already-open with no overrides is a no-op (preserves in-flight comparison)', () => {
 		const { state, controller } = setup({ repoPath: '/A', graphRepoPath: '/A' });
 

--- a/src/webviews/apps/plus/graph/components/detailsState.ts
+++ b/src/webviews/apps/plus/graph/components/detailsState.ts
@@ -40,7 +40,11 @@ import type {
 	ReviewResult,
 	ScopeSelection,
 } from '../../../../plus/graph/graphService.js';
-import type { GraphActionTarget, GraphShowAction } from '../../../../plus/graph/protocol.js';
+import type {
+	DidRequestOpenCompareModeParams,
+	GraphActionTarget,
+	GraphShowAction,
+} from '../../../../plus/graph/protocol.js';
 import type { BranchMergeTargetStatus } from '../../../../rpc/services/branches.js';
 import type { AiModelInfo } from '../../../../rpc/services/types.js';
 import type { OverviewBranchIssue, OverviewBranchPullRequest } from '../../../../shared/overviewBranches.js';
@@ -479,6 +483,7 @@ function createTransientState() {
 	const branchCompareRightRef = signal<string | undefined>(undefined);
 	const branchCompareRightRefType = signal<'branch' | 'tag' | 'commit' | undefined>(undefined);
 	const branchCompareIncludeWorkingTree = signal(false);
+	const branchCompareGraphRepoPath = signal<string | undefined>(undefined);
 	// Worktree path currently checked out at `branchCompareRightRef` (the Compare side), populated
 	// by each summary fetch. Drives IWT-toggle visibility and routes WT-touching file ops to the
 	// correct repo path. Cleared synchronously on rightRef changes so the toggle hides during
@@ -565,6 +570,7 @@ function createTransientState() {
 		branchCompareRightRef: branchCompareRightRef,
 		branchCompareRightRefType: branchCompareRightRefType,
 		branchCompareIncludeWorkingTree: branchCompareIncludeWorkingTree,
+		branchCompareGraphRepoPath: branchCompareGraphRepoPath,
 		branchCompareRightRefWorktreePath: branchCompareRightRefWorktreePath,
 		branchCompareMergeBase: branchCompareMergeBase,
 		branchCompareStale: branchCompareStale,
@@ -639,20 +645,75 @@ export function createDetailsState() {
 /** Graph Details state type — the return value of `createDetailsState()`. */
 export type DetailsState = ReturnType<typeof createDetailsState>;
 
-/** The live task the user is engaged in — read by the account-gate's task-specific sign-in
- *  messaging and post-sign-in restore when a sign-out interrupts the task (#5534). An active
+/** The two sides of a Graph comparison, as `GlGraphDetailsPanel.openCompareMode` accepts them. */
+export type CompareModeParams = Omit<DidRequestOpenCompareModeParams, 'leftRef'> & { leftRef?: string };
+
+/** The comparison currently open in the panel (sheet or pinned form), or `undefined` when none is. */
+export function getOpenComparison(
+	state: DetailsState,
+	compareRepoPath?: string,
+): { compare?: CompareModeParams; graphRepoPath?: string } | undefined {
+	if (!state.compareSheetOpen.get() && !state.compareAsPanel.get()) return undefined;
+
+	const graphRepoPath = state.branchCompareGraphRepoPath.get();
+	const rightRef = state.branchCompareRightRef.get();
+	const repoPath = graphRepoPath ?? compareRepoPath;
+	const compare =
+		rightRef && repoPath
+			? {
+					repoPath: repoPath,
+					leftRef: state.branchCompareLeftRef.get(),
+					leftRefType: state.branchCompareLeftRefType.get(),
+					rightRef: rightRef,
+					rightRefType: state.branchCompareRightRefType.get(),
+					includeWorkingTree: state.branchCompareIncludeWorkingTree.get(),
+				}
+			: undefined;
+	return { compare: compare, graphRepoPath: graphRepoPath };
+}
+
+/** An interrupted comparison as parked by the access-gate capture.
+ * `refs` may be absent — a ref-less open compare (base picked, Compare side empty) still parks,
+ * so the restore can decline or default-shape it. */
+export type CapturedComparison = { refs?: CompareModeParams; graphRepoPath?: string };
+
+/** Whether a parked comparison capture should be restored. */
+export function shouldRestoreCapturedComparison(
+	capturedRefs: CompareModeParams | undefined,
+	capturedRepoFamily: string | undefined,
+	currentRepoFamily: string | undefined,
+	live: ReturnType<typeof getOpenComparison>,
+): boolean {
+	if (capturedRepoFamily != null && currentRepoFamily != null && capturedRepoFamily !== currentRepoFamily) {
+		return false;
+	}
+
+	if (live != null && (live.compare != null || capturedRefs == null)) return false;
+
+	return true;
+}
+
+/** The live task the user is engaged in — read by the access-gate's task-specific sign-in
+ *  messaging and post-sign-in restore when a wall interrupts the task (#5534). An active
  *  compose/review/resolve mode wins over an open compare — the two can coexist (the sheet sits
  *  over the panel) and the mode is the more specific task. WIP and single-commit anchors are
  *  carried as the target so the restore reopens the SAME content (a secondary worktree's WIP
  *  included); a multi-commit anchor isn't representable in a show target, so it restores
- *  mode-level onto the working changes. An open compare degrades the same way — the sheet's refs
- *  would need a two-ref show target (a protocol change), so the restore reopens the default
- *  compare shape (current branch vs working tree), not the interrupted refs. Compose seeds
- *  (a recompose commit-range, typed instructions) aren't representable either — an interrupted
- *  compose restores as a plain compose of its anchor. */
+ *  mode-level onto the working changes.
+ * An open compare carries its refs (#5671) via {@link getOpenComparison};
+ * without a right ref or a repo path the consumer falls back to the default compare shape.
+ * Compose seeds (a recompose commit-range, typed instructions) aren't representable */
 export function getActiveTaskAction(
 	state: DetailsState,
-): { action: GraphShowAction; target?: GraphActionTarget } | undefined {
+	compareRepoPath?: string,
+):
+	| {
+			action: GraphShowAction;
+			target?: GraphActionTarget;
+			compare?: CompareModeParams;
+			compareGraphRepoPath?: string;
+	  }
+	| undefined {
 	const mode = state.activeMode.get();
 	if (mode != null) {
 		const context = state.activeModeContext.get();
@@ -671,7 +732,10 @@ export function getActiveTaskAction(
 		return { action: `enter-${mode}`, target: target };
 	}
 
-	if (state.compareSheetOpen.get() || state.compareAsPanel.get()) return { action: 'open-compare' };
+	const open = getOpenComparison(state, compareRepoPath);
+	if (open != null) {
+		return { action: 'open-compare', compare: open.compare, compareGraphRepoPath: open.graphRepoPath };
+	}
 
 	return undefined;
 }

--- a/src/webviews/apps/plus/graph/components/detailsWorkflowController.ts
+++ b/src/webviews/apps/plus/graph/components/detailsWorkflowController.ts
@@ -542,6 +542,7 @@ export class DetailsWorkflowController implements ReactiveController {
 		state.branchCompareRightRef.set(rightRef);
 		state.branchCompareRightRefType.set(rightRefType);
 		state.branchCompareIncludeWorkingTree.set(compareOverrides?.includeWorkingTree ?? false);
+		state.branchCompareGraphRepoPath.set(this.host.graphRepoPath());
 		state.branchCompareRightRefWorktreePath.set(undefined);
 		state.branchCompareMergeBase.set(undefined);
 		state.branchCompareAheadCount.set(0);
@@ -634,6 +635,7 @@ export class DetailsWorkflowController implements ReactiveController {
 		state.branchCompareRightRef.set(undefined);
 		state.branchCompareRightRefType.set(undefined);
 		state.branchCompareIncludeWorkingTree.set(false);
+		state.branchCompareGraphRepoPath.set(undefined);
 		state.branchCompareRightRefWorktreePath.set(undefined);
 		state.branchCompareMergeBase.set(undefined);
 		state.branchCompareStale.set(false);

--- a/src/webviews/apps/plus/graph/components/gl-graph-details-panel.ts
+++ b/src/webviews/apps/plus/graph/components/gl-graph-details-panel.ts
@@ -26,9 +26,7 @@ import type {
 } from '../../../../plus/graph/graphService.js';
 import type {
 	GetWipLineStatsResponse,
-	GraphActionTarget,
 	GraphComposeScopeSeed,
-	GraphShowAction,
 	GraphSidebarPullRequest,
 	State,
 } from '../../../../plus/graph/protocol.js';
@@ -75,8 +73,14 @@ import type { DetailsActions } from './detailsActions.js';
 import { countReviewFindingSeverities, getReviewDiffEndpoints, scopeSelectionEqual } from './detailsActions.js';
 import { detailsActionsContext, detailsStateContext, detailsWorkflowContext } from './detailsContext.js';
 import { resolveDetailsActions } from './detailsResolver.js';
-import type { DetailsContext, DetailsState, RunningOperation, RunningOperationExecState } from './detailsState.js';
-import { createDetailsState, getActiveTaskAction } from './detailsState.js';
+import type {
+	CompareModeParams,
+	DetailsContext,
+	DetailsState,
+	RunningOperation,
+	RunningOperationExecState,
+} from './detailsState.js';
+import { createDetailsState, getActiveTaskAction, getOpenComparison } from './detailsState.js';
 import type { DetailsSelection } from './detailsWorkflowController.js';
 import { DetailsWorkflowController } from './detailsWorkflowController.js';
 import type { ExpandState, GlDetailsAgentStatus } from './gl-details-agent-status.js';
@@ -289,9 +293,16 @@ export class GlGraphDetailsPanel extends SignalWatcher(LitElement) {
 	}
 
 	/** The live task the user is engaged in — see {@link getActiveTaskAction}. Read by the
-	 *  account-gate's task-specific sign-in messaging (#5534) when a sign-out interrupts it. */
-	get activeTaskAction(): { action: GraphShowAction; target?: GraphActionTarget } | undefined {
-		return getActiveTaskAction(this._state);
+	 *  access-gate's task-specific sign-in messaging when a wall interrupts it */
+	get activeTaskAction(): ReturnType<typeof getActiveTaskAction> {
+		return getActiveTaskAction(this._state, this.effectiveRepoPath);
+	}
+
+	/** The comparison currently open in this panel, regardless of any coexisting mode.
+	 * The access-gate restore probes this: an open live comparison
+	 * must win over a parked capture even while a mode sits on top of it. */
+	get liveComparison(): ReturnType<typeof getOpenComparison> {
+		return getOpenComparison(this._state, this.effectiveRepoPath);
 	}
 
 	/** Per-mode exec state + has-result of the engaged anchor's entry — drives the suffix-icon
@@ -875,17 +886,7 @@ export class GlGraphDetailsPanel extends SignalWatcher(LitElement) {
 	 *  explicit left/right refs (e.g. from a sidebar tree compare action). The current graph
 	 *  selection is left untouched; both sides of the comparison are driven by the supplied
 	 *  overrides. */
-	openCompareMode(
-		params: {
-			repoPath: string;
-			leftRef?: string;
-			leftRefType?: 'branch' | 'tag' | 'commit';
-			rightRef: string;
-			rightRefType?: 'branch' | 'tag' | 'commit';
-			includeWorkingTree?: boolean;
-		},
-		onReady?: () => void,
-	): boolean {
+	openCompareMode(params: CompareModeParams, onReady?: () => void): boolean {
 		if (this._workflow == null) {
 			this._pendingCompare = { params: params, onReady: onReady };
 			return false;

--- a/src/webviews/apps/plus/graph/graph-app.ts
+++ b/src/webviews/apps/plus/graph/graph-app.ts
@@ -86,6 +86,8 @@ import { subscribeAll } from '../../shared/events/subscriptions.js';
 import '../shared/components/account-bar.js';
 import type { KeymapDispatcher } from '../../shared/keymap/keymapDispatcher.js';
 import { emitTelemetrySentEvent } from '../../shared/telemetry.js';
+import type { CapturedComparison } from './components/detailsState.js';
+import { shouldRestoreCapturedComparison } from './components/detailsState.js';
 import type { BranchSheetRef } from './components/gl-graph-branch-sheet-pane.js';
 import type { GlGraphDetailsPanel } from './components/gl-graph-details-panel.js';
 import type { GlGraphKeyboardShortcuts } from './components/gl-graph-keyboard-shortcuts.js';
@@ -572,6 +574,15 @@ export class GraphApp extends SignalWatcher(LitElement) {
 		const repos = this.graphState.repositories;
 		const repo = repoId != null ? repos?.find(r => r.id === repoId) : repos?.[0];
 		return repo?.commonPath ?? repo?.path;
+	}
+
+	/** Family key for a repository path — mirrors {@link fallbackRepoFamily}'s `commonPath ?? path`.
+	 *  Only called at RESTORE time, when the state carries a populated repository list. */
+	private familyOfRepoPath(repoPath: string | undefined): string | undefined {
+		if (!repoPath) return undefined;
+
+		const repo = this.graphState.repositories?.find(r => r.path === repoPath);
+		return repo?.commonPath ?? repo?.path ?? repoPath;
 	}
 
 	/** Whether the selected repository is virtual (GitHub/GitLab-hosted, no local git) — gates the
@@ -1647,7 +1658,11 @@ export class GraphApp extends SignalWatcher(LitElement) {
 	 *  task-specific messaging, and is consumed once access is granted. `@state` so a warm arrival
 	 *  re-renders the already-shown screen with the task copy. */
 	@state()
-	private _gatedPendingAction?: NonNullable<AppState['pendingAction']>;
+	private _gatedPendingAction?: NonNullable<AppState['pendingAction']> & {
+		/** An interrupted comparison from the wall capture — never host-delivered, so its
+		 *  presence marks the parked action as a capture and arms the restore guards */
+		capturedComparison?: CapturedComparison;
+	};
 	private _wasAccessGated = false;
 
 	/** Drives the welcome's live-sign-in copy variant: armed when the account wall clears live (a
@@ -1697,8 +1712,18 @@ export class GraphApp extends SignalWatcher(LitElement) {
 		scopeOrigin?: GraphScopeOrigin;
 		composeInstructions?: string;
 		composeScope?: GraphComposeScopeSeed;
+		capturedComparison?: CapturedComparison;
 	}): Promise<void> {
-		const { action, target, commitMessage, scopeBranch, scopeOrigin, composeInstructions, composeScope } = pending;
+		const {
+			action,
+			target,
+			commitMessage,
+			scopeBranch,
+			scopeOrigin,
+			composeInstructions,
+			composeScope,
+			capturedComparison,
+		} = pending;
 
 		if (action === 'scope-to-branch') {
 			// A target branch (from a Focus on Branch/Worktree command) scopes to it; otherwise scope
@@ -1714,12 +1739,24 @@ export class GraphApp extends SignalWatcher(LitElement) {
 			return;
 		}
 
+		if (action === 'open-compare' && capturedComparison != null) {
+			const capturedFamily = this.familyOfRepoPath(capturedComparison.graphRepoPath);
+			const live = this.detailsPanelEl?.liveComparison;
+			if (
+				!shouldRestoreCapturedComparison(capturedComparison.refs, capturedFamily, this.fallbackRepoFamily, live)
+			) {
+				return;
+			}
+		}
+
 		// When a target is supplied (e.g. context-menu invocation on a secondary WIP row), route
 		// the action to that row's worktree; otherwise fall back to the primary repo + uncommitted.
 		const repoPath = target?.worktreePath ?? this.fallbackRepoPath ?? '';
 		const sha = target?.sha ?? uncommitted;
-		this._selectedCommit = { sha: sha, repoPath: repoPath };
-		this._selectedCommits = undefined;
+		if (!(action === 'open-compare' && capturedComparison?.refs != null)) {
+			this._selectedCommit = { sha: sha, repoPath: repoPath };
+			this._selectedCommits = undefined;
+		}
 
 		// Reliably select the target row in the graph itself, not just the details panel. The host's
 		// selection notification is prop-driven and can drop the synthetic WIP row to a render race
@@ -1755,7 +1792,8 @@ export class GraphApp extends SignalWatcher(LitElement) {
 
 		if (action === 'open-compare') {
 			const compareParams =
-				target != null
+				capturedComparison?.refs ??
+				(target != null
 					? {
 							repoPath: repoPath,
 							leftRef: this.graphState.branch?.name ?? 'HEAD',
@@ -1767,7 +1805,7 @@ export class GraphApp extends SignalWatcher(LitElement) {
 							rightRef: this.graphState.branch?.name ?? 'HEAD',
 							rightRefType: 'branch' as const,
 							includeWorkingTree: true,
-						};
+						});
 			void this.withDetailsPanel(panel => panel.openCompareMode(compareParams), 'request-mode');
 			return;
 		}
@@ -2330,7 +2368,16 @@ export class GraphApp extends SignalWatcher(LitElement) {
 			if (!this._wasAccessGated && this._gatedPendingAction == null) {
 				const task = this.detailsPanelEl?.activeTaskAction;
 				if (task != null) {
-					this._gatedPendingAction = task;
+					this._gatedPendingAction =
+						task.action === 'open-compare'
+							? {
+									action: task.action,
+									capturedComparison: {
+										refs: task.compare,
+										graphRepoPath: task.compareGraphRepoPath,
+									},
+								}
+							: task;
 				}
 			}
 		} else if (this._wasAccessGated) {


### PR DESCRIPTION
The sign-out capture now carries the open comparison's refs — they already live in the durable branchCompare* signals, so no transport is involved — and the post-sign-in restore feeds them back into openCompareMode instead of rebuilding the default current-branch-vs- working-tree shape. Ref-less compares (no right ref yet, or no repo path) keep the default-shape restore.

(#5671)
