### PR TITLE
feat(integrations): filter pull request search by draft state

### DIFF
--- a/packages/core/CHANGELOG.md
+++ b/packages/core/CHANGELOG.md
@@ -6,6 +6,10 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/) and this p
 
 ## [Unreleased]
 
+### Added
+
+- Adds `draft` to `PullRequestSearchCriteria`, a tri-state boolean that narrows the filtered PR search on draft state — `true` returns only drafts, `false` only ready-for-review, omitted places no constraint; `false` is a distinct request rather than the absence of one, so emission and validation both key on `!= null`. GitHub/GHE emit `draft:true` / `draft:false` on every relationship × state facet and declare the flag on `getSupportedFilters().pullRequestSearch`. Other providers report it false and the facade refuses the read all-or-nothing, the same contract the criteria already follow: dropping an unsupported criterion would widen the provider query while its page and cursor still describe the narrower set. Follow-up to [#5665](https://github.com/gitkraken/vscode-gitlens/issues/5665), which shipped the filtered PR search this extends ([#5708](https://github.com/gitkraken/vscode-gitlens/issues/5708)) (plus/integrations, git, plus/git-github)
+
 ## [0.5.109] - 2026-08-12
 
 ### Added

--- a/packages/core/docs/integrations.md
+++ b/packages/core/docs/integrations.md
@@ -408,7 +408,7 @@ const filters = wanted.filter(f => capability.includes(f));
 - `pullRequestsAccountWide` — the optional account-wide PR capability. Treat a missing field as empty.
 - `pullRequestSearch` — the filtered PR search (`searchPullRequestsPage`). Always present; empty `relationships`
   means the provider has no such search. It declares the exact `relationships` and `states`, plus `text`,
-  `includeArchived`, `repositoryScope`, and `organizationScope`.
+  `draft`, `includeArchived`, `repositoryScope`, and `organizationScope`.
 - `issues` — the **repo-scoped** git-host read, **and** the issue-tracker read
   (`listIssueTrackerIssuesPage` validates against this field).
 - `issuesAccountWide` — the account-wide git-host read only. Usually narrower (GitLab can express
@@ -479,9 +479,11 @@ Account-wide PR filters: GitHub/GHE `Author, Assignee, ReviewRequested, Mention`
 `Author, Assignee, ReviewRequested` · Bitbucket + Bitbucket DC `Author, ReviewRequested` · Azure
 `Author, Assignee, ReviewRequested`.
 PR **search** capabilities (`getSupportedFilters().pullRequestSearch`): GitHub/GHE express relationships
-`Author, Assignee, ReviewRequested, Mention`, states `open, closed, merged, all`, `text`, `includeArchived`, and
-repository/organization scopes. Every other provider declares empty lists and false flags, so the read is refused
-rather than returning a page that did not apply a requested criterion or scope.
+`Author, Assignee, ReviewRequested, Mention`, states `open, closed, merged, all`, `text`, `draft`,
+`includeArchived`, and repository/organization scopes. Every other provider declares empty lists and false flags, so
+the read is refused rather than returning a page that did not apply a requested criterion or scope. `draft` is
+tri-state: `true` returns only drafts, `false` only ready-for-review PRs, and omitting it places no constraint — so
+a consumer sending `draft: false` must not treat it as "unset".
 Issue filters: GitHub/GHE + Azure + Jira `Author, Assignee, Mention` · GitLab `Author, Assignee` ·
 Linear + Trello `Assignee` · Bitbucket family none.
 Account-wide issue filters: GitHub/GHE `Author, Assignee, Mention` · Azure `Author, Assignee` · GitLab

--- a/packages/git/src/models/pullRequest.ts
+++ b/packages/git/src/models/pullRequest.ts
@@ -183,6 +183,11 @@ export interface PullRequestSearchCriteria {
 	states?: PullRequestStateFilter[];
 	/** Includes PRs from archived repositories. They are excluded by default. */
 	includeArchived?: boolean;
+	/**
+	 * Narrows on draft state: `true` returns only drafts, `false` only ready-for-review PRs. Omitted places no
+	 * constraint. A boolean rather than a truthy flag because `false` is a distinct request, not the absence of one.
+	 */
+	draft?: boolean;
 }
 
 /**
@@ -196,6 +201,8 @@ export interface PullRequestSearchCapabilities {
 	states: PullRequestStateFilter[];
 	text: boolean;
 	includeArchived: boolean;
+	/** Whether the provider can constrain the search by draft state server-side. */
+	draft: boolean;
 	/** Whether the manager's repository-descriptor scope is supported. */
 	repositoryScope: boolean;
 	/** Whether the manager's organization scope is supported. */

--- a/packages/plus/git-github/src/api/__tests__/pullRequestSearch.test.ts
+++ b/packages/plus/git-github/src/api/__tests__/pullRequestSearch.test.ts
@@ -169,6 +169,28 @@ suite('GitHubApi.searchPullRequestsPage', () => {
 		assert.doesNotMatch(query, /@me/);
 	});
 
+	test('emits the draft qualifier only for the state it was set to, and never when omitted', async () => {
+		const onlyDrafts = capture();
+		await new GitHubApi(onlyDrafts.config).searchPullRequestsPage(provider, token, {
+			repos: ['o/a'],
+			criteria: { draft: true },
+		});
+		assert.match(search(onlyDrafts.getCalls()[0], 'scopeOpen'), /draft:true/);
+
+		const readyForReview = capture();
+		await new GitHubApi(readyForReview.config).searchPullRequestsPage(provider, token, {
+			repos: ['o/a'],
+			criteria: { draft: false },
+		});
+		const readyQuery = search(readyForReview.getCalls()[0], 'scopeOpen');
+		assert.match(readyQuery, /draft:false/);
+		assert.doesNotMatch(readyQuery, /draft:true/);
+
+		const unconstrained = capture();
+		await new GitHubApi(unconstrained.config).searchPullRequestsPage(provider, token, { repos: ['o/a'] });
+		assert.doesNotMatch(search(unconstrained.getCalls()[0], 'scopeOpen'), /draft:/);
+	});
+
 	test('uses a cost-safe default page size while preserving the explicit maximum', async () => {
 		const { config, getCalls } = capture([{}, {}]);
 		const api = new GitHubApi(config);

--- a/packages/plus/git-github/src/api/pullRequestSearchQuery.ts
+++ b/packages/plus/git-github/src/api/pullRequestSearchQuery.ts
@@ -70,6 +70,8 @@ export function toGitHubPullRequestSearchFacets(
 				'is:pr',
 				...(relationship != null ? [relationshipQualifier[relationship]] : []),
 				...stateQualifiers(state),
+				// `!= null`, not truthy: `draft:false` narrows to ready-for-review PRs just as `draft:true` narrows to drafts.
+				...(criteria?.draft != null ? [`draft:${criteria.draft}`] : []),
 				...(criteria?.includeArchived === true ? [] : ['archived:false']),
 				...(text.length > 0 ? [text] : []),
 				// Contract, not an option: a capped result is the N most recently updated only under this order.

--- a/packages/plus/integrations/src/__tests__/facadeSupportedFilters.test.ts
+++ b/packages/plus/integrations/src/__tests__/facadeSupportedFilters.test.ts
@@ -207,6 +207,7 @@ suite('IntegrationManager.getSupportedFilters', () => {
 					states: [],
 					text: false,
 					includeArchived: false,
+					draft: false,
 					repositoryScope: false,
 					organizationScope: false,
 				});
@@ -228,6 +229,7 @@ suite('IntegrationManager.getSupportedFilters', () => {
 					states: ['open', 'closed', 'merged', 'all'],
 					text: true,
 					includeArchived: true,
+					draft: true,
 					repositoryScope: true,
 					organizationScope: true,
 				});

--- a/packages/plus/integrations/src/__tests__/pullRequestSearch.test.ts
+++ b/packages/plus/integrations/src/__tests__/pullRequestSearch.test.ts
@@ -211,6 +211,11 @@ suite('IntegrationManager.searchPullRequestsPage', () => {
 					criteria: { relationships: [PullRequestFilter.Author], includeArchived: true },
 					expected: /includeArchived/,
 				},
+				{
+					capabilities: { ...supported!, draft: false },
+					criteria: { relationships: [PullRequestFilter.Author], draft: true },
+					expected: /draft/,
+				},
 			];
 
 			for (const testCase of cases) {

--- a/packages/plus/integrations/src/providers/models.ts
+++ b/packages/plus/integrations/src/providers/models.ts
@@ -870,6 +870,7 @@ const githubPullRequestSearchCapabilities: PullRequestSearchCapabilities = {
 	states: ['open', 'closed', 'merged', 'all'],
 	text: true,
 	includeArchived: true,
+	draft: true,
 	repositoryScope: true,
 	organizationScope: true,
 };

--- a/packages/plus/integrations/src/reads/filters.ts
+++ b/packages/plus/integrations/src/reads/filters.ts
@@ -107,6 +107,10 @@ export function resolvePullRequestSearchCriteria(
 	if (criteria.includeArchived === true && !supported.includeArchived) {
 		unsupported.push('includeArchived');
 	}
+	// `!= null`, not truthy: `draft: false` (only ready-for-review) is as much a request as `draft: true`.
+	if (criteria.draft != null && !supported.draft) {
+		unsupported.push('draft');
+	}
 
 	return unsupported.length > 0 ? { rejection: { reason: 'unsupported-criteria', criteria: unsupported } } : {};
 }
@@ -280,6 +284,7 @@ const unsupportedPullRequestSearchCapabilities: PullRequestSearchCapabilities = 
 	states: [],
 	text: false,
 	includeArchived: false,
+	draft: false,
 	repositoryScope: false,
 	organizationScope: false,
 };

--- a/packages/plus/integrations/src/reads/warnings.ts
+++ b/packages/plus/integrations/src/reads/warnings.ts
@@ -287,6 +287,7 @@ function describePullRequestSearchCapabilities(capabilities: PullRequestSearchCa
 		...(capabilities.states.length ? [`states:${capabilities.states.join('|')}`] : []),
 		...(capabilities.text ? ['text'] : []),
 		...(capabilities.includeArchived ? ['includeArchived'] : []),
+		...(capabilities.draft ? ['draft'] : []),
 		...(capabilities.repositoryScope ? ['repository scope'] : []),
 		...(capabilities.organizationScope ? ['organization scope'] : []),
 	].join(', ');


### PR DESCRIPTION
# Description

Adds a `draft` channel to the filtered pull-request search, so a caller can narrow on draft state — the "not ready to look at" distinction most PR workflows treat as first-class. `PullRequestSearchCriteria` gains a tri-state `draft` (`true` returns only drafts, `false` only ready-for-review, omitted places no constraint); `false` is a distinct request rather than the absence of one, so emission and validation both key on `!= null`.

GitHub/GHE emit `draft:true` / `draft:false` on every relationship × state facet, alongside the existing state qualifiers, and declare the flag on `getSupportedFilters().pullRequestSearch`. Other providers report it false and the facade refuses the read all-or-nothing — the same contract the existing criteria follow: dropping an unsupported criterion would widen the provider query while its page and cursor still describe the narrower set.

Follow-up to #5665, which shipped the filtered PR search this extends.

Closes #5708

## Changes

- `PullRequestSearchCriteria` / `PullRequestSearchCapabilities` — new `draft` field and capability flag (`packages/git`)
- PR query builder emits `draft:true` / `draft:false` per facet (`packages/plus/git-github`)
- GitHub/GHE capability table declares the flag; unsupported baseline, all-or-nothing validation, and the refusal message's "supported" list extended (`packages/plus/integrations`)
- Tests: draft-qualifier emission (true/false/omitted) in git-github, facade validation case, capability-parity assertions
- CHANGELOG entry (`packages/core`)

## Testing

- `@gitlens/git-github` unit tests pass (112), including the new draft-qualifier test.

> Note: `pnpm run check` and the `@gitlens/integrations` test suite currently fail on the base `core` branch, independent of this change, because the merged issue-sort work depends on an unreleased `@gitkraken/provider-apis` (the pinned `0.55.0` does not export `SUPPORTED_ISSUE_SORTS` et al.). Verified identical with and without this branch's changes; none of this PR's files appear in those failures.

# Checklist

- [x] I have followed the guidelines in the Contributing document
- [x] My changes follow the coding style of this project
- [ ] My changes build without any errors or warnings <!-- base branch has a pre-existing provider-apis break; see Testing note -->
- [x] My changes have been formatted and linted
- [x] My changes include any required corresponding changes to the documentation (including CHANGELOG.md)
- [x] My changes have been rebased and squashed to the minimal number (typically 1) of relevant commits
- [x] My changes have a descriptive commit message with a short title, including a `Closes #XXX -` prefix
