### PR TITLE
Fixes graphDetails close-panel E2E to assert dismissed state

### DIFF
--- a/tests/e2e/specs/graphDetails.test.ts
+++ b/tests/e2e/specs/graphDetails.test.ts
@@ -272,8 +272,17 @@ test.describe('Graph Details - Panel Visibility', () => {
 		await expect(hideButton).toBeVisible({ timeout: MaxTimeout });
 		await hideButton.click();
 
-		// Details content should no longer be visible
-		await expect(graphWebview.locator('.details-content')).not.toBeVisible({ timeout: MaxTimeout });
+		// The split panel is always rendered to avoid DOM re-parenting (which causes layout jumps);
+		// hiding collapses it (split position pinned to 100) and marks the details pane `inert` rather
+		// than unmounting `.details-content`. That element therefore stays in the DOM at ~0 size — a
+		// residual that rounds to 1–2px on some renderers — so `not.toBeVisible()` on it is not an
+		// invariant the implementation guarantees. Assert the observable dismissed state instead: the
+		// toggle flips to "Show Details Panel" and the details pane is inert (its content unreachable).
+		const showButton = graphWebview.locator('gl-button[aria-label="Show Details Panel"]').first();
+		await expect(showButton).toBeVisible({ timeout: MaxTimeout });
+		await expect(graphWebview.locator('.graph__details-pane').first()).toHaveAttribute('inert', '', {
+			timeout: MaxTimeout,
+		});
 	});
 });
 


### PR DESCRIPTION
## Problem

The E2E test `graphDetails.test.ts` › `should close details panel via the details-panel toggle` asserted `not.toBeVisible()` on `.details-content`. The split panel is **always rendered** to avoid DOM re-parenting (layout jumps): hiding collapses it (split `position` pinned to `100`) and marks the details pane `inert` rather than unmounting the content. So `.details-content` stays in the DOM at ~0 size — a residual that rounds to **1–2px on some renderers** (bottom orientation → height axis) and to exactly 0 on others. The assertion passed only where device-pixel rounding landed on 0 (CI VS Code) and failed elsewhere (Windsurf, Positron, local). Because the block runs `serial`, the failure aborted 15 downstream tests in the file.

This is a **wrong test invariant**, not a product defect.

## Evidence (measured live after Hide, VS Code, local)

```
viewport 871x544, dpr 1
.details-content:      w=871  h=1px  top=545  display=flex  visible
.graph__details-pane:  w=871  h=2px  inert=true
gl-split-panel:        position=100  orientation=vertical (bottom)  maximized=false
toggle aria-label:     "Show Details Panel"
```

Panel is genuinely dismissed (position 100, pane inert, toggle flipped); residual is subpixel, not real height.

## Fix

Assert the observable dismissed state the implementation guarantees — the toggle flips to **Show Details Panel** and the details pane is `inert` (content unreachable) — with a comment explaining why `not.toBeVisible()` on `.details-content` is not a held invariant. Not weakened, not skipped.

## Validation (local, `--project=vscode --workers=1 --retries=0`)

- `:265` isolated → **1 passed**
- full `graphDetails.test.ts` → **19 passed** (previously 1 failed / 15 did not run)
- group `treeView` + `graphConflictResolution` + `graphHeader` + `graphReview` + `smoke` + `graphRowActions` + `graphDetails` → **61 passed**
- `oxlint --type-aware --type-check` + `tsc -p tests/e2e/tsconfig.json` → clean

Forks not run locally (no binaries); mechanism above explains all environments and the new assertion is independent of subpixel geometry.
