### PR TITLE
Fixes the Commit Graph author avatar rendering as an oval when narrow

### DIFF
--- a/packages/plus/commit-graph/src/view.ts
+++ b/packages/plus/commit-graph/src/view.ts
@@ -125,7 +125,12 @@ export interface ZoneSpec {
 	hidden?: boolean;
 }
 
-// minWidth floors: ref/author 32 and message 50 (flex) match the legacy gitkraken-components zones;
+// minWidth floors: ref 32 and message 50 (flex) match the legacy gitkraken-components zones;
+// author (34) is the floor that still fits its content: at/below the floor the cell drops the name and
+// shows only the 1.8rem avatar, so 34 = that avatar + the zone's 0.8rem×2 border-box padding — the
+// legacy 32 left the content box 2px narrower than the avatar (VS Code's injected webview default
+// `img { max-width: 100% }` then squished the circle into an oval; the stylesheet also counters that,
+// but the floor should fit the avatar regardless);
 // date (44) is tighter than the legacy 50 since it renders in ultra-compact form ("2d") when narrow;
 // changes (36) is below the legacy CHANGES_ZONE_MIN_WIDTH of 50 on purpose — the cell degrades to a
 // single centered glyph at that floor (see `changesStageForWidth`), so it stays useful where the old
@@ -137,7 +142,7 @@ export interface ZoneSpec {
 export const defaultZones: readonly ZoneSpec[] = [
 	{ id: 'ref', label: 'Branches / Tags', width: 180, minWidth: 32 },
 	{ id: 'message', label: 'Message', width: 0, minWidth: 50, flex: true },
-	{ id: 'author', label: 'Author', width: 140, minWidth: 32 },
+	{ id: 'author', label: 'Author', width: 140, minWidth: 34 },
 	{ id: 'changes', label: 'Changes', width: 36, minWidth: 36, mode: 'bar' },
 	{ id: 'datetime', label: 'Date', width: 80, minWidth: 44 },
 	{ id: 'sha', label: 'SHA', width: 76, minWidth: 44 },

--- a/src/webviews/apps/plus/graph/graph.scss
+++ b/src/webviews/apps/plus/graph/graph.scss
@@ -1768,6 +1768,8 @@ gl-lit-graph {
 		flex-shrink: 0;
 		width: 1.8rem;
 		height: 1.8rem;
+		max-width: none;
+		max-height: none;
 		border-radius: 50%;
 		object-fit: cover;
 	}

--- a/src/webviews/plus/graph/graphWebview.utils.ts
+++ b/src/webviews/plus/graph/graphWebview.utils.ts
@@ -68,7 +68,7 @@ export const defaultGraphColumnsSettings: GraphColumnsSettings = {
 	ref: { width: 130, isHidden: false, order: 0, isFilterable: true },
 	graph: { width: 150, mode: undefined, isHidden: false, order: 1 },
 	message: { width: 300, isHidden: false, order: 2, isFilterable: true },
-	author: { width: 32, isHidden: false, order: 3, isFilterable: true },
+	author: { width: 34, isHidden: false, order: 3, isFilterable: true },
 	changes: { width: 36, isHidden: false, order: 4, isFilterable: true },
 	datetime: { width: 44, isHidden: false, order: 5, isFilterable: true },
 	sha: { width: 44, isHidden: false, order: 6, isFilterable: true },
@@ -77,7 +77,7 @@ export const defaultGraphColumnsSettings: GraphColumnsSettings = {
 export const compactGraphColumnsSettings: GraphColumnsSettings = {
 	ref: { width: 32, isHidden: false, isFilterable: true },
 	graph: { width: 150, mode: 'compact', isHidden: false },
-	author: { width: 32, isHidden: false, order: 2, isFilterable: true },
+	author: { width: 34, isHidden: false, order: 2, isFilterable: true },
 	message: { width: 500, isHidden: false, order: 3, isFilterable: true },
 	changes: { width: 36, isHidden: false, order: 4, isFilterable: true },
 	datetime: { width: 130, isHidden: true, order: 5, isFilterable: true },


### PR DESCRIPTION
# Description

<img width="800" alt="image" src="https://github.com/user-attachments/assets/b1fdbc87-05f0-46cf-a4d8-90dbc9d50b12" />


---

The author column's avatar in the Commit Graph rendered as a subtle oval (16×18) instead of a circle at the column's default/minimum width.

**Root cause:** VS Code injects `img { max-width: 100%; max-height: 100% }` into every webview. The author column's floor — which is also its default width — was 32px; with the cell's `0.8rem × 2` border-box padding that leaves a 16px content box for the 1.8rem (18px) avatar, so the injected rule clamped the image's width to 16px while the height stayed 18px. The initials fallback (a `<span>`) isn't affected by that rule, which is why only image avatars looked off.

**Fix, two layers:**

- `.gl-graph__avatar` now sets `max-width: none; max-height: none`, so the injected webview default can never deform the circle no matter how narrow the cell gets.
- The author zone's `minWidth` and the default/compact layout widths go from 32 to 34px (avatar + the zone's border-box padding), so the avatar-only floor actually fits its content — mirroring how the changes column's floor was sized. Existing persisted 32px widths are clamped up automatically by the layout solver.

Verified by reproducing the exact DOM/CSS in Chromium with VS Code's injected defaults: the avatar measured 16×18 at a 32px column before the fix, 18×18 in all cases after.

# Checklist

- [x] I have followed the guidelines in the Contributing document
- [x] My changes follow the coding style of this project
- [x] My changes build without any errors or warnings
- [x] My changes have been formatted and linted
- [x] My changes include any required corresponding changes to the documentation (including CHANGELOG.md and README.md) — no CHANGELOG entry: the reworked graph is still entirely in the Unreleased section, so this fixes a defect that never shipped
- [x] My changes have been rebased and squashed to the minimal number (typically 1) of relevant commits
- [x] My changes have a descriptive commit message with a short title — no issue reference: reported directly in chat

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_017zn8Ps2UKunA8hpgpAz2z4

---
_Generated by [Claude Code](https://claude.ai/code/session_017zn8Ps2UKunA8hpgpAz2z4)_