### PR TITLE
Fixes dismissed onboarding re-appearing in new windows

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -76,6 +76,7 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/) and this p
 
 ### Fixed
 
+- Fixes dismissed onboarding &mdash; the _Commit Graph_'s welcome and coach marks, banners, callouts, and other one-time surfaces &mdash; re-appearing in new windows and after window reloads: all onboarding state is saved together, and a save from a window still holding state from before a dismissal (dismissals never reach other open windows) wrote that older state back, silently un-dismissing what was dismissed elsewhere; saves now always apply to the freshest stored state, and activation no longer rewrites the state when there's nothing to migrate
 - Fixes signing back in after a sign-out interrupted a _Commit Graph_ comparison reopening the comparison on different references &mdash; the interrupted comparison's own references are now carried across the sign-in instead of the default current-branch-versus-working-tree shape ([#5671](https://github.com/gitkraken/vscode-gitlens/issues/5671))
 - Fixes AI agent sessions from other AI CLIs (Codex, GitHub Copilot CLI, Cursor, OpenCode, Antigravity) appearing as _Claude Code_ sessions on _Home_ and the _Commit Graph_ ([#5715](https://github.com/gitkraken/vscode-gitlens/issues/5715))
 - Fixes rows in the _Commit Graph_ side bar panels nudging their trailing decorations to the left on hover

--- a/src/onboarding/__tests__/onboardingService.test.ts
+++ b/src/onboarding/__tests__/onboardingService.test.ts
@@ -1,0 +1,110 @@
+import * as assert from 'assert';
+import '../../container.js';
+import type { Storage } from '../../system/-webview/storage.js';
+import { OnboardingService } from '../onboardingService.js';
+
+type Backing = Map<string, unknown>;
+
+function createFakeStorage(backing: Backing, onStore?: () => void): Storage {
+	const clone = <T>(value: T): T => (value == null ? value : structuredClone(value));
+	const fake = {
+		onDidChange: () => ({ dispose: () => {} }),
+		get: (key: string): unknown => clone(backing.get(`global|${key}`)),
+		getWorkspace: (key: string): unknown => clone(backing.get(`workspace|${key}`)),
+		store: (key: string, value: unknown): Promise<void> => {
+			onStore?.();
+			if (value === undefined) {
+				backing.delete(`global|${key}`);
+			} else {
+				backing.set(`global|${key}`, clone(value));
+			}
+
+			return Promise.resolve();
+		},
+		storeWorkspace: (key: string, value: unknown): Promise<void> => {
+			onStore?.();
+			if (value === undefined) {
+				backing.delete(`workspace|${key}`);
+			} else {
+				backing.set(`workspace|${key}`, clone(value));
+			}
+
+			return Promise.resolve();
+		},
+		delete: (key: string): Promise<void> => {
+			backing.delete(`global|${key}`);
+
+			return Promise.resolve();
+		},
+	};
+	return fake as unknown as Storage;
+}
+
+suite('OnboardingService Test Suite', () => {
+	test('dismissal persists across service instances (window reload)', async () => {
+		const backing: Backing = new Map();
+
+		const first = new OnboardingService(createFakeStorage(backing), '19.0.0');
+		await first.ready;
+		await first.dismiss('graph:intro');
+		first.dispose();
+
+		const second = new OnboardingService(createFakeStorage(backing), '19.0.0');
+		await second.ready;
+		try {
+			assert.strictEqual(second.isDismissed('graph:intro'), true);
+		} finally {
+			second.dispose();
+		}
+	});
+
+	test('a write from a window activated before a dismissal must not resurrect it', async () => {
+		const backing: Backing = new Map();
+
+		const windowA = new OnboardingService(createFakeStorage(backing), '19.0.0');
+		await windowA.ready;
+		windowA.dispose();
+
+		const windowB = new OnboardingService(createFakeStorage(backing), '19.0.0');
+		await windowB.ready;
+		await windowB.dismiss('graph:intro');
+		windowB.dispose();
+
+		await windowA.dismiss('graph:coachMark:details');
+
+		const windowC = new OnboardingService(createFakeStorage(backing), '19.0.0');
+		await windowC.ready;
+		try {
+			assert.strictEqual(
+				windowC.isDismissed('graph:intro'),
+				true,
+				"window A's stale write resurrected graph:intro",
+			);
+			assert.strictEqual(windowC.isDismissed('graph:coachMark:details'), true);
+		} finally {
+			windowC.dispose();
+		}
+	});
+
+	test('activation of an already-migrated state does not write', async () => {
+		const backing: Backing = new Map();
+		let stores = 0;
+
+		const first = new OnboardingService(
+			createFakeStorage(backing, () => stores++),
+			'19.0.0',
+		);
+		await first.ready;
+		first.dispose();
+		assert.ok(stores > 0, 'the initial migration should persist its completion marker');
+
+		stores = 0;
+		const second = new OnboardingService(
+			createFakeStorage(backing, () => stores++),
+			'19.0.0',
+		);
+		await second.ready;
+		second.dispose();
+		assert.strictEqual(stores, 0, 'an already-migrated activation should not rewrite the state');
+	});
+});

--- a/src/onboarding/onboardingService.ts
+++ b/src/onboarding/onboardingService.ts
@@ -82,9 +82,9 @@ export class OnboardingService implements Disposable {
 	private onStorageChanged(e: StorageChangeEvent): void {
 		if (e.type === 'scoped' || !e.keys.includes('onboarding:state')) return;
 
-		// Invalidate the appropriate cache when storage changes externally
+		// Saves made through this service pass the same (already updated) snapshot object, so the
+		// diff below only finds changes for writes made behind our back (e.g. a storage reset)
 		const previousState = this._onboarding[e.type];
-		this._onboarding[e.type] = undefined;
 
 		if (previousState != null) {
 			const currentState = this.getOnboarding(e.type);
@@ -269,6 +269,8 @@ export class OnboardingService implements Disposable {
 		const migratedVersion = onboarding.migratedVersion ?? (onboarding.migrated ? '17.8.0' : undefined);
 		/* oxlint-enable typescript/no-deprecated */
 
+		if (migratedVersion != null && compare(migratedVersion, '17.9.0') >= 0) return;
+
 		// Batch 1 (17.8.0): Original deprecated key migrations
 		if (!migratedVersion || compare(migratedVersion, '17.8.0') < 0) {
 			const batch1: { legacy: keyof DeprecatedGlobalStorage; current: OnboardingKeys }[] = [
@@ -357,13 +359,10 @@ export class OnboardingService implements Disposable {
 	}
 
 	private getOnboarding(scope: OnboardingStorageType): OnboardingStorage {
-		let onboarding = this._onboarding[scope];
-		if (onboarding == null) {
-			onboarding = (scope === 'workspace'
-				? this.storage.getWorkspace('onboarding:state')
-				: this.storage.get('onboarding:state')) ?? { items: {} };
-			this._onboarding[scope] = onboarding;
-		}
+		const onboarding = (scope === 'workspace'
+			? this.storage.getWorkspace('onboarding:state')
+			: this.storage.get('onboarding:state')) ?? { items: {} };
+		this._onboarding[scope] = onboarding;
 		return onboarding;
 	}
 


### PR DESCRIPTION
# Description

The Commit Graph's "Welcome to the Commit Graph" gate (`graph:intro`) kept re-appearing in every new window and after window reloads, even though the flag is already stored globally.

**Root cause:** all onboarding state persists as one aggregated `gitlens:onboarding:state` key in `globalState`, and `OnboardingService` served every read and write from a snapshot cached at first read (which happens during activation in every window, via `migrateLegacyState`). VS Code broadcasts `globalState` writes into the other running windows' extension hosts, but no event reaches the extension for those external changes — so the snapshot in every other open window went stale the moment one window dismissed something. Any later onboarding write from such a window (a coach mark's seen-state, a banner/callout dismissal, the layout prompt) then saved the entire stale aggregate back, silently resurrecting items dismissed elsewhere. This affects every dismissible surface, not just the Graph intro — the intro is just the most visible victim now that the graph writes coach-mark state routinely.

**Fix:**

- `OnboardingService.getOnboarding` now always reads through to the memento (which VS Code keeps fresh across windows), keeping the old snapshot only as the "previous" side of the external-change diff in `onStorageChanged` — the same read-through pattern `UsageTracker` already uses, which is why usage/walkthrough state never had this problem
- `migrateLegacyState` no longer rewrites the whole aggregate on every activation when there is nothing left to migrate
- Also fixes a literal `&mdash;` rendering as text in the welcome body copy (the entity sat in a plain string interpolated into the Lit template, so Lit escaped it)

Regression tests in `src/onboarding/__tests__/onboardingService.test.ts` model the multi-window scenario over a shared backing store with clone-on-read semantics; the "stale window resurrects a dismissal" and "activation rewrites migrated state" tests fail on the previous code and pass with the fix.

# Checklist

- [x] I have followed the guidelines in the Contributing document
- [x] My changes follow the coding style of this project
- [x] My changes build without any errors or warnings
- [x] My changes have been formatted and linted
- [x] My changes include any required corresponding changes to the documentation (including CHANGELOG.md and README.md)
- [x] My changes have been rebased and squashed to the minimal number (typically 1) of relevant commits
- [x] My changes have a descriptive commit message with a short title

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01NhWrffdMSoQ4L1v2LtgdH6

---
_Generated by [Claude Code](https://claude.ai/code/session_01NhWrffdMSoQ4L1v2LtgdH6)_