### PR TITLE
Fixes the two fork-only Graph details E2E failures left after #5721

### DIFF
--- a/tests/e2e/specs/graphConflictResolution.test.ts
+++ b/tests/e2e/specs/graphConflictResolution.test.ts
@@ -29,7 +29,7 @@
 import * as process from 'node:process';
 import type { FrameLocator } from '@playwright/test';
 import type { VSCodeInstance } from '../baseTest.js';
-import { test as base, createTmpDir, expect, GitFixture, MaxTimeout } from '../baseTest.js';
+import { test as base, createTmpDir, DefaultTimeout, expect, GitFixture, MaxTimeout } from '../baseTest.js';
 import { ensureGraphRowsRendered, scrollDetailsToFileTree, widenSideBarForGraph } from '../graphHelpers.js';
 
 const uncommittedSha = '0000000000000000000000000000000000000000';
@@ -75,63 +75,63 @@ function conflictFileContext(webview: FrameLocator) {
 }
 
 /**
- * Ensure the graph's details panel is collapsed, so the graph itself gets the pane's full height.
+ * Open or collapse the graph's details panel.
  *
- * The details panel splits the side bar's height with the graph, and once it is open the graph can be
- * left with too little room for its virtualizer to mount ANY row: measured on a cramped host, an open
- * panel leaves the graph pane at 26px with the commit tree at height 0 and zero `role="treeitem"` in
- * the DOM, while collapsing it puts the tree back at 19px with its rows mounted. A row gate run in the
- * first state reports "element(s) not found", which reads as a graph that never painted.
+ * Which state a step needs is load-bearing here, because the panel splits the side bar's HEIGHT with
+ * the graph. Open, it can leave the graph too short for its virtualizer to mount ANY row: measured on a
+ * cramped host, an open panel left the graph pane at 26px with the commit tree at height 0 and zero
+ * `role="treeitem"` in the DOM, while collapsing it put the tree back at 19px with its rows mounted. So
+ * anything that gates on graph rows — or clicks one — has to run while it is collapsed, and only the
+ * WIP details themselves need it open. This file reaches the starved state on its own: its gate opens
+ * the panel and the graph webview is retained across `resetUI`, so each test inherits the previous
+ * one's panel. The wider CI VS Code window has room to spare; the fork legs (Windsurf, Positron) did
+ * not.
  *
- * That state is reachable here because this file's own gate opens the panel and the graph webview is
- * retained across `resetUI`, so each test inherits the previous one's panel — on the wider CI VS Code
- * window there is room to spare, but the fork legs (Windsurf, Positron) ran out of it.
+ * Gated on the pane's `inert` attribute rather than the toggle's label: `inert` is bound directly to
+ * `graphState.details.visible` (`graph-app.ts`, `?inert=${!detailsVisible}`), so it can't report a
+ * transient pre-render label the way a single `aria-label` read can, and it is the same invariant
+ * `graphDetails.test.ts` asserts. Retried, because the click and that state land a frame apart.
  */
-async function ensureDetailsPanelClosed(webview: FrameLocator): Promise<void> {
-	const toggle = webview.locator('gl-button[aria-label$="Details Panel"]').first();
-	await expect(toggle).toBeVisible({ timeout: MaxTimeout });
-	if ((await toggle.getAttribute('aria-label')) !== 'Hide Details Panel') return;
+async function setDetailsPanel(webview: FrameLocator, open: boolean): Promise<void> {
+	const pane = webview.locator('.graph__details-pane').first();
+	const toggle = webview.locator(`gl-button[aria-label="${open ? 'Show' : 'Hide'} Details Panel"]`).first();
 
-	await toggle.click();
-	await expect(webview.locator('gl-button[aria-label="Show Details Panel"]').first()).toBeVisible({
-		timeout: MaxTimeout,
-	});
+	await expect(async () => {
+		if (await toggle.isVisible().catch(() => false)) {
+			await toggle.click({ timeout: DefaultTimeout }).catch(() => {});
+		}
+
+		if (open) {
+			await expect(pane).not.toHaveAttribute('inert', '', { timeout: DefaultTimeout });
+		} else {
+			await expect(pane).toHaveAttribute('inert', '', { timeout: DefaultTimeout });
+		}
+	}).toPass({ timeout: MaxTimeout });
 }
 
-/** Ensure the graph's details panel is expanded (it may start collapsed). */
-async function ensureDetailsPanelOpen(webview: FrameLocator): Promise<void> {
-	const toggle = webview.locator('gl-button[aria-label$="Details Panel"]').first();
-	await expect(toggle).toBeVisible({ timeout: MaxTimeout });
-	if ((await toggle.getAttribute('aria-label')) === 'Show Details Panel') {
-		await toggle.click();
-		await expect(webview.locator('gl-button[aria-label="Hide Details Panel"]').first()).toBeVisible({
-			timeout: MaxTimeout,
-		});
-	}
+/**
+ * Select the WIP row. Kept separate from opening its details because the click needs the panel
+ * COLLAPSED: the row it targets only exists in the DOM while the graph has the height to render it (see
+ * {@link setDetailsPanel}).
+ */
+async function selectWipRow(webview: FrameLocator): Promise<void> {
+	// New Lit engine: role="treeitem", accessible name "Working Changes". Forced, because a conflicted
+	// WIP row carries adornment overlays (the "Resolve Conflicts…" chip and the modified-file stats pill)
+	// that sit over it on slower/contended renders (the workers=4 flake).
+	const wipRow = webview
+		.getByRole('treeitem', { name: /Working Changes/ })
+		.filter({ visible: true })
+		.first();
+	await expect(wipRow).toBeVisible({ timeout: MaxTimeout });
+	await wipRow.click({ force: true });
 }
 
 /** Select the WIP row and wait for its details (file list) to render. */
 async function selectWipDetails(webview: FrameLocator): Promise<void> {
-	await ensureDetailsPanelOpen(webview);
-
-	// Prefer the dedicated WIP/overview button: it selects the WIP row from a stable, standalone target.
-	// A conflicted WIP row carries adornment overlays (the "Resolve Conflicts…" chip and the modified-
-	// file stats pill) that sit over the row on slower/contended renders (the workers=4 flake). Clicking
-	// the button sidesteps those overlays.
-	const overviewButton = webview.locator('gl-button[data-action="wip"]').first();
-	if (await overviewButton.isVisible().catch(() => false)) {
-		await overviewButton.click();
-	} else {
-		// Fallback: click the WIP row (new Lit engine: role="treeitem", accessible name "Working Changes").
-		const wipRow = webview
-			.getByRole('treeitem', { name: /Working Changes/ })
-			.filter({ visible: true })
-			.first();
-		await expect(wipRow).toBeVisible({ timeout: MaxTimeout });
-		await wipRow.click({ force: true });
-	}
-
-	await ensureDetailsPanelOpen(webview);
+	// Collapse first so the row is there to click, then open for the details themselves.
+	await setDetailsPanel(webview, false);
+	await selectWipRow(webview);
+	await setDetailsPanel(webview, true);
 	await expect(webview.locator('gl-details-wip-panel').first()).toBeVisible({ timeout: 30000 });
 }
 
@@ -179,26 +179,28 @@ async function openGraphWithConflict(vscode: VSCodeInstance): Promise<FrameLocat
 	// than reporting the same "context never appeared" for either. 15s each: still well over
 	// `MaxTimeout`, which the conflict state needs because it waits on a `git status` read. The stages
 	// below add to that, which is why this file raises its per-test timeout (see the describe).
-	// Collapse the details panel before gating on the rows: with it open the graph can be left too short
-	// to mount a single row (see `ensureDetailsPanelClosed`), and this gate would then blame the graph.
-	await ensureDetailsPanelClosed(webview!);
+	//
+	// The order of the stages is what makes them measure what they name:
+	// - The row gate AND the WIP-row click both run with the details panel COLLAPSED, because the graph
+	//   only has the height to render its rows in that state (see `setDetailsPanel`). Run them with the
+	//   panel open and the gate reports "element(s) not found", blaming a graph that painted fine.
+	// - The panel opens after that, because the WIP row has to be the selection for `+hasConflicts` to
+	//   exist at all in this fixture (see `wipConflictContext`): with a commit selected the panel renders
+	//   `gl-details-commit-panel` and there is no `gl-details-wip-header` to carry the context. A fresh
+	//   graph auto-selects the WIP row, which is why gating on the context alone held for the first specs
+	//   in this file — but nothing keeps that selection across a spec that left another row behind.
+	// - Resolve mode is left only once the panel is open, since `exitResolveMode` probes whether the mode
+	//   panel is VISIBLE: a collapsed panel hides it, so exiting earlier would early-return and leave the
+	//   mode active, and `renderWip` then renders it INSTEAD of `gl-details-wip-panel` — surfacing as
+	//   "the WIP details never rendered", the misdiagnosis this whole gate exists to prevent. The mode
+	//   leaks in the first place because the graph webview is retained across `resetUI` and this file's
+	//   `afterEach` can miss the close chip, which re-renders under the conflicted WIP's watcher.
+	await setDetailsPanel(webview!, false);
 	await ensureGraphRowsRendered(vscode, webview!, 15000);
-	// Then open the details panel, leave resolve mode, and select the WIP row. Order matters in each
-	// step:
-	// - `exitResolveMode` probes whether the mode panel is visible, and a collapsed details panel makes
-	//   it invisible — so exiting before opening would early-return and leave the mode active, which
-	//   `renderWip` then renders INSTEAD of `gl-details-wip-panel`, surfacing as "the WIP details never
-	//   rendered" (the misdiagnosis this whole gate exists to prevent). The mode leaks in the first place
-	//   because the graph webview is retained across `resetUI` and this file's `afterEach` can miss the
-	//   close chip, which re-renders under the conflicted WIP's watcher.
-	// - The WIP row has to be the selection for `+hasConflicts` to exist at all in this fixture (see
-	//   `wipConflictContext`): with a commit selected the panel renders `gl-details-commit-panel` and
-	//   there is no `gl-details-wip-header` to carry the context. A fresh graph auto-selects the WIP row,
-	//   which is why gating on the context alone held for the first specs in this file — but nothing
-	//   keeps that selection across a spec that left another row behind.
-	await ensureDetailsPanelOpen(webview!);
+	await selectWipRow(webview!);
+	await setDetailsPanel(webview!, true);
 	await exitResolveMode(webview!);
-	await selectWipDetails(webview!);
+	await expect(webview!.locator('gl-details-wip-panel').first()).toBeVisible({ timeout: 30000 });
 	await expect.poll(() => wipConflictContext(webview!).count(), { timeout: 15000 }).toBeGreaterThan(0);
 	return webview!;
 }

--- a/tests/e2e/specs/graphConflictResolution.test.ts
+++ b/tests/e2e/specs/graphConflictResolution.test.ts
@@ -74,6 +74,30 @@ function conflictFileContext(webview: FrameLocator) {
 	return webview.locator('[data-vscode-context*="+conflict"]');
 }
 
+/**
+ * Ensure the graph's details panel is collapsed, so the graph itself gets the pane's full height.
+ *
+ * The details panel splits the side bar's height with the graph, and once it is open the graph can be
+ * left with too little room for its virtualizer to mount ANY row: measured on a cramped host, an open
+ * panel leaves the graph pane at 26px with the commit tree at height 0 and zero `role="treeitem"` in
+ * the DOM, while collapsing it puts the tree back at 19px with its rows mounted. A row gate run in the
+ * first state reports "element(s) not found", which reads as a graph that never painted.
+ *
+ * That state is reachable here because this file's own gate opens the panel and the graph webview is
+ * retained across `resetUI`, so each test inherits the previous one's panel — on the wider CI VS Code
+ * window there is room to spare, but the fork legs (Windsurf, Positron) ran out of it.
+ */
+async function ensureDetailsPanelClosed(webview: FrameLocator): Promise<void> {
+	const toggle = webview.locator('gl-button[aria-label$="Details Panel"]').first();
+	await expect(toggle).toBeVisible({ timeout: MaxTimeout });
+	if ((await toggle.getAttribute('aria-label')) !== 'Hide Details Panel') return;
+
+	await toggle.click();
+	await expect(webview.locator('gl-button[aria-label="Show Details Panel"]').first()).toBeVisible({
+		timeout: MaxTimeout,
+	});
+}
+
 /** Ensure the graph's details panel is expanded (it may start collapsed). */
 async function ensureDetailsPanelOpen(webview: FrameLocator): Promise<void> {
 	const toggle = webview.locator('gl-button[aria-label$="Details Panel"]').first();
@@ -155,9 +179,12 @@ async function openGraphWithConflict(vscode: VSCodeInstance): Promise<FrameLocat
 	// than reporting the same "context never appeared" for either. 15s each: still well over
 	// `MaxTimeout`, which the conflict state needs because it waits on a `git status` read. The stages
 	// below add to that, which is why this file raises its per-test timeout (see the describe).
+	// Collapse the details panel before gating on the rows: with it open the graph can be left too short
+	// to mount a single row (see `ensureDetailsPanelClosed`), and this gate would then blame the graph.
+	await ensureDetailsPanelClosed(webview!);
 	await ensureGraphRowsRendered(vscode, webview!, 15000);
-	// Open the details panel FIRST, then leave resolve mode, then select the WIP row. Order matters in
-	// both steps:
+	// Then open the details panel, leave resolve mode, and select the WIP row. Order matters in each
+	// step:
 	// - `exitResolveMode` probes whether the mode panel is visible, and a collapsed details panel makes
 	//   it invisible — so exiting before opening would early-return and leave the mode active, which
 	//   `renderWip` then renders INSTEAD of `gl-details-wip-panel`, surfacing as "the WIP details never

--- a/tests/e2e/specs/graphDetails.test.ts
+++ b/tests/e2e/specs/graphDetails.test.ts
@@ -191,6 +191,25 @@ async function waitForDetailsLoaded(graphWebview: FrameLocator): Promise<void> {
 	await expect(commitDetails.or(wipDetails).or(comparePanel)).toBeVisible({ timeout: 30000 });
 }
 
+/**
+ * Assert the details panel is dismissed, as the implementation defines dismissed.
+ *
+ * The split panel is always rendered to avoid DOM re-parenting (which causes layout jumps): hiding
+ * collapses it (split position pinned to 100) and marks the details pane `inert` rather than unmounting
+ * `.details-content`. That element therefore stays in the DOM at ~0 size — a residual that rounds to
+ * 1–2px on some renderers (it did on Windsurf and Positron, while CI's VS Code landed on exactly 0) —
+ * so `not.toBeVisible()` on it is not an invariant the implementation guarantees. What it does
+ * guarantee: the toggle flips to "Show Details Panel" and the pane is inert, its content unreachable.
+ */
+async function expectDetailsPanelDismissed(graphWebview: FrameLocator): Promise<void> {
+	await expect(graphWebview.locator('gl-button[aria-label="Show Details Panel"]').first()).toBeVisible({
+		timeout: MaxTimeout,
+	});
+	await expect(graphWebview.locator('.graph__details-pane').first()).toHaveAttribute('inert', '', {
+		timeout: MaxTimeout,
+	});
+}
+
 // ============================================================================
 // Panel Visibility
 // ============================================================================
@@ -272,17 +291,7 @@ test.describe('Graph Details - Panel Visibility', () => {
 		await expect(hideButton).toBeVisible({ timeout: MaxTimeout });
 		await hideButton.click();
 
-		// The split panel is always rendered to avoid DOM re-parenting (which causes layout jumps);
-		// hiding collapses it (split position pinned to 100) and marks the details pane `inert` rather
-		// than unmounting `.details-content`. That element therefore stays in the DOM at ~0 size — a
-		// residual that rounds to 1–2px on some renderers — so `not.toBeVisible()` on it is not an
-		// invariant the implementation guarantees. Assert the observable dismissed state instead: the
-		// toggle flips to "Show Details Panel" and the details pane is inert (its content unreachable).
-		const showButton = graphWebview.locator('gl-button[aria-label="Show Details Panel"]').first();
-		await expect(showButton).toBeVisible({ timeout: MaxTimeout });
-		await expect(graphWebview.locator('.graph__details-pane').first()).toHaveAttribute('inert', '', {
-			timeout: MaxTimeout,
-		});
+		await expectDetailsPanelDismissed(graphWebview);
 	});
 });
 
@@ -426,16 +435,7 @@ test.describe('Graph Details - WIP Mode', () => {
 		await expect(hideButton).toBeVisible({ timeout: MaxTimeout });
 		await hideButton.click();
 
-		// Same invariant as the commit-details case above: hiding collapses the always-rendered split
-		// panel and marks the pane `inert` instead of unmounting `.details-content`, which stays in the
-		// DOM at a residual size that rounds to 1–2px on some renderers (it did on Windsurf and Positron,
-		// while CI's VS Code landed on exactly 0). Assert the dismissed state the implementation
-		// guarantees, not the element's absence.
-		const showButton = graphWebview.locator('gl-button[aria-label="Show Details Panel"]').first();
-		await expect(showButton).toBeVisible({ timeout: MaxTimeout });
-		await expect(graphWebview.locator('.graph__details-pane').first()).toHaveAttribute('inert', '', {
-			timeout: MaxTimeout,
-		});
+		await expectDetailsPanelDismissed(graphWebview);
 	});
 });
 

--- a/tests/e2e/specs/graphDetails.test.ts
+++ b/tests/e2e/specs/graphDetails.test.ts
@@ -426,8 +426,16 @@ test.describe('Graph Details - WIP Mode', () => {
 		await expect(hideButton).toBeVisible({ timeout: MaxTimeout });
 		await hideButton.click();
 
-		// Details content should close
-		await expect(graphWebview.locator('.details-content')).not.toBeVisible({ timeout: MaxTimeout });
+		// Same invariant as the commit-details case above: hiding collapses the always-rendered split
+		// panel and marks the pane `inert` instead of unmounting `.details-content`, which stays in the
+		// DOM at a residual size that rounds to 1–2px on some renderers (it did on Windsurf and Positron,
+		// while CI's VS Code landed on exactly 0). Assert the dismissed state the implementation
+		// guarantees, not the element's absence.
+		const showButton = graphWebview.locator('gl-button[aria-label="Show Details Panel"]').first();
+		await expect(showButton).toBeVisible({ timeout: MaxTimeout });
+		await expect(graphWebview.locator('.graph__details-pane').first()).toHaveAttribute('inert', '', {
+			timeout: MaxTimeout,
+		});
 	});
 });
 


### PR DESCRIPTION
The first dispatch run after #5721 landed ([31601001813](https://github.com/gitkraken/vscode-gitlens/actions/runs/31601001813), `main` @ `69eb2f05f`) was **green on VS Code** and still failed on **both forks**, 3 of 3 attempts each, on two tests. Both are fixed here, and both were measured live rather than guessed at.

### `graphDetails.test.ts:418` — the twin #5722 missed

Same `not.toBeVisible()` on `.details-content` as the `:265` case fixed in #5722, and it can't hold for the same reason: hiding the panel collapses the always-rendered split panel and marks the pane `inert` instead of unmounting the content, so the element stays in the DOM at a residual size. That residual rounds to 1–2px on some renderers (Windsurf and Positron) while CI's VS Code landed on exactly 0 — which is why only the forks ever saw it. #5722 only touched the *Panel Visibility* copy; the *WIP Mode* one kept the old assertion.

It now asserts the state the implementation actually guarantees — toggle flips to *Show Details Panel*, pane is `inert` — via a shared `expectDetailsPanelDismissed` so the invariant is stated once for both tests.

### `graphConflictResolution.test.ts:332` — a regression from #5721, mechanism measured

#5721's gate opened the details panel and left it open, and the graph webview is retained across `resetUI`, so each test inherited the previous one's panel. The panel splits the side bar's **height** with the graph, and once open the graph can be left too short for its virtualizer to mount a single row. Measured live on a cramped host:

| Details panel | graph pane | commit tree | `role="treeitem"` in DOM |
|---|---|---|---|
| open | 26px | height **0** | **0** → `element(s) not found` |
| collapsed | 48px | 19px | **7** |

So the row gate was reporting a graph that never painted, when the graph was fine and the panel had eaten its height. CI's VS Code window has room to spare; the forks ran out of it. Before #5721 this same test failed later, at the context poll — the regression moved the failure earlier, it didn't create it.

The gate now runs each stage in the state that makes it measure what it names: the **row gate and the WIP-row click** happen with the panel **collapsed** (the row only exists in the DOM there), the panel opens **after** that — because `+hasConflicts` lives on the WIP details header's overflow chip and needs the WIP row selected — and resolve mode is left **once the panel is open**, since `exitResolveMode` probes whether the mode panel is *visible*.

### Validation — all three CI editors, locally

`--workers=1 --retries=0`, over `graphConflictResolution`, `graphDetails` and `treeView`:

- **VS Code + Windsurf: 62 passed** (both before and after the review round below)
- **Positron: 31 passed**

Windsurf and Positron binaries were driven locally via `WINDSURF_E2E_PATH` / `POSITRON_E2E_PATH`, so the fork legs are genuinely covered and not inferred from VS Code. `tsc` over `tests/e2e` and `oxlint --type-aware --type-check` are clean.

An independent review of the first commit produced four findings, all applied in the second — and the first of them mattered: collapsing the panel for the row gate alone would have relocated the fork failure to the WIP-row click instead of removing it, because that click also needs the collapsed layout. It also caught that the helper's "preferred" target `gl-button[data-action="wip"]` matches nothing in the webview (no such `data-action` is emitted), so the fallback always ran; that dead branch is gone. The rest: gate on the pane's `inert` attribute instead of a single non-retried `aria-label` read, collapse the two mirrored open/closed helpers into one `setDetailsPanel(webview, open)`, and de-duplicate the dismissed-state assertion.

### Note on CI

E2E runs on `workflow_dispatch` only, so merging this does not by itself re-exercise the fork legs — a manual run is still needed to confirm on CI hardware.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
