### PR TITLE
Makes AI conflict-resolution telemetry attributable and countable

### DIFF
--- a/docs/telemetry-events.md
+++ b/docs/telemetry-events.md
@@ -258,6 +258,8 @@ void
   'changeType': 'wip' | 'stash' | 'commit' | 'branch' | 'compare' | 'draft-stash' | 'draft-patch' | 'draft-suggested_pr_change',
   'config.largePromptThreshold': number,
   'config.usedCustomInstructions': boolean,
+  // Groups every request of one AI session — the user's whole resolution task, and the unit the backend charges its flat per-feature fee on. Set only by conflict resolution. Counting distinct IDs (filtered to `type: 'resolveConflicts'`) is how feature usage is measured — the event count itself can't be, since one session is many round-trips of an agentic loop. For per-operation counts use `autoRebase/step/resolved` (automatic) and `graphDetails/resolve/generateResolutions/completed` (the panel). One caveat: an escalated rebase's ID is deliberately adopted by the panel that finishes it, so a single ID can carry requests from both paths and distinct-ID counts can't be split cleanly on `source.detail`.
+  'conversationId': string,
   'correlationId': string,
   'customInstructions.commitMessage.setting.length': number,
   'customInstructions.commitMessage.setting.used': boolean,
@@ -329,6 +331,8 @@ void
 {
   'config.largePromptThreshold': number,
   'config.usedCustomInstructions': boolean,
+  // Groups every request of one AI session — the user's whole resolution task, and the unit the backend charges its flat per-feature fee on. Set only by conflict resolution. Counting distinct IDs (filtered to `type: 'resolveConflicts'`) is how feature usage is measured — the event count itself can't be, since one session is many round-trips of an agentic loop. For per-operation counts use `autoRebase/step/resolved` (automatic) and `graphDetails/resolve/generateResolutions/completed` (the panel). One caveat: an escalated rebase's ID is deliberately adopted by the panel that finishes it, so a single ID can carry requests from both paths and distinct-ID counts can't be split cleanly on `source.detail`.
+  'conversationId': string,
   'correlationId': string,
   'customInstructions.commitMessage.setting.length': number,
   'customInstructions.commitMessage.setting.used': boolean,
@@ -371,6 +375,8 @@ or
 {
   'config.largePromptThreshold': number,
   'config.usedCustomInstructions': boolean,
+  // Groups every request of one AI session — the user's whole resolution task, and the unit the backend charges its flat per-feature fee on. Set only by conflict resolution. Counting distinct IDs (filtered to `type: 'resolveConflicts'`) is how feature usage is measured — the event count itself can't be, since one session is many round-trips of an agentic loop. For per-operation counts use `autoRebase/step/resolved` (automatic) and `graphDetails/resolve/generateResolutions/completed` (the panel). One caveat: an escalated rebase's ID is deliberately adopted by the panel that finishes it, so a single ID can carry requests from both paths and distinct-ID counts can't be split cleanly on `source.detail`.
+  'conversationId': string,
   'correlationId': string,
   'customInstructions.commitMessage.setting.length': number,
   'customInstructions.commitMessage.setting.used': boolean,
@@ -413,6 +419,8 @@ or
 {
   'config.largePromptThreshold': number,
   'config.usedCustomInstructions': boolean,
+  // Groups every request of one AI session — the user's whole resolution task, and the unit the backend charges its flat per-feature fee on. Set only by conflict resolution. Counting distinct IDs (filtered to `type: 'resolveConflicts'`) is how feature usage is measured — the event count itself can't be, since one session is many round-trips of an agentic loop. For per-operation counts use `autoRebase/step/resolved` (automatic) and `graphDetails/resolve/generateResolutions/completed` (the panel). One caveat: an escalated rebase's ID is deliberately adopted by the panel that finishes it, so a single ID can carry requests from both paths and distinct-ID counts can't be split cleanly on `source.detail`.
+  'conversationId': string,
   'correlationId': string,
   'customInstructions.commitMessage.setting.length': number,
   'customInstructions.commitMessage.setting.used': boolean,
@@ -456,6 +464,8 @@ or
 {
   'config.largePromptThreshold': number,
   'config.usedCustomInstructions': boolean,
+  // Groups every request of one AI session — the user's whole resolution task, and the unit the backend charges its flat per-feature fee on. Set only by conflict resolution. Counting distinct IDs (filtered to `type: 'resolveConflicts'`) is how feature usage is measured — the event count itself can't be, since one session is many round-trips of an agentic loop. For per-operation counts use `autoRebase/step/resolved` (automatic) and `graphDetails/resolve/generateResolutions/completed` (the panel). One caveat: an escalated rebase's ID is deliberately adopted by the panel that finishes it, so a single ID can carry requests from both paths and distinct-ID counts can't be split cleanly on `source.detail`.
+  'conversationId': string,
   'correlationId': string,
   'customInstructions.commitMessage.setting.length': number,
   'customInstructions.commitMessage.setting.used': boolean,
@@ -498,6 +508,8 @@ or
 {
   'config.largePromptThreshold': number,
   'config.usedCustomInstructions': boolean,
+  // Groups every request of one AI session — the user's whole resolution task, and the unit the backend charges its flat per-feature fee on. Set only by conflict resolution. Counting distinct IDs (filtered to `type: 'resolveConflicts'`) is how feature usage is measured — the event count itself can't be, since one session is many round-trips of an agentic loop. For per-operation counts use `autoRebase/step/resolved` (automatic) and `graphDetails/resolve/generateResolutions/completed` (the panel). One caveat: an escalated rebase's ID is deliberately adopted by the panel that finishes it, so a single ID can carry requests from both paths and distinct-ID counts can't be split cleanly on `source.detail`.
+  'conversationId': string,
   'correlationId': string,
   'customInstructions.commitMessage.setting.length': number,
   'customInstructions.commitMessage.setting.used': boolean,
@@ -540,6 +552,8 @@ or
 {
   'config.largePromptThreshold': number,
   'config.usedCustomInstructions': boolean,
+  // Groups every request of one AI session — the user's whole resolution task, and the unit the backend charges its flat per-feature fee on. Set only by conflict resolution. Counting distinct IDs (filtered to `type: 'resolveConflicts'`) is how feature usage is measured — the event count itself can't be, since one session is many round-trips of an agentic loop. For per-operation counts use `autoRebase/step/resolved` (automatic) and `graphDetails/resolve/generateResolutions/completed` (the panel). One caveat: an escalated rebase's ID is deliberately adopted by the panel that finishes it, so a single ID can carry requests from both paths and distinct-ID counts can't be split cleanly on `source.detail`.
+  'conversationId': string,
   'correlationId': string,
   'customInstructions.commitMessage.setting.length': number,
   'customInstructions.commitMessage.setting.used': boolean,
@@ -582,6 +596,8 @@ or
 {
   'config.largePromptThreshold': number,
   'config.usedCustomInstructions': boolean,
+  // Groups every request of one AI session — the user's whole resolution task, and the unit the backend charges its flat per-feature fee on. Set only by conflict resolution. Counting distinct IDs (filtered to `type: 'resolveConflicts'`) is how feature usage is measured — the event count itself can't be, since one session is many round-trips of an agentic loop. For per-operation counts use `autoRebase/step/resolved` (automatic) and `graphDetails/resolve/generateResolutions/completed` (the panel). One caveat: an escalated rebase's ID is deliberately adopted by the panel that finishes it, so a single ID can carry requests from both paths and distinct-ID counts can't be split cleanly on `source.detail`.
+  'conversationId': string,
   'correlationId': string,
   'customInstructions.commitMessage.setting.length': number,
   'customInstructions.commitMessage.setting.used': boolean,
@@ -624,6 +640,8 @@ or
 {
   'config.largePromptThreshold': number,
   'config.usedCustomInstructions': boolean,
+  // Groups every request of one AI session — the user's whole resolution task, and the unit the backend charges its flat per-feature fee on. Set only by conflict resolution. Counting distinct IDs (filtered to `type: 'resolveConflicts'`) is how feature usage is measured — the event count itself can't be, since one session is many round-trips of an agentic loop. For per-operation counts use `autoRebase/step/resolved` (automatic) and `graphDetails/resolve/generateResolutions/completed` (the panel). One caveat: an escalated rebase's ID is deliberately adopted by the panel that finishes it, so a single ID can carry requests from both paths and distinct-ID counts can't be split cleanly on `source.detail`.
+  'conversationId': string,
   'correlationId': string,
   'customInstructions.commitMessage.setting.length': number,
   'customInstructions.commitMessage.setting.used': boolean,
@@ -668,6 +686,8 @@ or
 {
   'config.largePromptThreshold': number,
   'config.usedCustomInstructions': boolean,
+  // Groups every request of one AI session — the user's whole resolution task, and the unit the backend charges its flat per-feature fee on. Set only by conflict resolution. Counting distinct IDs (filtered to `type: 'resolveConflicts'`) is how feature usage is measured — the event count itself can't be, since one session is many round-trips of an agentic loop. For per-operation counts use `autoRebase/step/resolved` (automatic) and `graphDetails/resolve/generateResolutions/completed` (the panel). One caveat: an escalated rebase's ID is deliberately adopted by the panel that finishes it, so a single ID can carry requests from both paths and distinct-ID counts can't be split cleanly on `source.detail`.
+  'conversationId': string,
   'correlationId': string,
   'customInstructions.commitMessage.setting.length': number,
   'customInstructions.commitMessage.setting.used': boolean,
@@ -4739,8 +4759,11 @@ reveal, …) settles without landing on its row and shows the jump-feedback toas
   'duration': number,
   // Number of resolutions excluded by the user before apply
   'excluded.count': number,
+  'refine.count': number,
   // Total resolutions in the pending set
-  'resolutions.count': number
+  'resolutions.count': number,
+  'retryFile.count': number,
+  'retryFromError.count': number
 }
 ```
 
@@ -4765,8 +4788,11 @@ reveal, …) settles without landing on its row and shows the jump-feedback toas
   'duration': number,
   // Number of resolutions excluded by the user before apply
   'excluded.count': number,
+  'refine.count': number,
   // Total resolutions in the pending set
-  'resolutions.count': number
+  'resolutions.count': number,
+  'retryFile.count': number,
+  'retryFromError.count': number
 }
 ```
 
@@ -4833,8 +4859,11 @@ reveal, …) settles without landing on its row and shows the jump-feedback toas
   'context.webview.id': string,
   'context.webview.instanceId': string,
   'context.webview.type': string,
+  'refine.count': number,
   // Number of pending resolutions that were discarded
-  'resolutions.count': number
+  'resolutions.count': number,
+  'retryFile.count': number,
+  'retryFromError.count': number
 }
 ```
 
@@ -4866,7 +4895,12 @@ reveal, …) settles without landing on its row and shows the jump-feedback toas
   // Whether the run was scoped to a focused subset of conflicted files rather than all
   'focused': boolean,
   // True when this run refined/retried a prior result; false on the initial resolve
-  'refine': boolean
+  'refine': boolean,
+  'refine.count': number,
+  'retryFile.count': number,
+  'retryFromError.count': number,
+  // How the run was dispatched. `refine` above is `run.kind !== 'start'`; this splits the two non-cold cases, so a retry-after-error is no longer indistinguishable from a fresh resolve.
+  'run.kind': 'start' | 'refine' | 'retry'
 }
 ```
 
@@ -4899,6 +4933,7 @@ reveal, …) settles without landing on its row and shows the jump-feedback toas
   'focused': boolean,
   // True when this run refined/retried a prior result; false on the initial resolve
   'refine': boolean,
+  'refine.count': number,
   // Number of files the resolver errored on
   'result.errors.count': number,
   // Number of files the AI produced a resolution for
@@ -4914,7 +4949,15 @@ reveal, …) settles without landing on its row and shows the jump-feedback toas
   // Resolutions resolved by taking the current/ours side
   'result.strategy.takeOurs.count': number,
   // Resolutions resolved by taking the incoming/theirs side
-  'result.strategy.takeTheirs.count': number
+  'result.strategy.takeTheirs.count': number,
+  'retryFile.count': number,
+  'retryFromError.count': number,
+  // How the run was dispatched. `refine` above is `run.kind !== 'start'`; this splits the two non-cold cases, so a retry-after-error is no longer indistinguishable from a fresh resolve.
+  'run.kind': 'start' | 'refine' | 'retry',
+  // Repo-consultation tool calls summed over the run
+  'tools.calls.count': number,
+  // Resolver steps summed over the run — one model round-trip each, mirroring `autoRebase/step/resolved` so both paths are comparable
+  'tools.steps.count': number
 }
 ```
 
@@ -4946,7 +4989,12 @@ reveal, …) settles without landing on its row and shows the jump-feedback toas
   // Whether the run was scoped to a focused subset of conflicted files rather than all
   'focused': boolean,
   // True when this run refined/retried a prior result; false on the initial resolve
-  'refine': boolean
+  'refine': boolean,
+  'refine.count': number,
+  'retryFile.count': number,
+  'retryFromError.count': number,
+  // How the run was dispatched. `refine` above is `run.kind !== 'start'`; this splits the two non-cold cases, so a retry-after-error is no longer indistinguishable from a fresh resolve.
+  'run.kind': 'start' | 'refine' | 'retry'
 }
 ```
 
@@ -4965,6 +5013,68 @@ reveal, …) settles without landing on its row and shows the jump-feedback toas
   'context.webview.id': string,
   'context.webview.instanceId': string,
   'context.webview.type': string
+}
+```
+
+### graphDetails/resolve/retryFile/completed
+
+> Sent when a per-file "retry with feedback" re-resolution succeeds
+
+```typescript
+{
+  'ai.model.id': string,
+  'ai.model.name': string,
+  'ai.model.provider.id': 'anthropic' | 'azure' | 'deepseek' | 'gemini' | 'gitkraken' | 'huggingface' | 'mistral' | 'ollama' | 'openai' | 'openaicompatible' | 'openrouter' | 'simulator' | 'vscode' | 'xai',
+  'ai.model.provider.name': string,
+  'context.repository.closed': boolean,
+  'context.repository.folder.scheme': string,
+  'context.repository.id': string,
+  'context.repository.provider.id': string,
+  'context.repository.scheme': string,
+  'context.webview.host': 'view' | 'editor' | 'panel',
+  'context.webview.id': string,
+  'context.webview.instanceId': string,
+  'context.webview.type': string,
+  'customInstructions.length': number,
+  'customInstructions.used': boolean,
+  // Time from dispatch to settlement in milliseconds
+  'duration': number,
+  // Only on `/failed` — `cancelled` is the host reporting the session went away mid-flight
+  'failed.reason': 'cancelled' | 'error',
+  'refine.count': number,
+  'retryFile.count': number,
+  'retryFromError.count': number
+}
+```
+
+### graphDetails/resolve/retryFile/failed
+
+> Sent when a per-file "retry with feedback" re-resolution fails or is cancelled
+
+```typescript
+{
+  'ai.model.id': string,
+  'ai.model.name': string,
+  'ai.model.provider.id': 'anthropic' | 'azure' | 'deepseek' | 'gemini' | 'gitkraken' | 'huggingface' | 'mistral' | 'ollama' | 'openai' | 'openaicompatible' | 'openrouter' | 'simulator' | 'vscode' | 'xai',
+  'ai.model.provider.name': string,
+  'context.repository.closed': boolean,
+  'context.repository.folder.scheme': string,
+  'context.repository.id': string,
+  'context.repository.provider.id': string,
+  'context.repository.scheme': string,
+  'context.webview.host': 'view' | 'editor' | 'panel',
+  'context.webview.id': string,
+  'context.webview.instanceId': string,
+  'context.webview.type': string,
+  'customInstructions.length': number,
+  'customInstructions.used': boolean,
+  // Time from dispatch to settlement in milliseconds
+  'duration': number,
+  // Only on `/failed` — `cancelled` is the host reporting the session went away mid-flight
+  'failed.reason': 'cancelled' | 'error',
+  'refine.count': number,
+  'retryFile.count': number,
+  'retryFromError.count': number
 }
 ```
 

--- a/src/constants.telemetry.ts
+++ b/src/constants.telemetry.ts
@@ -579,6 +579,10 @@ export interface TelemetryEvents extends WebviewShowAbortedEvents, WebviewShownE
 	'graphDetails/resolve/applyResolutions/failed': GraphDetailsResolveApplyEvent;
 	/** Sent when the user discards pending AI conflict resolutions without applying them */
 	'graphDetails/resolve/discarded': GraphDetailsResolveDiscardedEvent;
+	/** Sent when a per-file "retry with feedback" re-resolution succeeds */
+	'graphDetails/resolve/retryFile/completed': GraphDetailsResolveRetryFileEvent;
+	/** Sent when a per-file "retry with feedback" re-resolution fails or is cancelled */
+	'graphDetails/resolve/retryFile/failed': GraphDetailsResolveRetryFileEvent;
 	/** Sent when the user switches the AI model from the resolve-mode chip in the Graph Details panel */
 	'graphDetails/resolve/changeAiModel': GraphDetailsChangeAiModelEvent;
 
@@ -904,6 +908,20 @@ interface AIEventDataBase {
 
 interface AIEventDataSendBase extends AIEventDataBase {
 	correlationId?: string;
+	/**
+	 * Groups every request of one AI session — the user's whole resolution task, and the unit the
+	 * backend charges its flat per-feature fee on. Set only by conflict resolution.
+	 *
+	 * Counting distinct IDs (filtered to `type: 'resolveConflicts'`) is how feature usage is measured —
+	 * the event count itself can't be, since one session is many round-trips of an agentic loop. For
+	 * per-operation counts use `autoRebase/step/resolved` (automatic) and
+	 * `graphDetails/resolve/generateResolutions/completed` (the panel).
+	 *
+	 * One caveat: an escalated rebase's ID is deliberately adopted by the panel that finishes it, so a
+	 * single ID can carry requests from both paths and distinct-ID counts can't be split cleanly on
+	 * `source.detail`.
+	 */
+	conversationId?: string;
 
 	'retry.count': number;
 	duration?: number;
@@ -1483,7 +1501,11 @@ interface GraphDetailsReviewActionEvent extends GraphContextEventData {
 interface GraphDetailsResolveLifecycleEvent extends GraphContextEventData {}
 
 interface GraphDetailsResolveGenerateLifecycleEvent
-	extends GraphContextEventData, GraphDetailsInstructionsEventData, GraphDetailsAIModelEventData {
+	extends
+		GraphContextEventData,
+		GraphDetailsInstructionsEventData,
+		GraphDetailsAIModelEventData,
+		GraphDetailsResolveSessionCountsEventData {
 	/** True when this run refined/retried a prior result; false on the initial resolve */
 	refine: boolean;
 	/** Whether the run was scoped to a focused subset of conflicted files rather than all */
@@ -1492,6 +1514,24 @@ interface GraphDetailsResolveGenerateLifecycleEvent
 	'files.focused.count': number;
 	/** Time from dispatch to settlement in milliseconds */
 	duration: number;
+	/** How the run was dispatched. `refine` above is `run.kind !== 'start'`; this splits the two
+	 *  non-cold cases, so a retry-after-error is no longer indistinguishable from a fresh resolve. */
+	'run.kind': 'start' | 'refine' | 'retry';
+}
+
+/**
+ * Gesture counts for one resolve session, carried on every resolve event so a session reads as
+ * "resolved after N refines and M retries". A session is one panel engagement — a cold run or an
+ * escalation seed — through apply/discard.
+ *
+ * Note this is the PANEL's session, not the AI conversation's: going back from an error or
+ * cancelling ends a panel session but leaves the host conversation open, so one `conversationId`
+ * can span two of these.
+ */
+interface GraphDetailsResolveSessionCountsEventData {
+	'refine.count': number;
+	'retryFromError.count': number;
+	'retryFile.count': number;
 }
 
 interface GraphDetailsResolveGenerateCompletedEvent extends GraphDetailsResolveGenerateLifecycleEvent {
@@ -1511,9 +1551,14 @@ interface GraphDetailsResolveGenerateCompletedEvent extends GraphDetailsResolveG
 	'result.strategy.deleted.count': number;
 	/** Resolutions left as skipped */
 	'result.strategy.skipped.count': number;
+	/** Resolver steps summed over the run — one model round-trip each, mirroring
+	 *  `autoRebase/step/resolved` so both paths are comparable */
+	'tools.steps.count'?: number;
+	/** Repo-consultation tool calls summed over the run */
+	'tools.calls.count'?: number;
 }
 
-interface GraphDetailsResolveApplyEvent extends GraphContextEventData {
+interface GraphDetailsResolveApplyEvent extends GraphContextEventData, GraphDetailsResolveSessionCountsEventData {
 	/** Total resolutions in the pending set */
 	'resolutions.count': number;
 	/** Number of resolutions actually applied (post user file-exclusion) */
@@ -1524,9 +1569,26 @@ interface GraphDetailsResolveApplyEvent extends GraphContextEventData {
 	duration: number;
 }
 
-interface GraphDetailsResolveDiscardedEvent extends GraphContextEventData {
+interface GraphDetailsResolveDiscardedEvent extends GraphContextEventData, GraphDetailsResolveSessionCountsEventData {
 	/** Number of pending resolutions that were discarded */
 	'resolutions.count': number;
+}
+
+/**
+ * A per-file "retry with feedback" re-resolution. Terminal apply/discard aside, this is the only
+ * resolve gesture that runs the AI outside a whole-run dispatch — an escalation-seeded session can
+ * consist of nothing else.
+ */
+interface GraphDetailsResolveRetryFileEvent
+	extends
+		GraphContextEventData,
+		GraphDetailsInstructionsEventData,
+		GraphDetailsAIModelEventData,
+		GraphDetailsResolveSessionCountsEventData {
+	/** Time from dispatch to settlement in milliseconds */
+	duration: number;
+	/** Only on `/failed` — `cancelled` is the host reporting the session went away mid-flight */
+	'failed.reason'?: 'error' | 'cancelled';
 }
 
 interface DetailsReachabilityLoadedEvent {

--- a/src/plus/ai/__tests__/aiProviderService.telemetry.test.ts
+++ b/src/plus/ai/__tests__/aiProviderService.telemetry.test.ts
@@ -1,0 +1,95 @@
+import * as assert from 'assert';
+import type { AIModel } from '@gitlens/ai/models/model.js';
+import type { Container } from '../../../container.js';
+import type { AIRequestProvider } from '../aiProviderService.js';
+import { AIProviderService } from '../aiProviderService.js';
+
+/**
+ * `conversationId` is how conflict-resolution usage is measured (count distinct IDs on `ai/generate`
+ * with `type: 'resolveConflicts'`) — but the integration tests stop at the AI port boundary, asserting
+ * only that the option is threaded. The assignment that actually puts it on the event lives here, so
+ * without these a regression would silently zero out the adoption metric.
+ */
+suite('AIProviderService — conversationId reaches the ai/generate event', () => {
+	function makeFakes(model: AIModel) {
+		const sentEvents: { name: string; data: Record<string, unknown> }[] = [];
+
+		const requestProvider: AIRequestProvider = {
+			getMessages: () => Promise.resolve([]),
+			getProgressTitle: () => 'Resolving conflicts…',
+			getTelemetryInfo: (m: AIModel) => ({
+				key: 'ai/generate' as const,
+				data: {
+					type: 'resolveConflicts' as const,
+					id: undefined,
+					'model.id': m.id,
+					'model.provider.id': m.provider.id,
+					'model.provider.name': m.provider.name,
+					'retry.count': 0,
+				},
+			}),
+		};
+
+		// Prototype-backed so the real `sendRequest` body runs against stubbed collaborators — the
+		// alternative is standing up the whole provider/subscription graph for one assignment.
+		const fakeThis = Object.assign(Object.create(AIProviderService.prototype) as object, {
+			container: {
+				telemetry: {
+					sendEvent: (name: string, data: Record<string, unknown>) =>
+						void sentEvents.push({ name: name, data: data }),
+				},
+			} as unknown as Container,
+			ensureFeatureAccess: () => Promise.resolve(true),
+			// No API key, so the request fails out at the "Not authorized" branch — the cheapest failure
+			// past the stamp that still reports, and it needs no cancellation timing to hit reliably.
+			getProviderForModel: () =>
+				Promise.resolve({
+					provider: { getApiKey: () => Promise.resolve(undefined) },
+					dispose: () => {},
+				}),
+		});
+
+		return { fakeThis: fakeThis, requestProvider: requestProvider, sentEvents: sentEvents };
+	}
+
+	// Not `gitkraken` — that provider takes an all-access notification detour before the branch under test.
+	const model = {
+		id: 'gpt-4o',
+		name: 'GPT-4o',
+		provider: { id: 'openai', name: 'OpenAI' },
+	} as unknown as AIModel;
+
+	/** Every send in `sendRequest` spreads the one event-data object built at the top, so proving the
+	 *  stamp landed on a failure send proves it lands on the success path too. */
+	function sendFailing(fakeThis: object, requestProvider: AIRequestProvider, options: { conversationId?: string }) {
+		return (AIProviderService.prototype.sendRequest as unknown as (...args: unknown[]) => Promise<unknown>).call(
+			fakeThis,
+			'conflict-resolution',
+			model,
+			requestProvider,
+			{ source: 'graph' },
+			options,
+		);
+	}
+
+	test('stamps the conversation ID on the failure paths, where an unattributable request costs most', async () => {
+		const { fakeThis, requestProvider, sentEvents } = makeFakes(model);
+
+		await sendFailing(fakeThis, requestProvider, { conversationId: 'conv-42' });
+
+		const generated = sentEvents.filter(e => e.name === 'ai/generate');
+		assert.strictEqual(generated.length, 1, 'the failed request still reports');
+		assert.strictEqual(generated[0].data.conversationId, 'conv-42');
+		assert.strictEqual(generated[0].data.failed, true, 'and is marked as a failure');
+	});
+
+	test('leaves the conversation ID unset for features that do not drive a session', async () => {
+		// Most features are one-shot and pass no ID; a stray default would inflate the distinct-ID
+		// count that measures conflict-resolution adoption.
+		const { fakeThis, requestProvider, sentEvents } = makeFakes(model);
+
+		await sendFailing(fakeThis, requestProvider, {});
+
+		assert.strictEqual(sentEvents[0].data.conversationId, undefined);
+	});
+});

--- a/src/plus/ai/aiProviderService.ts
+++ b/src/plus/ai/aiProviderService.ts
@@ -1331,6 +1331,9 @@ export class AIProviderService implements AIService, Disposable {
 		}
 
 		const telementry = provider.getTelemetryInfo(model, 0);
+		// Stamped here, not in each caller's `getTelemetryInfo`, so it also lands on the failure paths
+		// below — where an unattributable request is most costly to investigate.
+		telementry.data.conversationId = options?.conversationId;
 
 		// Resolve the provider for the resolved model independent of `this._provider` — the
 		// singleton cache reflects whichever `getModel` ran most recently, which races with

--- a/src/plus/coretools/conflict/__tests__/integration.test.ts
+++ b/src/plus/coretools/conflict/__tests__/integration.test.ts
@@ -203,6 +203,8 @@ function makeAiFakes(responses: ScriptedResponse[], options?: { supportsTools?: 
 
 	const seenMessages: { role: string; content: string; toolCallId?: string; toolCalls?: unknown[] }[][] = [];
 	const seenTools: (readonly { name: string }[] | undefined)[] = [];
+	const seenReporting: Record<string, unknown>[] = [];
+	const seenOptions: { conversationId?: string }[] = [];
 	let call = 0;
 
 	const ai = {
@@ -216,7 +218,11 @@ function makeAiFakes(responses: ScriptedResponse[], options?: { supportsTools?: 
 			opts: any,
 		) => {
 			const scriptedRetries = responses[call]?.retries ?? 0;
-			const messages = await provider.getMessages(model, {}, {}, model.maxTokens.input, scriptedRetries);
+			// The real service passes the pending event's own data here, so keep it to assert write-backs.
+			const reporting: Record<string, unknown> = {};
+			seenReporting.push(reporting);
+			seenOptions.push(opts);
+			const messages = await provider.getMessages(model, reporting, {}, model.maxTokens.input, scriptedRetries);
 			seenMessages.push(messages);
 			// Mirror the service's own capability gate: tools are dropped for providers that can't carry them
 			seenTools.push(options?.supportsTools === false ? undefined : opts?.tools);
@@ -240,6 +246,8 @@ function makeAiFakes(responses: ScriptedResponse[], options?: { supportsTools?: 
 		container: { ai: ai } as unknown as Container,
 		seenMessages: seenMessages,
 		seenTools: seenTools,
+		seenReporting: seenReporting,
+		seenOptions: seenOptions,
 		callCount: () => call,
 	};
 }
@@ -656,5 +664,58 @@ suite('coretools/conflict repo-consultation tool loop', () => {
 		// prompt's primary evidence.
 		const prompt = ai.seenMessages[0].map(m => m.content).join('\n');
 		assert.strictEqual(prompt.includes('+line 2500'), true, 'the conflicted file’s diff must not be capped');
+	});
+});
+
+suite('coretools/conflict AI request attribution', () => {
+	let dir: string;
+
+	setup(async () => {
+		dir = await mkdtemp(join(tmpdir(), 'gitlens-conflict-telemetry-'));
+	});
+
+	teardown(async () => {
+		await rm(dir, { recursive: true, force: true });
+	});
+
+	test('reports the attempt’s real retry count, not a hardcoded 0', async () => {
+		// `sendRequest` builds the event data once and always asks for attempt 0, so without the
+		// write-back a budget-shrinking retry is indistinguishable from a clean first attempt.
+		const ai = makeAiFakes([{ text: takeTheirsResponse, retries: 2 }]);
+		const { integration, svc } = makeToolGitFakes(dir, ai.container);
+		await writeFile(join(dir, 'server.conf'), conflicted);
+		const conflict = await integration.extract({ svc: svc, filePath: 'server.conf' });
+
+		await integration.resolveSingle(
+			{ svc: svc, conflict: conflict!, conversationId: 'conv-1' },
+			{ source: 'graph' },
+		);
+
+		assert.strictEqual(ai.seenReporting[0]['retry.count'], 2, 'the retry count is written back per attempt');
+		const inputLength = ai.seenReporting[0]['input.length'];
+		assert.ok(typeof inputLength === 'number' && inputLength > 0, 'the prompt size is reported alongside it');
+	});
+
+	test('forwards the conversation ID with every request so the events can be grouped', async () => {
+		// One resolution is many requests; without this they can't be tied back to their session.
+		const ai = makeAiFakes([
+			{ toolCalls: [{ id: 'c1', name: 'grep', args: { pattern: 'useTimeout' } }] },
+			{ text: takeTheirsResponse },
+		]);
+		const { integration, svc } = makeToolGitFakes(dir, ai.container);
+		await writeFile(join(dir, 'server.conf'), conflicted);
+		const conflict = await integration.extract({ svc: svc, filePath: 'server.conf' });
+
+		await integration.resolveSingle(
+			{ svc: svc, conflict: conflict!, conversationId: 'conv-42' },
+			{ source: 'graph' },
+		);
+
+		assert.strictEqual(ai.seenOptions.length, 2, 'the tool round-trip is a second request');
+		assert.deepStrictEqual(
+			ai.seenOptions.map(o => o.conversationId),
+			['conv-42', 'conv-42'],
+			'every request in the loop carries the same conversation ID',
+		);
 	});
 });

--- a/src/plus/coretools/conflict/integration.ts
+++ b/src/plus/coretools/conflict/integration.ts
@@ -671,8 +671,15 @@ function createAiModelPort(
 				// `getMessages` is re-invoked on a provider retry with a reduced token budget, so build
 				// the history per attempt rather than once — see `buildMessages`.
 				const provider: AIRequestProvider = {
-					getMessages: (_model, _reporting, _cancellation, _maxInputTokens, retries) =>
-						Promise.resolve(buildMessages(params, useTools, signatures, retries)),
+					getMessages: (_model, reporting, _cancellation, _maxInputTokens, retries) => {
+						// `reporting` IS the pending event's data, built once before the first attempt — so the
+						// retry count must be written back here, as `resolvePrompt` does for the features built
+						// on prompt templates.
+						reporting['retry.count'] = retries;
+						const messages = buildMessages(params, useTools, signatures, retries);
+						reporting['input.length'] = messages.reduce((sum, m) => sum + m.content.length, 0);
+						return Promise.resolve(messages);
+					},
 					getProgressTitle: () => 'Resolving conflicts…',
 					getTelemetryInfo: model => ({
 						key: 'ai/generate' as const,
@@ -682,6 +689,7 @@ function createAiModelPort(
 							'model.id': model.id,
 							'model.provider.id': model.provider.id,
 							'model.provider.name': model.provider.name,
+							// Overwritten per attempt by `getMessages` above
 							'retry.count': 0,
 						},
 					}),

--- a/src/webviews/apps/plus/graph/components/__tests__/detailsWorkflowController.test.ts
+++ b/src/webviews/apps/plus/graph/components/__tests__/detailsWorkflowController.test.ts
@@ -1829,3 +1829,196 @@ suite('DetailsWorkflowController.enterComposeWithScope — recompose seeding', (
 		});
 	});
 });
+
+type SentEvent = { name: string; data: Record<string, unknown> };
+
+/** Harness for the resolve-session gesture counts: records every telemetry event and lets each
+ *  resolve/re-resolve RPC be scripted, so a run can be made to succeed, fail, or cancel. */
+function setupResolveCounts(options?: { resolveResults?: unknown[]; reresolveResults?: unknown[] }): {
+	controller: DetailsWorkflowController;
+	state: DetailsState;
+	sent: SentEvent[];
+} {
+	const sent: SentEvent[] = [];
+	const resolveResults = [...(options?.resolveResults ?? [])];
+	const reresolveResults = [...(options?.reresolveResults ?? [])];
+	const okResolve = { result: { resolutions: [] } };
+	const okReresolve = { result: { filePath: 'a.ts', strategy: 'ai', confidence: 1 } };
+
+	const services = {
+		repository: {
+			onRepositoryChanged: () => () => {},
+			onRepositoryWorkingChanged: () => () => {},
+			onRepositoryOrWorktreeChanged: () => () => {},
+		},
+		graphInspect: {
+			resolveConflicts: () => Promise.resolve(resolveResults.shift() ?? okResolve),
+			reresolveFile: () => Promise.resolve(reresolveResults.shift() ?? okReresolve),
+			discardResolutions: () => Promise.resolve(),
+		},
+		telemetry: {
+			sendEvent: (name: string, data: Record<string, unknown>) => {
+				sent.push({ name: name, data: data });
+				return Promise.resolve();
+			},
+		},
+	} as unknown as ResolvedServices;
+
+	const host = new FakeHost({ repoPath: '/A', graphRepoPath: '/A' });
+	const state = createDetailsState();
+	const actions = new DetailsActions(state, services, createResources());
+	const controller = new DetailsWorkflowController(host, actions);
+	host.connectAll();
+	host.tickHostUpdate();
+	state.activeMode.set('resolve');
+	state.activeModeRepoPath.set('/A');
+
+	return { controller: controller, state: state, sent: sent };
+}
+
+const generateEvents = (sent: SentEvent[]) =>
+	sent.filter(e => e.name.startsWith('graphDetails/resolve/generateResolutions/'));
+
+suite('DetailsWorkflowController — resolve session refine/retry counts', () => {
+	test('a cold run reports run.kind start with every count at zero', async () => {
+		const m = setupResolveCounts();
+
+		m.controller.runResolve('/A', undefined, undefined, 'start');
+		await flush();
+
+		const events = generateEvents(m.sent);
+		assert.strictEqual(events.length, 1);
+		assert.strictEqual(events[0].data['run.kind'], 'start');
+		assert.strictEqual(events[0].data['refine.count'], 0);
+		assert.strictEqual(events[0].data['retryFromError.count'], 0);
+		assert.strictEqual(events[0].data['retryFile.count'], 0);
+	});
+
+	test('each refine increments refine.count within the session', async () => {
+		const m = setupResolveCounts();
+
+		m.controller.runResolve('/A', undefined, undefined, 'start');
+		await flush();
+		m.controller.runResolve('/A', undefined, undefined, 'refine');
+		await flush();
+		m.controller.runResolve('/A', undefined, undefined, 'refine');
+		await flush();
+
+		const events = generateEvents(m.sent);
+		assert.deepStrictEqual(
+			events.map(e => e.data['refine.count']),
+			[0, 1, 2],
+			'the count accumulates across the session rather than resetting per run',
+		);
+		assert.deepStrictEqual(
+			events.map(e => e.data['run.kind']),
+			['start', 'refine', 'refine'],
+		);
+	});
+
+	test('a retry after an error reports run.kind retry, not start', async () => {
+		// The bug this fixes: `refine` was derived from the resource, which holds `{error}` after a
+		// failure — so a retry was indistinguishable from a cold start.
+		const m = setupResolveCounts({ resolveResults: [{ error: { message: 'boom' } }] });
+
+		m.controller.runResolve('/A', undefined, undefined, 'start');
+		await flush();
+		m.controller.resolve.retryFromError();
+		await flush();
+
+		const events = generateEvents(m.sent);
+		assert.strictEqual(events.length, 2);
+		assert.strictEqual(events[1].data['run.kind'], 'retry', 'a retry must not look like a cold start');
+		assert.strictEqual(events[1].data.refine, true);
+		assert.strictEqual(events[1].data['retryFromError.count'], 1);
+	});
+
+	test('a cold run resets counts carried over from the previous session', async () => {
+		const m = setupResolveCounts();
+
+		m.controller.runResolve('/A', undefined, undefined, 'start');
+		await flush();
+		m.controller.runResolve('/A', undefined, undefined, 'refine');
+		await flush();
+		m.controller.runResolve('/A', undefined, undefined, 'start');
+		await flush();
+
+		const events = generateEvents(m.sent);
+		assert.strictEqual(events[2].data['refine.count'], 0, 'a new session starts clean');
+	});
+
+	test('a per-file retry emits its own event carrying the running counts', async () => {
+		const m = setupResolveCounts();
+
+		m.controller.runResolve('/A', undefined, undefined, 'start');
+		await flush();
+		m.controller.runResolve('/A', undefined, undefined, 'refine');
+		await flush();
+		await m.controller.resolve.retryFile('a.ts', 'prefer ours');
+
+		const retry = m.sent.filter(e => e.name === 'graphDetails/resolve/retryFile/completed');
+		assert.strictEqual(retry.length, 1, 'the per-file retry path reported nothing before this');
+		assert.strictEqual(retry[0].data['retryFile.count'], 1);
+		assert.strictEqual(retry[0].data['refine.count'], 1, 'it carries the session context too');
+		assert.strictEqual(retry[0].data['customInstructions.length'], 'prefer ours'.length);
+		assert.strictEqual(retry[0].data['customInstructions.used'], true);
+	});
+
+	test('a failed per-file retry reports the reason', async () => {
+		const m = setupResolveCounts({ reresolveResults: [{ error: { message: 'nope' } }] });
+
+		m.controller.runResolve('/A', undefined, undefined, 'start');
+		await flush();
+		await m.controller.resolve.retryFile('a.ts', 'try again');
+
+		const retry = m.sent.filter(e => e.name === 'graphDetails/resolve/retryFile/failed');
+		assert.strictEqual(retry.length, 1);
+		assert.strictEqual(retry[0].data['failed.reason'], 'error');
+	});
+
+	test('concurrent per-file retries each count exactly once', async () => {
+		// The count is bumped on dispatch rather than on settle — `resolveRetryingFiles` is a Set, so
+		// several files can be in flight and a read-modify-write across the await would lose one.
+		const m = setupResolveCounts();
+
+		m.controller.runResolve('/A', undefined, undefined, 'start');
+		await flush();
+		await Promise.all([m.controller.resolve.retryFile('a.ts', 'x'), m.controller.resolve.retryFile('b.ts', 'y')]);
+
+		const counts = m.sent
+			.filter(e => e.name === 'graphDetails/resolve/retryFile/completed')
+			.map(e => e.data['retryFile.count']);
+		assert.deepStrictEqual(counts.sort(), [1, 2]);
+	});
+
+	test('discard carries the session totals', async () => {
+		const m = setupResolveCounts();
+
+		m.controller.runResolve('/A', undefined, undefined, 'start');
+		await flush();
+		m.controller.runResolve('/A', undefined, undefined, 'refine');
+		await flush();
+		await m.controller.resolve.retryFile('a.ts', 'x');
+		m.controller.resolve.discard();
+
+		const discarded = m.sent.filter(e => e.name === 'graphDetails/resolve/discarded');
+		assert.strictEqual(discarded.length, 1);
+		assert.strictEqual(discarded[0].data['refine.count'], 1);
+		assert.strictEqual(discarded[0].data['retryFile.count'], 1);
+	});
+
+	test('cancelling the mode ends the session', async () => {
+		const m = setupResolveCounts();
+
+		m.controller.runResolve('/A', undefined, undefined, 'start');
+		await flush();
+		m.controller.runResolve('/A', undefined, undefined, 'refine');
+		await flush();
+		m.controller.cancelOperation('resolve');
+		m.controller.runResolve('/A', undefined, undefined, 'start');
+		await flush();
+
+		const events = generateEvents(m.sent);
+		assert.strictEqual(events[2].data['refine.count'], 0);
+	});
+});

--- a/src/webviews/apps/plus/graph/components/detailsWorkflowController.ts
+++ b/src/webviews/apps/plus/graph/components/detailsWorkflowController.ts
@@ -161,6 +161,19 @@ export class DetailsWorkflowController implements ReactiveController {
 	private _reviewFetchedForSelection: AnchorKey | undefined;
 	private _composeFetchedForSelection: AnchorKey | undefined;
 	private _resolveFetchedForSelection: AnchorKey | undefined;
+	/**
+	 * Resolve-session gesture counts, reported on every resolve telemetry event so a session can be
+	 * read as "resolved after N refines and M retries" rather than as unrelated runs. A session is one
+	 * engagement — a cold run or an escalation seed — through apply/discard; `resetResolveSession` is
+	 * the choke point that zeroes them alongside the resource.
+	 *
+	 * Panel-scoped, matching `resources.resolve` itself (only one live resolve session). Note this is
+	 * NOT the host's conversation lifetime: `backFromError`/`cancelOperation` end a panel session but
+	 * leave the host conversation open, so one conversation can span two of these.
+	 */
+	private _resolveRefineCount = 0;
+	private _resolveRetryFromErrorCount = 0;
+	private _resolveRetryFileCount = 0;
 	// endregion
 
 	constructor(
@@ -355,7 +368,7 @@ export class DetailsWorkflowController implements ReactiveController {
 		} else {
 			const resolveHasValue = resources.resolve.value.get() != null;
 			if (resolveHasValue && this._resolveFetchedForSelection !== newKey) {
-				resources.resolve.reset();
+				this.resetResolveSession();
 				this.resolve.invalidateErrorRecovery();
 				this._resolveFetchedForSelection = undefined;
 			} else {
@@ -702,7 +715,7 @@ export class DetailsWorkflowController implements ReactiveController {
 				this.compose.invalidateContinuation();
 				this._composeFetchedForSelection = undefined;
 			} else if (wasMode === 'resolve') {
-				this.actions.resources.resolve.reset();
+				this.resetResolveSession();
 				this.resolve.invalidateErrorRecovery();
 				this._resolveFetchedForSelection = undefined;
 				this.actions.state.resolveFocusedFilePaths.set(undefined);
@@ -819,6 +832,11 @@ export class DetailsWorkflowController implements ReactiveController {
 		this.removeRunningOperation(key, kind);
 		this.workflowFor(kind).invalidateSnapshot();
 		this.resourceFor(kind).reset();
+		// Destroying resolve ends its session, so the gesture counts go with it — the resource reset
+		// above is mode-generic, so it can't carry them.
+		if (kind === 'resolve') {
+			this.resetResolveSessionCounts();
+		}
 		// Forget on the engaged anchor (what's being destroyed), not the host's current selection —
 		// they can diverge (e.g. destroy via the active-toggle chip while the host's selection
 		// already moved to a different row).
@@ -1664,7 +1682,7 @@ export class DetailsWorkflowController implements ReactiveController {
 		backFromError: (): void => {
 			const anchor = this.currentAnchor();
 			this.removeRunningOperation(anchorKey(anchor), 'resolve');
-			this.actions.resources.resolve.reset();
+			this.resetResolveSession();
 		},
 		// Retry after error — re-run with the same scope (single file or all) and the run's prompt.
 		// Read the scope off the entry (survives a row-switch-and-return that clears the signal),
@@ -1677,6 +1695,7 @@ export class DetailsWorkflowController implements ReactiveController {
 				this.actions.state.activeModeRepoPath.get(),
 				entry?.focusedFilePaths ?? this.actions.state.resolveFocusedFilePaths.get(),
 				entry?.prompt,
+				'retry',
 			);
 		},
 		// Apply the (optionally filtered) resolutions to the working tree. Terminal: on success the
@@ -1704,6 +1723,7 @@ export class DetailsWorkflowController implements ReactiveController {
 					'applied.count': appliedCount,
 					'excluded.count': excludedCount,
 					duration: duration,
+					...this.resolveSessionCounts(),
 				});
 				const entry = this.host.crossPaneState.runningOperations.get().get(anchorKey(engagedAnchor))?.resolve;
 				if (entry == null) return;
@@ -1717,7 +1737,10 @@ export class DetailsWorkflowController implements ReactiveController {
 				'applied.count': appliedCount,
 				'excluded.count': excludedCount,
 				duration: duration,
+				...this.resolveSessionCounts(),
 			});
+			// Apply is terminal — zero only after the event above has carried the totals.
+			this.resetResolveSessionCounts();
 			this.removeRunningOperation(anchorKey(engagedAnchor), 'resolve');
 			this.forgetMode(engagedAnchor);
 		},
@@ -1730,10 +1753,11 @@ export class DetailsWorkflowController implements ReactiveController {
 			this.actions.sendTelemetryEvent('graphDetails/resolve/discarded', {
 				'resolutions.count':
 					planValue != null && 'result' in planValue ? planValue.result.resolutions.length : 0,
+				...this.resolveSessionCounts(),
 			});
 			void this.actions.discardResolutions(repoPath);
 			this.removeRunningOperation(anchorKey(anchor), 'resolve');
-			this.actions.resources.resolve.reset();
+			this.resetResolveSession();
 			this.forgetMode(anchor);
 			this.hideMode(this.host.currentSelection());
 		},
@@ -1742,6 +1766,14 @@ export class DetailsWorkflowController implements ReactiveController {
 		retryFile: async (filePath: string, feedback: string): Promise<void> => {
 			const repoPath = this.actions.state.activeModeRepoPath.get();
 			if (!repoPath) return;
+
+			// Count on dispatch, before any await — `resolveRetryingFiles` is a Set, so several files can
+			// be retrying at once, and a read-modify-write across the await would lose one. Snapshot the
+			// counts here too: read at settle instead, two concurrent retries would both report the
+			// higher total rather than their own position in the session.
+			this._resolveRetryFileCount++;
+			const counts = this.resolveSessionCounts();
+			const startedAt = performance.now();
 
 			const busy = this.actions.state.resolveRetryingFiles;
 			busy.set(new Set(busy.get()).add(filePath));
@@ -1752,8 +1784,21 @@ export class DetailsWorkflowController implements ReactiveController {
 				// or host-owned registry after that is UB (same guard as `onRunSettled`).
 				if (this._disconnected) return;
 
+				const base = {
+					...this.actions.buildAIModelTelemetryContext(),
+					'customInstructions.used': feedback.length > 0,
+					'customInstructions.length': feedback.length,
+					...counts,
+					duration: performance.now() - startedAt,
+				};
 				if ('result' in result) {
 					this.mergeResolvedFile(result.result);
+					this.actions.sendTelemetryEvent('graphDetails/resolve/retryFile/completed', base);
+				} else {
+					this.actions.sendTelemetryEvent('graphDetails/resolve/retryFile/failed', {
+						...base,
+						'failed.reason': 'cancelled' in result ? 'cancelled' : 'error',
+					});
 				}
 			} finally {
 				const next = new Set(this.actions.state.resolveRetryingFiles.get());
@@ -1849,6 +1894,37 @@ export class DetailsWorkflowController implements ReactiveController {
 		this.actions.resources.resolve.mutate(merged);
 	}
 
+	/** Ends the resolve session — clears the result AND the gesture counts together. A choke point
+	 *  because the reset sites are many (anchor switch, back-from-error, discard, cancel, repo switch)
+	 *  and a missed one would report the previous session's counts on the next cold run. */
+	private resetResolveSession(): void {
+		this.actions.resources.resolve.reset();
+		this.resetResolveSessionCounts();
+	}
+
+	/** The session gesture counts, for the events that don't go through `fireRunTelemetry`'s
+	 *  `resolveBase` — apply, discard, and the per-file retry. On the terminal pair they answer "how
+	 *  much work did this resolution take?" in a single row. */
+	private resolveSessionCounts(): {
+		'refine.count': number;
+		'retryFromError.count': number;
+		'retryFile.count': number;
+	} {
+		return {
+			'refine.count': this._resolveRefineCount,
+			'retryFromError.count': this._resolveRetryFromErrorCount,
+			'retryFile.count': this._resolveRetryFileCount,
+		};
+	}
+
+	/** The counts alone, for the two callers that must not touch the resource: `destroyEngagedOperation`
+	 *  (already resets it generically) and `seedResolveFromEscalation` (about to mutate a value in). */
+	private resetResolveSessionCounts(): void {
+		this._resolveRefineCount = 0;
+		this._resolveRetryFromErrorCount = 0;
+		this._resolveRetryFileCount = 0;
+	}
+
 	/** Runs the resolver over `focusedFilePaths` — the user-checked subset from the idle file tree
 	 *  (the full conflict set when everything is checked). Stored on `resolveFocusedFilePaths` so the
 	 *  whole-run Refine and `retryFromError` re-run the same scope. */
@@ -1856,14 +1932,23 @@ export class DetailsWorkflowController implements ReactiveController {
 		repoPath: string | undefined,
 		focusedFilePaths: readonly string[] | undefined,
 		instructions: string | undefined,
+		/** Why this run was dispatched. Declared by the caller rather than derived from the resource:
+		 *  after an error the resource holds `{error}`, so a retry used to look like a cold start. */
+		runKind: 'start' | 'refine' | 'retry' = 'start',
 	): void {
 		if (!repoPath) return;
 
 		this.actions.state.wipStale.set(false);
 		this.actions.state.resolveFocusedFilePaths.set(focusedFilePaths);
-		// A prior result-bearing value means this run is a Refine (re-resolve) rather than a fresh run
-		// — used only for the `refine` telemetry flag below.
-		const currentValue = this.actions.resources.resolve.value.get();
+		// Count before dispatching — `dispatchOperation` resets the resource but deliberately leaves the
+		// counts alone, since a refine continues the session it is refining.
+		if (runKind === 'start') {
+			this.resetResolveSession();
+		} else if (runKind === 'refine') {
+			this._resolveRefineCount++;
+		} else {
+			this._resolveRetryFromErrorCount++;
+		}
 		this._resolveFetchedForSelection = this.selectionKey();
 		this.dispatchOperation(
 			'resolve',
@@ -1877,9 +1962,15 @@ export class DetailsWorkflowController implements ReactiveController {
 				// undefined/0 for a whole-run over all conflicts.
 				excludedFilesCount: 0,
 				effectiveFilesCount: 0,
-				refine: currentValue != null && 'result' in currentValue,
+				refine: runKind !== 'start',
 				focused: focusedFilePaths != null && focusedFilePaths.length > 0,
 				focusedCount: focusedFilePaths?.length ?? 0,
+				// Captured at dispatch, not read at settle — a later gesture must not retroactively
+				// change what this run reported.
+				runKind: runKind,
+				refineCount: this._resolveRefineCount,
+				retryFromErrorCount: this._resolveRetryFromErrorCount,
+				retryFileCount: this._resolveRetryFileCount,
 			},
 			undefined,
 			focusedFilePaths,
@@ -1906,6 +1997,9 @@ export class DetailsWorkflowController implements ReactiveController {
 		if (this.actions.resources.resolve.value.get() != null) return;
 
 		this._resolveFetchedForSelection = this.selectionKey();
+		// A seed starts a fresh panel session even though no run was dispatched — counts only, since
+		// `resetResolveSession` would clear the value being mutated in.
+		this.resetResolveSessionCounts();
 		this.actions.resources.resolve.mutate(seeded);
 	}
 
@@ -1933,6 +2027,11 @@ export class DetailsWorkflowController implements ReactiveController {
 			refine: boolean;
 			focused?: boolean;
 			focusedCount?: number;
+			/** Resolve-only — the session gesture counts, captured at dispatch. */
+			runKind?: 'start' | 'refine' | 'retry';
+			refineCount?: number;
+			retryFromErrorCount?: number;
+			retryFileCount?: number;
 		},
 		basePrompt?: string,
 		/** Resolve-only run scope, persisted on the entry so it survives anchor switches. */
@@ -1992,6 +2091,11 @@ export class DetailsWorkflowController implements ReactiveController {
 			refine: boolean;
 			focused?: boolean;
 			focusedCount?: number;
+			/** Resolve-only — the session gesture counts, captured at dispatch. */
+			runKind?: 'start' | 'refine' | 'retry';
+			refineCount?: number;
+			retryFromErrorCount?: number;
+			retryFileCount?: number;
 		},
 		controller: AbortController,
 		startedAt: number,
@@ -2018,6 +2122,10 @@ export class DetailsWorkflowController implements ReactiveController {
 				focused: runContext.focused ?? false,
 				'files.focused.count': runContext.focusedCount ?? 0,
 				duration: duration,
+				'run.kind': runContext.runKind ?? 'start',
+				'refine.count': runContext.refineCount ?? 0,
+				'retryFromError.count': runContext.retryFromErrorCount ?? 0,
+				'retryFile.count': runContext.retryFileCount ?? 0,
 			};
 
 			if (isCancelled) {
@@ -2065,6 +2173,10 @@ export class DetailsWorkflowController implements ReactiveController {
 					'result.strategy.takeTheirs.count': takeTheirs,
 					'result.strategy.deleted.count': deleted,
 					'result.strategy.skipped.count': skipped,
+					// Absent when no resolution reported a count — not zero, which would read as "the
+					// resolver did the work for free" against `autoRebase/step/resolved`.
+					'tools.steps.count': r.metrics?.steps,
+					'tools.calls.count': r.metrics?.toolCalls,
 				});
 			}
 			return;
@@ -2669,7 +2781,7 @@ export class DetailsWorkflowController implements ReactiveController {
 		this._composeBackSnapshot = undefined;
 		this.actions.resources.review.reset();
 		this.actions.resources.compose.reset();
-		this.actions.resources.resolve.reset();
+		this.resetResolveSession();
 		// Prior repo's anchors are gone — drop their remembered modes too.
 		const modes = this.host.crossPaneState.lastModeByAnchor;
 		if (modes.get().size > 0) {
@@ -2725,7 +2837,7 @@ export class DetailsWorkflowController implements ReactiveController {
 		if (kind === 'resolve') {
 			// Resolve has no Back/Resume — cancelling returns to idle (the conflicted-file list).
 			this.removeRunningOperation(key, 'resolve');
-			this.actions.resources.resolve.reset();
+			this.resetResolveSession();
 			return;
 		}
 

--- a/src/webviews/apps/plus/graph/components/gl-graph-details-panel.ts
+++ b/src/webviews/apps/plus/graph/components/gl-graph-details-panel.ts
@@ -3668,7 +3668,7 @@ export class GlGraphDetailsPanel extends SignalWatcher(LitElement) {
 				const run = this.getResolveRunScope();
 				if (run == null) return;
 
-				this._workflow.runResolve(this.effectiveRepoPath, run.scope, e.detail?.prompt);
+				this._workflow.runResolve(this.effectiveRepoPath, run.scope, e.detail?.prompt, 'start');
 			}}
 			@resolve-view-diff=${(e: CustomEvent<{ filePath: string }>) =>
 				this.handleResolveViewDiff(e.detail.filePath)}
@@ -3698,6 +3698,7 @@ export class GlGraphDetailsPanel extends SignalWatcher(LitElement) {
 					this.effectiveRepoPath,
 					resolveEntry?.focusedFilePaths ?? this._state.resolveFocusedFilePaths.get(),
 					e.detail?.prompt,
+					'refine',
 				);
 			}}
 			@resolve-retry-file=${(e: CustomEvent<{ filePath: string; prompt: string }>) =>

--- a/src/webviews/plus/graph/__tests__/graphInspectServices.test.ts
+++ b/src/webviews/plus/graph/__tests__/graphInspectServices.test.ts
@@ -707,3 +707,85 @@ suite('graphInspectServices — resolve progress reports repo consultation (#558
 		]);
 	});
 });
+
+/** Same prototype-backed shape as {@link createResolveProgressFake}, but with the per-file resolver
+ *  metrics under test standing in for the consultation replay. */
+function createResolveMetricsFake(metrics: ({ stepCount?: number; toolCallCount?: number } | undefined)[]) {
+	const container = {
+		git: { getRepositoryService: () => ({}) },
+		virtualFs: { registerProvider: () => ({ dispose: () => {} }) },
+	} as unknown as Container;
+
+	const paths = metrics.map((_, i) => `src/${i}.ts`);
+	const integration = {
+		listUnmergedEntries: () => Promise.resolve(paths.map(p => ({ path: p, reason: 'both-modified' }))),
+		resolveAllParallel: () =>
+			Promise.resolve({
+				resolutions: paths.map((p, i) => ({
+					filePath: p,
+					content: 'resolved',
+					strategy: 'ai',
+					confidence: 0.9,
+					description: 'why',
+					metrics: metrics[i],
+				})),
+				errors: [],
+				skipped: [],
+			}),
+		readWorkingFiles: () => Promise.resolve(new Map(paths.map(p => [p, 'conflicted']))),
+	};
+
+	const fakeThis = Object.assign(Object.create(GraphInspectServices.prototype) as object, {
+		context: { container: container },
+		_aiCancellations: new Set(),
+		_activeResolveSessions: new Map(),
+		_resolveConversationIds: new Map(),
+		_composeProgressEvent: { subscribe: () => () => {} },
+		_resolveProgressEvent: { subscribe: () => () => {}, fire: () => {} },
+		getOrCreateConflictToolsForGraph: () => Promise.resolve(integration),
+	});
+
+	return (GraphInspectServices.prototype.createServices as unknown as CreateServices).call(fakeThis).graphInspect;
+}
+
+suite('graphInspectServices — resolver effort aggregation', () => {
+	async function resolveMetrics(metrics: ({ stepCount?: number; toolCallCount?: number } | undefined)[]) {
+		const graphInspect = createResolveMetricsFake(metrics);
+		const result = await graphInspect.resolveConflicts('/repo', undefined);
+		assert.ok(!('error' in result) && !('cancelled' in result), `resolve failed: ${JSON.stringify(result)}`);
+		return result.result.metrics;
+	}
+
+	test('sums each file’s step and tool-call counts over the run', async () => {
+		// The panel resolves files concurrently but reports one run-level total, so the per-file counts
+		// have to be added rather than last-write-wins.
+		assert.deepStrictEqual(
+			await resolveMetrics([
+				{ stepCount: 3, toolCallCount: 2 },
+				{ stepCount: 4, toolCallCount: 1 },
+			]),
+			{ steps: 7, toolCalls: 3 },
+		);
+	});
+
+	test('stays undefined when no resolution reported counts, rather than collapsing to 0', async () => {
+		// `autoRebase/step/resolved` reports undefined in this case. Sending 0 instead would make a
+		// provider that reports nothing look like one that resolved the conflict for free, and the two
+		// paths exist to be compared on exactly this.
+		assert.deepStrictEqual(await resolveMetrics([undefined, undefined]), {
+			steps: undefined,
+			toolCalls: undefined,
+		});
+	});
+
+	test('sums only the files that reported, ignoring the ones that did not', async () => {
+		assert.deepStrictEqual(await resolveMetrics([{ stepCount: 5, toolCallCount: 2 }, undefined]), {
+			steps: 5,
+			toolCalls: 2,
+		});
+	});
+
+	test('tracks the two counts independently — tools can be unreported while steps are not', async () => {
+		assert.deepStrictEqual(await resolveMetrics([{ stepCount: 6 }]), { steps: 6, toolCalls: undefined });
+	});
+});

--- a/src/webviews/plus/graph/graphInspectServices.ts
+++ b/src/webviews/plus/graph/graphInspectServices.ts
@@ -1587,6 +1587,7 @@ export class GraphInspectServices {
 								resolutions: summaries,
 								errors: errors.length > 0 ? errors : undefined,
 								skipped: skipped.length > 0 ? skipped : undefined,
+								metrics: sumResolutionEffort(resolutions),
 							},
 						};
 					} catch (ex) {
@@ -1902,6 +1903,10 @@ export class GraphInspectServices {
 							resolutions: summaries,
 							errors: errors.length > 0 ? errors : undefined,
 							skipped: skipped.length > 0 ? skipped : undefined,
+							// The escalated step's effort, for the same reason the run path reports it —
+							// the panel doesn't report a completion for a seeded session today, so this is
+							// only for shape parity if it ever does.
+							metrics: sumResolutionEffort(handoff.resolutions),
 							autoRebase: {
 								sessionId: handoff.sessionId,
 								stepNumber: escalation?.stepNumber,
@@ -3127,6 +3132,28 @@ function combineResolveGuidance(instructions: string | undefined): string | unde
 	if (!typed) return setting;
 
 	return `${setting}\n\nAnd here is additional guidance for this run (it takes highest priority): ${typed}`;
+}
+
+/** Sums the resolver's step and tool-call counts over a run for the panel's completion telemetry —
+ *  the same accounting `autoRebase/step/resolved` reports, so the two paths can be compared. Stays
+ *  `undefined` when no resolution reported a count, matching that path's `sumOf`: a provider that
+ *  reports no metrics has to stay distinguishable from one that did the work in zero steps, or the
+ *  comparison reads "no data" as "free". */
+function sumResolutionEffort(resolutions: readonly ConflictToolsResolution[]): {
+	steps: number | undefined;
+	toolCalls: number | undefined;
+} {
+	let steps: number | undefined;
+	let toolCalls: number | undefined;
+	for (const r of resolutions) {
+		if (r.metrics?.stepCount != null) {
+			steps = (steps ?? 0) + r.metrics.stepCount;
+		}
+		if (r.metrics?.toolCallCount != null) {
+			toolCalls = (toolCalls ?? 0) + r.metrics.toolCallCount;
+		}
+	}
+	return { steps: steps, toolCalls: toolCalls };
 }
 
 /** Logs each resolution's AI token usage (when the provider reported it) plus a run total to the

--- a/src/webviews/plus/graph/graphService.ts
+++ b/src/webviews/plus/graph/graphService.ts
@@ -102,6 +102,10 @@ export type ResolveResult =
 				/** Present only when seeded from an automatic-rebase escalation — tells the panel the
 				 *  run is mid-rebase so it can offer "Apply & Resume with AI" instead of a plain Apply. */
 				autoRebase?: { sessionId: string; stepNumber?: number; totalSteps?: number };
+				/** Resolver effort summed over the run, for telemetry only — aggregated host-side because
+				 *  the per-file `metrics` never cross the IPC boundary. A count is `undefined` when no
+				 *  resolution reported it, so "not measured" stays distinct from "zero". */
+				metrics?: { steps?: number; toolCalls?: number };
 			};
 	  }
 	| { error: { message: string } }


### PR DESCRIPTION
Closes #5734

One commit, telemetry-only. Makes conflict-resolution usage measurable, individual AI requests attributable, and the panel's refine/retry gestures countable.

## The problem

`ai/generate` with `type: 'resolveConflicts'` — the event the Amplitude dashboard uses — counts model round-trips inside the resolver's agentic loop, not user actions. It's emitted from the model port handed to `@gitkraken/conflict-tools`, which the library calls once per step, and `sendRequest` sends one event per call.

Up to 15 steps (+5 refine) per file, across up to 5 files in flight, once per paused step in an automatic rebase. Net effect: 3,978 events from 17 unique users in one day, which reads as a 2330% usage spike but is roughly two automatic rebases per user.

Nothing on the event tied a request back to the work that produced it, either.

## 1. Attribution: `conversationId`, `retry.count`, resolver effort

**`conversationId` never reached the event.** It was threaded to `sendRequest` but only used for BYOK usage aggregation, so a resolution's many requests couldn't be grouped, nor reconciled against the backend's flat per-session fee. It's now stamped in `sendRequest`, so every looping feature gets it and it lands on the failure paths too — which is where an unattributable request is most costly to investigate.

**This makes usage measurable.** A conversation is the user's whole resolution task, so counting distinct IDs (filtered to `type: 'resolveConflicts'`) counts sessions. The panel mints one on the first AI call and clears it on Apply or Discard, so refine and per-file retry fold into the session containing them. An automatic rebase keeps one ID across an escalation, the manual finishing (the panel adopts the run's ID), and re-engaging automation.

No new event is needed for per-operation counts — `autoRebase/step/resolved` and `graphDetails/resolve/generateResolutions/completed` already provide them on the automatic and manual paths respectively. Counting IDs answers "how many people resolved conflicts"; those two answer "how much work did the resolver do". One caveat: because an escalated rebase shares its ID with the panel, an ID alone can't be attributed to a single path — split on `source.detail` for that.

**`retry.count` was always 0 for conflict resolution.** `sendRequest` builds the event data once, before the first attempt, and always asks for attempt 0. The prompt-template features get a real value only because `resolvePrompt` writes it back onto the shared reporting object as each attempt runs. This path builds its own messages, so it now writes `retry.count` and `input.length` back itself — a request whose provider shrank its token budget and retried is no longer indistinguishable from a clean first attempt.

**The resolve panel reported no resolver effort.** `autoRebase/step/resolved` carries `tools.steps.count` and `tools.calls.count` — what separates a cheap resolution from one where the model burned its `maxSteps` budget on validation retries. The manual path had no equivalent, so the two couldn't be compared on cost despite running the same resolver.

The library's per-file `metrics` never cross the IPC boundary, so rather than pushing analytics-only fields onto `ResolvedFileSummary` (a UI type), they're aggregated host-side in `sumResolutionEffort` and passed to the panel as one run-level total. A count stays **`undefined` when no resolution reported one**, matching `autoRebase/step/resolved`'s `sumOf` — reporting `0` would make "not measured" read as "the resolver did the work for free", which defeats the comparison the field exists for.

## 2. Session counts: `run.kind`, refine/retry

The panel reports `refine` as a boolean derived from whether a result is on screen, and never accumulates it — so "how many times does a user refine before accepting?" is unanswerable. Two paths are worse than uncounted:

- **Retry-after-error is reported as a cold start.** After a failure the resolve resource holds `{error}`, so the `'result' in value` test is false. Runs now declare their kind, and `run.kind` (`start` | `refine` | `retry`) splits the two non-cold cases. `refine` keeps its existing meaning so no current dashboard shifts.
- **Per-file "retry with feedback" emits nothing at all** — no duration, model, or outcome. It gets its own `graphDetails/resolve/retryFile/completed|failed` pair.

Every resolve event now carries the session's gesture counts, so a resolution reads as "accepted after N refines and M retries":

| Field | Notes |
|---|---|
| `run.kind` | `start` / `refine` / `retry` — generate events only |
| `refine.count` | Whole-run Refines so far this session |
| `retryFromError.count` | Retry-after-error dispatches so far this session |
| `retryFile.count` | Per-file feedback retries so far this session |

Deliberately not a bare `retry.count`, which already means provider-level request retries on `AIEventDataSendBase`.

A session is one panel engagement — a cold run or an escalation seed — through apply/discard. `resetResolveSession()` is the single choke point that zeroes the counts alongside the resource; the two mode-generic reset sites are handled separately, since `dispatchOperation` resets the resource at the start of *every* run including a refine and must not touch the counts. Apply and discard are terminal and fire once per session, so `avg('refine.count')` over `applyResolutions/completed` answers the question directly.

Counts are captured at dispatch rather than read at settle — with several per-file retries in flight, reading at settle makes them all report the same running total instead of their own position in the session.

## Testing

17 tests across four files:

- `plus/coretools/conflict/__tests__/integration.test.ts` — the retry-count/`input.length` write-back and the conversation ID being carried by every request in a loop, driving the real resolver loop through the existing AI fakes.
- `plus/ai/__tests__/aiProviderService.telemetry.test.ts` *(new)* — the `conversationId` stamp landing on the event, including on a failure path, and staying unset for one-shot features. Since counting distinct IDs is the usage metric, this assignment is load-bearing enough to cover directly.
- `webviews/plus/graph/__tests__/graphInspectServices.test.ts` — resolver-effort aggregation, including the `undefined`-not-zero case.
- `webviews/apps/plus/graph/components/__tests__/detailsWorkflowController.test.ts` — session counts across refine/retry/cold-start, the retry-after-error regression, the new per-file retry events, concurrent retries counting once each, and terminal totals on discard.

`pnpm run build` (type-check + lint) clean, full unit suite passing (2267).

## Notes

- No CHANGELOG entry — telemetry-only, matching `b60401572`.
- `docs/telemetry-events.md` is regenerated, not hand-edited.
- Blocked attempts stay invisible: a user who hits the paywall makes no AI request, so there's no `ai/generate` to count. If "users who tried and were blocked" is wanted, it belongs in its own event at the gate rather than folded into a usage counter.

## Not included

- **`takeSide` / `promoteToResolved` still emit nothing.** Manual override is arguably the strongest quality signal in the panel, but it's neither refine nor retry — worth its own change.
- **Compose has the same measurement problem** (one plan generation is 4–10+ `sendRequest` calls, with no grouping ID). Being handled separately; the likely shape is telemetry-only `source.correlationId` rather than a `conversationId`, since the latter carries BYOK/fee coupling that compose doesn't need.
- **The conversation ID outlives a panel session in one case.** Going back from an error or cancelling ends the panel session but leaves the host conversation open, so one ID can span two of them. The session counts are documented as per-panel-session for that reason.
- #5734 documents ~20 declared-but-never-emitted events found while scanning all 321 keys in `TelemetryEvents`, including `graphDetails/resolve/opened`/`closed`, which blocks the panel funnel. Left out deliberately; the systemic fix (a `lint:ci` check that every declared key is emitted or template-matched) is the more valuable follow-up.
