### PR TITLE
Fixes flaky and failing Graph pin-to-edge E2E tests - #5627

### DIFF
--- a/tests/e2e/fixtures/git.ts
+++ b/tests/e2e/fixtures/git.ts
@@ -75,11 +75,22 @@ export class GitFixture {
 		await new Promise(resolve => setTimeout(resolve, 500));
 	}
 
-	async commit(message: string, fileName: string = 'test-file.txt', content: string = 'content'): Promise<void> {
+	async commit(
+		message: string,
+		fileName: string = 'test-file.txt',
+		content: string = 'content',
+		options?: { date?: string },
+	): Promise<void> {
 		const filePath = path.join(this.repoPath, fileName);
 		await fs.writeFile(filePath, content);
 		await this.git('add', undefined, fileName);
-		await this.git('commit', undefined, '-m', message);
+		// A fixed author/committer date makes row order deterministic: commits created within the same
+		// second otherwise sort arbitrarily, which floats a branch's row in the graph.
+		const commitOptions =
+			options?.date != null
+				? { env: { GIT_AUTHOR_DATE: options.date, GIT_COMMITTER_DATE: options.date } }
+				: undefined;
+		await this.git('commit', commitOptions, '-m', message);
 	}
 
 	/**
@@ -396,7 +407,11 @@ export class GitFixture {
 		await this.git('worktree', undefined, 'prune');
 	}
 
-	private async git(command: string, options?: { configs?: string[] }, ...args: string[]): Promise<string> {
+	private async git(
+		command: string,
+		options?: { configs?: string[]; env?: Record<string, string> },
+		...args: string[]
+	): Promise<string> {
 		const fullArgs = [...(options?.configs ?? []), command, ...args];
 		return new Promise((resolve, reject) => {
 			// Fixture repos must not inherit the developer's global/system git config. A `merge.ff=only`,
@@ -406,7 +421,12 @@ export class GitFixture {
 			// on what these methods set explicitly.
 			const child = spawn('git', fullArgs, {
 				cwd: this.repoPath,
-				env: { ...process.env, GIT_CONFIG_GLOBAL: '/dev/null', GIT_CONFIG_SYSTEM: '/dev/null' },
+				env: {
+					...process.env,
+					GIT_CONFIG_GLOBAL: '/dev/null',
+					GIT_CONFIG_SYSTEM: '/dev/null',
+					...(options?.env ?? {}),
+				},
 			});
 
 			let stdout = '';

--- a/tests/e2e/specs/graphPin.test.ts
+++ b/tests/e2e/specs/graphPin.test.ts
@@ -7,8 +7,9 @@
  * - Unpin and verify state cleared
  */
 import * as process from 'node:process';
-import type { FrameLocator } from '@playwright/test';
-import { test as base, createTmpDir, expect, GitFixture } from '../baseTest.js';
+import type { FrameLocator, Locator } from '@playwright/test';
+import type { VSCodeInstance } from '../baseTest.js';
+import { test as base, createTmpDir, expect, GitFixture, MaxTimeout } from '../baseTest.js';
 
 interface GraphStateInfo {
 	webviewId: string | undefined;
@@ -73,6 +74,45 @@ async function getPinnedRef(webview: FrameLocator): Promise<GraphStateInfo['pinn
 	return JSON.parse(json) as GraphStateInfo['pinnedRef'] | null;
 }
 
+/**
+ * Clear any edge pin and wait for it to actually leave the webview state before tearing down. The no-arg
+ * `unpinBranchFromEdge` clears the pin for the LIVE graph session's repo, so the graph has to be shown (a
+ * session must exist), and the pin is persisted per-repo in workspace storage — a fire-and-forget unpin can
+ * lose the race with `resetUI` and leak the pin into the next serial test. Polling the state to null closes
+ * that race; a genuinely stuck pin (an unpin regression) is still surfaced by the next test that asserts on it.
+ */
+async function clearEdgePin(vscode: VSCodeInstance): Promise<void> {
+	await vscode.gitlens.showCommitGraphView();
+	const webview = await vscode.gitlens.commitGraphViewWebview;
+	if (webview == null) return;
+
+	const pinned = await getPinnedRef(webview);
+	if (pinned == null) return;
+
+	const state = await getGraphState(webview);
+	if (state == null) return;
+
+	// `unpinBranchFromEdge` is a webview command: it ignores its item arg (it clears the LIVE graph
+	// session's repo) but the webview framework still routes on the `webview`/`webviewInstance` ids, so a
+	// no-arg call reaches no controller and silently no-ops — leaking the pin (persisted per-repo in
+	// workspace storage) into the next serial test. Passing the routing context is what actually lands the
+	// unpin; poll the webview state to confirm it cleared before tearing down.
+	await expect
+		.poll(
+			async () => {
+				await vscode.gitlens
+					.executeCommand('gitlens.graph.unpinBranchFromEdge', {
+						webview: state.webviewId,
+						webviewInstance: state.webviewInstanceId,
+					})
+					.catch(() => {});
+				return getPinnedRef(webview);
+			},
+			{ timeout: 15000, intervals: [250, 500, 1000, 1000, 2000] },
+		)
+		.toBeNull();
+}
+
 async function hasPinButton(webview: FrameLocator): Promise<boolean> {
 	const json = String(await webview.locator(':root').evaluate(hasPinButtonScript));
 	return JSON.parse(json) as boolean;
@@ -99,6 +139,166 @@ async function ensureDetailsPanelClosed(webview: FrameLocator): Promise<void> {
 			timeout: 15000,
 		});
 	}
+}
+
+/**
+ * The `GraphItemContext` the graph's own menus carry into the pin/unpin commands. Built here rather
+ * than inline per test: `pinBranchToEdge` bails unless `refType === 'branch'` and `ref.id != null`
+ * (`graphCommands.ts`), and the id has to be the one the rows carry — `<repoPath>|heads/<name>` or
+ * `|remotes/<name>` (`getBranchId`) — or the webview never matches the pin to a row.
+ */
+function graphRefContext(state: GraphStateInfo, name: string, remote: boolean, pinned: boolean = false) {
+	return {
+		webview: state.webviewId,
+		webviewInstance: state.webviewInstanceId,
+		webviewItem: pinned ? 'gitlens:branch+pinned' : 'gitlens:branch',
+		webviewItemValue: {
+			type: 'branch',
+			ref: {
+				refType: 'branch',
+				repoPath: state.repoPath,
+				ref: name,
+				name: name,
+				id: `${state.repoPath}|${remote ? 'remotes' : 'heads'}/${name}`,
+				remote: remote,
+			},
+		},
+	};
+}
+
+/**
+ * Pin a branch and wait for the webview to have it. Gated on the state rather than a fixed delay: the
+ * command resolves as soon as the host records the pin, while the webview learns about it over a
+ * separate notification.
+ */
+async function pinBranch(
+	vscode: VSCodeInstance,
+	webview: FrameLocator,
+	state: GraphStateInfo,
+	name: string,
+	options?: { remote?: boolean },
+): Promise<void> {
+	const remote = options?.remote === true;
+	await vscode.gitlens.executeCommand('gitlens.graph.pinBranchToEdge', graphRefContext(state, name, remote));
+	await expect
+		.poll(async () => (await getPinnedRef(webview))?.id, { timeout: 15000 })
+		.toBe(`${state.repoPath}|${remote ? 'remotes' : 'heads'}/${name}`);
+}
+
+/** Unpin via the command, and wait for the webview's state to clear. */
+async function unpinBranch(
+	vscode: VSCodeInstance,
+	webview: FrameLocator,
+	state: GraphStateInfo,
+	name: string,
+	options?: { remote?: boolean },
+): Promise<void> {
+	await vscode.gitlens.executeCommand(
+		'gitlens.graph.unpinBranchFromEdge',
+		graphRefContext(state, name, options?.remote === true, true),
+	);
+	await expect.poll(() => getPinnedRef(webview), { timeout: 15000 }).toBeNull();
+}
+
+/** A row's ref pill, addressed by the ref it names. */
+function refPill(webview: FrameLocator, refName: string): Locator {
+	return webview.locator('.gl-graph__ref-pill').filter({ hasText: refName }).first();
+}
+
+/**
+ * The pin control on a ref pill — the pinned glyph at rest, `close` on hover, and the only in-graph way
+ * to unpin (`renderPinControl`).
+ *
+ * Scoped to `.gl-graph__ref-pill-expand`: a pill renders the leading slot TWICE, and the in-flow copy
+ * under `.gl-graph__ref-pill-main` is the covered one — `pinnedTargetForEvent` in `gl-lit-graph.ts`
+ * redirects to the expand copy for exactly this reason, so a click has to target the same one.
+ */
+function refPillPinControl(webview: FrameLocator, refName: string): Locator {
+	return refPill(webview, refName).locator('.gl-graph__ref-pill-expand .gl-graph__ref-pill-icon--pin').first();
+}
+
+/**
+ * The edge-pin control's IN-FLOW copy — the resting pin indicator in the leading slot of
+ * `.gl-graph__ref-pill-main`. This copy is the one visible at rest (the `-expand` overlay is
+ * `display:none` until the pill fills on hover/focus), so it — not `refPillPinControl` — is what an
+ * indicator / aria assertion reads without first hovering.
+ */
+function refPillPinIndicator(webview: FrameLocator, refName: string): Locator {
+	return refPill(webview, refName).locator('.gl-graph__ref-pill-main .gl-graph__ref-pill-icon--pin').first();
+}
+
+/**
+ * Click an edge-pin control the way a user does. Hovering the pill fills it, which flips the in-flow
+ * `-main` copy to `visibility:hidden` and reveals the `-expand` overlay on top — so the only copy that
+ * actually receives the click is the overlay one. Playwright's own auto-hover during `click()` triggers
+ * exactly this flip, so a click aimed at the resting copy lands on a hidden element; hover first, then
+ * click the overlay copy.
+ */
+async function clickPinControl(webview: FrameLocator, refName: string, control: Locator): Promise<void> {
+	await refPill(webview, refName).hover();
+	await expect(control).toBeVisible({ timeout: MaxTimeout });
+	await control.click();
+}
+
+/**
+ * Scroll the virtualized graph to a fraction of its range (0 = top, 1 = bottom). Writing `scrollTop`
+ * fires the scroller's `scroll` event, which drives `updateHeadPillDirection` / `updatePinnedPillDirection`.
+ * Half-way puts BOTH the newest (HEAD) and the oldest rows off-screen at once.
+ */
+async function scrollGraphToFraction(webview: FrameLocator, fraction: number): Promise<void> {
+	await webview.locator(':root').evaluate((_el, f) => {
+		const scroller = document.querySelector('gl-lit-graph lit-virtualizer');
+		if (scroller != null) {
+			scroller.scrollTop = Math.max(0, (scroller.scrollHeight - scroller.clientHeight) * f);
+		}
+	}, fraction);
+}
+
+/**
+ * Toggle the details panel and wait for the opposite state — a real resize of the row grid (which fires
+ * the graph's ResizeObserver) with NO scrolling.
+ */
+async function toggleDetailsPanel(webview: FrameLocator): Promise<void> {
+	const toggle = webview.locator('gl-button[aria-label$="Details Panel"]').first();
+	await expect(toggle).toBeVisible({ timeout: 15000 });
+	const wasHiding = (await toggle.getAttribute('aria-label')) === 'Hide Details Panel';
+	await toggle.click();
+	const nextLabel = wasHiding ? 'Show Details Panel' : 'Hide Details Panel';
+	await expect(webview.locator(`gl-button[aria-label="${nextLabel}"]`).first()).toBeVisible({ timeout: 15000 });
+}
+
+/**
+ * The pinned branch's band on the scroll rail. Matched on its colour variable, because the rendered box
+ * carries no type of its own — `renderScrollMarkers` emits only geometry plus `backgroundColor`, and
+ * `pinned` is the one lane painted with `--color-graph-scroll-marker-pinned` (`graph-scroll-markers.ts`).
+ */
+function pinnedScrollMarker(webview: FrameLocator): Locator {
+	return webview.locator('.gl-graph__scroll-marker-box[style*="scroll-marker-pinned"]');
+}
+
+/** The floating waypoints capsule and its two possible segments (`renderWaypoints`). */
+function waypointsCapsule(webview: FrameLocator): Locator {
+	return webview.locator('.gl-graph__waypoints');
+}
+
+function headWaypoint(webview: FrameLocator): Locator {
+	return webview.locator('.gl-graph__waypoint--head');
+}
+
+function pinnedWaypoint(webview: FrameLocator): Locator {
+	return webview.locator('.gl-graph__waypoint--pinned');
+}
+
+const getSelectedShasScript = `(() => {
+	const graph = document.querySelector('gl-lit-graph');
+	const rows = graph?.selectedRows;
+	return JSON.stringify(rows != null ? Object.keys(rows).sort() : []);
+})()`;
+
+/** The shas the graph considers selected — the invariant the pin control's `stopPropagation` protects. */
+async function getSelectedShas(webview: FrameLocator): Promise<string[]> {
+	const json = String(await webview.locator(':root').evaluate(getSelectedShasScript));
+	return JSON.parse(json) as string[];
 }
 
 const test = base.extend({
@@ -183,6 +383,7 @@ test.describe('Graph — Pin Branch to Edge', () => {
 	test.describe.configure({ mode: 'serial' });
 
 	test.afterEach(async ({ vscode }) => {
+		await clearEdgePin(vscode);
 		await vscode.gitlens.resetUI();
 	});
 
@@ -206,24 +407,7 @@ test.describe('Graph — Pin Branch to Edge', () => {
 		expect(stateInfo!.pinnedRef).toBeUndefined();
 
 		const branchId = `${stateInfo!.repoPath}|heads/branch-a`;
-		await vscode.gitlens.executeCommand('gitlens.graph.pinBranchToEdge', {
-			webview: stateInfo!.webviewId,
-			webviewInstance: stateInfo!.webviewInstanceId,
-			webviewItem: 'gitlens:branch',
-			webviewItemValue: {
-				type: 'branch',
-				ref: {
-					refType: 'branch',
-					repoPath: stateInfo!.repoPath,
-					ref: 'branch-a',
-					name: 'branch-a',
-					id: branchId,
-					remote: false,
-				},
-			},
-		});
-
-		await vscode.page.waitForTimeout(1000);
+		await pinBranch(vscode, graphWebview!, stateInfo!, 'branch-a');
 
 		const pinnedState = await getPinnedRef(graphWebview!);
 		expect(pinnedState).not.toBeNull();
@@ -253,47 +437,117 @@ test.describe('Graph — Pin Branch to Edge', () => {
 		const stateInfo = await getGraphState(graphWebview!);
 		expect(stateInfo).not.toBeNull();
 
-		await vscode.gitlens.executeCommand('gitlens.graph.pinBranchToEdge', {
-			webview: stateInfo!.webviewId,
-			webviewInstance: stateInfo!.webviewInstanceId,
-			webviewItem: 'gitlens:branch',
-			webviewItemValue: {
-				type: 'branch',
-				ref: {
-					refType: 'branch',
-					repoPath: stateInfo!.repoPath,
-					ref: 'branch-b',
-					name: 'branch-b',
-					id: `${stateInfo!.repoPath}|heads/branch-b`,
-					remote: false,
-				},
-			},
-		});
-		await vscode.page.waitForTimeout(1000);
+		await pinBranch(vscode, graphWebview!, stateInfo!, 'branch-b');
 
 		const pinnedBefore = await getPinnedRef(graphWebview!);
 		expect(pinnedBefore).not.toBeNull();
 
-		await vscode.gitlens.executeCommand('gitlens.graph.unpinBranchFromEdge', {
-			webview: stateInfo!.webviewId,
-			webviewInstance: stateInfo!.webviewInstanceId,
-			webviewItem: 'gitlens:branch+pinned',
-			webviewItemValue: {
-				type: 'branch',
-				ref: {
-					refType: 'branch',
-					repoPath: stateInfo!.repoPath,
-					ref: 'branch-b',
-					name: 'branch-b',
-					id: `${stateInfo!.repoPath}|heads/branch-b`,
-					remote: false,
-				},
-			},
-		});
-		await vscode.page.waitForTimeout(1000);
+		await unpinBranch(vscode, graphWebview!, stateInfo!, 'branch-b');
 
 		const pinnedAfter = await getPinnedRef(graphWebview!);
 		expect(pinnedAfter).toBeNull();
+	});
+
+	test('renders the pin indicator on the pinned pill, and unpin is reachable from it', async ({ vscode }) => {
+		using _ = await vscode.gitlens.startSubscriptionSimulation({ state: 6, planId: 'pro' });
+
+		await vscode.gitlens.showCommitGraphView();
+		const graphWebview = await vscode.gitlens.commitGraphViewWebview;
+		expect(graphWebview).not.toBeNull();
+		await vscode.page.waitForTimeout(3000);
+
+		// The branch rows have to be painted for their pills to exist at all — see `ensureDetailsPanelClosed`
+		await ensureDetailsPanelClosed(graphWebview!);
+		const pill = refPill(graphWebview!, 'branch-a');
+		await expect(pill).toBeVisible({ timeout: MaxTimeout });
+
+		// Unpinned: the pill carries no pin control anywhere, but it does carry its kind glyph.
+		await expect(pill.locator('.gl-graph__ref-pill-icon--pin')).toHaveCount(0);
+		await expect(pill.locator('.gl-graph__ref-pill-main .gl-graph__ref-pill-icon').first()).toBeVisible({
+			timeout: MaxTimeout,
+		});
+
+		const stateInfo = await getGraphState(graphWebview!);
+		expect(stateInfo).not.toBeNull();
+		await pinBranch(vscode, graphWebview!, stateInfo!, 'branch-a');
+
+		// The pin renders as an at-rest INDICATOR in the leading slot — visible without hovering, since the
+		// edge pin is not a `$pill-filled` trigger (the `-expand` overlay stays hidden at rest).
+		const indicator = refPillPinIndicator(graphWebview!, 'branch-a');
+		await expect(indicator).toBeVisible({ timeout: MaxTimeout });
+		await expect(indicator).toHaveAttribute('aria-label', 'Unpin Branch from Edge');
+		// At rest it shows the pinned glyph; it swaps to `close` only on hover of the control itself.
+		await expect(indicator.locator('code-icon[icon="gl-pinned-filled"]')).toBeVisible({ timeout: MaxTimeout });
+
+		// The real contract is that the pin JOINS the kind glyph rather than replacing it (the glyph is the
+		// only thing naming WHAT is pinned), so the pinned leading slot still carries the ref's kind icon
+		// next to the pin. The pill is deliberately allowed to grow to fit — this is NOT a no-layout-shift
+		// check, which an earlier version wrongly asserted against a `display:none` overlay box.
+		await expect(
+			pill.locator(
+				'.gl-graph__ref-pill-main .gl-graph__ref-pill-pinned-slot .gl-graph__ref-pill-icon:not(.gl-graph__ref-pill-icon--pin)',
+			),
+		).toBeVisible({ timeout: MaxTimeout });
+	});
+
+	test('unpins from the pill without selecting the row or opening the branch sheet', async ({ vscode }) => {
+		using _ = await vscode.gitlens.startSubscriptionSimulation({ state: 6, planId: 'pro' });
+
+		await vscode.gitlens.showCommitGraphView();
+		const graphWebview = await vscode.gitlens.commitGraphViewWebview;
+		expect(graphWebview).not.toBeNull();
+		await vscode.page.waitForTimeout(3000);
+
+		await ensureDetailsPanelClosed(graphWebview!);
+		const stateInfo = await getGraphState(graphWebview!);
+		expect(stateInfo).not.toBeNull();
+		await pinBranch(vscode, graphWebview!, stateInfo!, 'branch-a');
+
+		// The at-rest indicator confirms the pin landed; the unpin click itself has to go through the
+		// `-expand` overlay copy (see `clickPinControl`).
+		await expect(refPillPinIndicator(graphWebview!, 'branch-a')).toBeVisible({ timeout: MaxTimeout });
+		await expect(pinnedScrollMarker(graphWebview!).first()).toBeVisible({ timeout: MaxTimeout });
+
+		// The contract `renderPinControl`'s `stopPropagation` exists for: the click must not reach the pill,
+		// which selects the row and opens the branch sheet. Captured BEFORE the click so the assertion is
+		// about what the click changed, not about what the graph happened to have selected.
+		const selectedBefore = await getSelectedShas(graphWebview!);
+
+		await clickPinControl(graphWebview!, 'branch-a', refPillPinControl(graphWebview!, 'branch-a'));
+
+		// Pin cleared everywhere it was shown: state, pill glyph, rail band
+		await expect.poll(() => getPinnedRef(graphWebview!), { timeout: MaxTimeout }).toBeNull();
+		await expect(refPill(graphWebview!, 'branch-a').locator('.gl-graph__ref-pill-icon--pin')).toHaveCount(0);
+		await expect(pinnedScrollMarker(graphWebview!)).toHaveCount(0);
+
+		// ...and the click did nothing else
+		expect(await getSelectedShas(graphWebview!)).toEqual(selectedBefore);
+		await expect(graphWebview!.locator('gl-graph-branch-sheet-pane, gl-graph-branch-sheet')).toHaveCount(0);
+	});
+
+	test('shows the pinned band on the scroll rail only while pinned', async ({ vscode }) => {
+		using _ = await vscode.gitlens.startSubscriptionSimulation({ state: 6, planId: 'pro' });
+
+		await vscode.gitlens.showCommitGraphView();
+		const graphWebview = await vscode.gitlens.commitGraphViewWebview;
+		expect(graphWebview).not.toBeNull();
+		await vscode.page.waitForTimeout(3000);
+
+		await ensureDetailsPanelClosed(graphWebview!);
+		// The rail itself is always present while any marker type is enabled (it is also the right-click
+		// target for its own menu), so the band — not the rail — is what the pin adds.
+		await expect(graphWebview!.locator('.gl-graph__scroll-markers')).toBeVisible({ timeout: MaxTimeout });
+		await expect(pinnedScrollMarker(graphWebview!)).toHaveCount(0);
+
+		const stateInfo = await getGraphState(graphWebview!);
+		expect(stateInfo).not.toBeNull();
+		await pinBranch(vscode, graphWebview!, stateInfo!, 'branch-b');
+
+		// `pinned` is an always-on marker role — it does not depend on `graph.scrollMarkers.additionalTypes`
+		await expect(pinnedScrollMarker(graphWebview!).first()).toBeVisible({ timeout: MaxTimeout });
+
+		await unpinBranch(vscode, graphWebview!, stateInfo!, 'branch-b');
+		await expect(pinnedScrollMarker(graphWebview!)).toHaveCount(0);
 	});
 });
 
@@ -303,6 +557,7 @@ testTall.describe('Graph — Pin Branch to Edge — jump-to-pinned pill', () => 
 	testTall.describe.configure({ mode: 'serial' });
 
 	testTall.afterEach(async ({ vscode }) => {
+		await clearEdgePin(vscode);
 		await vscode.gitlens.resetUI();
 	});
 
@@ -354,4 +609,198 @@ testTall.describe('Graph — Pin Branch to Edge — jump-to-pinned pill', () => 
 			await expect.poll(() => hasPinButton(graphWebview!), { timeout: 10000 }).toBe(true);
 		},
 	);
+
+	testTall('adds the pinned segment left of HEAD without moving HEAD', async ({ vscode }) => {
+		using _ = await vscode.gitlens.startSubscriptionSimulation({ state: 6, planId: 'pro' });
+
+		await vscode.gitlens.showCommitGraphView();
+		const graphWebview = await vscode.gitlens.commitGraphViewWebview;
+		expect(graphWebview).not.toBeNull();
+		await vscode.page.waitForTimeout(3000);
+
+		// Scroll to the MIDDLE of the range so BOTH the newest (HEAD) and the oldest (branch-c) rows sit
+		// off-screen at once: HEAD's waypoint is the capsule's anchor here, and branch-c's row has to be
+		// off-screen too for the pinned segment to render. An over-large delta would instead land at the
+		// bottom, bringing branch-c back into view.
+		await scrollGraphToFraction(graphWebview!, 0.5);
+
+		const head = headWaypoint(graphWebview!);
+		await expect(head).toBeVisible({ timeout: MaxTimeout });
+		await expect(pinnedWaypoint(graphWebview!)).toHaveCount(0);
+
+		const headBefore = await head.boundingBox();
+		expect(headBefore).not.toBeNull();
+
+		const stateInfo = await getGraphState(graphWebview!);
+		expect(stateInfo).not.toBeNull();
+		await pinBranch(vscode, graphWebview!, stateInfo!, 'branch-c');
+
+		const pinned = pinnedWaypoint(graphWebview!);
+		await expect(pinned).toBeVisible({ timeout: MaxTimeout });
+
+		// Both segments in one capsule, pinned first
+		await expect(waypointsCapsule(graphWebview!)).toHaveCount(1);
+
+		const pinnedBox = await pinned.boundingBox();
+		const headAfter = await head.boundingBox();
+		expect(pinnedBox).not.toBeNull();
+		expect(headAfter).not.toBeNull();
+
+		// Pinned sits to the LEFT of HEAD...
+		expect(pinnedBox!.x + pinnedBox!.width).toBeLessThanOrEqual(headAfter!.x + 1);
+		// ...and HEAD's right edge is where it was: the capsule grows leftward, which is the whole point of
+		// making HEAD the trailing anchor (a pin appearing must not shift the target the user is aiming at).
+		expect(Math.abs(headAfter!.x + headAfter!.width - (headBefore!.x + headBefore!.width))).toBeLessThanOrEqual(1);
+	});
+});
+
+// The resize-recompute test needs a NON-head branch that is on screen at the resting grid height but
+// leaves the viewport when the grid shrinks. `main` (HEAD, row 0) stays pinned to the top on any resize,
+// and pinning it collapses into the head waypoint (`pinnedIsHead`) so the pinned segment never renders —
+// hence a dedicated branch. `pinme` diverges from the initial commit and `main` is then buried under 6
+// newer commits, so pinme lands at a stable ~row 7: within the resting grid (~10 rows) but below the fold
+// once the details panel shrinks it (~5 rows). The commit dates are explicit and well separated because
+// same-second timestamps let git order same-date commits arbitrarily, which floated pinme's row and made
+// the on-screen->off-screen transition flaky; they are anchored an hour ahead of `init()`'s undated
+// initial commit so that commit always sorts oldest (bottom) no matter when the suite runs.
+const testResize = base.extend({
+	vscodeOptions: [
+		{
+			vscodeVersion: process.env.VSCODE_VERSION ?? 'stable',
+			setup: async () => {
+				const repoDir = await createTmpDir();
+				const git = new GitFixture(repoDir);
+				await git.init();
+
+				const anchorMs = Date.now() + 60 * 60 * 1000;
+				const at = (i: number) => new Date(anchorMs + i * 60_000).toISOString();
+
+				await git.branch('pinme');
+				await git.checkout('pinme');
+				await git.commit('Commit on pinme', 'pinme.txt', 'pinme change', { date: at(0) });
+				await git.checkout('main');
+				for (let i = 1; i <= 6; i++) {
+					await git.commit(`Main commit ${i}`, `main-${i}.txt`, `main change ${i}`, { date: at(i) });
+				}
+
+				return repoDir;
+			},
+		},
+		{ scope: 'worker' },
+	],
+});
+
+testResize.describe('Graph — Pin Branch to Edge — recompute on resize', () => {
+	testResize.describe.configure({ mode: 'serial' });
+
+	testResize.afterEach(async ({ vscode }) => {
+		await clearEdgePin(vscode);
+		await vscode.gitlens.resetUI();
+	});
+
+	// Regression for fdd3c3b7b: before it, the off-screen direction was recomputed only on scroll, so
+	// resizing while pinned left the capsule stale. Toggling the details panel resizes the row grid (firing
+	// the graph's ResizeObserver) with NO scroll — exactly the path the fix added.
+	testResize('recomputes the pinned segment when the grid resizes, without scrolling', async ({ vscode }) => {
+		using _ = await vscode.gitlens.startSubscriptionSimulation({ state: 6, planId: 'pro' });
+
+		await vscode.gitlens.showCommitGraphView();
+		const graphWebview = await vscode.gitlens.commitGraphViewWebview;
+		expect(graphWebview).not.toBeNull();
+		await vscode.page.waitForTimeout(3000);
+
+		// Start from the resting grid (details panel closed), where pinme's row is on screen.
+		await ensureDetailsPanelClosed(graphWebview!);
+
+		const stateInfo = await getGraphState(graphWebview!);
+		expect(stateInfo).not.toBeNull();
+
+		// Pin a NON-head branch whose row is on screen: the pinned waypoint must NOT render yet.
+		await pinBranch(vscode, graphWebview!, stateInfo!, 'pinme');
+		await expect(pinnedWaypoint(graphWebview!)).toHaveCount(0);
+
+		// Shrink the grid by opening the details panel — no scrolling. pinme's row leaves the viewport and
+		// the recompute-on-resize surfaces its segment.
+		await toggleDetailsPanel(graphWebview!);
+		await expect(pinnedWaypoint(graphWebview!)).toBeVisible({ timeout: MaxTimeout });
+		// It is the pin's own segment, not HEAD's — HEAD (row 0) is still on screen at the top.
+		await expect(headWaypoint(graphWebview!)).toHaveCount(0);
+
+		// Growing the grid back (closing the panel) brings the row into view again, and the segment goes
+		// away on the same resize signal.
+		await toggleDetailsPanel(graphWebview!);
+		await expect(pinnedWaypoint(graphWebview!)).toHaveCount(0);
+	});
+});
+
+// #5624's case A needs a row carrying BOTH the current branch and its in-sync upstream, so the two
+// combine into one pill. Built offline: `createRemoteBranch` writes `refs/remotes/origin/main` with
+// `update-ref` and `setUpstream` writes the tracking config, so no network or bare repo is involved.
+const testUpstream = base.extend({
+	vscodeOptions: [
+		{
+			vscodeVersion: process.env.VSCODE_VERSION ?? 'stable',
+			setup: async () => {
+				const repoDir = await createTmpDir();
+				const git = new GitFixture(repoDir);
+				await git.init();
+
+				await git.commit('Initial commit', 'test.txt', 'content');
+				await git.commit('Second commit', 'test2.txt', 'more content');
+
+				await git.addRemote('origin', 'https://example.com/gitlens-e2e/pin.git');
+				await git.createRemoteBranch('origin', 'main');
+				await git.setUpstream('main', 'origin/main');
+
+				return repoDir;
+			},
+		},
+		{ scope: 'worker' },
+	],
+});
+
+testUpstream.describe('Graph — Pin Branch to Edge — pinned upstream on the current row', () => {
+	testUpstream.describe.configure({ mode: 'serial' });
+
+	testUpstream.afterEach(async ({ vscode }) => {
+		await clearEdgePin(vscode);
+		await vscode.gitlens.resetUI();
+	});
+
+	// Regression for #5624 case A. The upstream is absorbed into the primary pill's own segment rather
+	// than rendered as a `+N` popover row, so before the fix a pin on it had nowhere to show: a deep
+	// search of the webview found zero `+pinned` elements, and the pin could not be cleared from the
+	// graph at all. It now gets a real control on that segment (`renderUpstreamSegment`).
+	testUpstream('surfaces the pin on the combined pill’s upstream segment', async ({ vscode }) => {
+		using _ = await vscode.gitlens.startSubscriptionSimulation({ state: 6, planId: 'pro' });
+
+		await vscode.gitlens.showCommitGraphView();
+		const graphWebview = await vscode.gitlens.commitGraphViewWebview;
+		expect(graphWebview).not.toBeNull();
+		await vscode.page.waitForTimeout(3000);
+
+		await ensureDetailsPanelClosed(graphWebview!);
+		const stateInfo = await getGraphState(graphWebview!);
+		expect(stateInfo).not.toBeNull();
+
+		// Pin the REMOTE ref while its local counterpart is checked out and in sync
+		await pinBranch(vscode, graphWebview!, stateInfo!, 'origin/main', { remote: true });
+
+		// The control lives on the upstream segment, which carries its own class so it can be told apart
+		// from the leading-slot pin of a single-ref row
+		const upstreamPin = graphWebview!.locator('.gl-graph__ref-pill-icon--pin-upstream').first();
+		await expect(upstreamPin).toBeVisible({ timeout: MaxTimeout });
+		await expect(upstreamPin).toHaveAttribute('aria-label', 'Unpin Branch from Edge');
+
+		// And it unpins, which is the half that was unreachable from the graph body entirely. The click has
+		// to go through the `-expand` overlay copy — hovering the pill hides the in-flow one (see
+		// `clickPinControl`).
+		await clickPinControl(
+			graphWebview!,
+			'main',
+			graphWebview!.locator('.gl-graph__ref-pill-expand .gl-graph__ref-pill-icon--pin-upstream').first(),
+		);
+		await expect.poll(() => getPinnedRef(graphWebview!), { timeout: MaxTimeout }).toBeNull();
+		await expect(graphWebview!.locator('.gl-graph__ref-pill-icon--pin-upstream')).toHaveCount(0);
+	});
 });


### PR DESCRIPTION
# Description

Fixes flaky and failing Commit Graph "pin branch to edge" E2E tests (#5627). All nine tests in `graphPin.test.ts` now pass reliably (verified with `--repeat-each=2` → 18/18). Every failure turned out to be a test-mechanics/fixture defect — no product bugs were found; the pin controls and the resize-recompute behavior (fdd3c3b7b) were confirmed working.

## What changed

- **Pinned-slot glyph assertion**: scoped to the in-flow `.gl-graph__ref-pill-main` copy so it no longer matches both the `-main` and `-expand` renderings of the pill (strict-mode violation).
- **Reliable edge-pin teardown**: `gitlens.graph.unpinBranchFromEdge` is a *webview* command — it ignores its item arg, but the webview framework still routes on the `webview`/`webviewInstance` ids, so a no-arg call reached no controller and silently no-op'd, leaking the per-repo pin (persisted in workspace storage) into the next serial test. The shared `clearEdgePin` helper now passes the routing context and polls the webview state until the pin actually clears.
- **Deterministic resize fixture**: rebuilt `testResize` with explicit, well-separated commit dates so the pinned branch lands at a stable row (same-second timestamps let git order commits arbitrarily, which floated the row and flaked the on-screen → off-screen transition). The pinned segment is now surfaced via a details-panel resize instead of the non-functional decrease-view-height command.
- **GitFixture**: added an optional `{ date? }` to `commit` (sets `GIT_AUTHOR_DATE`/`GIT_COMMITTER_DATE`, threaded through the private `git()` runner) so tests can pin commit ordering.

Independent code review: no material issues.

# Checklist

- [x] I have followed the guidelines in the Contributing document
- [x] My changes follow the coding style of this project
- [x] My changes build without any errors or warnings
- [x] My changes have been formatted and linted
- [x] My changes include any required corresponding changes to the documentation (including CHANGELOG.md and README.md)
- [x] My changes have been rebased and squashed to the minimal number (typically 1) of relevant commits
- [x] My changes have a descriptive commit message with a short title
