### PR TITLE
Fixes rebase E2E specs matching the AI twins of the default action

### DIFF
--- a/tests/e2e/specs/rebase.test.ts
+++ b/tests/e2e/specs/rebase.test.ts
@@ -1,8 +1,26 @@
 import * as fs from 'node:fs';
 import * as path from 'node:path';
 import * as process from 'node:process';
+import type { FrameLocator, Locator } from '@playwright/test';
 import type { VSCodeInstance } from '../baseTest.js';
 import { test as base, createTmpDir, DefaultTimeout, expect, GitFixture, ShortTimeout } from '../baseTest.js';
+
+/**
+ * The rebase editor's DEFAULT action: *Start Rebase* before the rebase runs, *Continue* while it is
+ * paused (`renderStartRebaseActions` / `renderActiveRebaseActions` in `apps/rebase/rebase.ts`).
+ *
+ * Excluding the AI actions is what makes this unambiguous, not a nicety. Since `d7a92df15` each default
+ * action has an AI twin whenever AI is allowed — *Start Auto-Rebase* beside *Start Rebase*, *Continue
+ * with AI* beside *Continue* — so a bare `/Start|Continue/` resolves to two `gl-button`s and every use
+ * fails Playwright's strict mode. It isn't a state a spec can steer around either: `aiAllowed` follows
+ * `gitlens.ai.enabled`, which `defaultUserSettings` turns on for every instance.
+ */
+function primaryRebaseAction(webviewFrame: FrameLocator): Locator {
+	return webviewFrame
+		.locator('gl-button')
+		.filter({ hasText: /Start|Continue/i })
+		.filter({ hasNotText: /Auto-Rebase|with AI/i });
+}
 
 /** SHA of the initial commit - captured during repo setup */
 let initialCommitSha: string;
@@ -482,7 +500,7 @@ test.describe('Editor — Core', () => {
 			await page.waitForTimeout(ShortTimeout / 2);
 
 			// Click Start/Continue button (gl-button custom element)
-			const startButton = webviewFrame.locator('gl-button').filter({ hasText: /Start|Continue/i });
+			const startButton = primaryRebaseAction(webviewFrame);
 			// Wait for any notifications to disappear or timeout
 			await page.waitForTimeout(ShortTimeout * 2);
 			// Try to close any visible notifications
@@ -538,7 +556,7 @@ test.describe('Editor — Core', () => {
 			await page.waitForTimeout(ShortTimeout / 2);
 
 			// Click Start/Continue button
-			const startButton = webviewFrame.locator('gl-button').filter({ hasText: /Start|Continue/i });
+			const startButton = primaryRebaseAction(webviewFrame);
 			// Wait for any notifications to disappear or timeout
 			await page.waitForTimeout(ShortTimeout * 2);
 			// Try to close any visible notifications
@@ -814,7 +832,7 @@ test.describe('Editor — Rebase Merges', () => {
 		expect(afterMessages).toEqual(beforeMessages);
 
 		// Verify Start button is NOT disabled
-		const startButton = webviewFrame.locator('gl-button').filter({ hasText: /Start|Continue/i });
+		const startButton = primaryRebaseAction(webviewFrame);
 		await expect(startButton).not.toBeDisabled();
 
 		// Signal editor done to keep it open, then abort


### PR DESCRIPTION
# Description

Two `rebase.test.ts` specs were failing on **every** editor in CI — three attempts each, so not a flake:

- `Editor — Core › Execute rebase › completes rebase after dropping a commit`
- `Editor — Rebase Merges › disables reordering but allows action changes for --rebase-merges with merge commits`

Both failed the same way: `locator('gl-button').filter({ hasText: /Start|Continue/i })` resolved to two elements, so Playwright's strict mode rejected the click and the `not.toBeDisabled()` assertion.

**Root cause is a test locator, not the product.** Since #5714 (`d7a92df15`, 2026-08-14) the rebase editor renders an AI twin beside its default action whenever AI is allowed:

| Editor state | Default action | AI twin |
| --- | --- | --- |
| before the rebase runs (`renderStartRebaseActions`) | `Start Rebase` | `Start Auto-Rebase` |
| while it is paused (`renderActiveRebaseActions`) | `Continue` | `Continue with AI` |

Both twins match a bare `/Start|Continue/`. No spec can steer around the state either: `state.aiAllowed` follows `gitlens.ai.enabled`, which `defaultUserSettings` turns on for every instance, so the ambiguity is permanent rather than conditional.

## What changed

`tests/e2e/specs/rebase.test.ts` only. The locator now names the default action and excludes the AI twins, in a single `primaryRebaseAction` helper that the three call sites share — so the next twin does not have to be excluded in three places. The comment records why the exclusion is load-bearing, since a future reader would otherwise be tempted to simplify it back.

## Validation

- Locally, whole `rebase.test.ts` at `--workers=1 --retries=0`: **13 passed / 1 skipped** on VS Code and on Windsurf (the pre-existing skip is the drag-and-drop spec).
- CI dispatch on this branch, `cli_insiders` off: https://github.com/gitkraken/vscode-gitlens/actions/runs/32035687391 — **green**. Both required legs pass: **E2E Tests (VS Code)** 220 passed / 4 skipped / 2 flaky and **E2E Tests (Windsurf)**, with both target specs ✓, plus Unit Tests and Build.
- The Positron leg is still red, on a failure this change does not touch and which also fails on `main`: `smoke.test.ts:207 › should show GitLens Inspect views when clicking GitLens Inspect icon`, 3 of 3 attempts, Positron-only. That leg is non-blocking by design (`continue-on-error: ${{ matrix.editor.experimental }}`, `ci.yml:171`), which is why the run is green. Its remaining 8 "did not run" sit behind that spec's serial group, not behind the rebase specs — dropping the two rebase failures moved that count by exactly one (9 → 8).

Note on the template's "create an issue first": there is no issue for this one — it was found while investigating https://github.com/gitkraken/vscode-gitlens/actions/runs/32032770137, the dispatch run on `main` right after #5738. Happy to file one if you want the paper trail.

# Checklist

- [x] I have followed the guidelines in the Contributing document
- [x] My changes follow the coding style of this project
- [x] My changes build without any errors or warnings
- [x] My changes have been formatted and linted
- [x] My changes include any required corresponding changes to the documentation — none required: the change is test-only, with no user-facing behavior, so no CHANGELOG entry
- [x] My changes have been rebased and squashed to the minimal number (typically 1) of relevant commits
- [x] My changes have a descriptive commit message with a short title
