### PR TITLE
perf(integrations): let scoped PR reads request the lightweight row shape

### DIFF
--- a/packages/plus/git-github/src/api/__tests__/pullRequestSearch.test.ts
+++ b/packages/plus/git-github/src/api/__tests__/pullRequestSearch.test.ts
@@ -219,6 +219,51 @@ suite('GitHubApi.searchPullRequestsPage', () => {
 		assert.match(getCalls()[1].query, /scopeOpen: search\(first: 100,/);
 	});
 
+	test('selects the lite fragment and the maximum default page size for a summary read', async () => {
+		// The full fragment resolves assignees(25) + latestReviews(25) + reviewRequests(25) per node,
+		// which is SERVER time rather than payload: measured against a 992-PR repo, one 30-node page
+		// took ~3090ms full vs ~1150ms lite for near-identical bytes (155KB vs 140KB). It compounds
+		// with the page size, since the default follows the projection: 100 PRs cost four sequential
+		// full pages (~12.4s) or one lite page (~1.8s).
+		const { config, getCalls } = capture();
+		await new GitHubApi(config).searchPullRequestsPage(provider, token, {
+			repos: ['o/a'],
+			summary: true,
+		});
+
+		const query = getCalls()[0].query;
+		assert.match(query, /scopeOpen: search\(first: 100,/);
+		// Review/check/diff selections are what the lite shape drops.
+		assert.doesNotMatch(query, /latestReviews/);
+		assert.doesNotMatch(query, /reviewRequests/);
+		assert.doesNotMatch(query, /statusCheckRollup/);
+		// What its consumers DO read must survive.
+		assert.match(query, /baseRefName/);
+		assert.match(query, /headRefName/);
+		assert.match(query, /body/);
+	});
+
+	test('keeps the full fragment and the cost-safe default when summary is not requested', async () => {
+		const { config, getCalls } = capture();
+		await new GitHubApi(config).searchPullRequestsPage(provider, token, { repos: ['o/a'] });
+
+		const query = getCalls()[0].query;
+		assert.match(query, /scopeOpen: search\(first: 30,/);
+		assert.match(query, /latestReviews/);
+	});
+
+	test('honours an explicit page size on the summary path too', async () => {
+		// Only the DEFAULT follows the projection; an explicit preference is still the caller's.
+		const { config, getCalls } = capture();
+		await new GitHubApi(config).searchPullRequestsPage(provider, token, {
+			repos: ['o/a'],
+			summary: true,
+			pageSize: 10,
+		});
+
+		assert.match(getCalls()[0].query, /scopeOpen: search\(first: 10,/);
+	});
+
 	test('translates the declared mention relationship without widening to commenter', async () => {
 		const { config, getCalls } = capture();
 		await new GitHubApi(config).searchPullRequestsPage(provider, token, {

--- a/packages/plus/git-github/src/api/__tests__/pullRequestSearch.test.ts
+++ b/packages/plus/git-github/src/api/__tests__/pullRequestSearch.test.ts
@@ -244,6 +244,26 @@ suite('GitHubApi.searchPullRequestsPage', () => {
 		assert.match(query, /stackEntry \{/);
 	});
 
+	test('shares the summary default page budget across active facets', async () => {
+		const { config, getCalls } = capture();
+		await new GitHubApi(config).searchPullRequestsPage(provider, token, {
+			repos: ['o/a'],
+			summary: true,
+			criteria: {
+				relationships: [
+					PullRequestFilter.Author,
+					PullRequestFilter.Assignee,
+					PullRequestFilter.ReviewRequested,
+					PullRequestFilter.Reviewed,
+					PullRequestFilter.Mention,
+				],
+				states: ['open', 'closed', 'merged'],
+			},
+		});
+
+		assert.equal(getCalls()[0].query.match(/search\(first: 6,/g)?.length, 15);
+	});
+
 	test('keeps the full fragment and the cost-safe default when summary is not requested', async () => {
 		const { config, getCalls } = capture();
 		await new GitHubApi(config).searchPullRequestsPage(provider, token, { repos: ['o/a'] });

--- a/packages/plus/git-github/src/api/__tests__/pullRequestSearch.test.ts
+++ b/packages/plus/git-github/src/api/__tests__/pullRequestSearch.test.ts
@@ -220,11 +220,8 @@ suite('GitHubApi.searchPullRequestsPage', () => {
 	});
 
 	test('selects the lite fragment and the maximum default page size for a summary read', async () => {
-		// The full fragment resolves assignees(25) + latestReviews(25) + reviewRequests(25) per node,
-		// which is SERVER time rather than payload: measured against a 992-PR repo, one 30-node page
-		// took ~3090ms full vs ~1150ms lite for near-identical bytes (155KB vs 140KB). It compounds
-		// with the page size, since the default follows the projection: 100 PRs cost four sequential
-		// full pages (~12.4s) or one lite page (~1.8s).
+		// Why the lite fragment is worth a separate projection, and why the default size follows it:
+		// see the `summary` option's doc on `GitHubApi.searchPullRequestsPage`.
 		const { config, getCalls } = capture();
 		await new GitHubApi(config).searchPullRequestsPage(provider, token, {
 			repos: ['o/a'],
@@ -241,6 +238,10 @@ suite('GitHubApi.searchPullRequestsPage', () => {
 		assert.match(query, /baseRefName/);
 		assert.match(query, /headRefName/);
 		assert.match(query, /body/);
+		// The lite mapper reads stack, and stack absence is a NEGATIVE fact (a stacked PR would read as
+		// unstacked); the summary projection is about what costs server time, not about dropping this.
+		assert.match(query, /stack \{/);
+		assert.match(query, /stackEntry \{/);
 	});
 
 	test('keeps the full fragment and the cost-safe default when summary is not requested', async () => {

--- a/packages/plus/git-github/src/api/github.ts
+++ b/packages/plus/git-github/src/api/github.ts
@@ -4527,20 +4527,9 @@ export class GitHubApi {
 			cursor?: string;
 			pageSize?: number;
 			/**
-			 * Uses the lightweight PR fragment while retaining identity, body, author, repository, branch refs and
-			 * stack info. Intended for aggregate/list surfaces that do not consume review, check, or diff
-			 * statistics — the same contract as `searchMyPullRequests`' option of the same name, stack fragment
-			 * included: the lite mapper reads `stack`/`stackEntry`, and their absence is indistinguishable from
-			 * "not stacked", so dropping them would report a negative as a fact.
-			 *
-			 * The full fragment resolves `assignees(25)`, `latestReviews(25)` and `reviewRequests(25)` per node, and
-			 * that is SERVER time rather than payload: measured against a 992-PR repo, one 30-node page took ~3090 ms
-			 * with the full fragment and ~1150 ms with the lite one, for near-identical bytes (155 KB vs 140 KB). Per
-			 * node that is 103 ms → 38 ms.
-			 *
-			 * It compounds with the page size, because the size follows the projection (see below): a single-facet
-			 * caller that wants 100 PRs pays four sequential full-fragment pages (~12.4 s) or one lite page
-			 * (~1.8 s, 18 ms/node). Multi-facet searches share that default budget across their active facets.
+			 * Uses the lightweight PR fragment, retaining identity, body, author, repository, branch refs, and stack
+			 * info while omitting review, check, and diff statistics. It also raises the default page budget, which
+			 * multi-facet searches share across their active facets.
 			 */
 			summary?: boolean;
 		},

--- a/packages/plus/git-github/src/api/github.ts
+++ b/packages/plus/git-github/src/api/github.ts
@@ -4525,14 +4525,35 @@ export class GitHubApi {
 			avatarSize?: number;
 			cursor?: string;
 			pageSize?: number;
+			/**
+			 * Uses the lightweight PR fragment while retaining identity, body, author, repository, and branch refs.
+			 * Intended for aggregate/list surfaces that do not consume review, check, or diff statistics — the same
+			 * contract as `searchMyPullRequests`' option of the same name.
+			 *
+			 * The full fragment resolves `assignees(25)`, `latestReviews(25)` and `reviewRequests(25)` per node, and
+			 * that is SERVER time rather than payload: measured against a 992-PR repo, one 30-node page took ~3090 ms
+			 * with the full fragment and ~1150 ms with the lite one, for near-identical bytes (155 KB vs 140 KB). Per
+			 * node that is 103 ms → 38 ms.
+			 *
+			 * It compounds with the page size, because the size follows the projection (see below): a caller that
+			 * wants 100 PRs pays four sequential full-fragment pages (~12.4 s) or one lite page (~1.8 s, 18 ms/node).
+			 */
+			summary?: boolean;
 		},
 		cancellation?: AbortSignal,
 	): Promise<PullRequestSearchResult | undefined> {
 		const scope = getScopedLogger();
 
+		// Only the DEFAULT follows the projection; an explicit `pageSize` is still honoured up to the
+		// maximum, which is the existing contract (a caller asking for 500 gets 100, full fragment or
+		// not — see the `cost-safe default page size` test). What the lite shape changes is that the
+		// default stops being the cost-safe 30: the full fragment is what GitHub rejects at 100 nodes
+		// (see `defaultPullRequestSearchPageSize`), and the lite shape's per-node cost is a fraction
+		// of it, so a summary caller that expressed no preference can safely take the maximum.
+		const defaultSize = options?.summary === true ? maxPullRequestSearchPageSize : defaultPullRequestSearchPageSize;
 		const pageSize = Math.min(
 			maxPullRequestSearchPageSize,
-			Math.max(1, Math.trunc(options?.pageSize ?? defaultPullRequestSearchPageSize)),
+			Math.max(1, Math.trunc(options?.pageSize ?? defaultSize)),
 		);
 		const facets = toGitHubPullRequestSearchFacets(options?.criteria);
 		const facetAliases = facets.map(f => f.alias).sort();
@@ -4626,8 +4647,8 @@ export class GitHubApi {
 				}
 				nodes {
 					... on PullRequest {
-						${gqlPullRequestFragment}
-						${gqlPullRequestStackFragmentFor(options)}
+						${options?.summary ? gqlPullRequestLiteFragment : gqlPullRequestFragment}
+						${options?.summary ? '' : gqlPullRequestStackFragmentFor(options)}
 					}
 				}
 			}`,
@@ -4666,7 +4687,14 @@ export class GitHubApi {
 					if (node?.id == null) continue;
 
 					try {
-						pullRequests.push(fromGitHubPullRequest(node, provider));
+						// Must follow the projection: the lite fragment does not select reviews, checks or diff
+						// stats, and the full mapper reads them — mapping a lite node with it would silently
+						// report "no reviewers"/"no checks" as FACTS rather than as unselected.
+						pullRequests.push(
+							options?.summary
+								? fromGitHubPullRequestLite(node, provider)
+								: fromGitHubPullRequest(node, provider),
+						);
 					} catch (ex) {
 						scope?.warn(`skipped unmappable pull request; id=${node.id}, url=${node.url}, ex=${ex}`);
 					}

--- a/packages/plus/git-github/src/api/github.ts
+++ b/packages/plus/git-github/src/api/github.ts
@@ -4526,9 +4526,11 @@ export class GitHubApi {
 			cursor?: string;
 			pageSize?: number;
 			/**
-			 * Uses the lightweight PR fragment while retaining identity, body, author, repository, and branch refs.
-			 * Intended for aggregate/list surfaces that do not consume review, check, or diff statistics — the same
-			 * contract as `searchMyPullRequests`' option of the same name.
+			 * Uses the lightweight PR fragment while retaining identity, body, author, repository, branch refs and
+			 * stack info. Intended for aggregate/list surfaces that do not consume review, check, or diff
+			 * statistics — the same contract as `searchMyPullRequests`' option of the same name, stack fragment
+			 * included: the lite mapper reads `stack`/`stackEntry`, and their absence is indistinguishable from
+			 * "not stacked", so dropping them would report a negative as a fact.
 			 *
 			 * The full fragment resolves `assignees(25)`, `latestReviews(25)` and `reviewRequests(25)` per node, and
 			 * that is SERVER time rather than payload: measured against a 992-PR repo, one 30-node page took ~3090 ms
@@ -4648,7 +4650,7 @@ export class GitHubApi {
 				nodes {
 					... on PullRequest {
 						${options?.summary ? gqlPullRequestLiteFragment : gqlPullRequestFragment}
-						${options?.summary ? '' : gqlPullRequestStackFragmentFor(options)}
+						${gqlPullRequestStackFragmentFor(options)}
 					}
 				}
 			}`,

--- a/packages/plus/git-github/src/api/github.ts
+++ b/packages/plus/git-github/src/api/github.ts
@@ -114,7 +114,8 @@ const accountResolveBatchSize = 25;
 // exceeded` on large repositories. Thirty keeps the default within that GraphQL cost budget;
 // the 100-node maximum the connection accepts is for the lite shape, whose per-node cost is a
 // fraction of it. The budget is per DOCUMENT, and one document holds every relationship × state
-// facet, so the worst case scales with the facet count (five relationships × four states = 20).
+// facet, so the worst case scales with the facet count (five relationships × three states = 15;
+// `all` subsumes the concrete states).
 const defaultPullRequestSearchPageSize = 30;
 const maxPullRequestSearchPageSize = 100;
 // Pages `searchMyPullRequests` drains for a caller that wants a whole list rather than a page.
@@ -4537,8 +4538,9 @@ export class GitHubApi {
 			 * with the full fragment and ~1150 ms with the lite one, for near-identical bytes (155 KB vs 140 KB). Per
 			 * node that is 103 ms → 38 ms.
 			 *
-			 * It compounds with the page size, because the size follows the projection (see below): a caller that
-			 * wants 100 PRs pays four sequential full-fragment pages (~12.4 s) or one lite page (~1.8 s, 18 ms/node).
+			 * It compounds with the page size, because the size follows the projection (see below): a single-facet
+			 * caller that wants 100 PRs pays four sequential full-fragment pages (~12.4 s) or one lite page
+			 * (~1.8 s, 18 ms/node). Multi-facet searches share that default budget across their active facets.
 			 */
 			summary?: boolean;
 		},
@@ -4546,17 +4548,6 @@ export class GitHubApi {
 	): Promise<PullRequestSearchResult | undefined> {
 		const scope = getScopedLogger();
 
-		// Only the DEFAULT follows the projection; an explicit `pageSize` is still honoured up to the
-		// maximum, which is the existing contract (a caller asking for 500 gets 100, full fragment or
-		// not — see the `cost-safe default page size` test). What the lite shape changes is that the
-		// default stops being the cost-safe 30: the full fragment is what GitHub rejects at 100 nodes
-		// (see `defaultPullRequestSearchPageSize`), and the lite shape's per-node cost is a fraction
-		// of it, so a summary caller that expressed no preference can safely take the maximum.
-		const defaultSize = options?.summary === true ? maxPullRequestSearchPageSize : defaultPullRequestSearchPageSize;
-		const pageSize = Math.min(
-			maxPullRequestSearchPageSize,
-			Math.max(1, Math.trunc(options?.pageSize ?? defaultSize)),
-		);
 		const facets = toGitHubPullRequestSearchFacets(options?.criteria);
 		const facetAliases = facets.map(f => f.alias).sort();
 		const scopeQualifiers = toGitHubIssueSearchScopeQualifiers(options?.org, options?.repos);
@@ -4632,6 +4623,17 @@ export class GitHubApi {
 				totalCount: cursor?.totalCount,
 			};
 		}
+
+		// Each active facet selects its own page in the same GraphQL document. Share the lite projection's
+		// 100-node default across those selections; an explicit page size remains a per-facet request.
+		const defaultSize =
+			options?.summary === true
+				? Math.max(1, Math.floor(maxPullRequestSearchPageSize / activeFacets.length))
+				: defaultPullRequestSearchPageSize;
+		const pageSize = Math.min(
+			maxPullRequestSearchPageSize,
+			Math.max(1, Math.trunc(options?.pageSize ?? defaultSize)),
+		);
 
 		const includeVar = (alias: string): string => `include${alias.charAt(0).toUpperCase()}${alias.slice(1)}`;
 		const params = facets.flatMap(f => [

--- a/packages/plus/integrations/src/__tests__/summaryPullRequestFields.test.ts
+++ b/packages/plus/integrations/src/__tests__/summaryPullRequestFields.test.ts
@@ -8,21 +8,8 @@ import { PagingMode } from '../providers/models.js';
 import { createFakeRuntime } from './fakeRuntime.js';
 
 /**
- * The summary PR read's field map has to stay aligned with provider-apis' gating contract, and this is
- * the test that makes a drift a failing build rather than a silent no-op.
- *
- * Why it needs a test of its own: the map lives in `gitHostIntegration.ts`, the gate that interprets it
- * lives in another package, and NOTHING connects the two. provider-apis gates the
- * `commits(last: 1) { totalCount ... statusCheckRollup { contexts(first: 100) } }` subtree on BOTH keys,
- * because `commitCount` is that subtree's `totalCount`, so a map that leaves either truthy reads as
- * correct, ships the exact payload it exists to avoid, and keeps every test in both packages green.
- *
- * The assertion is on the map that actually reaches provider-apis, captured from the real read, rather
- * than on the map's declaration — a test that restated the declaration would pass no matter what the
- * gate does with it. It deliberately does NOT reach into provider-apis' query builder: that is not
- * public API of that package, and coupling to it here would be a second, worse version of the same
- * cross-package assumption. What it pins instead is the contract this side owes: the two keys that share
- * the gated subtree must both be false, and nothing else may be.
+ * provider-apis gates the shared commits/status subtree on both keys. Assert the map at the integration boundary,
+ * rather than restating its declaration, so a wiring regression cannot leave the expensive subtree selected.
  */
 
 /** Keys provider-apis gates the `commits`/`statusCheckRollup` subtree on. Both must be omitted. */
@@ -83,29 +70,9 @@ suite('summary pull request field selection', () => {
 		return { fields: fields, called: called };
 	}
 
-	test('a summary read omits BOTH keys that gate the check-status subtree', async () => {
+	test('a summary read drops exactly both keys that gate the check-status subtree', async () => {
 		const { fields } = await captureFields({ summary: true });
-		assert.ok(fields != null, 'the summary read passed a field map to provider-apis');
-
-		for (const key of gatedSubtreeKeys) {
-			assert.equal(
-				fields[key],
-				false,
-				`${key} must be false: provider-apis gates the commits/statusCheckRollup subtree on both keys, so leaving either truthy keeps the whole payload and the summary read saves nothing`,
-			);
-		}
-	});
-
-	test('a summary read drops ONLY those keys', async () => {
-		// This gates one subtree, not the row. Dropping more would be a different — and worse — bug than
-		// dropping none, and it would surface as missing data rather than as wasted bytes.
-		const { fields } = await captureFields({ summary: true });
-		const dropped = Object.entries(fields ?? {})
-			.filter(([, selected]) => !selected)
-			.map(([key]) => key)
-			.sort();
-
-		assert.deepEqual(dropped, [...gatedSubtreeKeys].sort());
+		assert.deepEqual(fields, { headCommit: false, commitCount: false });
 	});
 
 	test('a non-summary read passes no field map at all', async () => {

--- a/packages/plus/integrations/src/__tests__/summaryPullRequestFields.test.ts
+++ b/packages/plus/integrations/src/__tests__/summaryPullRequestFields.test.ts
@@ -12,11 +12,10 @@ import { createFakeRuntime } from './fakeRuntime.js';
  * the test that makes a drift a failing build rather than a silent no-op.
  *
  * Why it needs a test of its own: the map lives in `gitHostIntegration.ts`, the gate that interprets it
- * lives in another package, and NOTHING connected the two. The first version of the map set
- * `commitCount: true` with only `headCommit: false`, which reads as correct and is not — provider-apis
- * gates the `commits(last: 1) { totalCount ... statusCheckRollup { contexts(first: 100) } }` subtree on
- * BOTH keys, because `commitCount` is that subtree's `totalCount`. The summary read therefore shipped
- * the exact payload it exists to avoid, and every test in both packages still passed.
+ * lives in another package, and NOTHING connects the two. provider-apis gates the
+ * `commits(last: 1) { totalCount ... statusCheckRollup { contexts(first: 100) } }` subtree on BOTH keys,
+ * because `commitCount` is that subtree's `totalCount`, so a map that leaves either truthy reads as
+ * correct, ships the exact payload it exists to avoid, and keeps every test in both packages green.
  *
  * The assertion is on the map that actually reaches provider-apis, captured from the real read, rather
  * than on the map's declaration — a test that restated the declaration would pass no matter what the
@@ -27,11 +26,17 @@ import { createFakeRuntime } from './fakeRuntime.js';
  */
 
 /** Keys provider-apis gates the `commits`/`statusCheckRollup` subtree on. Both must be omitted. */
-const GATED_SUBTREE_KEYS = ['headCommit', 'commitCount'] as const;
+const gatedSubtreeKeys = ['headCommit', 'commitCount'] as const;
 
 suite('summary pull request field selection', () => {
-	/** The field map the repo-scoped summary read really sends to provider-apis. */
-	async function captureSummaryFields(): Promise<Record<string, boolean> | undefined> {
+	/**
+	 * The field map the repo-scoped read really sends to provider-apis, plus whether the read reached the
+	 * provider at all — the non-summary case asserts an ABSENT map, which is indistinguishable from a read
+	 * that never fired.
+	 */
+	async function captureFields(options?: {
+		summary: boolean;
+	}): Promise<{ fields: Record<string, boolean> | undefined; called: boolean }> {
 		const runtime = createFakeRuntime();
 		await runtime.storage.store('integrations:configured', {
 			github: [{ id: 'tok', cloud: true, integrationId: 'github', scopes: 'repo', primary: true }],
@@ -51,6 +56,7 @@ suite('summary pull request field selection', () => {
 		const gh = await manager.get(GitCloudHostIntegrationId.GitHub);
 
 		let fields: Record<string, boolean> | undefined;
+		let called = false;
 		const api = await (
 			gh as unknown as { getProvidersApi(): Promise<{ providers: Record<string, unknown> }> }
 		).getProvidersApi();
@@ -58,33 +64,30 @@ suite('summary pull request field selection', () => {
 			string,
 			(input: { fields?: Record<string, boolean> }) => Promise<unknown>
 		>;
-		const capture = (input: { fields?: Record<string, boolean> }) => {
+		provider.getPullRequestsForReposFn = (input: { fields?: Record<string, boolean> }) => {
+			called = true;
 			fields ??= input.fields;
 			return Promise.resolve({ data: [], pageInfo: undefined });
 		};
-		// Both variants, so the capture holds regardless of the provider's paging mode.
-		for (const fnName of ['getPullRequestsForReposFn', 'getPullRequestsForRepoFn']) {
-			provider[fnName] = capture;
-		}
 
 		await (
 			gh as unknown as {
 				getMyPullRequestsForReposResult: (
 					repos: { namespace: string; name: string }[],
-					options: { summary: boolean },
+					options?: { summary: boolean },
 				) => Promise<unknown>;
 			}
-		).getMyPullRequestsForReposResult([{ namespace: 'octo', name: 'repo' }], { summary: true });
+		).getMyPullRequestsForReposResult([{ namespace: 'octo', name: 'repo' }], options);
 
 		manager.dispose();
-		return fields;
+		return { fields: fields, called: called };
 	}
 
 	test('a summary read omits BOTH keys that gate the check-status subtree', async () => {
-		const fields = await captureSummaryFields();
+		const { fields } = await captureFields({ summary: true });
 		assert.ok(fields != null, 'the summary read passed a field map to provider-apis');
 
-		for (const key of GATED_SUBTREE_KEYS) {
+		for (const key of gatedSubtreeKeys) {
 			assert.equal(
 				fields[key],
 				false,
@@ -96,63 +99,22 @@ suite('summary pull request field selection', () => {
 	test('a summary read drops ONLY those keys', async () => {
 		// This gates one subtree, not the row. Dropping more would be a different — and worse — bug than
 		// dropping none, and it would surface as missing data rather than as wasted bytes.
-		const fields = await captureSummaryFields();
+		const { fields } = await captureFields({ summary: true });
 		const dropped = Object.entries(fields ?? {})
 			.filter(([, selected]) => !selected)
 			.map(([key]) => key)
 			.sort();
 
-		assert.deepEqual(dropped, [...GATED_SUBTREE_KEYS].sort());
+		assert.deepEqual(dropped, [...gatedSubtreeKeys].sort());
 	});
 
 	test('a non-summary read passes no field map at all', async () => {
 		// The opt-in half of the contract: an ABSENT map is what means "request every field", so the
 		// default read must not start sending one.
-		const runtime = createFakeRuntime();
-		await runtime.storage.store('integrations:configured', {
-			github: [{ id: 'tok', cloud: true, integrationId: 'github', scopes: 'repo', primary: true }],
-		});
-		await runtime.storage.storeSecret(
-			'integration.auth.cloud:github|tok',
-			JSON.stringify({
-				id: 'tok',
-				accessToken: 'token',
-				scopes: ['repo'],
-				cloud: true,
-				type: 'oauth',
-				domain: 'github.com',
-			}),
-		);
-		const manager = createIntegrationManager(runtime);
-		const gh = await manager.get(GitCloudHostIntegrationId.GitHub);
+		const { fields, called } = await captureFields();
 
-		let sawFields: Record<string, boolean> | undefined;
-		let called = false;
-		const api = await (
-			gh as unknown as { getProvidersApi(): Promise<{ providers: Record<string, unknown> }> }
-		).getProvidersApi();
-		const provider = api.providers.github as Record<
-			string,
-			(input: { fields?: Record<string, boolean> }) => Promise<unknown>
-		>;
-		const capture = (input: { fields?: Record<string, boolean> }) => {
-			called = true;
-			sawFields ??= input.fields;
-			return Promise.resolve({ data: [], pageInfo: undefined });
-		};
-		for (const fnName of ['getPullRequestsForReposFn', 'getPullRequestsForRepoFn']) {
-			provider[fnName] = capture;
-		}
-
-		await (
-			gh as unknown as {
-				getMyPullRequestsForReposResult: (repos: { namespace: string; name: string }[]) => Promise<unknown>;
-			}
-		).getMyPullRequestsForReposResult([{ namespace: 'octo', name: 'repo' }]);
-
-		manager.dispose();
 		assert.equal(called, true, 'the read reached the provider');
-		assert.equal(sawFields, undefined, 'a non-summary read must send no field map');
+		assert.equal(fields, undefined, 'a non-summary read must send no field map');
 	});
 
 	test('EVERY request of a drained summary read carries the map, not just the first', async () => {
@@ -162,8 +124,8 @@ suite('summary pull request field selection', () => {
 		// on the path that issues the MOST requests, and would return rows of a different shape than page
 		// 1 — a summary row reports `headCommit`/`commitCount` as absent, a full one does not.
 		//
-		// Asserted over all calls rather than the first because that is exactly what a single-capture test
-		// cannot see: this bug lived past a test that pinned the first request's map.
+		// Asserted over ALL calls rather than the first, because a single-capture test cannot see a map that
+		// is present on page 1 and dropped on the continuations.
 		const runtime = createFakeRuntime();
 		const manager = createIntegrationManager(runtime);
 		const gh = await manager.get(GitCloudHostIntegrationId.GitHub);
@@ -209,7 +171,7 @@ suite('summary pull request field selection', () => {
 		assert.ok(seen.length > 1, `the read drained (${seen.length} upstream requests), so re-reads are covered`);
 		for (const [i, fields] of seen.entries()) {
 			assert.ok(fields != null, `request ${i + 1} of ${seen.length} sent a field map`);
-			for (const key of GATED_SUBTREE_KEYS) {
+			for (const key of gatedSubtreeKeys) {
 				assert.equal(fields[key], false, `request ${i + 1} of ${seen.length} dropped ${key}`);
 			}
 		}

--- a/packages/plus/integrations/src/__tests__/summaryPullRequestFields.test.ts
+++ b/packages/plus/integrations/src/__tests__/summaryPullRequestFields.test.ts
@@ -2,6 +2,9 @@ import * as assert from 'node:assert/strict';
 import { suite, test } from 'mocha';
 import { GitCloudHostIntegrationId } from '../constants.js';
 import { createIntegrationService as createIntegrationManager } from '../integrationService.js';
+import type { GitHostIntegration } from '../models/gitHostIntegration.js';
+import type { ProviderPullRequest } from '../providers/models.js';
+import { PagingMode } from '../providers/models.js';
 import { createFakeRuntime } from './fakeRuntime.js';
 
 /**
@@ -55,12 +58,13 @@ suite('summary pull request field selection', () => {
 			string,
 			(input: { fields?: Record<string, boolean> }) => Promise<unknown>
 		>;
+		const capture = (input: { fields?: Record<string, boolean> }) => {
+			fields ??= input.fields;
+			return Promise.resolve({ data: [], pageInfo: undefined });
+		};
 		// Both variants, so the capture holds regardless of the provider's paging mode.
 		for (const fnName of ['getPullRequestsForReposFn', 'getPullRequestsForRepoFn']) {
-			provider[fnName] = input => {
-				fields ??= input.fields;
-				return Promise.resolve({ data: [], pageInfo: undefined });
-			};
+			provider[fnName] = capture;
 		}
 
 		await (
@@ -131,12 +135,13 @@ suite('summary pull request field selection', () => {
 			string,
 			(input: { fields?: Record<string, boolean> }) => Promise<unknown>
 		>;
+		const capture = (input: { fields?: Record<string, boolean> }) => {
+			called = true;
+			sawFields ??= input.fields;
+			return Promise.resolve({ data: [], pageInfo: undefined });
+		};
 		for (const fnName of ['getPullRequestsForReposFn', 'getPullRequestsForRepoFn']) {
-			provider[fnName] = input => {
-				called = true;
-				sawFields ??= input.fields;
-				return Promise.resolve({ data: [], pageInfo: undefined });
-			};
+			provider[fnName] = capture;
 		}
 
 		await (
@@ -148,5 +153,65 @@ suite('summary pull request field selection', () => {
 		manager.dispose();
 		assert.equal(called, true, 'the read reached the provider');
 		assert.equal(sawFields, undefined, 'a non-summary read must send no field map');
+	});
+
+	test('EVERY request of a drained summary read carries the map, not just the first', async () => {
+		// A page-only request on a PagingMode.Repos host (GitHub included) walks the provider's own
+		// continuations to reach the requested page, so one call from the caller becomes N upstream
+		// requests. All N must carry the map: dropping it on the re-reads would revert to the full payload
+		// on the path that issues the MOST requests, and would return rows of a different shape than page
+		// 1 — a summary row reports `headCommit`/`commitCount` as absent, a full one does not.
+		//
+		// Asserted over all calls rather than the first because that is exactly what a single-capture test
+		// cannot see: this bug lived past a test that pinned the first request's map.
+		const runtime = createFakeRuntime();
+		const manager = createIntegrationManager(runtime);
+		const gh = await manager.get(GitCloudHostIntegrationId.GitHub);
+		(gh as unknown as { _session: unknown })._session = {
+			id: 'primary',
+			accessToken: 't',
+			account: { id: 'me', label: 'me' },
+			scopes: ['repo'],
+			cloud: true,
+			type: 'oauth',
+			domain: 'github.com',
+		};
+
+		const seen: (Record<string, boolean> | undefined)[] = [];
+		(gh as unknown as { getProvidersApi: () => Promise<unknown> }).getProvidersApi = () =>
+			Promise.resolve({
+				isRepoIdsInput: () => false,
+				getProviderPullRequestsPagingMode: () => PagingMode.Repos,
+				getPullRequestsForRepos: (
+					_token: unknown,
+					_repos: unknown,
+					input: { fields?: Record<string, boolean> },
+				) => {
+					seen.push(input.fields);
+					return Promise.resolve({
+						values: [{ id: `page-${seen.length}` } as unknown as ProviderPullRequest],
+						paging: {
+							more: true,
+							cursor: JSON.stringify({ value: `next-${seen.length}`, type: 'cursor' }),
+						},
+					});
+				},
+			} as unknown as Awaited<ReturnType<GitHostIntegration['getProvidersApi']>>);
+
+		await manager.listPullRequestsPage({
+			providerId: GitCloudHostIntegrationId.GitHub,
+			repos: [{ namespace: 'octo', name: 'repo' }],
+			page: 3,
+			summary: true,
+		});
+
+		manager.dispose();
+		assert.ok(seen.length > 1, `the read drained (${seen.length} upstream requests), so re-reads are covered`);
+		for (const [i, fields] of seen.entries()) {
+			assert.ok(fields != null, `request ${i + 1} of ${seen.length} sent a field map`);
+			for (const key of GATED_SUBTREE_KEYS) {
+				assert.equal(fields[key], false, `request ${i + 1} of ${seen.length} dropped ${key}`);
+			}
+		}
 	});
 });

--- a/packages/plus/integrations/src/__tests__/summaryPullRequestFields.test.ts
+++ b/packages/plus/integrations/src/__tests__/summaryPullRequestFields.test.ts
@@ -1,0 +1,152 @@
+import * as assert from 'node:assert/strict';
+import { suite, test } from 'mocha';
+import { GitCloudHostIntegrationId } from '../constants.js';
+import { createIntegrationService as createIntegrationManager } from '../integrationService.js';
+import { createFakeRuntime } from './fakeRuntime.js';
+
+/**
+ * The summary PR read's field map has to stay aligned with provider-apis' gating contract, and this is
+ * the test that makes a drift a failing build rather than a silent no-op.
+ *
+ * Why it needs a test of its own: the map lives in `gitHostIntegration.ts`, the gate that interprets it
+ * lives in another package, and NOTHING connected the two. The first version of the map set
+ * `commitCount: true` with only `headCommit: false`, which reads as correct and is not — provider-apis
+ * gates the `commits(last: 1) { totalCount ... statusCheckRollup { contexts(first: 100) } }` subtree on
+ * BOTH keys, because `commitCount` is that subtree's `totalCount`. The summary read therefore shipped
+ * the exact payload it exists to avoid, and every test in both packages still passed.
+ *
+ * The assertion is on the map that actually reaches provider-apis, captured from the real read, rather
+ * than on the map's declaration — a test that restated the declaration would pass no matter what the
+ * gate does with it. It deliberately does NOT reach into provider-apis' query builder: that is not
+ * public API of that package, and coupling to it here would be a second, worse version of the same
+ * cross-package assumption. What it pins instead is the contract this side owes: the two keys that share
+ * the gated subtree must both be false, and nothing else may be.
+ */
+
+/** Keys provider-apis gates the `commits`/`statusCheckRollup` subtree on. Both must be omitted. */
+const GATED_SUBTREE_KEYS = ['headCommit', 'commitCount'] as const;
+
+suite('summary pull request field selection', () => {
+	/** The field map the repo-scoped summary read really sends to provider-apis. */
+	async function captureSummaryFields(): Promise<Record<string, boolean> | undefined> {
+		const runtime = createFakeRuntime();
+		await runtime.storage.store('integrations:configured', {
+			github: [{ id: 'tok', cloud: true, integrationId: 'github', scopes: 'repo', primary: true }],
+		});
+		await runtime.storage.storeSecret(
+			'integration.auth.cloud:github|tok',
+			JSON.stringify({
+				id: 'tok',
+				accessToken: 'token',
+				scopes: ['repo'],
+				cloud: true,
+				type: 'oauth',
+				domain: 'github.com',
+			}),
+		);
+		const manager = createIntegrationManager(runtime);
+		const gh = await manager.get(GitCloudHostIntegrationId.GitHub);
+
+		let fields: Record<string, boolean> | undefined;
+		const api = await (
+			gh as unknown as { getProvidersApi(): Promise<{ providers: Record<string, unknown> }> }
+		).getProvidersApi();
+		const provider = api.providers.github as Record<
+			string,
+			(input: { fields?: Record<string, boolean> }) => Promise<unknown>
+		>;
+		// Both variants, so the capture holds regardless of the provider's paging mode.
+		for (const fnName of ['getPullRequestsForReposFn', 'getPullRequestsForRepoFn']) {
+			provider[fnName] = input => {
+				fields ??= input.fields;
+				return Promise.resolve({ data: [], pageInfo: undefined });
+			};
+		}
+
+		await (
+			gh as unknown as {
+				getMyPullRequestsForReposResult: (
+					repos: { namespace: string; name: string }[],
+					options: { summary: boolean },
+				) => Promise<unknown>;
+			}
+		).getMyPullRequestsForReposResult([{ namespace: 'octo', name: 'repo' }], { summary: true });
+
+		manager.dispose();
+		return fields;
+	}
+
+	test('a summary read omits BOTH keys that gate the check-status subtree', async () => {
+		const fields = await captureSummaryFields();
+		assert.ok(fields != null, 'the summary read passed a field map to provider-apis');
+
+		for (const key of GATED_SUBTREE_KEYS) {
+			assert.equal(
+				fields[key],
+				false,
+				`${key} must be false: provider-apis gates the commits/statusCheckRollup subtree on both keys, so leaving either truthy keeps the whole payload and the summary read saves nothing`,
+			);
+		}
+	});
+
+	test('a summary read drops ONLY those keys', async () => {
+		// This gates one subtree, not the row. Dropping more would be a different — and worse — bug than
+		// dropping none, and it would surface as missing data rather than as wasted bytes.
+		const fields = await captureSummaryFields();
+		const dropped = Object.entries(fields ?? {})
+			.filter(([, selected]) => !selected)
+			.map(([key]) => key)
+			.sort();
+
+		assert.deepEqual(dropped, [...GATED_SUBTREE_KEYS].sort());
+	});
+
+	test('a non-summary read passes no field map at all', async () => {
+		// The opt-in half of the contract: an ABSENT map is what means "request every field", so the
+		// default read must not start sending one.
+		const runtime = createFakeRuntime();
+		await runtime.storage.store('integrations:configured', {
+			github: [{ id: 'tok', cloud: true, integrationId: 'github', scopes: 'repo', primary: true }],
+		});
+		await runtime.storage.storeSecret(
+			'integration.auth.cloud:github|tok',
+			JSON.stringify({
+				id: 'tok',
+				accessToken: 'token',
+				scopes: ['repo'],
+				cloud: true,
+				type: 'oauth',
+				domain: 'github.com',
+			}),
+		);
+		const manager = createIntegrationManager(runtime);
+		const gh = await manager.get(GitCloudHostIntegrationId.GitHub);
+
+		let sawFields: Record<string, boolean> | undefined;
+		let called = false;
+		const api = await (
+			gh as unknown as { getProvidersApi(): Promise<{ providers: Record<string, unknown> }> }
+		).getProvidersApi();
+		const provider = api.providers.github as Record<
+			string,
+			(input: { fields?: Record<string, boolean> }) => Promise<unknown>
+		>;
+		for (const fnName of ['getPullRequestsForReposFn', 'getPullRequestsForRepoFn']) {
+			provider[fnName] = input => {
+				called = true;
+				sawFields ??= input.fields;
+				return Promise.resolve({ data: [], pageInfo: undefined });
+			};
+		}
+
+		await (
+			gh as unknown as {
+				getMyPullRequestsForReposResult: (repos: { namespace: string; name: string }[]) => Promise<unknown>;
+			}
+		).getMyPullRequestsForReposResult([{ namespace: 'octo', name: 'repo' }]);
+
+		manager.dispose();
+		assert.equal(called, true, 'the read reached the provider');
+		assert.equal(sawFields, undefined, 'a non-summary read must send no field map');
+	});
+});

--- a/packages/plus/integrations/src/integrationService.ts
+++ b/packages/plus/integrations/src/integrationService.ts
@@ -1053,6 +1053,8 @@ export class IntegrationService implements Disposable, RepositoryResolutionConte
 		 * from the trusted authentication configuration, not repository or remote data.
 		 */
 		domain?: string;
+		/** See {@link IntegrationManager.listPullRequestsPage}. */
+		summary?: boolean;
 	}): Promise<ProviderPagedResult<PullRequestShape>> {
 		return listPullRequestsPage(this, options);
 	}
@@ -1069,6 +1071,8 @@ export class IntegrationService implements Disposable, RepositoryResolutionConte
 		forceSync?: boolean;
 		connectionId?: string;
 		domain?: string;
+		/** See {@link IntegrationManager.searchPullRequestsPage}. */
+		summary?: boolean;
 	}): Promise<ProviderPagedResult<PullRequestShape>> {
 		return searchPullRequestsPage(this, options);
 	}

--- a/packages/plus/integrations/src/manager.ts
+++ b/packages/plus/integrations/src/manager.ts
@@ -366,11 +366,11 @@ export interface IntegrationManager {
 		domain?: string;
 		/**
 		 * Requests the lightweight row shape: everything except the per-row build-status rollup
-		 * (`statusCheckRollupState`). Set it on list/aggregate surfaces that do not read build statuses.
+		 * (`statusCheckRollupState`) and `commitCount`, which share one provider selection and are therefore
+		 * dropped together. Set it on list/aggregate surfaces that read neither.
 		 *
-		 * On GitHub that rollup expands to `commits(last: 1) { ... statusCheckRollup { contexts(first: 100) } }`
-		 * per row — up to 100 check contexts per PR for a page of up to 100 — and consumers collapse the whole
-		 * thing into one tri-state. Measured against a 100-PR repo: 55.6 KB → 14.1 KB and ~2.0s → ~1.1s per page.
+		 * See `summaryPullRequestFields` in `models/gitHostIntegration.ts` for what that selection costs on
+		 * GitHub and the measurements behind it.
 		 *
 		 * The ACCOUNT-WIDE branch of this read has always requested the lightweight shape; this makes it
 		 * available on the repo-scoped branch, which had no way to ask. A provider with no lightweight
@@ -422,11 +422,11 @@ export interface IntegrationManager {
 		/** Self-managed host domain fallback; see {@link ProviderSweepTarget.domain}. */
 		domain?: string;
 		/**
-		 * Requests the lightweight row shape: identity, body, author, repository and branch refs, without review,
-		 * check or diff statistics. Set it on aggregate/list surfaces that do not read those — the provider's full
-		 * projection resolves them per node, which is server time rather than payload (measured on GitHub against a
-		 * 992-PR repo: ~3090ms vs ~1150ms for one 30-node page, at near-identical bytes), and it also raises the
-		 * default page size, since that follows the projection.
+		 * Requests the lightweight row shape: identity, body, author, repository, branch refs and stack info,
+		 * without review, check or diff statistics. Set it on aggregate/list surfaces that do not read those —
+		 * the provider's full projection resolves them per node, which is server time rather than payload — and
+		 * note it also raises the default page size, since that follows the projection. See the `summary` option
+		 * on `GitHubApi.searchPullRequestsPage` for the measurements.
 		 *
 		 * A provider without a lightweight projection ignores it and returns its usual shape, so this is a hint
 		 * rather than a contract about which fields are present.

--- a/packages/plus/integrations/src/manager.ts
+++ b/packages/plus/integrations/src/manager.ts
@@ -369,13 +369,8 @@ export interface IntegrationManager {
 		 * (`statusCheckRollupState`) and `commitCount`, which share one provider selection and are therefore
 		 * dropped together. Set it on list/aggregate surfaces that read neither.
 		 *
-		 * See `summaryPullRequestFields` in `models/gitHostIntegration.ts` for what that selection costs on
-		 * GitHub and the measurements behind it.
-		 *
-		 * The ACCOUNT-WIDE branch of this read has always requested the lightweight shape; this makes it
-		 * available on the repo-scoped branch, which had no way to ask. A provider with no lightweight
-		 * projection ignores it and returns its usual shape, so it is a hint rather than a guarantee about
-		 * which fields are present.
+		 * The account-wide branch already requests this shape. A provider without a lightweight projection
+		 * ignores the option, so it is a hint rather than a guarantee about which fields are present.
 		 */
 		summary?: boolean;
 	}): Promise<ProviderPagedResult<PullRequestShape>>;
@@ -423,10 +418,7 @@ export interface IntegrationManager {
 		domain?: string;
 		/**
 		 * Requests the lightweight row shape: identity, body, author, repository, branch refs and stack info,
-		 * without review, check or diff statistics. Set it on aggregate/list surfaces that do not read those —
-		 * the provider's full projection resolves them per node, which is server time rather than payload — and
-		 * note it also raises the default page size, since that follows the projection. See the `summary` option
-		 * on `GitHubApi.searchPullRequestsPage` for the measurements.
+		 * without review, check or diff statistics. It also raises the default page size.
 		 *
 		 * A provider without a lightweight projection ignores it and returns its usual shape, so this is a hint
 		 * rather than a contract about which fields are present.

--- a/packages/plus/integrations/src/manager.ts
+++ b/packages/plus/integrations/src/manager.ts
@@ -364,6 +364,20 @@ export interface IntegrationManager {
 		 * it must come from the trusted authentication configuration, not repository or remote data.
 		 */
 		domain?: string;
+		/**
+		 * Requests the lightweight row shape: everything except the per-row build-status rollup
+		 * (`statusCheckRollupState`). Set it on list/aggregate surfaces that do not read build statuses.
+		 *
+		 * On GitHub that rollup expands to `commits(last: 1) { ... statusCheckRollup { contexts(first: 100) } }`
+		 * per row — up to 100 check contexts per PR for a page of up to 100 — and consumers collapse the whole
+		 * thing into one tri-state. Measured against a 100-PR repo: 55.6 KB → 14.1 KB and ~2.0s → ~1.1s per page.
+		 *
+		 * The ACCOUNT-WIDE branch of this read has always requested the lightweight shape; this makes it
+		 * available on the repo-scoped branch, which had no way to ask. A provider with no lightweight
+		 * projection ignores it and returns its usual shape, so it is a hint rather than a guarantee about
+		 * which fields are present.
+		 */
+		summary?: boolean;
 	}): Promise<ProviderPagedResult<PullRequestShape>>;
 	/**
 	 * Pull requests matching structured criteria over a repository/organization or current-user relationship
@@ -407,6 +421,17 @@ export interface IntegrationManager {
 		connectionId?: string;
 		/** Self-managed host domain fallback; see {@link ProviderSweepTarget.domain}. */
 		domain?: string;
+		/**
+		 * Requests the lightweight row shape: identity, body, author, repository and branch refs, without review,
+		 * check or diff statistics. Set it on aggregate/list surfaces that do not read those — the provider's full
+		 * projection resolves them per node, which is server time rather than payload (measured on GitHub against a
+		 * 992-PR repo: ~3090ms vs ~1150ms for one 30-node page, at near-identical bytes), and it also raises the
+		 * default page size, since that follows the projection.
+		 *
+		 * A provider without a lightweight projection ignores it and returns its usual shape, so this is a hint
+		 * rather than a contract about which fields are present.
+		 */
+		summary?: boolean;
 	}): Promise<ProviderPagedResult<PullRequestShape>>;
 	listIssuesPage(options: {
 		providerId: IntegrationIds;

--- a/packages/plus/integrations/src/models/gitHostIntegration.ts
+++ b/packages/plus/integrations/src/models/gitHostIntegration.ts
@@ -150,12 +150,14 @@ function unsupportedRead<T>(message: string, start: number, logContext?: string)
  * selects no `commits` either. Both fields are optional on `PullRequestShape`, so a summary row reports
  * them as absent rather than as a zero.
  *
- * Typed as provider-apis' own `GitHubPullRequestFieldMap`, which is narrowed to exactly these two keys,
- * so naming a field that gates nothing is a compile error rather than a silent no-op. Note the map is
- * only meaningful when PRESENT: an absent map is what tells provider-apis to select everything, which is
- * why non-summary reads pass none at all.
+ * Typed as `Required<GitHubPullRequestFieldMap>`: the map is narrowed to exactly these two keys, so naming
+ * a field that gates nothing is a compile error, and `Required` makes OMITTING one an error too. That
+ * second half matters as much as the first, since `fieldQuery` keeps the whole subtree if either key is
+ * truthy, so a map that simply forgot `commitCount` would save nothing at all — the exact bug this branch
+ * already shipped once. Note the map is only meaningful when PRESENT: an absent map is what tells
+ * provider-apis to select everything, which is why non-summary reads pass none at all.
  */
-const summaryPullRequestFields: GitHubPullRequestFieldMap = {
+const summaryPullRequestFields: Required<GitHubPullRequestFieldMap> = {
 	headCommit: false,
 	commitCount: false,
 };
@@ -1321,6 +1323,11 @@ export abstract class GitHostIntegration<
 								states: states,
 								// Azure DevOps only populates clone URLs on request (extra call); no-op elsewhere.
 								includeRemoteInfo: isAzureDevOpsProvider(providerId) ? true : undefined,
+								// Forwarded on this branch too, so the projection cannot depend on which paging
+								// mode the provider happens to use. The map is GitHub-shaped and GitHub is
+								// `PagingMode.Repos`, so today this is inert here; it stops being a question the
+								// moment a `PagingMode.Repo` provider learns to gate on it.
+								fields: options?.summary ? summaryPullRequestFields : undefined,
 							},
 						);
 						return { repoInput: repoInput, results: results };
@@ -1398,13 +1405,10 @@ export abstract class GitHostIntegration<
 				states: states,
 				// Azure DevOps only populates clone URLs on request (extra call); no-op elsewhere.
 				includeRemoteInfo: isAzureDevOpsProvider(providerId) ? true : undefined,
-				// A summary read drops the per-row build-status subtree, which on GitHub is
-				// `commits(last: 1) { totalCount ... statusCheckRollup { contexts(first: 100) } }` per PR
-				// for a page of up to 100. That subtree is all the map can gate, so the rest of the row is
-				// unaffected; what a summary consumer gives up is `statusCheckRollupState` and
-				// `commitCount`, which share that one selection. Spread rather than passed as `undefined`
-				// because an absent map is what means "select everything" (see summaryPullRequestFields).
-				...(options?.summary ? { fields: summaryPullRequestFields } : {}),
+				// See {@link summaryPullRequestFields} for what a summary read gives up and why the two keys
+				// travel together. `undefined` and an absent map are the same thing to provider-apis, whose
+				// `fieldQuery` gates on truthiness, so a non-summary read still selects everything.
+				fields: options?.summary ? summaryPullRequestFields : undefined,
 			});
 			return { value: result, duration: performance.now() - start };
 		} catch (ex) {
@@ -1646,6 +1650,8 @@ export abstract class GitHostIntegration<
 			criteria?: PullRequestSearchCriteria;
 			cursor?: string;
 			pageSize?: number;
+			/** See the caller's option of the same name on {@link searchPullRequestsPage}. */
+			summary?: boolean;
 		},
 		cancellation?: AbortSignal,
 	): Promise<ProviderPullRequestSearchPage | undefined>;

--- a/packages/plus/integrations/src/models/gitHostIntegration.ts
+++ b/packages/plus/integrations/src/models/gitHostIntegration.ts
@@ -1,4 +1,4 @@
-import type { CollectionMetadata, CollectionScopeFailure, FieldMap, GitPullRequest } from '@gitkraken/provider-apis';
+import type { CollectionMetadata, CollectionScopeFailure, GitHubPullRequestFieldMap } from '@gitkraken/provider-apis';
 import type { Account, UnidentifiedAuthor } from '@gitlens/git/models/author.js';
 import type { DefaultBranch } from '@gitlens/git/models/defaultBranch.js';
 import type { IssueSearchCriteria, IssueShape } from '@gitlens/git/models/issue.js';
@@ -148,7 +148,7 @@ function unsupportedRead<T>(message: string, start: number, logContext?: string)
  * Both fields gate the same GitHub `commits` subtree, so either truthy key retains the build-status rollup.
  * An absent map retains the full row; a summary read explicitly drops both optional fields.
  */
-const summaryPullRequestFields: Required<Pick<FieldMap<GitPullRequest>, 'headCommit' | 'commitCount'>> = {
+const summaryPullRequestFields: Required<GitHubPullRequestFieldMap> = {
 	headCommit: false,
 	commitCount: false,
 };

--- a/packages/plus/integrations/src/models/gitHostIntegration.ts
+++ b/packages/plus/integrations/src/models/gitHostIntegration.ts
@@ -139,7 +139,7 @@ function unsupportedRead<T>(message: string, start: number, logContext?: string)
 
 /**
  * The provider-apis field map a summary PR read requests: every `GitPullRequest` field EXCEPT
- * `headCommit`.
+ * `headCommit` and `commitCount`.
  *
  * Spelled as an explicit allow-list rather than a negation because provider-apis' `fieldQuery` treats
  * an ABSENT map as "select everything" and a present one as the complete request — so omitting a field
@@ -147,10 +147,19 @@ function unsupportedRead<T>(message: string, start: number, logContext?: string)
  * added here would silently stop being selected on summary reads. `FullFieldMap` (a `Record` over every
  * key, not a `Partial`) is what turns that into a compile error instead.
  *
- * Only `headCommit` is dropped, and it is the whole point: on GitHub it expands to
- * `commits(last: 1) { ... statusCheckRollup { contexts(first: 100) } }` per row — up to 100 check
- * contexts per PR for a page of up to 100 PRs, collapsed by consumers into a single tri-state.
- * Measured against a 100-PR repo: 55.6 KB → 14.1 KB and ~2.0s → ~1.1s per page.
+ * BOTH omissions are required, and this is the subtle part: on GitHub the two fields come from the SAME
+ * selection — `commits(last: 1) { totalCount nodes { commit { statusCheckRollup { contexts(first: 100) }
+ * } } }`, where `commitCount` is the `totalCount` and `headCommit.buildStatuses` is the rollup. So
+ * provider-apis gates the subtree on the pair; leaving `commitCount: true` here would keep the whole
+ * thing and this map would save nothing at all.
+ *
+ * That is up to 100 check contexts per PR for a page of up to 100 PRs, which consumers collapse into a
+ * single tri-state. Measured against a 100-PR repo: 55.6 KB → 14.1 KB and ~2.0s → ~1.1s per page.
+ *
+ * Giving up `commitCount` alongside the rollup is consistent with what `summary` already means here:
+ * `gqlPullRequestLiteFragment`, which `searchMyPullRequests` has always used for its summary reads,
+ * selects no `commits` either. Both fields are optional on `PullRequestShape`, so a summary row reports
+ * them as absent rather than as a zero.
  */
 const summaryPullRequestFields: FullFieldMap<GitPullRequest> = {
 	id: true,
@@ -169,7 +178,9 @@ const summaryPullRequestFields: FullFieldMap<GitPullRequest> = {
 	headRef: true,
 	commentCount: true,
 	upvoteCount: true,
-	commitCount: true,
+	// Dropped together with `headCommit`: it is that subtree's `totalCount`, so keeping it would
+	// keep the whole rollup (see the note above).
+	commitCount: false,
 	fileCount: true,
 	additions: true,
 	deletions: true,
@@ -1428,9 +1439,10 @@ export abstract class GitHostIntegration<
 				// Azure DevOps only populates clone URLs on request (extra call); no-op elsewhere.
 				includeRemoteInfo: isAzureDevOpsProvider(providerId) ? true : undefined,
 				// A summary read drops the per-row build-status subtree, which on GitHub is
-				// `statusCheckRollup.contexts(first: 100)` per PR for a page of up to 100. The map is
-				// opt-out by omission, so every OTHER field stays selected and only this subtree goes;
-				// `statusCheckRollupState` is the one thing a summary consumer gives up.
+				// `commits(last: 1) { totalCount ... statusCheckRollup { contexts(first: 100) } }` per PR
+				// for a page of up to 100. The map is opt-out by omission, so every OTHER field stays
+				// selected; what a summary consumer gives up is `statusCheckRollupState` and
+				// `commitCount`, which share that one selection.
 				...(options?.summary ? { fields: summaryPullRequestFields } : {}),
 			});
 			return { value: result, duration: performance.now() - start };

--- a/packages/plus/integrations/src/models/gitHostIntegration.ts
+++ b/packages/plus/integrations/src/models/gitHostIntegration.ts
@@ -1,9 +1,4 @@
-import type {
-	CollectionMetadata,
-	CollectionScopeFailure,
-	FullFieldMap,
-	GitPullRequest,
-} from '@gitkraken/provider-apis';
+import type { CollectionMetadata, CollectionScopeFailure, GitHubPullRequestFieldMap } from '@gitkraken/provider-apis';
 import type { Account, UnidentifiedAuthor } from '@gitlens/git/models/author.js';
 import type { DefaultBranch } from '@gitlens/git/models/defaultBranch.js';
 import type { IssueSearchCriteria, IssueShape } from '@gitlens/git/models/issue.js';
@@ -138,66 +133,31 @@ function unsupportedRead<T>(message: string, start: number, logContext?: string)
 }
 
 /**
- * The provider-apis field map a summary PR read requests: every `GitPullRequest` field EXCEPT
- * `headCommit` and `commitCount`.
+ * The provider-apis field map a summary PR read requests. Both keys it can name are dropped; every other
+ * field of the row comes back untouched, because those two are all this map is able to gate.
  *
- * Spelled as an explicit allow-list rather than a negation because provider-apis' `fieldQuery` treats
- * an ABSENT map as "select everything" and a present one as the complete request — so omitting a field
- * here drops it. That makes the list load-bearing: a `GitPullRequest` field added upstream and not
- * added here would silently stop being selected on summary reads. `FullFieldMap` (a `Record` over every
- * key, not a `Partial`) is what turns that into a compile error instead.
+ * They must go TOGETHER, and that is the subtle part: on GitHub both come from the SAME selection —
+ * `commits(last: 1) { totalCount nodes { commit { statusCheckRollup { contexts(first: 100) } } } }`,
+ * where `commitCount` is the `totalCount` and `headCommit.buildStatuses` is the rollup. provider-apis
+ * therefore gates the subtree on the pair, and `fieldQuery` keys off truthiness: leaving `commitCount:
+ * true` here would keep the whole thing and this map would save nothing at all.
  *
- * BOTH omissions are required, and this is the subtle part: on GitHub the two fields come from the SAME
- * selection — `commits(last: 1) { totalCount nodes { commit { statusCheckRollup { contexts(first: 100) }
- * } } }`, where `commitCount` is the `totalCount` and `headCommit.buildStatuses` is the rollup. So
- * provider-apis gates the subtree on the pair; leaving `commitCount: true` here would keep the whole
- * thing and this map would save nothing at all.
- *
- * That is up to 100 check contexts per PR for a page of up to 100 PRs, which consumers collapse into a
- * single tri-state. Measured against a 100-PR repo: 55.6 KB → 14.1 KB and ~2.0s → ~1.1s per page.
+ * That subtree is up to 100 check contexts per PR for a page of up to 100 PRs, which consumers collapse
+ * into a single tri-state. Measured against a 100-PR repo: 55.6 KB → 14.1 KB and ~2.0s → ~1.1s per page.
  *
  * Giving up `commitCount` alongside the rollup is consistent with what `summary` already means here:
  * `gqlPullRequestLiteFragment`, which `searchMyPullRequests` has always used for its summary reads,
  * selects no `commits` either. Both fields are optional on `PullRequestShape`, so a summary row reports
  * them as absent rather than as a zero.
+ *
+ * Typed as provider-apis' own `GitHubPullRequestFieldMap`, which is narrowed to exactly these two keys,
+ * so naming a field that gates nothing is a compile error rather than a silent no-op. Note the map is
+ * only meaningful when PRESENT: an absent map is what tells provider-apis to select everything, which is
+ * why non-summary reads pass none at all.
  */
-const summaryPullRequestFields: FullFieldMap<GitPullRequest> = {
-	id: true,
-	graphQLId: true,
-	number: true,
-	title: true,
-	description: true,
-	url: true,
-	state: true,
-	isDraft: true,
-	createdDate: true,
-	updatedDate: true,
-	closedDate: true,
-	mergedDate: true,
-	baseRef: true,
-	headRef: true,
-	commentCount: true,
-	upvoteCount: true,
-	// Dropped together with `headCommit`: it is that subtree's `totalCount`, so keeping it would
-	// keep the whole rollup (see the note above).
-	commitCount: false,
-	fileCount: true,
-	additions: true,
-	deletions: true,
-	author: true,
-	assignees: true,
-	reviews: true,
-	reviewDecision: true,
-	isCrossRepository: true,
-	repository: true,
-	headRepository: true,
-	// The one field a summary read gives up.
+const summaryPullRequestFields: GitHubPullRequestFieldMap = {
 	headCommit: false,
-	mergeableState: true,
-	milestone: true,
-	labels: true,
-	permissions: true,
-	version: true,
+	commitCount: false,
 };
 
 export abstract class GitHostIntegration<
@@ -1440,9 +1400,10 @@ export abstract class GitHostIntegration<
 				includeRemoteInfo: isAzureDevOpsProvider(providerId) ? true : undefined,
 				// A summary read drops the per-row build-status subtree, which on GitHub is
 				// `commits(last: 1) { totalCount ... statusCheckRollup { contexts(first: 100) } }` per PR
-				// for a page of up to 100. The map is opt-out by omission, so every OTHER field stays
-				// selected; what a summary consumer gives up is `statusCheckRollupState` and
-				// `commitCount`, which share that one selection.
+				// for a page of up to 100. That subtree is all the map can gate, so the rest of the row is
+				// unaffected; what a summary consumer gives up is `statusCheckRollupState` and
+				// `commitCount`, which share that one selection. Spread rather than passed as `undefined`
+				// because an absent map is what means "select everything" (see summaryPullRequestFields).
 				...(options?.summary ? { fields: summaryPullRequestFields } : {}),
 			});
 			return { value: result, duration: performance.now() - start };

--- a/packages/plus/integrations/src/models/gitHostIntegration.ts
+++ b/packages/plus/integrations/src/models/gitHostIntegration.ts
@@ -1,4 +1,4 @@
-import type { CollectionMetadata, CollectionScopeFailure, GitHubPullRequestFieldMap } from '@gitkraken/provider-apis';
+import type { CollectionMetadata, CollectionScopeFailure, FieldMap, GitPullRequest } from '@gitkraken/provider-apis';
 import type { Account, UnidentifiedAuthor } from '@gitlens/git/models/author.js';
 import type { DefaultBranch } from '@gitlens/git/models/defaultBranch.js';
 import type { IssueSearchCriteria, IssueShape } from '@gitlens/git/models/issue.js';
@@ -117,6 +117,18 @@ export type SearchMyPullRequestsOptions = {
 	includeReviewRequested?: boolean;
 };
 
+type MyPullRequestsForReposOptions = {
+	filters?: PullRequestFilter[];
+	cursor?: string;
+	customUrl?: string;
+	page?: number;
+	pageSize?: number;
+	/** PR states to include; when omitted the provider returns its default (open only). */
+	state?: PullRequestStateFilter | PullRequestStateFilter[];
+	/** Requests the lightweight row shape without per-row build status or commit count. */
+	summary?: boolean;
+};
+
 /**
  * Rejects a read the provider can't serve as asked: logs the reason and returns it as the `{ error }` half of an
  * {@link IntegrationResult}, timed from `start`.
@@ -133,31 +145,10 @@ function unsupportedRead<T>(message: string, start: number, logContext?: string)
 }
 
 /**
- * The provider-apis field map a summary PR read requests. Both keys it can name are dropped; every other
- * field of the row comes back untouched, because those two are all this map is able to gate.
- *
- * They must go TOGETHER, and that is the subtle part: on GitHub both come from the SAME selection —
- * `commits(last: 1) { totalCount nodes { commit { statusCheckRollup { contexts(first: 100) } } } }`,
- * where `commitCount` is the `totalCount` and `headCommit.buildStatuses` is the rollup. provider-apis
- * therefore gates the subtree on the pair, and `fieldQuery` keys off truthiness: leaving `commitCount:
- * true` here would keep the whole thing and this map would save nothing at all.
- *
- * That subtree is up to 100 check contexts per PR for a page of up to 100 PRs, which consumers collapse
- * into a single tri-state. Measured against a 100-PR repo: 55.6 KB → 14.1 KB and ~2.0s → ~1.1s per page.
- *
- * Giving up `commitCount` alongside the rollup is consistent with what `summary` already means here:
- * `gqlPullRequestLiteFragment`, which `searchMyPullRequests` has always used for its summary reads,
- * selects no `commits` either. Both fields are optional on `PullRequestShape`, so a summary row reports
- * them as absent rather than as a zero.
- *
- * Typed as `Required<GitHubPullRequestFieldMap>`: the map is narrowed to exactly these two keys, so naming
- * a field that gates nothing is a compile error, and `Required` makes OMITTING one an error too. That
- * second half matters as much as the first, since `fieldQuery` keeps the whole subtree if either key is
- * truthy, so a map that simply forgot `commitCount` would save nothing at all — the exact bug this branch
- * already shipped once. Note the map is only meaningful when PRESENT: an absent map is what tells
- * provider-apis to select everything, which is why non-summary reads pass none at all.
+ * Both fields gate the same GitHub `commits` subtree, so either truthy key retains the build-status rollup.
+ * An absent map retains the full row; a summary read explicitly drops both optional fields.
  */
-const summaryPullRequestFields: Required<GitHubPullRequestFieldMap> = {
+const summaryPullRequestFields: Required<Pick<FieldMap<GitPullRequest>, 'headCommit' | 'commitCount'>> = {
 	headCommit: false,
 	commitCount: false,
 };
@@ -1114,15 +1105,7 @@ export abstract class GitHostIntegration<
 
 	async getMyPullRequestsForRepos(
 		reposOrRepoIds: ProviderReposInput,
-		options?: {
-			filters?: PullRequestFilter[];
-			cursor?: string;
-			customUrl?: string;
-			page?: number;
-			pageSize?: number;
-			/** PR states to include; when omitted the provider returns its default (open only). */
-			state?: PullRequestStateFilter | PullRequestStateFilter[];
-		},
+		options?: MyPullRequestsForReposOptions,
 		connectionId?: string,
 	): Promise<ProviderApiPagedResult<ProviderPullRequest> | undefined> {
 		return (await this.getMyPullRequestsForReposResult(reposOrRepoIds, options, connectionId))?.value;
@@ -1136,20 +1119,7 @@ export abstract class GitHostIntegration<
 	 */
 	async getMyPullRequestsForReposResult(
 		reposOrRepoIds: ProviderReposInput,
-		options?: {
-			filters?: PullRequestFilter[];
-			cursor?: string;
-			customUrl?: string;
-			page?: number;
-			pageSize?: number;
-			state?: PullRequestStateFilter | PullRequestStateFilter[];
-			/**
-			 * Requests the lightweight row shape, dropping the per-row build-status subtree the provider
-			 * otherwise selects. See {@link IntegrationManager.searchPullRequestsPage}; the account-wide
-			 * sibling read has always passed it, and this is the repo-scoped counterpart.
-			 */
-			summary?: boolean;
-		},
+		options?: MyPullRequestsForReposOptions,
 		connectionId?: string,
 	): Promise<IntegrationResult<ProviderApiPagedResult<ProviderPullRequest> | undefined>> {
 		const scope = getScopedLogger();
@@ -1323,11 +1293,6 @@ export abstract class GitHostIntegration<
 								states: states,
 								// Azure DevOps only populates clone URLs on request (extra call); no-op elsewhere.
 								includeRemoteInfo: isAzureDevOpsProvider(providerId) ? true : undefined,
-								// Forwarded on this branch too, so the projection cannot depend on which paging
-								// mode the provider happens to use. The map is GitHub-shaped and GitHub is
-								// `PagingMode.Repos`, so today this is inert here; it stops being a question the
-								// moment a `PagingMode.Repo` provider learns to gate on it.
-								fields: options?.summary ? summaryPullRequestFields : undefined,
 							},
 						);
 						return { repoInput: repoInput, results: results };
@@ -1405,9 +1370,6 @@ export abstract class GitHostIntegration<
 				states: states,
 				// Azure DevOps only populates clone URLs on request (extra call); no-op elsewhere.
 				includeRemoteInfo: isAzureDevOpsProvider(providerId) ? true : undefined,
-				// See {@link summaryPullRequestFields} for what a summary read gives up and why the two keys
-				// travel together. `undefined` and an absent map are the same thing to provider-apis, whose
-				// `fieldQuery` gates on truthiness, so a non-summary read still selects everything.
 				fields: options?.summary ? summaryPullRequestFields : undefined,
 			});
 			return { value: result, duration: performance.now() - start };

--- a/packages/plus/integrations/src/models/gitHostIntegration.ts
+++ b/packages/plus/integrations/src/models/gitHostIntegration.ts
@@ -1,4 +1,9 @@
-import type { CollectionMetadata, CollectionScopeFailure } from '@gitkraken/provider-apis';
+import type {
+	CollectionMetadata,
+	CollectionScopeFailure,
+	FullFieldMap,
+	GitPullRequest,
+} from '@gitkraken/provider-apis';
 import type { Account, UnidentifiedAuthor } from '@gitlens/git/models/author.js';
 import type { DefaultBranch } from '@gitlens/git/models/defaultBranch.js';
 import type { IssueSearchCriteria, IssueShape } from '@gitlens/git/models/issue.js';
@@ -131,6 +136,58 @@ function unsupportedRead<T>(message: string, start: number, logContext?: string)
 	Logger.warn(message, logContext);
 	return { error: new Error(message), duration: performance.now() - start };
 }
+
+/**
+ * The provider-apis field map a summary PR read requests: every `GitPullRequest` field EXCEPT
+ * `headCommit`.
+ *
+ * Spelled as an explicit allow-list rather than a negation because provider-apis' `fieldQuery` treats
+ * an ABSENT map as "select everything" and a present one as the complete request — so omitting a field
+ * here drops it. That makes the list load-bearing: a `GitPullRequest` field added upstream and not
+ * added here would silently stop being selected on summary reads. `FullFieldMap` (a `Record` over every
+ * key, not a `Partial`) is what turns that into a compile error instead.
+ *
+ * Only `headCommit` is dropped, and it is the whole point: on GitHub it expands to
+ * `commits(last: 1) { ... statusCheckRollup { contexts(first: 100) } }` per row — up to 100 check
+ * contexts per PR for a page of up to 100 PRs, collapsed by consumers into a single tri-state.
+ * Measured against a 100-PR repo: 55.6 KB → 14.1 KB and ~2.0s → ~1.1s per page.
+ */
+const summaryPullRequestFields: FullFieldMap<GitPullRequest> = {
+	id: true,
+	graphQLId: true,
+	number: true,
+	title: true,
+	description: true,
+	url: true,
+	state: true,
+	isDraft: true,
+	createdDate: true,
+	updatedDate: true,
+	closedDate: true,
+	mergedDate: true,
+	baseRef: true,
+	headRef: true,
+	commentCount: true,
+	upvoteCount: true,
+	commitCount: true,
+	fileCount: true,
+	additions: true,
+	deletions: true,
+	author: true,
+	assignees: true,
+	reviews: true,
+	reviewDecision: true,
+	isCrossRepository: true,
+	repository: true,
+	headRepository: true,
+	// The one field a summary read gives up.
+	headCommit: false,
+	mergeableState: true,
+	milestone: true,
+	labels: true,
+	permissions: true,
+	version: true,
+};
 
 export abstract class GitHostIntegration<
 	ID extends IntegrationIds = IntegrationIds,
@@ -1113,6 +1170,12 @@ export abstract class GitHostIntegration<
 			page?: number;
 			pageSize?: number;
 			state?: PullRequestStateFilter | PullRequestStateFilter[];
+			/**
+			 * Requests the lightweight row shape, dropping the per-row build-status subtree the provider
+			 * otherwise selects. See {@link IntegrationManager.searchPullRequestsPage}; the account-wide
+			 * sibling read has always passed it, and this is the repo-scoped counterpart.
+			 */
+			summary?: boolean;
 		},
 		connectionId?: string,
 	): Promise<IntegrationResult<ProviderApiPagedResult<ProviderPullRequest> | undefined>> {
@@ -1364,6 +1427,11 @@ export abstract class GitHostIntegration<
 				states: states,
 				// Azure DevOps only populates clone URLs on request (extra call); no-op elsewhere.
 				includeRemoteInfo: isAzureDevOpsProvider(providerId) ? true : undefined,
+				// A summary read drops the per-row build-status subtree, which on GitHub is
+				// `statusCheckRollup.contexts(first: 100)` per PR for a page of up to 100. The map is
+				// opt-out by omission, so every OTHER field stays selected and only this subtree goes;
+				// `statusCheckRollupState` is the one thing a summary consumer gives up.
+				...(options?.summary ? { fields: summaryPullRequestFields } : {}),
 			});
 			return { value: result, duration: performance.now() - start };
 		} catch (ex) {
@@ -1575,6 +1643,8 @@ export abstract class GitHostIntegration<
 			criteria?: PullRequestSearchCriteria;
 			cursor?: string;
 			pageSize?: number;
+			/** See {@link IntegrationManager.searchPullRequestsPage}. */
+			summary?: boolean;
 		},
 		cancellation?: AbortSignal,
 		connectionId?: string,

--- a/packages/plus/integrations/src/providers/github.ts
+++ b/packages/plus/integrations/src/providers/github.ts
@@ -612,6 +612,7 @@ abstract class GitHubIntegrationBase<ID extends GitHubIntegrationIds> extends Gi
 			criteria?: PullRequestSearchCriteria;
 			cursor?: string;
 			pageSize?: number;
+			summary?: boolean;
 		},
 		cancellation?: AbortSignal,
 	): Promise<ProviderPullRequestSearchPage | undefined> {
@@ -625,6 +626,7 @@ abstract class GitHubIntegrationBase<ID extends GitHubIntegrationIds> extends Gi
 				baseUrl: this.apiBaseUrl,
 				cursor: options.cursor,
 				pageSize: options.pageSize,
+				summary: options.summary,
 			},
 			cancellation,
 		);

--- a/packages/plus/integrations/src/providers/models.ts
+++ b/packages/plus/integrations/src/providers/models.ts
@@ -16,6 +16,7 @@ import type {
 	GitBuildStatus,
 	GitBuildStatusState as GitBuildStatusStateType,
 	GitHub,
+	GitHubPullRequestFieldMap,
 	GitIssueState as GitIssueStateType,
 	GitLab,
 	GitLabGroup,
@@ -329,6 +330,11 @@ export interface GetPullRequestsOptions {
 	// Opt in to repository remote metadata (clone URLs) when the PR payload lacks it. Only Azure DevOps
 	// acts on this today (extra API call); it is a no-op for the other providers.
 	includeRemoteInfo?: boolean;
+	// Field selection for the row shape. GitHub-shaped because it is the only provider whose PR read gates
+	// anything on it; the others ignore it. Declared here rather than passed through a spread so a typo or a
+	// wrong-shaped map is a compile error instead of a silently ignored key. An ABSENT map means "select
+	// everything", so only summary reads pass one.
+	fields?: GitHubPullRequestFieldMap;
 }
 
 export interface GetPullRequestsForUserOptions {

--- a/packages/plus/integrations/src/providers/models.ts
+++ b/packages/plus/integrations/src/providers/models.ts
@@ -12,11 +12,11 @@ import type {
 	CollectionMetadata,
 	CursorPageInput,
 	EnterpriseOptions,
+	FieldMap,
 	GetRepoInput,
 	GitBuildStatus,
 	GitBuildStatusState as GitBuildStatusStateType,
 	GitHub,
-	GitHubPullRequestFieldMap,
 	GitIssueState as GitIssueStateType,
 	GitLab,
 	GitLabGroup,
@@ -334,7 +334,7 @@ export interface GetPullRequestsOptions {
 	// anything on it; the others ignore it. Declared here rather than passed through a spread so a typo or a
 	// wrong-shaped map is a compile error instead of a silently ignored key. An ABSENT map means "select
 	// everything", so only summary reads pass one.
-	fields?: GitHubPullRequestFieldMap;
+	fields?: FieldMap<GitPullRequest>;
 }
 
 export interface GetPullRequestsForUserOptions {

--- a/packages/plus/integrations/src/providers/models.ts
+++ b/packages/plus/integrations/src/providers/models.ts
@@ -12,11 +12,11 @@ import type {
 	CollectionMetadata,
 	CursorPageInput,
 	EnterpriseOptions,
-	FieldMap,
 	GetRepoInput,
 	GitBuildStatus,
 	GitBuildStatusState as GitBuildStatusStateType,
 	GitHub,
+	GitHubPullRequestFieldMap,
 	GitIssueState as GitIssueStateType,
 	GitLab,
 	GitLabGroup,
@@ -334,7 +334,7 @@ export interface GetPullRequestsOptions {
 	// anything on it; the others ignore it. Declared here rather than passed through a spread so a typo or a
 	// wrong-shaped map is a compile error instead of a silently ignored key. An ABSENT map means "select
 	// everything", so only summary reads pass one.
-	fields?: FieldMap<GitPullRequest>;
+	fields?: GitHubPullRequestFieldMap;
 }
 
 export interface GetPullRequestsForUserOptions {

--- a/packages/plus/integrations/src/reads/pullRequests.ts
+++ b/packages/plus/integrations/src/reads/pullRequests.ts
@@ -121,6 +121,25 @@ export async function listPullRequestsPage(
 	}
 
 	const includeReviewRequested = accountWide ? (options.includeReviewRequested ?? false) : false;
+	// Everything but the cursor, shared by the initial read and the drain's re-reads below so the two cannot
+	// drift. `summary` is the reason this matters beyond tidiness: a re-read that dropped it would both
+	// revert to the full payload — on the very path that issues the most requests — and return rows of a
+	// different shape than the first page, since a summary row reports `headCommit`/`commitCount` as absent.
+	const accountWideInput = {
+		state: options.states,
+		includeReviewRequested: includeReviewRequested,
+		filters: resolvedFilters.filters,
+		summary: true,
+	};
+	// `filters` scopes the read to the current user (the core resolves the account for these), so it returns
+	// the user's PRs. `pageSize` rides along so PagingMode.Repo hosts (GitLab, Bitbucket, Azure), whose
+	// per-repo cursor path ignores a synthesized page-number cursor, honor the requested size.
+	const scopedInput = {
+		state: options.states,
+		filters: resolvedFilters.filters,
+		pageSize: options.itemsPerPage,
+		summary: options.summary,
+	};
 	const { value, warning } = await runCaptured(
 		options.providerId,
 		domain,
@@ -128,31 +147,20 @@ export async function listPullRequestsPage(
 		() =>
 			accountWide
 				? integration.getMyPullRequestsForUserResult(
-						{
-							state: options.states,
-							cursor: cursor,
-							includeReviewRequested: includeReviewRequested,
-							filters: resolvedFilters.filters,
-							summary: true,
-						},
+						{ ...accountWideInput, cursor: cursor },
 						options.connectionId,
 					)
 				: integration.getMyPullRequestsForReposResult(
 						options.repos ?? [],
-						// Forward `page`/`pageSize` alongside the cursor so PagingMode.Repo hosts (GitLab, Bitbucket,
-						// Azure), whose per-repo cursor path ignores a synthesized page-number cursor, still honor the
-						// requested page and page size instead of always returning page 1. `filters` scopes the read to
-						// the current user (the core resolves the account for these), so it returns the user's PRs.
 						{
-							state: options.states,
-							filters: resolvedFilters.filters,
+							...scopedInput,
 							cursor: cursor,
-							// The normalized `page`, so the number forwarded to the provider can't disagree with the
-							// page-number cursor beside it — both are built from the same value. Only when the caller
-							// asked for one: an omitted page is the provider's own first page.
+							// Forward `page` alongside the cursor so PagingMode.Repo hosts honor the requested page
+							// instead of always returning page 1. The normalized `page`, so the number forwarded to the
+							// provider can't disagree with the page-number cursor beside it — both are built from the
+							// same value. Only when the caller asked for one: an omitted page is the provider's own
+							// first page.
 							page: options.page != null ? page : undefined,
-							pageSize: options.itemsPerPage,
-							summary: options.summary,
 						},
 						options.connectionId,
 					),
@@ -192,25 +200,16 @@ export async function listPullRequestsPage(
 						domain,
 						options.connectionId,
 						() =>
+							// No `page` here, unlike the initial read: a drain advances through the provider's own
+							// continuations, so the cursor is what positions these.
 							accountWide
 								? integration.getMyPullRequestsForUserResult(
-										{
-											state: options.states,
-											cursor: cursor,
-											includeReviewRequested: includeReviewRequested,
-											filters: resolvedFilters.filters,
-											summary: true,
-										},
+										{ ...accountWideInput, cursor: cursor },
 										options.connectionId,
 									)
 								: integration.getMyPullRequestsForReposResult(
 										options.repos ?? [],
-										{
-											state: options.states,
-											filters: resolvedFilters.filters,
-											cursor: cursor,
-											pageSize: options.itemsPerPage,
-										},
+										{ ...scopedInput, cursor: cursor },
 										options.connectionId,
 									),
 						{

--- a/packages/plus/integrations/src/reads/pullRequests.ts
+++ b/packages/plus/integrations/src/reads/pullRequests.ts
@@ -48,6 +48,11 @@ export async function listPullRequestsPage(
 		includeReviewRequested?: boolean;
 		page?: number;
 		cursor?: string;
+		/**
+		 * Requests the lightweight row shape (see {@link IntegrationManager.listPullRequestsPage}). The
+		 * account-wide branch has always asked for it; this forwards it on the repo-scoped branch too.
+		 */
+		summary?: boolean;
 		itemsPerPage?: number;
 		forceSync?: boolean;
 		connectionId?: string;
@@ -147,6 +152,7 @@ export async function listPullRequestsPage(
 							// asked for one: an omitted page is the provider's own first page.
 							page: options.page != null ? page : undefined,
 							pageSize: options.itemsPerPage,
+							summary: options.summary,
 						},
 						options.connectionId,
 					),

--- a/packages/plus/integrations/src/reads/pullRequests.ts
+++ b/packages/plus/integrations/src/reads/pullRequests.ts
@@ -143,34 +143,27 @@ export async function listPullRequestsPage(
 		pageSize: options.itemsPerPage,
 		summary: options.summary,
 	};
-	const { value, warning } = await runCaptured(
-		options.providerId,
-		domain,
-		options.connectionId,
-		() =>
-			accountWide
-				? integration.getMyPullRequestsForUserResult(
-						{ ...accountWideInput, cursor: cursor },
-						options.connectionId,
-					)
-				: integration.getMyPullRequestsForReposResult(
-						options.repos ?? [],
-						{
-							...scopedInput,
-							cursor: cursor,
-							// Forward `page` alongside the cursor so PagingMode.Repo hosts honor the requested page
-							// instead of always returning page 1. The normalized `page`, so the number forwarded to the
-							// provider can't disagree with the page-number cursor beside it — both are built from the
-							// same value. Only when the caller asked for one: an omitted page is the provider's own
-							// first page.
-							page: options.page != null ? page : undefined,
-						},
-						options.connectionId,
-					),
-		{
-			warnOnMissingSession: warnOnMissingSessionForDomain(options.providerId, options.domain),
-		},
-	);
+	const readPage = (pageCursor: string | undefined, requestedPage?: number) =>
+		runCaptured(
+			options.providerId,
+			domain,
+			options.connectionId,
+			() =>
+				accountWide
+					? integration.getMyPullRequestsForUserResult(
+							{ ...accountWideInput, cursor: pageCursor },
+							options.connectionId,
+						)
+					: integration.getMyPullRequestsForReposResult(
+							options.repos ?? [],
+							{ ...scopedInput, cursor: pageCursor, page: requestedPage },
+							options.connectionId,
+						),
+			{
+				warnOnMissingSession: warnOnMissingSessionForDomain(options.providerId, options.domain),
+			},
+		);
+	const { value, warning } = await readPage(cursor, options.page != null ? page : undefined);
 
 	let items = value?.values ?? [];
 	// Cursor-only account-wide reads start at page 1; a page-only request is advanced through opaque
@@ -197,28 +190,8 @@ export async function listPullRequestsPage(
 				requestedPage: page,
 				itemsPerPage: options.itemsPerPage,
 				warnings: warnings,
-				readPage: (cursor: string) =>
-					runCaptured(
-						options.providerId,
-						domain,
-						options.connectionId,
-						() =>
-							// No `page` here, unlike the initial read: a drain advances through the provider's own
-							// continuations, so the cursor is what positions these.
-							accountWide
-								? integration.getMyPullRequestsForUserResult(
-										{ ...accountWideInput, cursor: cursor },
-										options.connectionId,
-									)
-								: integration.getMyPullRequestsForReposResult(
-										options.repos ?? [],
-										{ ...scopedInput, cursor: cursor },
-										options.connectionId,
-									),
-						{
-							warnOnMissingSession: warnOnMissingSessionForDomain(options.providerId, options.domain),
-						},
-					),
+				// A drain advances through provider continuations, so only the cursor positions these reads.
+				readPage: (cursor: string) => readPage(cursor),
 			},
 		);
 		items = drained.items;

--- a/packages/plus/integrations/src/reads/pullRequests.ts
+++ b/packages/plus/integrations/src/reads/pullRequests.ts
@@ -49,8 +49,9 @@ export async function listPullRequestsPage(
 		page?: number;
 		cursor?: string;
 		/**
-		 * Requests the lightweight row shape (see {@link IntegrationManager.listPullRequestsPage}). The
-		 * account-wide branch has always asked for it; this forwards it on the repo-scoped branch too.
+		 * Requests the lightweight row shape (see {@link IntegrationManager.listPullRequestsPage}). Opt-in
+		 * only, and only on the repo-scoped branch: the account-wide branch has always read the lightweight
+		 * shape and keeps doing so, so an explicit `false` does not widen it back to the full projection.
 		 */
 		summary?: boolean;
 		itemsPerPage?: number;
@@ -120,14 +121,16 @@ export async function listPullRequestsPage(
 		);
 	}
 
-	const includeReviewRequested = accountWide ? (options.includeReviewRequested ?? false) : false;
 	// Everything but the cursor, shared by the initial read and the drain's re-reads below so the two cannot
 	// drift. `summary` is the reason this matters beyond tidiness: a re-read that dropped it would both
 	// revert to the full payload — on the very path that issues the most requests — and return rows of a
 	// different shape than the first page, since a summary row reports `headCommit`/`commitCount` as absent.
+	// `summary` is pinned true here rather than forwarded: this branch has never had a full projection to
+	// fall back to (see the option's doc), so honoring an explicit `false` would promise a widening the read
+	// cannot deliver.
 	const accountWideInput = {
 		state: options.states,
-		includeReviewRequested: includeReviewRequested,
+		includeReviewRequested: options.includeReviewRequested ?? false,
 		filters: resolvedFilters.filters,
 		summary: true,
 	};

--- a/packages/plus/integrations/src/reads/searchPullRequests.ts
+++ b/packages/plus/integrations/src/reads/searchPullRequests.ts
@@ -48,6 +48,8 @@ export async function searchPullRequestsPage(
 		forceSync?: boolean;
 		connectionId?: string;
 		domain?: string;
+		/** See {@link IntegrationManager.searchPullRequestsPage}. */
+		summary?: boolean;
 	},
 ): Promise<ProviderPagedResult<PullRequestShape>> {
 	const page = Math.max(1, Math.trunc(options.page ?? 1));
@@ -142,6 +144,7 @@ export async function searchPullRequestsPage(
 						criteria: options.criteria,
 						cursor: cursor,
 						pageSize: options.itemsPerPage,
+						summary: options.summary,
 					},
 					undefined,
 					options.connectionId,

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -7,8 +7,8 @@ settings:
 catalogs:
   default:
     '@gitkraken/provider-apis':
-      specifier: 0.56.0
-      version: 0.56.0
+      specifier: 0.57.0
+      version: 0.57.0
     '@octokit/graphql':
       specifier: 9.0.4
       version: 9.0.4
@@ -100,7 +100,7 @@ importers:
         version: 0.2.3
       '@gitkraken/provider-apis':
         specifier: 'catalog:'
-        version: 0.56.0(encoding@0.1.13)
+        version: 0.57.0(encoding@0.1.13)
       '@gitkraken/shared-tools':
         specifier: 0.2.0
         version: 0.2.0
@@ -422,7 +422,7 @@ importers:
     dependencies:
       '@gitkraken/provider-apis':
         specifier: 'catalog:'
-        version: 0.56.0(encoding@0.1.13)
+        version: 0.57.0(encoding@0.1.13)
       '@octokit/graphql':
         specifier: 'catalog:'
         version: 9.0.4
@@ -614,7 +614,7 @@ importers:
     dependencies:
       '@gitkraken/provider-apis':
         specifier: 'catalog:'
-        version: 0.56.0(encoding@0.1.13)
+        version: 0.57.0(encoding@0.1.13)
       '@gitlens/git':
         specifier: workspace:*
         version: link:../../git
@@ -1101,8 +1101,8 @@ packages:
     resolution: {integrity: sha512-Up/vFkYsYPE8uJYpTcoSbrs9Tdv49z44lsb+LVTDjqozoQ5vd5jbcXR6Pi0L1u451RKk4cS/fhrfG9s9ZpRULg==}
     engines: {node: '>= 22'}
 
-  '@gitkraken/provider-apis@0.56.0':
-    resolution: {integrity: sha512-ioGLje6F7df8SqAByXSPM1ap+LfYLLht5m2Ez8rUVcZnUwY8Pe486Up+YAsei08XY6wUGyzjLBGNnhsNVZlMNQ==}
+  '@gitkraken/provider-apis@0.57.0':
+    resolution: {integrity: sha512-OewkidbLhW+Sxz6OB06wkNmH9zvFuOxWvFETk20r8oZoe5m8dVcnw4eDoS0rGrIrNS7BLfGIsQO55uukYk9h9A==}
     engines: {node: '>= 20'}
 
   '@gitkraken/shared-tools@0.2.0':
@@ -7930,7 +7930,7 @@ snapshots:
       '@gitkraken/shared-tools': 0.2.0
       picomatch: 4.0.5
 
-  '@gitkraken/provider-apis@0.56.0(encoding@0.1.13)':
+  '@gitkraken/provider-apis@0.57.0(encoding@0.1.13)':
     dependencies:
       '@linear/sdk': 58.1.0(encoding@0.1.13)
       diff: 8.0.4

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -20,7 +20,7 @@ allowBuilds:
 blockExoticSubdeps: true
 
 catalog:
-    '@gitkraken/provider-apis': 0.56.0
+    '@gitkraken/provider-apis': 0.57.0
     # The @octokit/* packages depend on each other; version them as a family so a lone bump can't
     # split them. @octokit/graphql wants `@octokit/request: ^10.0.6` — see the overrides entry.
     '@octokit/graphql': 9.0.4


### PR DESCRIPTION
> Targets `core`, not `main`.
>
> The provider-apis half landed in gitkraken/provider-apis-package-js#300. This PR
> consumes `@gitkraken/provider-apis` 0.57.0, so the repo-scoped `fields` map is honored at runtime; the `searchPullRequestsPage` half is self-contained.

## Why

The **account-wide** branch of `listPullRequestsPage` has always asked its provider
for the lightweight row shape (`summary: true`). The **repo-scoped** branch had no way
to, so every scoped page paid for a per-row build-status rollup regardless of what the
consumer read. On GitHub that rollup is:

```
commits(last: 1) { ... statusCheckRollup { contexts(first: 100) { ... } } }
```

per row — up to 100 check contexts per PR for a page of up to 100 — and consumers
collapse the whole thing into one tri-state (`statusCheckRollupState`).

Separately, `searchPullRequestsPage` always selects the full PR fragment, which
resolves `assignees(25)` + `latestReviews(25)` + `reviewRequests(25)` per node. That
one is *server* time rather than payload, and it is already known to be expensive
here: it is why `defaultPullRequestSearchPageSize` is 30 rather than 100 (GitHub
rejects the wide search with `Resource limits for this query exceeded`).

## Measured

Interleaved to cancel network drift:

**provider-apis path** — `gh api graphql`, 100-PR repo, 4 pairs:

| | with rollup | without |
|---|---|---|
| Payload | 55620 B | 14110 B |
| Wall clock | median ~2000 ms | median ~1070 ms |

**Own-GraphQL path** — 992-PR repo, one 30-node page, 3 rounds:

| Query | Wall clock | Bytes | Per node |
|---|---|---|---|
| full fragment, 30 | ~3090 ms | 155 KB | 103 ms |
| lite fragment, 30 | ~1150 ms | 140 KB | 38 ms |
| lite fragment, 100 | ~1800 ms | 455 KB | 18 ms |

Near-identical bytes at equal node count, so the win is server-side field resolution.
It compounds with the page size, since the default follows the projection: 100 PRs
cost four sequential full pages (~12.4 s) or one lite page (~1.8 s).

**End to end** in a real consumer (Kepler's worktree correlation, which reads neither
reviews nor checks): the scoped PR search went from **~7474 ms to ~3714 ms median** per
request (range 2557-5901 across runs) — its slowest cold-start request.

Re-measured after the `commitCount` fix. The earlier ~5040 ms figure was taken while
the map still kept the subtree, so it reflected only the fragment change on the
own-GraphQL route; the remaining gap is what the provider-apis gate contributes.

## What this does

`summary` is accepted on `listPullRequestsPage` / `searchPullRequestsPage` and threaded
down. Two mechanisms, because the two reads reach GitHub by different routes:

- **Repo-scoped list read** → provider-apis, so it translates to that package's
  `GitHubPullRequestFieldMap` (`summaryPullRequestFields`). The map explicitly drops
  both gated fields because provider-apis treats an absent map as "select everything"
  and a present one as the complete request. The required local map type makes it a
  compile error to omit either gate.

  **`headCommit` AND `commitCount` are both `false`, and both are required.** On GitHub
  the two come from one selection — `commits(last: 1) { totalCount nodes { commit {
  statusCheckRollup { contexts(first: 100) } } } }`, where `commitCount` is the
  `totalCount` — so provider-apis gates the subtree on the pair. An earlier revision of
  this PR left `commitCount: true`, which kept the whole subtree and made the map save
  nothing on this route while still passing every test in both packages. Dropping
  `commitCount` matches what `summary` already means here: `gqlPullRequestLiteFragment`
  selects no `commits` either, and both fields are optional on `PullRequestShape`.
- **`searchPullRequestsPage`** builds its own GraphQL, so it selects
  `gqlPullRequestLiteFragment` — the same projection `searchMyPullRequests` already
  uses — while retaining stack info and omitting review, check, and diff enrichment.
  Its mapper follows the projection too
  (`fromGitHubPullRequestLite`): mapping a lite node with the full mapper would report
  "no reviewers"/"no checks" as facts rather than as unselected.

For `searchPullRequestsPage` only the **default** page size follows the projection,
matching what `searchMyPullRequests` documents. An explicit `pageSize` is still
honoured up to the maximum either way — that contract has a test, which is how the
first version of this change was caught capping it.

## Compatibility

Opt-in throughout: every existing caller keeps today's shape and payload byte for
byte, and a provider with no lightweight projection ignores the flag, so it is a hint
rather than a guarantee about which fields are present. Callers that DO read the
rollup — the Graph sidebar and PR sheet — are unaffected, which is exactly why this is
per-call rather than a removal.

## Testing

- New `summaryPullRequestFields.test.ts`, which is the test whose absence allowed the
  `commitCount` bug: the map lives in this package, the gate that interprets it lives
  in another, and nothing connected them. It asserts the map that actually **reaches**
  provider-apis (captured from the real read) rather than the map's declaration —
  restating the declaration would pass regardless of what the gate does with it — and
  pins both halves: exactly the two gated keys are false, and a non-summary read sends
  no map at all. Verified it fails when `commitCount: true` is restored.
- 3 new tests in `pullRequestSearch.test.ts`: the summary read selects the lite
  fragment and the maximum default page size and drops
  `latestReviews`/`reviewRequests`/`statusCheckRollup` while keeping
  `baseRefName`/`headRefName`/`body`; the non-summary read keeps the full fragment and
  the cost-safe default; an explicit page size is honoured on the summary path too.
- `pnpm test:packages` green across every package (git-github 153, integrations 775,
  git 562, utils 451, git-cli 451, agents 235, ai 113, commit-graph 296, ipc 18).
- `tsc --noEmit` clean for both changed packages.



## Dependency update

- Updated the workspace catalog and lockfile to `@gitkraken/provider-apis` 0.57.0, which includes the runtime support for the scoped `fields` projection.
- Targeted validation after the update: GitHub 153 tests, integrations 775 tests, type-check, build, and consumer fixture all pass.
