### PR TITLE
Fixes the Compare panel opening an unrenderable tab for a nested repository

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -50,6 +50,7 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/) and this p
 
 ### Fixed
 
+- Fixes clicking an untracked nested repository's row in the _Commit Graph_'s _Compare_ panel opening a tab that fails to render ([#5657](https://github.com/gitkraken/vscode-gitlens/issues/5657))
 - Fixes the push confirmation pre-selecting _Force Push_ when the branch is behind its upstream &mdash; Enter force-pushed; _Cancel_ is now the default
 - Fixes `:command`-scoped entries in `gitlens.gitCommands.skipConfirmations` never applying to subcommands &mdash; e.g. `stash-push:command` still confirmed when stashing from a view
 - Fixes _Hide Remote_ in the _Commit Graph_ only hiding the selected branch instead of all of the remote's branches ([#5728](https://github.com/gitkraken/vscode-gitlens/issues/5728))

--- a/src/webviews/rpc/services/files.ts
+++ b/src/webviews/rpc/services/files.ts
@@ -167,6 +167,10 @@ export class FilesService {
 		rhsRef?: string,
 	): Promise<void> {
 		if (file.repoPath == null || lhsRef == null || rhsRef == null) return;
+		// An untracked directory that is itself a repository is reported with a trailing slash. It is a
+		// directory on disk with no content to diff against any ref. Guarded here rather than in the row
+		// component because this is where the path becomes a URI that gets handed to the diff editor.
+		if (file.path.endsWith('/')) return;
 
 		const lhsUri = GitUri.fromFile(file.originalPath ?? file.path, file.repoPath, lhsRef);
 		// `rhsRef === ''` means "working tree": construct an absolute `file://` URI directly.


### PR DESCRIPTION
Closes #5657

## What the user saw

In the _Commit Graph_'s **Compare** panel with _Include Working Tree Changes_ on, clicking the row for an untracked directory that is itself a git repository opened an editor tab titled `nested-repo (Added)` showing "The editor could not be opened due to an unexpected error", with _Try Again_ / _Show Logs_ buttons. The log recorded the real cause:

```
Unable to read file '…/nested-repo' (Error: Unable to read file '…' that is actually a directory)
```

## Why it happened

`git status -u` recurses into ordinary untracked directories, but it cannot recurse past an embedded repository boundary — so a nested repo is reported as a **single entry with a trailing slash** (`nested-repo/`). That entry reaches the file list as one "Added" row whose `path` names a directory, not a file.

`FilesService.openFileCompareBetween` built the right-hand side of the diff by hand:

```ts
const rhsUri =
    rhsRef === '' ? svc.getAbsoluteUri(file.path, file.repoPath) : GitUri.fromFile(file, file.repoPath, rhsRef);
```

With `rhsRef === ''` (the working tree), `getAbsoluteUri` happily produced a `file://` URI pointing at the directory and handed it to `gitlens.diffWith`, which asked VS Code to read a directory as a file.

Worth correcting one assumption in the issue: the same row in the **Review**, **Compose** and **WIP** lists is *not* deliberately unclickable. All four panels share `gl-file-tree-pane`, whose `onTreeItemSelected` dispatches unconditionally for every row — there is no clickability predicate anywhere. Those three panels only appear inert because their action routes through `DiffWithWorkingCommand` → `getWorkingUri`, which stats the path, sees a directory, finds no submodule head for an untracked one, and bails. Compare was the only panel building the URI itself, which is why it was the only one that broke.

## How it's resolved

One guard in `openFileCompareBetween`, placed where the bad URI is actually created — the host — rather than in the shared row component, so the click is not taken away from ordinary files:

```ts
if (file.path.endsWith('/')) return;
```

The trailing slash is the existing in-repo idiom for this case: `buildFileTooltip` already tests it to label the row "(nested repository)", and `trimTrailingSlash` in `packages/utils/src/path.ts` documents why the slash is unambiguous — status is fetched with `-u`, so ordinary untracked directories are recursed into and never appear as a single slash-terminated entry. Ordinary untracked files carry no slash, so their diffs (empty left side and all) are untouched.

## Scope: the gitlink case is deliberately not fixed here

A **staged** nested repository is a different shape — git reports it as a gitlink (mode `160000`) on a normal tracked status line, with **no** trailing slash — so the guard above does not catch it, and clicking such a row against the working tree still produces the same unrenderable tab.

An earlier revision of this PR tried to cover it with `file.submodule != null && rhsRef === ''`, plus forwarding `submodule` through the file tree's dispatched event detail. That was **removed, because it was dead code**: nothing populates `submodule` in the Compare panel's state. Both construction sites build `BranchComparisonFile` as explicit object literals that omit the field —

- `graphInspectServices.ts:~2127` (All Files) builds from `diff.getDiffStatus()`, and `submodule` is populated only by `statusParser` and `logParser`, never by the diff-status parser — so the field is **absent at the source**, not merely dropped.
- `graphInspectServices.ts:~2707` (per-side working-tree list) builds from `status.getStatus()`, whose `GitStatusFile` *does* carry `submodule` — so that one site could forward it.

Since the All Files tab is the path in the issue's own repro, covering gitlinks properly means teaching that diff path to carry gitlink information (the raw `git diff --summary` output does emit `create mode 160000 …`, so it is feasible) — a change to shared diff parsing, well outside this fix. Shipping a guard that cannot fire seemed worse than shipping the working fix and naming the gap. Credit to the automated review on this PR for catching that the guard was inert.

## Tests

None added. The guard is a one-line expression in `FilesService`, reachable only through the `vscode-test` extension-host harness, which could not be run locally in this environment; CI is the first execution of this path.

An earlier revision also extracted the predicate into a shared `isNestedRepoPath` helper with unit tests. That was reverted too: a helper taking an arbitrary string returns `true` for any directory path, so it claimed to identify a nested repository when it could only test for a trailing slash — correctness depends on the value having come from `git status -u`, which no signature can enforce. The inline test plus the adjacent comment is the honest form, and it leaves this discrimination without automated coverage.

## Validation

1. In a repo with some working changes, create an untracked nested repository: `git init nested-repo`, then commit something inside it.
2. Select the _Working Changes_ row in the _Commit Graph_ and open the **Compare** panel.
3. Turn on _Include Working Tree Changes_ and open the _All Files_ tab — the `nested-repo` row appears alongside the ordinary changed files.
4. Click the row body. **Expected:** nothing happens — no tab, no error. Previously: a dead tab.
5. Click an ordinary changed file, and an ordinary untracked file (`new-untracked.txt`). **Expected:** both still open their diffs, the untracked one against an empty left side.
6. Check the tree layout too — with the files-as-tree layout the entry should still appear as a leaf under its parent folders, with its "(nested repository)" tooltip intact.

These steps have not been exercised in a running instance; they are the checks a reviewer should make.

## Related

- #5629 named this row and fixed its tree placement and hover text, but never touched the click path; this is the loose end it left open.
- Not fixed here: the staged-gitlink case described above, and the multi-select _Open All Changes_ path (`openMultipleChanges` in `src/git/actions/commit.ts`), which pushes a directory resource into the multi-diff editor for the same row. Both are pre-existing and independent of the reported click.
- #5603, #5611.
