### PR TITLE
Fixes deep links leaving a progress notification spinning when they fail

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -61,6 +61,7 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/) and this p
 - Fixes searching by author or committer `@me` in GitHub virtual repositories skipping the filter entirely for accounts without a display name
 - Fixes the _Commit Graph_'s search history reading and saving under the first-opened repository after switching repositories in a multi-repo workspace
 - Fixes the _Commit Graph_'s _Review_ mode choosing focus areas from wrong file details on large change sets &mdash; newly added files counted as modified, and changed-line counts included unchanged context ([#5658](https://github.com/gitkraken/vscode-gitlens/issues/5658))
+- Fixes a deep link that fails to open leaving its progress notification spinning indefinitely &mdash; the spinner cleared only when another link was opened, making the failure easy to miss ([#5651](https://github.com/gitkraken/vscode-gitlens/issues/5651))
 
 ## [19.0.1] - 2026-08-13
 

--- a/src/uris/deepLinks/deepLinkService.ts
+++ b/src/uris/deepLinks/deepLinkService.ts
@@ -18,6 +18,8 @@ import { once } from '@gitlens/utils/event.js';
 import { Logger } from '@gitlens/utils/logger.js';
 import { getScopedLogger } from '@gitlens/utils/logger.scoped.js';
 import { maybeUri, normalizePath } from '@gitlens/utils/path.js';
+import type { Deferred } from '@gitlens/utils/promise.js';
+import { defer } from '@gitlens/utils/promise.js';
 import type { OpenChatActionCommandArgs } from '../../commands/openChatAction.js';
 import type { OpenCloudPatchCommandArgs } from '../../commands/patches.js';
 import type { StoredDeepLinkContext, StoredNamedRef } from '../../constants.storage.js';
@@ -67,6 +69,7 @@ type OpenLocationQuickPickItem = {
 
 export class DeepLinkService implements Disposable {
 	private _context: DeepLinkServiceContext;
+	private _progress: Deferred<void> | undefined;
 	private readonly _onDeepLinkProgressUpdated = new EventEmitter<DeepLinkProgress>();
 	private readonly _disposables: Disposable[] = [];
 
@@ -90,6 +93,7 @@ export class DeepLinkService implements Disposable {
 	}
 
 	dispose(): void {
+		this.completeProgress();
 		Disposable.from(...this._disposables).dispose();
 	}
 
@@ -331,6 +335,10 @@ export class DeepLinkService implements Disposable {
 
 		const link = parseDeepLinkUri(Uri.parse(pendingDeepLink.url));
 		if (link == null) return;
+
+		// A pending link can arrive from another window at any point, including while a link is suspended waiting on a
+		// repository. Taking the context away from it also takes away its only chance to finish its notification.
+		this.completeProgress();
 
 		this._context = { state: pendingDeepLink.state ?? DeepLinkServiceState.MaybeOpenRepo };
 		this.setContextFromDeepLink(link, pendingDeepLink.url);
@@ -616,46 +624,125 @@ export class DeepLinkService implements Disposable {
 		initialAction: DeepLinkServiceAction = DeepLinkServiceAction.DeepLinkEventFired,
 		useProgress: boolean = true,
 	): Promise<void> {
-		let message = '';
-		let action = initialAction;
-		if (action === DeepLinkServiceAction.DeepLinkCancelled && this._context.state === DeepLinkServiceState.Idle) {
+		if (
+			initialAction === DeepLinkServiceAction.DeepLinkCancelled &&
+			this._context.state === DeepLinkServiceState.Idle
+		) {
 			return;
 		}
 
-		//Repo match
-		let matchingLocalRepoPaths: string[] = [];
-		const { targetType } = this._context;
+		// Cancelling or starting another link replaces the context wholesale, so holding onto it here is what lets a
+		// late-returning link tell whether it still owns the flow it started
+		const context = this._context;
 
+		// A link can suspend and resume in a later call (waiting on a repository to be opened), so the notification is
+		// owned by the service and adopted by the resuming call rather than being created again
+		let progress: Deferred<void> | undefined;
 		if (useProgress) {
-			queueMicrotask(
-				() =>
-					void window.withProgress(
-						{
-							cancellable: true,
-							location: ProgressLocation.Notification,
-							title: `Opening ${deepLinkTypeToString(targetType ?? DeepLinkType.Repository)} link...`,
-						},
-						(progress, token) => {
-							progress.report({ increment: 0 });
-							return new Promise<void>(resolve => {
-								token.onCancellationRequested(() => {
-									queueMicrotask(() => this.processDeepLink(DeepLinkServiceAction.DeepLinkCancelled));
-									resolve();
-								});
-
-								this._onDeepLinkProgressUpdated.event(({ message, increment }) => {
-									progress.report({ message: message, increment: increment });
-									if (increment === 100) {
-										resolve();
-									}
-								});
-							});
-						},
-					),
-			);
+			progress = this._progress ??= this.showProgress(context.targetType);
 		}
 
+		let unfinished = false;
+		try {
+			unfinished = await this.runDeepLink(initialAction, useProgress, context);
+		} catch (ex) {
+			Logger.error(ex, `Unable to resolve link: ${context.url}`);
+
+			// Only the idle state resets the context, so a throw would otherwise leave it mid-flight and every
+			// subsequent link would be dropped without any feedback. Reset it only while it is still ours -- a
+			// cancelled link can throw long after the user moved on, and resetting then strands the current one.
+			if (this._context === context) {
+				this.resetContext();
+
+				// Nothing opted out of progress comes from a link the user followed, so a message about an
+				// unresolvable link would be reported against an action they never took
+				if (useProgress) {
+					void window.showErrorMessage('Unable to resolve link');
+				}
+			}
+
+			// These already reached their caller before this catch existed, so keep them propagating. Two of the
+			// internal resumes are fire-and-forget and have nowhere to propagate to -- they are logged above.
+			if (!useProgress) throw ex;
+		} finally {
+			if (!unfinished && progress != null) {
+				this.completeProgress(progress);
+			}
+		}
+	}
+
+	private showProgress(targetType: DeepLinkType | undefined): Deferred<void> {
+		const deferred = defer<void>();
+
+		// Held back a turn because a link can resolve (or fail) without ever suspending -- e.g. an unknown command --
+		// and a notification for work that has already finished is just a flash
+		setTimeout(() => {
+			if (!deferred.pending) return;
+
+			void window.withProgress(
+				{
+					cancellable: true,
+					location: ProgressLocation.Notification,
+					title: `Opening ${deepLinkTypeToString(targetType ?? DeepLinkType.Repository)} link...`,
+				},
+				(progress, token) => {
+					progress.report({ increment: 0 });
+
+					const disposables = [
+						token.onCancellationRequested(() => {
+							// Cancel the link this notification was opened for, never whichever one happens to be
+							// current -- a superseded deferred has already been fulfilled and its link is gone
+							if (this._progress !== deferred) return;
+
+							this.completeProgress(deferred);
+							queueMicrotask(
+								() => void this.processDeepLink(DeepLinkServiceAction.DeepLinkCancelled, false),
+							);
+						}),
+						this._onDeepLinkProgressUpdated.event(({ message, increment }) =>
+							progress.report({ message: message, increment: increment }),
+						),
+					];
+
+					return deferred.promise.finally(() => {
+						Disposable.from(...disposables).dispose();
+					});
+				},
+			);
+		}, 0);
+
+		return deferred;
+	}
+
+	private completeProgress(deferred?: Deferred<void>): void {
+		// Don't complete a notification belonging to a newer link
+		if (deferred != null && this._progress !== deferred) return;
+
+		this._progress?.fulfill();
+		this._progress = undefined;
+	}
+
+	/**
+	 * Returns `true` if the link didn't reach a final state -- either it suspended to be resumed by a later call, or
+	 * it was cancelled or superseded and no longer owns the context it started on
+	 */
+	private async runDeepLink(
+		initialAction: DeepLinkServiceAction,
+		useProgress: boolean,
+		context: DeepLinkServiceContext,
+	): Promise<boolean> {
+		let message = '';
+		let action = initialAction;
+
+		//Repo match
+		let matchingLocalRepoPaths: string[] = [];
+
 		while (true) {
+			// Cancelling, or another link starting, replaces the context. Driving one that is no longer ours walks the
+			// transition table from a state it has no entry for, which leaves behind a state that matches nothing and
+			// silently swallows every later link.
+			if (this._context !== context) return true;
+
 			this._context.state = deepLinkStateTransitionTable[this._context.state][action];
 			const {
 				state,
@@ -685,8 +772,11 @@ export class DeepLinkService implements Disposable {
 					}
 
 					// Deep link processing complete. Reset the context and return.
+					// Reaching idle means nothing is in flight, so nothing should still be reporting progress -- a
+					// resume that raced a cancellation can leave a notification behind that no call owns.
+					this.completeProgress();
 					this.resetContext();
-					return;
+					return false;
 				}
 				case DeepLinkServiceState.AccountCheck: {
 					if (targetType == null) {
@@ -1168,10 +1258,18 @@ export class DeepLinkService implements Disposable {
 				case DeepLinkServiceState.RepoOpening: {
 					this._disposables.push(
 						once(this.container.git.onDidChangeRepositories)(() => {
-							queueMicrotask(() => this.processDeepLink(DeepLinkServiceAction.RepoOpened));
+							queueMicrotask(() => {
+								// This listener outlives a cancellation, and a later link can be waiting on a
+								// repository of its own, so resume only the exact link that registered it
+								if (this._context !== context || context.state !== DeepLinkServiceState.RepoOpening) {
+									return;
+								}
+
+								void this.processDeepLink(DeepLinkServiceAction.RepoOpened, useProgress);
+							});
 						}),
 					);
-					return;
+					return true;
 				}
 				case DeepLinkServiceState.GoToTarget: {
 					// Need to re-fetch the remotes in case we opened in a new window


### PR DESCRIPTION
Closes #5651

## What the user saw

A command deep link that fails to resolve left its "Opening Command link..." progress notification spinning indefinitely, so a link that had already failed still looked like it was being opened. The accompanying "Unable to resolve link" error is transient, so the real outcome was easy to miss entirely. The spinner cleared only if another deep link happened to be triggered afterwards, which made it read as intermittent rather than reproducible.

## Why it happened

The notification's completion was driven by *observing an event*, not by the flow finishing.

`processDeepLink` created the notification inside a `queueMicrotask`, and the promise handed to `window.withProgress` resolved only when a `_onDeepLinkProgressUpdated` event arrived with `increment === 100` — the value `deepLinkStateToProgress` maps to the terminal `Idle` state.

For a failing command link, nothing in the walk awaits. `Command` is in neither `AccountDeepLinkTypes` nor `PaidDeepLinkTypes` (`deepLink.ts:74-75`), so `AccountCheck` and `PlanCheck` both `break` before their `await`, and `TypeMatch → RunCommand` rejects the command synchronously. The whole state machine therefore ran to completion — firing `increment: 100` — *before* the queued microtask ever registered the listener that was supposed to hear it. The notification then appeared with a promise nothing would ever resolve.

The "clears when you open another link" tell has the same origin: the `_onDeepLinkProgressUpdated` subscriptions were never disposed, so every past notification's listener stayed live on the shared emitter and the *next* link's terminal event resolved all the stale ones at once.

## How it's resolved

Completion is now driven by the flow reaching a final state rather than by observing an event, so it cannot be missed. `runDeepLink` reports whether it finished, and the notification is completed in a `finally` — which also covers a link that throws. The notification is held back a macrotask, so a link that fails without ever suspending completes first and never opens one at all.

Review of that change surfaced several adjacent defects on the same shared state, all reachable and all fixed here:

| Change | Symptom it addresses |
| --- | --- |
| Notification is service-owned and adopted by a resuming call | A link suspending to wait on a repository had its resume open a *second* notification beside the first |
| Subscriptions disposed with their notification | Every link leaked one listener; this is why an unrelated later link cleared a stale spinner |
| `catch` resets the context on a throw | A throw left the context mid-flight, and `processDeepLinkUri` only proceeds from `Idle` — every later deep link in the window was dropped with no error, no log, no UI |
| Loop stops when it no longer owns its context | A cancelled or superseded run kept driving the state machine, walked off the transition table into an unmapped state, and produced that same silent-drop wedge — unrecoverable short of reloading the window |
| Cancel pass runs without progress | Cancelling opened a second notification for the cancel itself |

The context object is replaced wholesale by `resetContext` and `setContextFromDeepLink`, so its identity is used as the ownership token throughout. `defer()`/`Deferred` from `packages/utils/src/promise.ts` replaced a hand-rolled deferred, matching the existing idiom in `annotationProvider.ts`, `gitProviderService.ts`, and `scmGroupedView.ts`.

## Behavior changes

- **A link that fails without suspending now shows no notification at all**, rather than one that appears and immediately completes. The issue asked for "completes and disappears"; this is the same outcome without the flash. Worth an explicit look if you'd rather see a brief spinner.
- **Notification appearance is timing-dependent.** A link that resolves entirely from warm caches can also finish before the notification is due and show nothing, where the same link cold shows one. Deliberate, but it makes fast-path feedback nondeterministic.
- **Errors thrown out of the state machine now reset the context**, and show "Unable to resolve link" for user-followed links. The six internal callers that pass `useProgress: false` (Launchpad, view commands, graph commands) still receive the exception exactly as before and get no toast — matching pre-change behavior for them.

## Tests

**None added, and none run.** There is no test infrastructure under `src/uris/` and `test:packages` matches no projects; the behavior is `window.withProgress` timing in the extension host, which only `vscode-test` could exercise, and that is blocked locally. `pnpm run build` (type-check + lint) passes on the committed state. CI will be the first automated run.

In place of coverage, the change went through five adversarial review cycles that walked every deep link type, action type, state, and internal consumer end to end against the pre-change file. That is careful reading, not execution — treat the validation steps below as the real confirmation.

## Validation

1. Open a window with GitLens active.
2. Trigger `vscode://eamodio.gitlens/link/command/definitely-not-a-command`. Expected: no progress notification appears; "Unable to resolve link" is the visible outcome.
3. Same with `vscode://eamodio.gitlens/link/command/graph?mode=bogus`.
4. Trigger several failing links in a row — each should behave identically, with nothing left spinning.
5. Trigger `vscode://eamodio.gitlens/link/command/graph`. Expected: it opens, and any notification it shows completes.
6. Trigger a repository link that needs cloning or adding, and confirm the notification stays for the duration and its **Cancel** still works.
7. Cancel a link mid-flight, then trigger another link — the second should open normally.

## Related

- #4094 — umbrella issue.
- #5226 — where this was found; it predates that change and reproduces with an unknown command name.
- Deliberately not fixed here: inside the state machine, property writes that happen after a long `await` still target the live context rather than the captured one, so a stale prompt answered after a cancel can write into a subsequent link's context. Pre-existing and unchanged by this PR; the coherent fix is to thread the captured context through every reference in that function, which is better done on its own.
