### PR TITLE
Gates the smoke Inspect specs on state they establish themselves

### DIFF
--- a/tests/e2e/specs/smoke.test.ts
+++ b/tests/e2e/specs/smoke.test.ts
@@ -70,8 +70,14 @@ test.describe('Smoke Tests — Core', () => {
 	});
 
 	test('should contain GitLens & GitLens Inspect icons in activity bar', async ({ vscode }) => {
-		const tabCount = await vscode.gitlens.getActivityBarTabCount();
-		expect(tabCount).toBeGreaterThanOrEqual(1);
+		await expect(vscode.gitlens.gitlensTab).toBeVisible({ timeout: MaxTimeout });
+
+		// GitLens Inspect is its own view container, and VS Code registers a container the first time
+		// one of its views is shown — so the tab is simply absent on a freshly launched instance. Show
+		// an Inspect view here: the old `countTabs(/GitLens/) >= 1` was satisfied by the GitLens tab
+		// alone, so this test passed without ever seeing the second icon it is named for.
+		await vscode.gitlens.executeCommand('gitlens.showCommitDetailsView');
+		await expect(vscode.gitlens.gitlensInspectTab).toBeVisible({ timeout: MaxTimeout });
 	});
 
 	test('should show GitLens status bar items', async ({ vscode }) => {
@@ -205,6 +211,18 @@ test.describe('Smoke Tests — GitLens Inspect views', () => {
 	});
 
 	test('should show GitLens Inspect views when clicking GitLens Inspect icon', async ({ vscode }) => {
+		// Register the Inspect view container and wait for its tab before clicking it. Opening the file
+		// above happens to register it too, but relying on that side effect is what made this spec fail
+		// on Positron in CI: the tab had not appeared yet, so the click below spent its full actionability
+		// timeout waiting for an element that nothing had asked VS Code to create.
+		await vscode.gitlens.executeCommand('gitlens.showCommitDetailsView');
+		await expect(vscode.gitlens.gitlensInspectTab).toBeVisible({ timeout: MaxTimeout });
+
+		// Showing the view also makes Inspect the active container, and clicking the active tab collapses
+		// the sidebar. Go back to Explorer so the click below is what opens Inspect — which is the whole
+		// subject of this test.
+		await vscode.gitlens.executeCommand('workbench.view.explorer');
+
 		// open inspect
 		await vscode.gitlens.openGitLensInspect();
 		await expect(vscode.gitlens.inspectViewSection).toBeVisible({ timeout: MaxTimeout });


### PR DESCRIPTION
`GitLens Inspect` is its own view container, and VS Code registers a container's activity-bar tab only the first time one of its views is shown. Two smoke specs leaned on the file opened by a sibling `beforeEach` to do that for them:

- **`should show GitLens Inspect views when clicking GitLens Inspect icon`** — the spec CI has been failing on Positron. The tab was still absent when the click went looking for it, so the click spent its full 30s actionability timeout waiting for an element nothing had asked VS Code to create. Reproduced three times in run [32140169872](https://github.com/gitkraken/vscode-gitlens/actions/runs/32140169872), each at exactly 30.6s.
- **`should contain GitLens & GitLens Inspect icons in activity bar`** — asserted `countTabs(/GitLens/) >= 1`, which the `GitLens` tab satisfies on its own. It has never checked for the second icon it is named for, which is why the Positron leg did not catch the lazy registration earlier.

Each spec now establishes that state itself and waits for the tab, rather than depending on a side effect of a neighbouring hook — the same treatment #5721 gave the Graph details specs. The icons spec asserts on both tabs by name.

### Why the click spec also switches back to Explorer

Showing an Inspect view makes Inspect the active container, and clicking the tab of the active container collapses the primary side bar. `ActivityBar.openTab` is supposed to guard against exactly that, but its guard reads `aria-checked` — an attribute VS Code does not set on activity-bar tabs — so it never skips the click. Measured across the three states:

| Step | `aria-checked` | `aria-expanded` | `aria-selected` | side bar |
|---|---|---|---|---|
| fresh (Explorer active) | `null` | `false` | `false` | visible |
| after `gitlens.showCommitDetailsView` | `null` | `true` | `true` | visible |
| after `openGitLensInspect()` | `null` | `false` | `false` | **hidden** |

The spec had been passing only because the active container at that moment was always Explorer, so the unconditional click happened to do the right thing. Returning to Explorer keeps that true and keeps the click the thing that opens Inspect — which is the whole subject of the spec.

The page-object guard itself is left alone here and filed as #5748; the tab-count helpers this leaves without consumers are #5749.

### Verification

- VS Code 1.134.0, full `smoke.test.ts`: **13 passed**. Same file on the unmodified base: 13 passed — no regression.
- Positron 2026.08.1-2 (the build CI provisions), full `smoke.test.ts` under WSL: **13 passed**; the click spec at 1.3s against the 30.6s timeouts in CI.
- `oxlint --type-aware --type-check tests/e2e/specs/smoke.test.ts`: clean.

Note that the local Positron rig has never reproduced the original CI failure, so its green run shows the change does not regress Positron rather than proving the CI failure cured. A `workflow_dispatch` E2E run on this branch would settle that.
