### PR TITLE
Follows the quick wizard specs to the new confirm-step grammar

### DIFF
--- a/tests/e2e/specs/quickWizard.test.ts
+++ b/tests/e2e/specs/quickWizard.test.ts
@@ -1927,19 +1927,12 @@ test.describe('Quick Wizard — Worktree Commands', () => {
 			expect(await quickPick.isVisible()).toBeFalsy();
 		});
 
-		test('Specific Folder: selecting folder returns to confirm, escaping returns to confirm', async ({
+		test('Specific Folder: the Location row opens the specific-folder chooser', async ({
 			vscode,
 			vscode: {
 				gitlens: { quickPick },
-				page,
 			},
 		}) => {
-			// Expected to fail until #5752: `b52976a1c` turned this row into a `Directive.Noop` that opens
-			// the picker from `onDidSelect`, and the picker's cancel path returns without re-showing the
-			// confirm, so dismissing it drops the whole wizard. Remove this once the wizard comes back —
-			// the run will report an unexpected pass to say so.
-			test.fail();
-
 			await selectCommandSubcommandAndWaitForStepWithOptionalRepo(vscode, 'worktree', 'create', {
 				title: /Create Worktree/i,
 				placeholder: /Choose a branch/i,
@@ -1952,35 +1945,27 @@ test.describe('Quick Wizard — Worktree Commands', () => {
 			// Wait for confirm step
 			await quickPick.waitForStep({ title: /Confirm Create Worktree.*feature-2/i });
 
-			// Renamed with the `Location` property rows in `b52976a1c` — was "Choose Specific Folder…".
+			// The Location rows open the folder chooser through `window.showOpenDialog`. The harness sets
+			// `files.simpleDialog.enable` (baseTest.ts), so that renders as a quick input which *replaces*
+			// this wizard's own quick pick rather than a native dialog floating above it, and GitLens only
+			// re-renders the confirm on the picker's success path. Measured: once the chooser is up the
+			// confirm never comes back, whether the chooser is dismissed or accepted. At default settings
+			// the dialog is native and the confirm survives behind it on `ignoreFocusOut` (create.ts:673),
+			// so the round trip back to the confirm is not something this harness can exercise. What is
+			// real here is that the row opens the right chooser — the two rows are easy to cross-wire.
 			await quickPick.selectItem(/^Specific Folder/);
-
-			// The folder picker dialog should appear - press Escape to cancel it
-			await page.waitForTimeout(ShortTimeout);
-			await page.keyboard.press('Escape');
-
-			// Should return to confirm step after escaping folder picker
-			await quickPick.waitForStep({ title: /Confirm Create Worktree.*feature-2/i });
-
-			// === REVERSE NAVIGATION ===
-
-			// Back from confirm → branch picker
-			await quickPick.goBackAndWaitForStep({ title: /Create Worktree/i, placeholder: /Choose a branch/i });
+			await quickPick.waitForTitle(/Choose a Specific Folder for this Worktree/i);
 
 			await quickPick.cancel();
 			expect(await quickPick.isVisible()).toBeFalsy();
 		});
 
-		test('Root Folder: selecting folder returns to confirm, escaping returns to confirm', async ({
+		test('Root Folder: the Location row opens the root-folder chooser', async ({
 			vscode,
 			vscode: {
 				gitlens: { quickPick },
-				page,
 			},
 		}) => {
-			// Expected to fail until #5752 — same cause as the Specific Folder spec above.
-			test.fail();
-
 			await selectCommandSubcommandAndWaitForStepWithOptionalRepo(vscode, 'worktree', 'create', {
 				title: /Create Worktree/i,
 				placeholder: /Choose a branch/i,
@@ -1993,20 +1978,10 @@ test.describe('Quick Wizard — Worktree Commands', () => {
 			// Wait for confirm step
 			await quickPick.waitForStep({ title: /Confirm Create Worktree.*feature-2/i });
 
-			// Renamed with the `Location` property rows in `b52976a1c` — was "Change Root Folder…".
+			// Same harness constraint as the Specific Folder spec above: the chooser replaces the wizard's
+			// quick pick, so only the wiring is observable here.
 			await quickPick.selectItem(/^Root Folder/);
-
-			// The folder picker dialog should appear - press Escape to cancel it
-			await page.waitForTimeout(ShortTimeout);
-			await page.keyboard.press('Escape');
-
-			// Should return to confirm step after escaping folder picker
-			await quickPick.waitForStep({ title: /Confirm Create Worktree.*feature-2/i });
-
-			// === REVERSE NAVIGATION ===
-
-			// Back from confirm → branch picker
-			await quickPick.goBackAndWaitForStep({ title: /Create Worktree/i, placeholder: /Choose a branch/i });
+			await quickPick.waitForTitle(/Choose a Different Root Folder for this Worktree/i);
 
 			await quickPick.cancel();
 			expect(await quickPick.isVisible()).toBeFalsy();
@@ -2017,6 +1992,7 @@ test.describe('Quick Wizard — Worktree Commands', () => {
 			vscode,
 			vscode: {
 				gitlens: { quickPick },
+				page,
 			},
 		}) => {
 			await selectCommandSubcommandAndWaitForStepWithOptionalRepo(vscode, 'worktree', 'create', {
@@ -2034,33 +2010,74 @@ test.describe('Quick Wizard — Worktree Commands', () => {
 			// `b52976a1c` moved the open decision into this confirm as an `After Creating` radio group,
 			// seeded from `worktrees.openAfterCreate`, so there is no separate open prompt after creation
 			// any more. The choice is visible up front and folded into the action row's detail.
-			let items = await quickPick.getVisibleItems();
-			expect(items.some(item => item.startsWith('Open in New Window'))).toBeTruthy();
-			expect(items.some(item => item.startsWith('Open in Current Window'))).toBeTruthy();
-			expect(items.some(item => item.startsWith('Add to Workspace'))).toBeTruthy();
-			expect(items.some(item => item.startsWith("Don't Open"))).toBeTruthy();
+			//
+			// This confirm is the longest in the suite — action row, two Location rows, two separators and
+			// four radios — so the tail sits below the fold on a short window and the list is virtualized.
+			// Collect by walking it rather than trusting one `getVisibleItems()` snapshot, the same way the
+			// search-operator spec does; a snapshot here would go missing exactly on the shorter forks.
+			const rows = new Set<string>();
+			const collect = async () => {
+				for (const item of await quickPick.getVisibleItems()) {
+					rows.add(item);
+				}
+			};
+			const walk = async () => {
+				rows.clear();
+				await collect();
+				let previous = 0;
+				for (let stable = 0; stable < 2 && rows.size < 50;) {
+					await page.keyboard.press('ArrowDown');
+					await collect();
+					stable = rows.size === previous ? stable + 1 : 0;
+					previous = rows.size;
+				}
+			};
+			const shows = (text: string) => [...rows].some(item => item.includes(text));
+
+			await walk();
+			expect(shows('Open in New Window')).toBeTruthy();
+			expect(shows('Open in Current Window')).toBeTruthy();
+			expect(shows('Add to Workspace')).toBeTruthy();
+			expect(shows("Don't Open")).toBeTruthy();
 
 			// The seeded choice is spelled out on the action row
-			expect(
-				items.some(item => item.includes('Will create worktree') && item.includes('open it in a new window')),
-			).toBeTruthy();
+			expect(shows('Will create worktree')).toBeTruthy();
+			expect(shows('open it in a new window')).toBeTruthy();
 
 			// Choosing "Don't Open" is a `Directive.Noop` radio: it stays on this step and rewrites the
-			// action row, dropping the open clause. Picking it before creating is also what keeps this
-			// spec from opening a window or touching the workspace.
+			// action row, dropping the open clause.
 			await quickPick.selectItem(/^Don't Open/);
 			await quickPick.waitForStep({ title: /Confirm Create Worktree.*feature-2/i });
 
-			items = await quickPick.getVisibleItems();
-			expect(
-				items.some(item => item.includes('Will create worktree') && !item.includes('open it in')),
-			).toBeTruthy();
+			// Every open mode appends a ", then …" clause to the action row — newWindow says "then open it
+			// in a new window", currentWindow "then switch this window to it", addToWorkspace "then add it
+			// to this workspace". Assert the clause is gone entirely rather than just the newWindow wording:
+			// the `vscode` fixture is worker-scoped, so creating with either of the other two selected would
+			// move this window out from under every spec that follows.
+			await walk();
+			const actionRow = [...rows].find(item => item.includes('Will create worktree'));
+			expect(actionRow).toBeDefined();
+			expect(actionRow).not.toContain(', then');
 
 			// Create the worktree. With "Don't Open" selected the wizard finishes here rather than
 			// handing off to a follow-up prompt.
 			await quickPick.selectItem(/^Create Worktree from Branch/);
 
 			await quickPick.waitForHidden();
+			expect(await quickPick.isVisible()).toBeFalsy();
+
+			// `waitForHidden` alone is also satisfied when the create *fails* — on a CI retry the branch
+			// already has a worktree, `worktrees.create` throws and the quick pick closes just the same,
+			// which would leave the spec green while proving nothing. Observe the worktree through the
+			// wizard that lists them, so the name ("applied on create") stays honest.
+			await selectCommandSubcommandAndWaitForStepWithOptionalRepo(vscode, 'worktree', 'open', {
+				title: /Open Worktree|Worktree/i,
+				placeholder: /Choose worktree/i,
+			});
+			await quickPick.waitForItems(ShortTimeout);
+			expect((await quickPick.getVisibleItems()).some(item => item.includes('feature-2'))).toBeTruthy();
+
+			await quickPick.cancel();
 			expect(await quickPick.isVisible()).toBeFalsy();
 		});
 	});

--- a/tests/e2e/specs/quickWizard.test.ts
+++ b/tests/e2e/specs/quickWizard.test.ts
@@ -2128,7 +2128,7 @@ test.describe('Quick Wizard — Worktree Commands', () => {
 			expect(await quickPick.isVisible()).toBeFalsy();
 		});
 
-		test('Confirm options: Delete, Force Delete, Delete with Branch, Force Delete with Branch', async ({
+		test('Confirm options: the Force and Delete Branch toggles fold into the action row', async ({
 			vscode,
 			vscode: {
 				gitlens: { quickPick },
@@ -2146,21 +2146,32 @@ test.describe('Quick Wizard — Worktree Commands', () => {
 			// Wait for confirm step
 			await quickPick.waitForStep({ title: /Confirm Delete Worktree/i });
 
-			// Verify all expected options are present
+			// `e216d7553` converted this confirm to the modes-plus-toggles grammar. Where there were four
+			// fixed rows (Delete / Force Delete / Delete with Branch / Force Delete with Branch) there is
+			// now a single action row whose label and detail fold in the `Force` and `Delete Branch`
+			// toggles, so the combinations are asserted by flipping them rather than by looking for four
+			// labels. Toggles are `Directive.Noop`: selecting one re-renders this step instead of
+			// advancing, and nothing is deleted unless the action row itself is selected — which this
+			// spec deliberately never does.
 			// Note: getVisibleItems() returns all text content including descriptions
-			const items = await quickPick.getVisibleItems();
-			// Basic delete has "Will delete worktree" without "forcibly"
-			const hasDelete = items.some(
-				item => item.includes('Delete Worktree') && item.includes('Will delete') && !item.includes('forcibly'),
-			);
-			const hasForceDelete = items.some(item => item.includes('Force Delete Worktree'));
-			const hasDeleteWithBranch = items.some(item => item.includes('Delete Worktree & Branch'));
-			const hasForceDeleteWithBranch = items.some(item => item.includes('Force Delete Worktree & Branch'));
+			let items = await quickPick.getVisibleItems();
+			expect(items.some(item => item.includes('Delete Worktree') && item.includes('Will delete'))).toBeTruthy();
+			expect(items.some(item => item.startsWith('Force'))).toBeTruthy();
+			expect(items.some(item => item.startsWith('Delete Branch'))).toBeTruthy();
 
-			expect(hasDelete).toBeTruthy();
-			expect(hasForceDelete).toBeTruthy();
-			expect(hasDeleteWithBranch).toBeTruthy();
-			expect(hasForceDeleteWithBranch).toBeTruthy();
+			// Force folds into the action row, which restates itself as a forcible delete
+			await quickPick.selectItem(/^Force/);
+			items = await quickPick.getVisibleItems();
+			expect(
+				items.some(item => item.includes('Force Delete Worktree') && item.includes('Will forcibly delete')),
+			).toBeTruthy();
+
+			// Delete Branch folds in as well — the branch shows up in the detail, not in the label
+			await quickPick.selectItem(/^Delete Branch/);
+			items = await quickPick.getVisibleItems();
+			expect(
+				items.some(item => item.includes('Force Delete Worktree') && item.includes('along with its branch')),
+			).toBeTruthy();
 
 			await quickPick.cancel();
 			expect(await quickPick.isVisible()).toBeFalsy();

--- a/tests/e2e/specs/quickWizard.test.ts
+++ b/tests/e2e/specs/quickWizard.test.ts
@@ -1575,6 +1575,7 @@ test.describe('Quick Wizard — Log/Show/Search Commands', () => {
 			vscode,
 			vscode: {
 				gitlens: { quickPick },
+				page,
 			},
 		}) => {
 			await selectCommandAndWaitForStepWithOptionalRepo(vscode, 'search', {
@@ -1582,19 +1583,46 @@ test.describe('Quick Wizard — Log/Show/Search Commands', () => {
 				placeholder: /e.g. "Updates dependencies" author:eamodio/i,
 			});
 
-			// Verify search operators are shown in the list
-			const items = await quickPick.getVisibleItems();
+			// The quick pick list is virtualized, so `getVisibleItems()` only ever reports the rows
+			// currently rendered — a single snapshot answers "does this row fit on screen", not "is this
+			// operator offered". That distinction stopped being academic when `7ed75990e` grew the list to
+			// 11 rows with Search by Committer and Exclude by Message: the tail stopped fitting on the
+			// shorter Windsurf window in CI and this spec failed there alone, on its last assertion, while
+			// passing everywhere the window happened to be tall enough. Walk the list with the keyboard
+			// instead and union what each step renders, which holds at any window height.
+			const seen = new Set<string>();
+			const collect = async () => {
+				for (const item of await quickPick.getVisibleItems()) {
+					seen.add(item);
+				}
+			};
+
+			await collect();
+			let previous = 0;
+			// Stop once two consecutive steps reveal nothing new — the walk has reached the end
+			for (let stable = 0; stable < 2 && seen.size < 50;) {
+				await page.keyboard.press('ArrowDown');
+				await collect();
+				stable = seen.size === previous ? stable + 1 : 0;
+				previous = seen.size;
+			}
+
+			const offers = (operator: string) => [...seen].some(item => item.includes(operator));
 
 			// Check for expected search operators
-			expect(items.some(item => item.includes('Search by Message'))).toBeTruthy();
-			expect(items.some(item => item.includes('Search by Author'))).toBeTruthy();
-			expect(items.some(item => item.includes('Search by Commit SHA'))).toBeTruthy();
-			expect(items.some(item => item.includes('Search by Reference or Range'))).toBeTruthy();
-			expect(items.some(item => item.includes('Search by Type'))).toBeTruthy();
-			expect(items.some(item => item.includes('Search by File'))).toBeTruthy();
-			expect(items.some(item => item.includes('Search by Changes'))).toBeTruthy();
-			expect(items.some(item => item.includes('Search After Date'))).toBeTruthy();
-			expect(items.some(item => item.includes('Search Before Date'))).toBeTruthy();
+			expect(offers('Search by Message')).toBeTruthy();
+			expect(offers('Search by Author')).toBeTruthy();
+			expect(offers('Search by Commit SHA')).toBeTruthy();
+			expect(offers('Search by Reference or Range')).toBeTruthy();
+			expect(offers('Search by Type')).toBeTruthy();
+			expect(offers('Search by File')).toBeTruthy();
+			expect(offers('Search by Changes')).toBeTruthy();
+			expect(offers('Search After Date')).toBeTruthy();
+			expect(offers('Search Before Date')).toBeTruthy();
+
+			// Added by `7ed75990e`; asserted so the list growing again is a deliberate change
+			expect(offers('Search by Committer')).toBeTruthy();
+			expect(offers('Exclude by Message')).toBeTruthy();
 
 			await quickPick.cancel();
 			expect(await quickPick.isVisible()).toBeFalsy();

--- a/tests/e2e/specs/quickWizard.test.ts
+++ b/tests/e2e/specs/quickWizard.test.ts
@@ -1899,13 +1899,19 @@ test.describe('Quick Wizard — Worktree Commands', () => {
 			expect(await quickPick.isVisible()).toBeFalsy();
 		});
 
-		test('Choose Specific Folder: selecting folder returns to confirm, escaping returns to confirm', async ({
+		test('Specific Folder: selecting folder returns to confirm, escaping returns to confirm', async ({
 			vscode,
 			vscode: {
 				gitlens: { quickPick },
 				page,
 			},
 		}) => {
+			// Expected to fail until #5752: `b52976a1c` turned this row into a `Directive.Noop` that opens
+			// the picker from `onDidSelect`, and the picker's cancel path returns without re-showing the
+			// confirm, so dismissing it drops the whole wizard. Remove this once the wizard comes back —
+			// the run will report an unexpected pass to say so.
+			test.fail();
+
 			await selectCommandSubcommandAndWaitForStepWithOptionalRepo(vscode, 'worktree', 'create', {
 				title: /Create Worktree/i,
 				placeholder: /Choose a branch/i,
@@ -1918,8 +1924,8 @@ test.describe('Quick Wizard — Worktree Commands', () => {
 			// Wait for confirm step
 			await quickPick.waitForStep({ title: /Confirm Create Worktree.*feature-2/i });
 
-			// Select "Choose Specific Folder..." option
-			await quickPick.selectItem(/Choose Specific Folder/i);
+			// Renamed with the `Location` property rows in `b52976a1c` — was "Choose Specific Folder…".
+			await quickPick.selectItem(/^Specific Folder/);
 
 			// The folder picker dialog should appear - press Escape to cancel it
 			await page.waitForTimeout(ShortTimeout);
@@ -1937,13 +1943,16 @@ test.describe('Quick Wizard — Worktree Commands', () => {
 			expect(await quickPick.isVisible()).toBeFalsy();
 		});
 
-		test('Change Root Folder: selecting folder returns to confirm, escaping returns to confirm', async ({
+		test('Root Folder: selecting folder returns to confirm, escaping returns to confirm', async ({
 			vscode,
 			vscode: {
 				gitlens: { quickPick },
 				page,
 			},
 		}) => {
+			// Expected to fail until #5752 — same cause as the Specific Folder spec above.
+			test.fail();
+
 			await selectCommandSubcommandAndWaitForStepWithOptionalRepo(vscode, 'worktree', 'create', {
 				title: /Create Worktree/i,
 				placeholder: /Choose a branch/i,
@@ -1956,8 +1965,8 @@ test.describe('Quick Wizard — Worktree Commands', () => {
 			// Wait for confirm step
 			await quickPick.waitForStep({ title: /Confirm Create Worktree.*feature-2/i });
 
-			// Select "Change Root Folder..." option
-			await quickPick.selectItem(/Change Root Folder/i);
+			// Renamed with the `Location` property rows in `b52976a1c` — was "Change Root Folder…".
+			await quickPick.selectItem(/^Root Folder/);
 
 			// The folder picker dialog should appear - press Escape to cancel it
 			await page.waitForTimeout(ShortTimeout);
@@ -1976,7 +1985,7 @@ test.describe('Quick Wizard — Worktree Commands', () => {
 		});
 
 		// This test must run LAST in the Worktree Create Flow section because it actually creates a worktree
-		test('Create → Open transition: after creating worktree, open prompt appears', async ({
+		test('After Creating: the open choice folds into the action row and is applied on create', async ({
 			vscode,
 			vscode: {
 				gitlens: { quickPick },
@@ -1994,24 +2003,36 @@ test.describe('Quick Wizard — Worktree Commands', () => {
 			// Should go directly to confirm step (no branch name input needed)
 			await quickPick.waitForStep({ title: /Confirm Create Worktree.*feature-2/i });
 
-			// Confirm to actually create the worktree
-			// Select the default option "Create Worktree from Branch"
-			await quickPick.selectItem(/Create Worktree from Branch/i);
+			// `b52976a1c` moved the open decision into this confirm as an `After Creating` radio group,
+			// seeded from `worktrees.openAfterCreate`, so there is no separate open prompt after creation
+			// any more. The choice is visible up front and folded into the action row's detail.
+			let items = await quickPick.getVisibleItems();
+			expect(items.some(item => item.startsWith('Open in New Window'))).toBeTruthy();
+			expect(items.some(item => item.startsWith('Open in Current Window'))).toBeTruthy();
+			expect(items.some(item => item.startsWith('Add to Workspace'))).toBeTruthy();
+			expect(items.some(item => item.startsWith("Don't Open"))).toBeTruthy();
 
-			// After worktree is created, should transition to "Open Worktree" confirm step
-			// The default setting is "prompt" so the open dialog should appear
-			await quickPick.waitForStep(
-				{ title: /Open Worktree.*feature-2|Confirm.*Open.*Worktree/i },
-				15000, // Worktree creation can take a moment
-			);
+			// The seeded choice is spelled out on the action row
+			expect(
+				items.some(item => item.includes('Will create worktree') && item.includes('open it in a new window')),
+			).toBeTruthy();
 
-			// Verify the open options are shown
-			const items = await quickPick.getVisibleItems();
-			expect(items.some(item => item.includes('Open Worktree'))).toBeTruthy();
-			expect(items.some(item => item.includes('New Window'))).toBeTruthy();
+			// Choosing "Don't Open" is a `Directive.Noop` radio: it stays on this step and rewrites the
+			// action row, dropping the open clause. Picking it before creating is also what keeps this
+			// spec from opening a window or touching the workspace.
+			await quickPick.selectItem(/^Don't Open/);
+			await quickPick.waitForStep({ title: /Confirm Create Worktree.*feature-2/i });
 
-			// Cancel without opening the worktree (to avoid changing the workspace)
-			await quickPick.cancel();
+			items = await quickPick.getVisibleItems();
+			expect(
+				items.some(item => item.includes('Will create worktree') && !item.includes('open it in')),
+			).toBeTruthy();
+
+			// Create the worktree. With "Don't Open" selected the wizard finishes here rather than
+			// handing off to a follow-up prompt.
+			await quickPick.selectItem(/^Create Worktree from Branch/);
+
+			await quickPick.waitForHidden();
 			expect(await quickPick.isVisible()).toBeFalsy();
 		});
 	});

--- a/tests/e2e/specs/quickWizard.test.ts
+++ b/tests/e2e/specs/quickWizard.test.ts
@@ -1098,7 +1098,7 @@ test.describe('Quick Wizard — Merge/Rebase/Cherry-pick/Reset/Revert Commands',
 			expect(await quickPick.isVisible()).toBeFalsy();
 		});
 
-		test('Toggle commit selection: command → toggle button → branch → commits & reverse', async ({
+		test('Toggle commit selection: command → toggle row → branch → commits & reverse', async ({
 			vscode,
 			vscode: {
 				gitlens: { quickPick },
@@ -1110,11 +1110,15 @@ test.describe('Quick Wizard — Merge/Rebase/Cherry-pick/Reset/Revert Commands',
 				placeholder: /Choose a branch/i,
 			});
 
-			// At branch selection step, click the commit toggle button (initially shows "Choose a Branch")
-			// The button tooltip when off is "Choose a Branch or Tag", click to toggle to commit mode
-			await quickPick.clickActionButton(/Choose a Branch/i);
+			// `76a9d1425` dropped the icon-only title-bar toggle in favour of a worded row at the top of
+			// the ref list. It is a `Directive.Noop` checkbox, so selecting it flips the pick-commit
+			// state in place and stays on this step instead of advancing.
+			await quickPick.selectItem(/Choose a Specific Commit/i);
 
-			// Select a branch (after toggle, selecting a branch will then show commits)
+			// Still on the branch step — the toggle modifies it rather than moving past it
+			await quickPick.waitForStep({ title: /Merge/i, placeholder: /Choose a branch/i });
+
+			// Select a branch (with the toggle on, selecting a branch leads to the commit step)
 			await quickPick.enterTextAndWaitForItems('feature-1');
 			await quickPick.selectItem(/feature-1/i);
 			await page.waitForTimeout(ShortTimeout);
@@ -1243,7 +1247,7 @@ test.describe('Quick Wizard — Merge/Rebase/Cherry-pick/Reset/Revert Commands',
 			expect(await quickPick.isVisible()).toBeFalsy();
 		});
 
-		test('Toggle commit selection: command → toggle button → branch → commits → confirm & reverse', async ({
+		test('Toggle commit selection: command → toggle row → branch → commits → confirm & reverse', async ({
 			vscode,
 			vscode: {
 				gitlens: { quickPick },
@@ -1255,11 +1259,15 @@ test.describe('Quick Wizard — Merge/Rebase/Cherry-pick/Reset/Revert Commands',
 				placeholder: /Choose a branch/i,
 			});
 
-			// At branch selection step, click the commit toggle button (initially shows "Choose a Branch")
-			// The button tooltip when off is "Choose a Branch or Tag", click to toggle to commit mode
-			await quickPick.clickActionButton(/Choose a Branch/i);
+			// `76a9d1425` dropped the icon-only title-bar toggle in favour of a worded row at the top of
+			// the ref list. It is a `Directive.Noop` checkbox, so selecting it flips the pick-commit
+			// state in place and stays on this step instead of advancing.
+			await quickPick.selectItem(/Choose a Specific Commit/i);
 
-			// Select a branch (after toggle, selecting a branch will then show commits)
+			// Still on the branch step — the toggle modifies it rather than moving past it
+			await quickPick.waitForStep({ title: /Rebase/i, placeholder: /Choose a branch/i });
+
+			// Select a branch (with the toggle on, selecting a branch leads to the commit step)
 			await quickPick.enterTextAndWaitForItems('feature-1');
 			await quickPick.selectItem(/feature-1/i);
 			await page.waitForTimeout(ShortTimeout);

--- a/tests/e2e/specs/quickWizard.test.ts
+++ b/tests/e2e/specs/quickWizard.test.ts
@@ -2038,11 +2038,14 @@ test.describe('Quick Wizard — Worktree Commands', () => {
 			const shows = (text: string) => [...rows].some(item => item.includes(text));
 			// Bounded by a press count, not by "nothing new appeared" — the early presses move the active
 			// row within what is already on screen, so a no-growth test stops the walk before it scrolls.
-			const walk = async (expected: string[]) => {
+			// The direction is a parameter because the caller knows where the active row is: walking away
+			// from it reaches the far end through wrap-around, which happens to work but leaves the spec
+			// resting on list-wrapping semantics it never states.
+			const walk = async (expected: string[], direction: 'ArrowDown' | 'ArrowUp' = 'ArrowDown') => {
 				rows.clear();
 				await collect();
 				for (let press = 0; press < 30 && expected.some(text => !shows(text)); press++) {
-					await page.keyboard.press('ArrowDown');
+					await page.keyboard.press(direction);
 					await collect();
 				}
 			};
@@ -2073,7 +2076,10 @@ test.describe('Quick Wizard — Worktree Commands', () => {
 			// to this workspace". Assert the clause is gone entirely rather than just the newWindow wording:
 			// the `vscode` fixture is worker-scoped, so creating with either of the other two selected would
 			// move this window out from under every spec that follows.
-			await walk(['Will create worktree']);
+			// Selecting a radio leaves the active row near the bottom of the list, so walk back up: the
+			// action row is the first row, and it has to be on screen both to be read here and to be
+			// clicked below — `selectItem` only matches rows the virtualized list has rendered.
+			await walk(['Will create worktree'], 'ArrowUp');
 			const actionRow = [...rows].find(item => item.includes('Will create worktree'));
 			expect(actionRow).toBeDefined();
 			expect(actionRow).not.toContain(', then');

--- a/tests/e2e/specs/quickWizard.test.ts
+++ b/tests/e2e/specs/quickWizard.test.ts
@@ -2244,21 +2244,31 @@ test.describe('Quick Wizard — Worktree Commands', () => {
 			// labels. Toggles are `Directive.Noop`: selecting one re-renders this step instead of
 			// advancing, and nothing is deleted unless the action row itself is selected — which this
 			// spec deliberately never does.
+			//
+			// Match the toggles on their details rather than their labels. `Force` renders as
+			// `$(warning) Force` once checked, so its text stops starting with "Force" — while the action
+			// row starts with "Force Delete Worktree" in exactly that state. A `/^Force/` selector points
+			// at the toggle in one state and at the action row in the other, and the action row is one
+			// click from deleting a worktree and its branch. The details are unique and state-independent.
+			const forceToggle = 'Delete even with uncommitted changes';
+			// A regex here because the wording is singular or plural with the number of worktrees picked
+			const deleteBranchToggle = /Also delete the .* checked out in the/;
+
 			// Note: getVisibleItems() returns all text content including descriptions
 			let items = await quickPick.getVisibleItems();
 			expect(items.some(item => item.includes('Delete Worktree') && item.includes('Will delete'))).toBeTruthy();
-			expect(items.some(item => item.startsWith('Force'))).toBeTruthy();
-			expect(items.some(item => item.startsWith('Delete Branch'))).toBeTruthy();
+			expect(items.some(item => item.includes(forceToggle))).toBeTruthy();
+			expect(items.some(item => deleteBranchToggle.test(item))).toBeTruthy();
 
 			// Force folds into the action row, which restates itself as a forcible delete
-			await quickPick.selectItem(/^Force/);
+			await quickPick.selectItem(forceToggle);
 			items = await quickPick.getVisibleItems();
 			expect(
 				items.some(item => item.includes('Force Delete Worktree') && item.includes('Will forcibly delete')),
 			).toBeTruthy();
 
 			// Delete Branch folds in as well — the branch shows up in the detail, not in the label
-			await quickPick.selectItem(/^Delete Branch/);
+			await quickPick.selectItem(deleteBranchToggle);
 			items = await quickPick.getVisibleItems();
 			expect(
 				items.some(item => item.includes('Force Delete Worktree') && item.includes('along with its branch')),

--- a/tests/e2e/specs/quickWizard.test.ts
+++ b/tests/e2e/specs/quickWizard.test.ts
@@ -1597,17 +1597,33 @@ test.describe('Quick Wizard — Log/Show/Search Commands', () => {
 				}
 			};
 
+			const offers = (operator: string) => [...seen].some(item => item.includes(operator));
+
+			const operators = [
+				'Search by Message',
+				'Search by Author',
+				'Search by Commit SHA',
+				'Search by Reference or Range',
+				'Search by Type',
+				'Search by File',
+				'Search by Changes',
+				'Search After Date',
+				'Search Before Date',
+				// Added by `7ed75990e`; asserted so the list growing again is a deliberate change
+				'Search by Committer',
+				'Exclude by Message',
+			];
+
+			// Bound the walk by a press count and stop once everything expected has been seen. Stopping on
+			// "the last press revealed nothing new" instead ends it early: the first presses move the active
+			// row within the rows already on screen and reveal nothing, so the walk quits before it ever
+			// scrolls — which passes wherever the whole list happens to fit and still misses the tail where
+			// it does not.
 			await collect();
-			let previous = 0;
-			// Stop once two consecutive steps reveal nothing new — the walk has reached the end
-			for (let stable = 0; stable < 2 && seen.size < 50;) {
+			for (let press = 0; press < 30 && operators.some(operator => !offers(operator)); press++) {
 				await page.keyboard.press('ArrowDown');
 				await collect();
-				stable = seen.size === previous ? stable + 1 : 0;
-				previous = seen.size;
 			}
-
-			const offers = (operator: string) => [...seen].some(item => item.includes(operator));
 
 			// Check for expected search operators
 			expect(offers('Search by Message')).toBeTruthy();
@@ -1619,8 +1635,6 @@ test.describe('Quick Wizard — Log/Show/Search Commands', () => {
 			expect(offers('Search by Changes')).toBeTruthy();
 			expect(offers('Search After Date')).toBeTruthy();
 			expect(offers('Search Before Date')).toBeTruthy();
-
-			// Added by `7ed75990e`; asserted so the list growing again is a deliberate change
 			expect(offers('Search by Committer')).toBeTruthy();
 			expect(offers('Exclude by Message')).toBeTruthy();
 
@@ -2021,20 +2035,25 @@ test.describe('Quick Wizard — Worktree Commands', () => {
 					rows.add(item);
 				}
 			};
-			const walk = async () => {
+			const shows = (text: string) => [...rows].some(item => item.includes(text));
+			// Bounded by a press count, not by "nothing new appeared" — the early presses move the active
+			// row within what is already on screen, so a no-growth test stops the walk before it scrolls.
+			const walk = async (expected: string[]) => {
 				rows.clear();
 				await collect();
-				let previous = 0;
-				for (let stable = 0; stable < 2 && rows.size < 50;) {
+				for (let press = 0; press < 30 && expected.some(text => !shows(text)); press++) {
 					await page.keyboard.press('ArrowDown');
 					await collect();
-					stable = rows.size === previous ? stable + 1 : 0;
-					previous = rows.size;
 				}
 			};
-			const shows = (text: string) => [...rows].some(item => item.includes(text));
 
-			await walk();
+			await walk([
+				'Open in New Window',
+				'Open in Current Window',
+				'Add to Workspace',
+				"Don't Open",
+				'Will create worktree',
+			]);
 			expect(shows('Open in New Window')).toBeTruthy();
 			expect(shows('Open in Current Window')).toBeTruthy();
 			expect(shows('Add to Workspace')).toBeTruthy();
@@ -2054,7 +2073,7 @@ test.describe('Quick Wizard — Worktree Commands', () => {
 			// to this workspace". Assert the clause is gone entirely rather than just the newWindow wording:
 			// the `vscode` fixture is worker-scoped, so creating with either of the other two selected would
 			// move this window out from under every spec that follows.
-			await walk();
+			await walk(['Will create worktree']);
 			const actionRow = [...rows].find(item => item.includes('Will create worktree'));
 			expect(actionRow).toBeDefined();
 			expect(actionRow).not.toContain(', then');

--- a/tests/e2e/specs/quickWizard.test.ts
+++ b/tests/e2e/specs/quickWizard.test.ts
@@ -621,35 +621,31 @@ test.describe('Quick Wizard — Tag Commands', () => {
 
 test.describe('Quick Wizard — Stash Commands', () => {
 	test.describe('Stash Push Flow', () => {
-		test('Complete flow: command → subcommand → confirm → message & reverse', async ({
+		test('Complete flow: command → subcommand → message → confirm & reverse', async ({
 			vscode,
 			vscode: {
 				gitlens: { quickPick },
 			},
 		}) => {
-			// The push wizard was reversed (commit "Reverses the stash push wizard"): the confirm
-			// step now precedes the message input to avoid back-navigation loops with confirm overrides.
-			// The confirm step shows because launching via the menu (`gitlens.gitCommands`, no args) makes
-			// `startedFrom === 'menu'`, so the skip key is `stash-push:menu` — not the default-skipped
-			// `stash-push:command`. If `stash-push:menu` is ever added to `gitCommands.skipConfirmations`,
-			// the confirm step vanishes and this test would time out on the (now-absent) confirm step.
+			// "Reverses the stash push wizard" (ed34a9fbd) had once put the confirm ahead of the message
+			// input, gating it on `!steps.isAtStep(Steps.InputMessage)`. The confirm-grammar conversion
+			// (76a9d1425) dropped that gate, so the order is back to repo → message → confirm.
 			await selectCommandSubcommandAndWaitForStepWithOptionalRepo(vscode, 'stash', 'push', {
-				title: /Confirm Push Stash/i,
-				placeholder: /Confirm Push Stash/i,
+				title: /Push Stash/i,
+				placeholder: /Stash message/i,
 			});
 
-			// Select the plain "Push Stash" confirmation option (negative lookahead excludes the
-			// "Snapshot" / "& …" variants, so this is order-independent rather than relying on `.first()`)
-			await quickPick.selectItem(/Push Stash(?! Snapshot| &)/);
+			// Submitting a message is safe: the confirm step still stands between it and execution.
+			await quickPick.enterTextAndSubmit('e2e stash message');
 
-			// Message step (placeholder distinguishes it from the still-matching "Confirm Push Stash" title)
-			await quickPick.waitForStep({ title: /Push Stash/i, placeholder: /Stash message/i });
+			// Confirm step (title and placeholder both carry the "Confirm" prefix)
+			await quickPick.waitForStep({ title: /Confirm Push Stash/i, placeholder: /Confirm Push Stash/i });
 
 			// === REVERSE NAVIGATION ===
-			// Do not submit a message — submitting would execute the stash. Navigate back instead.
+			// Do not select a confirm row — that would execute the stash. Navigate back instead.
 
-			// Back from message → confirm
-			await quickPick.goBackAndWaitForStep({ title: /Confirm Push Stash/i, placeholder: /Confirm Push Stash/i });
+			// Back from confirm → message
+			await quickPick.goBackAndWaitForStep({ title: /Push Stash/i, placeholder: /Stash message/i });
 
 			await reverseCommandSubcommandAndRepo(vscode, 'stash');
 


### PR DESCRIPTION
Closes #5751.

`quickWizard.test.ts` had seven specs failing on VS Code and Positron and eight on Windsurf, three times each — stable divergence, not flake. Both required E2E legs were red, so the suite gated nothing. Reproduced identically in dispatches [32140169872](https://github.com/gitkraken/vscode-gitlens/actions/runs/32140169872) and [32239133373](https://github.com/gitkraken/vscode-gitlens/actions/runs/32239133373).

The confirm-step series (`ecd54f244` and the six flow conversions) landed on 14.08 without touching the specs, and the E2E job only runs on `workflow_dispatch`, so nothing surfaced it until `main` was dispatched on the 18th.

### What each spec needed

| Spec | Cause |
|---|---|
| Stash push | `76a9d1425` dropped the `!steps.isAtStep(Steps.InputMessage)` gate — the order is repo → **message → confirm** again |
| Merge / rebase toggle | `76a9d1425` deleted `PickCommitToggleQuickInputButton`; it is a `Choose a Specific Commit` row via `prependItems` now |
| Worktree delete | `e216d7553` made force / delete-branch / delete-upstream toggles: four fixed rows became one action row × toggles |
| Worktree create · folder rows | Rows renamed; the round trip they asserted is not observable under the harness — see below |
| Worktree create · open prompt | `b52976a1c` moved the open decision into the confirm as the `After Creating` radio group; the follow-up prompt is gone |
| Search operators | Never editor-specific — see below |

Each flow is a commit of its own, verified on VS Code before the next.

### Two that were not spec drift

**Search operators** was fragile from the start. `getVisibleItems()` reports only the rows a virtualized list currently renders, so the assertion answered "does this row fit on screen" rather than "is this operator offered". When `7ed75990e` grew the list from 9 rows to 11, the tail stopped fitting on the shorter Windsurf window in CI — it failed there alone, always on the final assertion while the one directly above it passed, which is the signature of truncation rather than of missing content. It now walks the list with the keyboard and unions what renders, at any height, and asserts the two new operators so the next growth is deliberate.

**The two folder specs** are limited by the harness, not by the product. `files.simpleDialog.enable` is on in `baseTest.ts`, so `window.showOpenDialog` renders as a quick input that replaces the wizard's own quick pick, and GitLens re-renders the confirm only on the picker's success path. Measured both ways — dismissing the chooser and accepting a folder leave the quick pick equally invisible — so it is the simple-dialog mode that ends the wizard, not a stray `Escape`. At default settings the dialog is native and the confirm survives behind it on `ignoreFocusOut` (`create.ts:673`). They now assert that each `Location` row opens *its own* chooser, which is worth pinning since the two are easy to cross-wire. I filed #5752 against this before measuring it properly; it is closed as not-a-bug.

### Specs that got stronger, not just repaired

- The merge and rebase specs now assert the toggle row **does not** advance the step, which nothing checked when it was a title-bar button.
- Worktree delete flips each toggle and asserts the action row restates itself, instead of looking for four static labels — and never selects the action row, since it sits one click from deleting a worktree and its branch.
- The `After Creating` spec picks "Don't Open" before creating, so it cannot open a window or touch the workspace; the version it replaces created with "open" still selected and relied on cancelling the prompt in time. It also asserts the action row carries no ", then …" clause at all — the earlier guard only excluded the new-window wording, and the `vscode` fixture is worker-scoped.
- That spec also reopens the wizard at worktree → open to confirm `feature-2` exists: `waitForHidden()` alone is satisfied when `worktrees.create` throws, which a CI retry would hit.

### Verification

Dispatch [32253643738](https://github.com/gitkraken/vscode-gitlens/actions/runs/32253643738) — **all three legs green, no failures and no flakes**:

| Leg | Before this branch | Now |
|---|---|---|
| VS Code | 214 passed / 7 failed / 1 flaky / 4 skipped | **222 passed** / 4 skipped |
| Windsurf | 214 passed / 8 failed / 4 skipped | **222 passed** / 4 skipped |
| Positron | 214 passed / 7 failed / 5 skipped | **221 passed** / 5 skipped |

Positron is `continue-on-error` (`ci.yml:171`), so its conclusion is reported here explicitly rather than inferred from the run's.

It took two dispatches. The first ([32252196295](https://github.com/gitkraken/vscode-gitlens/actions/runs/32252196295)) fixed six of the seven flows but left the search spec failing on Windsurf: the keyboard walk ended once two presses in a row revealed nothing new, and the early presses do reveal nothing — they move the active row within what is already on screen — so it quit before it ever scrolled. Locally the whole list fits in both editors, so the spec passed without the walk contributing anything and looked verified when it was not. Both walks are now bounded by a press count and stop once everything expected has been seen.

An independent review of the branch caught three further problems before the PR: the `After Creating` confirm is the longest list in the suite and its tail falls below the fold on the shorter forks; the guard meant to stop that spec moving the shared window excluded only one of the three open modes, which matters because the `vscode` fixture is worker-scoped; and the spec had stopped observing that anything was created, which a CI retry would have turned green on a failed create.
