### PR TITLE
Reads the attribute that says an activity-bar tab is active

### DIFF
--- a/tests/e2e/pageObjects/components/activityBar.ts
+++ b/tests/e2e/pageObjects/components/activityBar.ts
@@ -1,4 +1,5 @@
 import type { Locator, Page } from '@playwright/test';
+import { expect } from '@playwright/test';
 import { MaxTimeout } from '../../baseTest.js';
 import type { VSCodePage } from '../vscodePage.js';
 
@@ -54,24 +55,41 @@ export class ActivityBar {
 	}
 
 	/**
+	 * Whether a tab's view container is currently open.
+	 *
+	 * The active tab carries `aria-expanded="true"` and `aria-selected="true"` (plus a `checked` class),
+	 * both written by the same branch of the composite bar's `updateChecked`. It has no `aria-checked`,
+	 * which is what the guard below used to read — so it never skipped anything.
+	 *
+	 * `aria-expanded` is the one that means "the container is open", so it wins whenever it is present;
+	 * `aria-selected` is only a fallback for a fork that omits it. They are not interchangeable: under
+	 * tablist semantics a selected tab may keep `aria-selected="true"` while its panel is hidden, and
+	 * treating that as open would leave `openTab` never clicking at all.
+	 */
+	private async isTabOpen(tab: Locator): Promise<boolean> {
+		const expanded = await tab.getAttribute('aria-expanded');
+		if (expanded != null) return expanded === 'true';
+
+		return (await tab.getAttribute('aria-selected')) === 'true';
+	}
+
+	/**
 	 * Open a tab's view, only clicking if not already active.
 	 * This prevents accidentally closing an already-open sidebar.
-	 *
-	 * The active tab carries `aria-expanded="true"` and `aria-selected="true"` (plus a `checked` class);
-	 * it has no `aria-checked`, so reading that one never skipped the click and the guard did nothing.
-	 * Both are checked, matching `Panel.isTabSelected` — they move together on VS Code, but these specs
-	 * run on forks too, and a guard resting on one attribute would fail the same silent way the
-	 * `aria-checked` one did if a fork rendered only the other.
 	 */
 	async openTab(name: string | RegExp, exact = true): Promise<void> {
 		const tab = this.getTab(name, exact);
-		const [expanded, selected] = await Promise.all([
-			tab.getAttribute('aria-expanded'),
-			tab.getAttribute('aria-selected'),
-		]);
-		if (expanded !== 'true' && selected !== 'true') {
-			await tab.click();
-		}
+		if (await this.isTabOpen(tab)) return;
+
+		await tab.click();
+
+		// Clicking a tab toggles its container, so confirm the click opened one rather than closing it.
+		// A single pre-click snapshot is not enough: `workbench.action.focusSideBar` un-hides the side
+		// bar without awaiting the composite's activation, so a read taken a moment too early says "not
+		// open" and the click then lands on a container that has since become active — collapsing the
+		// very side bar this guard exists to protect. Failing here names that, instead of leaving the
+		// caller to time out later on a view that never appears.
+		await expect.poll(() => this.isTabOpen(tab), { timeout: MaxTimeout }).toBe(true);
 	}
 
 	/**

--- a/tests/e2e/pageObjects/components/activityBar.ts
+++ b/tests/e2e/pageObjects/components/activityBar.ts
@@ -56,10 +56,14 @@ export class ActivityBar {
 	/**
 	 * Open a tab's view, only clicking if not already active.
 	 * This prevents accidentally closing an already-open sidebar.
+	 *
+	 * The active tab carries `aria-expanded="true"` (alongside `aria-selected` and a `checked` class);
+	 * it has no `aria-checked`, so reading that one never skipped the click and the guard did nothing.
+	 * `aria-expanded` is the one that says what this cares about — whether the container is open.
 	 */
 	async openTab(name: string | RegExp, exact = true): Promise<void> {
 		const tab = this.getTab(name, exact);
-		const isActive = await tab.getAttribute('aria-checked');
+		const isActive = await tab.getAttribute('aria-expanded');
 		if (isActive !== 'true') {
 			await tab.click();
 		}

--- a/tests/e2e/pageObjects/components/activityBar.ts
+++ b/tests/e2e/pageObjects/components/activityBar.ts
@@ -57,14 +57,19 @@ export class ActivityBar {
 	 * Open a tab's view, only clicking if not already active.
 	 * This prevents accidentally closing an already-open sidebar.
 	 *
-	 * The active tab carries `aria-expanded="true"` (alongside `aria-selected` and a `checked` class);
+	 * The active tab carries `aria-expanded="true"` and `aria-selected="true"` (plus a `checked` class);
 	 * it has no `aria-checked`, so reading that one never skipped the click and the guard did nothing.
-	 * `aria-expanded` is the one that says what this cares about — whether the container is open.
+	 * Both are checked, matching `Panel.isTabSelected` — they move together on VS Code, but these specs
+	 * run on forks too, and a guard resting on one attribute would fail the same silent way the
+	 * `aria-checked` one did if a fork rendered only the other.
 	 */
 	async openTab(name: string | RegExp, exact = true): Promise<void> {
 		const tab = this.getTab(name, exact);
-		const isActive = await tab.getAttribute('aria-expanded');
-		if (isActive !== 'true') {
+		const [expanded, selected] = await Promise.all([
+			tab.getAttribute('aria-expanded'),
+			tab.getAttribute('aria-selected'),
+		]);
+		if (expanded !== 'true' && selected !== 'true') {
 			await tab.click();
 		}
 	}

--- a/tests/e2e/specs/smoke.test.ts
+++ b/tests/e2e/specs/smoke.test.ts
@@ -233,6 +233,19 @@ test.describe('Smoke Tests — GitLens Inspect views', () => {
 		await expect(inspectWebview!.locator('gl-commit-details-app')).toBeVisible({ timeout: MaxTimeout });
 	});
 
+	test('should keep GitLens Inspect open when it is already the active container', async ({ vscode }) => {
+		// `openTab` is meant to skip the click when the container is already active, because clicking the
+		// active tab collapses the side bar. Nothing exercised that: every caller reached it from another
+		// container, so the click always did the right thing by accident and a broken guard looked fine.
+		await vscode.gitlens.executeCommand('gitlens.showCommitDetailsView');
+		await expect(vscode.gitlens.inspectViewSection).toBeVisible({ timeout: MaxTimeout });
+
+		await vscode.gitlens.openGitLensInspect();
+
+		// Still open — asking for a container that is already showing is not a request to hide it
+		await expect(vscode.gitlens.inspectViewSection).toBeVisible({ timeout: MaxTimeout });
+	});
+
 	test('should show File History view', async ({ vscode }) => {
 		// open the file history view
 		await vscode.gitlens.showFileHistoryView();


### PR DESCRIPTION
Closes #5748.

`ActivityBar.openTab` documents itself as "only clicking if not already active. This prevents accidentally closing an already-open sidebar", and then reads `aria-checked` — an attribute VS Code does not put on activity-bar tabs. `getAttribute` returned `null` every time, so the guard never fired and the click was unconditional. Clicking the tab of the active container collapses the side bar, so the method did the opposite of what it promised whenever the container was already open.

Measured across the three states of the `GitLens Inspect` tab on VS Code 1.134.0:

| State | `aria-checked` | `aria-expanded` | `aria-selected` | class | side bar |
|---|---|---|---|---|---|
| fresh (Explorer active) | `null` | `false` | `false` | `action-item icon` | visible |
| after `gitlens.showCommitDetailsView` | `null` | `true` | `true` | `… checked` | visible |
| after `openGitLensInspect()` | `null` | `false` | `false` | `… clicked` | **hidden** |

### Why it went unnoticed

Every caller happened to reach `openTab` from another container, where the unconditional click did the right thing by accident, and nothing asserted the skip. So the fix comes with the spec that was missing — show an Inspect view, then ask for it again, and expect it to still be there.

That spec was run against the unfixed guard first: it fails there, with the side bar gone by the assertion. It is what the two versions were checked against each other with, rather than a green run taken at face value.

### From review

An independent review raised two things about the guard itself, both applied:

- The guard read state once, before the click, and never checked what the click did. Both callers run `workbench.action.focusSideBar` immediately before, which un-hides the side bar **without awaiting the composite's activation** — so a read taken between the two says "not open", the click lands on a container that has since become active, and the side bar collapses. Neither call site can reach that today, since both follow an awaited command that leaves the side bar up, but it is latent in the page object. `openTab` now polls the postcondition after clicking, which turns that into a failure naming the toggle instead of a caller timing out later on a view that never appears.
- An intermediate commit here read "expanded **or** selected", on the theory that a fork might render only one. Checked against Positron's own workbench bundle, that is not so — `CompositeBarActionViewItem.updateChecked` writes both from the same branch — while the OR costs something real: under tablist semantics a selected tab may keep `aria-selected="true"` while its panel is hidden, and treating that as open would make `openTab` never click at all. `aria-expanded` means what this cares about, so it wins whenever present; `aria-selected` is only a fallback for its absence.

`Panel.isTabSelected` answers the same question two files over, so `ActivityBar` now has the matching `isTabOpen` predicate rather than an inline read.

### Verification

`pnpm run build` clean (typecheck and lint included). Full `smoke.test.ts` on VS Code: 14 passed, including the new spec. The click-the-icon spec is unaffected — it switches to Explorer first, so the tab is not expanded and the click still happens.

Not yet run on Windsurf or Positron. This is a shared page object used by every leg, so a `workflow_dispatch` is worth having before merge.

### Not in scope

`openGitLensSidebar()` still has no callers, so the guard on the GitLens container remains unexercised — that, and the orphaned tab-count helpers, are #5749.
