### PR TITLE
Drops the activity-bar tab-count helpers and the chain behind them

### DIFF
--- a/tests/e2e/pageObjects/components/activityBar.ts
+++ b/tests/e2e/pageObjects/components/activityBar.ts
@@ -41,13 +41,6 @@ export class ActivityBar {
 	}
 
 	/**
-	 * Get all tabs matching a pattern
-	 */
-	getTabs(name: string | RegExp): Locator {
-		return this.container.getByRole('tab', { name: name });
-	}
-
-	/**
 	 * Click a tab to activate its view
 	 */
 	async clickTab(name: string | RegExp, exact = true): Promise<void> {
@@ -104,13 +97,6 @@ export class ActivityBar {
 	 */
 	async waitForTab(name: string | RegExp, exact = true, timeout = MaxTimeout): Promise<void> {
 		await this.getTab(name, exact).waitFor({ state: 'visible', timeout: timeout });
-	}
-
-	/**
-	 * Count tabs matching a pattern
-	 */
-	async countTabs(name: string | RegExp): Promise<number> {
-		return this.getTabs(name).count();
 	}
 
 	// Common VS Code activity bar tabs

--- a/tests/e2e/pageObjects/gitLensPage.ts
+++ b/tests/e2e/pageObjects/gitLensPage.ts
@@ -44,14 +44,6 @@ export class GitLensPage extends VSCodePage {
 	}
 
 	/**
-	 * Get the count of GitLens-related tabs in the activity bar
-	 * Should be 2: GitLens and GitLens Inspect
-	 */
-	async getActivityBarTabCount(): Promise<number> {
-		return this.activityBar.countTabs(/GitLens/);
-	}
-
-	/**
 	 * Wait for GitLens extension to fully activate
 	 * This is indicated by the GitLens activity bar icon becoming visible
 	 */

--- a/tests/e2e/specs/smoke.test.ts
+++ b/tests/e2e/specs/smoke.test.ts
@@ -74,8 +74,8 @@ test.describe('Smoke Tests — Core', () => {
 
 		// GitLens Inspect is its own view container, and VS Code registers a container the first time
 		// one of its views is shown — so the tab is simply absent on a freshly launched instance. Show
-		// an Inspect view here: the old `countTabs(/GitLens/) >= 1` was satisfied by the GitLens tab
-		// alone, so this test passed without ever seeing the second icon it is named for.
+		// an Inspect view here: this used to assert that at least one tab matched /GitLens/, which the
+		// GitLens tab satisfied alone, so it passed without ever seeing the second icon it is named for.
 		await vscode.gitlens.executeCommand('gitlens.showCommitDetailsView');
 		await expect(vscode.gitlens.gitlensInspectTab).toBeVisible({ timeout: MaxTimeout });
 	});


### PR DESCRIPTION
Closes #5749.

`GitLensPage.getActivityBarTabCount()` had exactly one consumer: the smoke spec asserting `countTabs(/GitLens/) >= 1` for the activity-bar icons. That assertion was satisfied by the `GitLens` tab alone, so it passed without ever seeing the `GitLens Inspect` icon it was named for — which is also why the leg never caught the lazily registered Inspect container. #5750 replaced it with an assertion naming both tabs, and the helper has had no callers since.

### The chain

Removing it orphans `ActivityBar.countTabs()`, whose only caller it was, and removing that orphans `ActivityBar.getTabs()` in turn. Leaving either behind would move the dead surface one level down rather than clear it, so all three go together.

`getTab()` — singular — is untouched. It has more than twenty call sites across `ActivityBar` and `Panel` and is unrelated beyond the name; worth stating explicitly since the two differ by one character.

The comment in `smoke.test.ts` explaining what the old assertion used to do no longer names `countTabs`, since that method is gone. The explanation itself still earns its place.

### Verification

`oxlint --type-aware --type-check` over all of `tests/e2e` is clean. For a pure deletion that is the check that matters: no surviving reference could type-check, and a text search for all three names across `tests/` comes back empty, so there is no dynamic access either. `pnpm run bundle:e2e` compiles and `smoke.test.ts` passes 14/14 on VS Code.

### Not included

`GitLensPage.openGitLensSidebar()` also has no callers — it surfaced during the review of #5748. It is deliberately left alone: it is not a helper that something better replaced, it is a capability no spec happens to use yet, and it is not what #5749 scoped. Worth a separate decision rather than folding it in here.
