### PR TITLE
Fixes #5757 - Recognizes forward slashes as autolink boundaries

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -50,6 +50,7 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/) and this p
 
 ### Fixed
 
+- Fixes custom autolinks failing to match references after a forward slash ([#5757](https://github.com/gitkraken/vscode-gitlens/issues/5757))
 - Fixes cancelling the _Root Folder..._ or _Specific Folder..._ picker closing the _Create Worktree_ wizard instead of returning to its confirmation step ([#5752](https://github.com/gitkraken/vscode-gitlens/issues/5752))
 - Fixes clicking an untracked nested repository's row in the _Commit Graph_'s _Compare_ panel opening a tab that fails to render ([#5657](https://github.com/gitkraken/vscode-gitlens/issues/5657))
 - Fixes the push confirmation pre-selecting _Force Push_ when the branch is behind its upstream &mdash; Enter force-pushed; _Cancel_ is now the default

--- a/packages/git/src/utils/__tests__/autolink.utils.test.ts
+++ b/packages/git/src/utils/__tests__/autolink.utils.test.ts
@@ -39,11 +39,11 @@ suite('Autolink Utils Test Suite', () => {
 			assert.strictEqual(match[3], '456');
 		});
 
-		test('matches prefix after opening brackets', () => {
+		test('matches prefix after supported boundaries', () => {
 			const ref = makeRef();
 			ensureCachedRegex(ref, 'plaintext');
 
-			for (const opener of ['(', '[', '{']) {
+			for (const opener of ['(', '[', '{', '/']) {
 				ref.messageRegex.lastIndex = 0;
 				const match = ref.messageRegex.exec(`${opener}JIRA-99)`);
 				assert.ok(match != null, `Should match after '${opener}'`);

--- a/packages/git/src/utils/autolink.utils.ts
+++ b/packages/git/src/utils/autolink.utils.ts
@@ -58,20 +58,21 @@ export function ensureCachedRegex(
 	// If the ref is a matched Autolink then only match the exact `id`
 	const refPattern = ref.id ? ref.id : ref.alphanumeric ? '\\w+' : '\\d+';
 	const refFlags = !ref.id && ref.ignoreCase ? 'gi' : 'g';
+	const prefixBoundary = '^|[\\[\\s({/]';
 
 	// Regexes matches the ref prefix followed by a token (e.g. #1234)
 	if (outputFormat === 'markdown') {
 		ref.messageMarkdownRegex ??= new RegExp(
-			`(^|\\s|\\(|\\[|\\{)(${escapeRegex(encodeHtmlWeak(ref.prefix))}(${refPattern}))\\b`,
+			`(${prefixBoundary})(${escapeRegex(encodeHtmlWeak(ref.prefix))}(${refPattern}))\\b`,
 			refFlags,
 		);
 	} else if (outputFormat === 'html') {
 		ref.messageHtmlRegex ??= new RegExp(
-			`(^|\\s|\\(|\\[|\\{)(${escapeRegex(encodeHtmlWeak(ref.prefix))}(${refPattern}))\\b`,
+			`(${prefixBoundary})(${escapeRegex(encodeHtmlWeak(ref.prefix))}(${refPattern}))\\b`,
 			refFlags,
 		);
 	} else {
-		ref.messageRegex ??= new RegExp(`(^|\\s|\\(|\\[|\\{)(${escapeRegex(ref.prefix)}(${refPattern}))\\b`, refFlags);
+		ref.messageRegex ??= new RegExp(`(${prefixBoundary})(${escapeRegex(ref.prefix)}(${refPattern}))\\b`, refFlags);
 	}
 }
 


### PR DESCRIPTION
# Description

Closes #5757. Extracts common prefix boundary to constant.

- [x] I have followed the guidelines in the Contributing document
- [x] My changes follow the coding style of this project
- [x] My changes build without any errors or warnings
- [x] My changes have been formatted and linted
- [x] My changes include any required corresponding changes to the documentation (including CHANGELOG.md and README.md)
- [x] My changes have been rebased and squashed to the minimal number (typically 1) of relevant commits
- [x] My changes have a descriptive commit message with a short title, including a `Fixes $XXX -` or `Closes #XXX -` prefix to auto-close the issue that your PR addresses
