### PR TITLE
Fixes transient Community state when switching organizations

### DIFF
--- a/src/constants.storage.ts
+++ b/src/constants.storage.ts
@@ -139,7 +139,6 @@ type GlobalStorageDynamic = Record<`plus:preview:${FeaturePreviews}:usages`, Sto
 	Record<`provider:authentication:skip:${string}`, boolean> &
 	Record<`gk:promo:${string}:ai:allAccess:dismissed`, boolean> &
 	Record<`gk:promo:${string}:ai:allAccess:notified`, boolean> &
-	Record<`gk:${string}:checkin`, Stored<StoredGKCheckInResponse>> &
 	Record<`gk:${string}:organizations`, Stored<StoredOrganization[]>> &
 	Record<`jira:${string}:organizations`, Stored<StoredJiraOrganization[] | undefined>> &
 	Record<`jira:${string}:projects`, Stored<StoredJiraProject[] | undefined>> &
@@ -269,59 +268,6 @@ export interface Stored<T, SchemaVersion extends number = 1> {
 	data: T;
 	timestamp?: number;
 }
-
-export type StoredGKLicenses = Partial<Record<StoredGKLicenseType, StoredGKLicense>>;
-
-export interface StoredGKCheckInResponse {
-	user: StoredGKUser;
-	licenses: {
-		paidLicenses: StoredGKLicenses;
-		effectiveLicenses: StoredGKLicenses;
-	};
-}
-
-export interface StoredGKUser {
-	id: string;
-	name: string;
-	email: string;
-	status: 'activated' | 'pending';
-	createdDate: string;
-	firstGitLensCheckIn?: string;
-}
-
-export interface StoredGKLicense {
-	latestStatus: 'active' | 'canceled' | 'cancelled' | 'expired' | 'in_trial' | 'non_renewing' | 'trial';
-	latestStartDate: string;
-	latestEndDate: string;
-	organizationId: string | undefined;
-	reactivationCount?: number;
-}
-
-export type StoredGKLicenseType =
-	| 'gitlens-pro'
-	| 'gitlens-advanced'
-	| 'gitlens-teams'
-	| 'gitlens-hosted-enterprise'
-	| 'gitlens-self-hosted-enterprise'
-	| 'gitlens-standalone-enterprise'
-	| 'bundle-pro'
-	| 'bundle-advanced'
-	| 'bundle-teams'
-	| 'bundle-hosted-enterprise'
-	| 'bundle-self-hosted-enterprise'
-	| 'bundle-standalone-enterprise'
-	| 'gitkraken_v1-pro'
-	| 'gitkraken_v1-advanced'
-	| 'gitkraken_v1-teams'
-	| 'gitkraken_v1-hosted-enterprise'
-	| 'gitkraken_v1-self-hosted-enterprise'
-	| 'gitkraken_v1-standalone-enterprise'
-	| 'gitkraken-v1-pro'
-	| 'gitkraken-v1-advanced'
-	| 'gitkraken-v1-teams'
-	| 'gitkraken-v1-hosted-enterprise'
-	| 'gitkraken-v1-self-hosted-enterprise'
-	| 'gitkraken-v1-standalone-enterprise';
 
 export interface StoredOrganization {
 	id: string;

--- a/src/plus/gk/organizationService.ts
+++ b/src/plus/gk/organizationService.ts
@@ -67,10 +67,11 @@ export class OrganizationService implements Disposable {
 		}
 
 		if (this._organizations === undefined || options?.force) {
-			if (!options?.force) {
+			if (this._organizations == null) {
 				this.loadStoredOrganizations(userId);
-				if (this._organizations != null) return this._organizations;
 			}
+
+			if (!options?.force && this._organizations != null) return this._organizations;
 
 			let rsp;
 			try {
@@ -94,7 +95,9 @@ export class OrganizationService implements Disposable {
 					`Unable to get organizations due to error: ${getPresentableErrorMessage(ex)}`,
 					'OK',
 				);
-				this.updateOrganizations(undefined);
+				if (this._organizations == null) {
+					this.updateOrganizations(undefined);
+				}
 				return this._organizations;
 			}
 
@@ -104,8 +107,10 @@ export class OrganizationService implements Disposable {
 
 				void window.showErrorMessage(`Unable to get organizations; Status: ${rsp.statusText}`, 'OK');
 
-				// Setting to null prevents hitting the API again until you reload
-				this.updateOrganizations(null);
+				if (this._organizations == null) {
+					// Setting to null prevents hitting the API again until you reload
+					this.updateOrganizations(null);
+				}
 				return this._organizations;
 			}
 

--- a/src/plus/gk/subscriptionService.ts
+++ b/src/plus/gk/subscriptionService.ts
@@ -127,7 +127,6 @@ export class SubscriptionService implements Disposable {
 
 	private _disposable: Disposable;
 	private _subscription!: Subscription;
-	private _getCheckInData: () => Promise<GKCheckInResponse | undefined>;
 	private _statusBarSubscription: StatusBarItem | undefined;
 	private _validationTimer: ReturnType<typeof setInterval> | undefined;
 
@@ -156,11 +155,6 @@ export class SubscriptionService implements Disposable {
 		);
 
 		const subscription = this.getStoredSubscription();
-		this._getCheckInData = () => Promise.resolve(undefined);
-		if (subscription?.account?.id != null) {
-			this._getCheckInData = () => this.loadStoredCheckInData(subscription.account!.id);
-		}
-
 		this.changeSubscription(subscription, undefined, { silent: true });
 		setTimeout(() => void this.ensureSession(false, undefined), 10000);
 
@@ -1080,21 +1074,15 @@ export class SubscriptionService implements Disposable {
 			);
 
 			if (!rsp.ok) {
-				this._getCheckInData = () => Promise.resolve(undefined);
 				throw new AccountValidationError('Unable to validate account', undefined, rsp.status, rsp.statusText);
 			}
 
 			this._onDidCheckIn.fire({ force: force });
 
 			const data: GKCheckInResponse = (await rsp.json()) as GKCheckInResponse;
-			this._getCheckInData = () => Promise.resolve(data);
-			this.storeCheckInData(data);
-
-			await this.validateAndUpdateSubscriptions(data, session, source);
+			await this.validateAndUpdateSubscriptions(data, session, source, organizationId);
 			return data;
 		} catch (ex) {
-			this._getCheckInData = () => Promise.resolve(undefined);
-
 			scope?.error(ex);
 			debugger;
 
@@ -1124,67 +1112,39 @@ export class SubscriptionService implements Disposable {
 		);
 	}
 
-	private storeCheckInData(data: GKCheckInResponse): void {
-		if (data.user?.id == null) return;
-
-		void this.container.storage
-			.store(`gk:${data.user.id}:checkin`, {
-				v: 1,
-				timestamp: Date.now(),
-				data: data,
-			})
-			.catch();
-	}
-
-	@trace()
-	private async loadStoredCheckInData(userId: string): Promise<GKCheckInResponse | undefined> {
-		const scope = getScopedLogger();
-
-		const storedCheckIn = this.container.storage.get(`gk:${userId}:checkin`);
-		// If more than a day old, ignore
-		if (storedCheckIn?.timestamp == null || Date.now() - storedCheckIn.timestamp > 24 * 60 * 60 * 1000) {
-			// Attempt a check-in to see if we can get a new one
-			const session = await this.getAuthenticationSession(false);
-			if (session == null) return undefined;
-
-			try {
-				return await this.checkInAndValidate(session, undefined, { force: true });
-			} catch (ex) {
-				scope?.error(ex);
-				return undefined;
-			}
-		}
-
-		return storedCheckIn?.data;
-	}
-
 	@trace()
 	private async validateAndUpdateSubscriptions(
 		data: GKCheckInResponse,
 		session: AuthenticationSession,
 		source: Source | undefined,
+		organizationId?: string,
 	): Promise<void> {
 		const scope = getScopedLogger();
-		let organizations: Organization[];
+		let organizations: Organization[] | undefined;
 		try {
 			organizations =
 				(await this.container.organizations.getOrganizations({
 					force: true,
 					accessToken: session.accessToken,
 					userId: session.account.id,
-				})) ?? [];
+				})) ?? undefined;
 		} catch (ex) {
 			scope?.error(ex);
-			organizations = [];
+			organizations = undefined;
 		}
-		let chosenOrganizationId = getConfiguredActiveOrganizationId();
+		let chosenOrganizationId = organizationId ?? getConfiguredActiveOrganizationId();
 		if (chosenOrganizationId === '') {
 			chosenOrganizationId = undefined;
-		} else if (chosenOrganizationId != null && !organizations.some(o => o.id === chosenOrganizationId)) {
+		} else if (
+			chosenOrganizationId != null &&
+			organizations != null &&
+			!organizations.some(o => o.id === chosenOrganizationId)
+		) {
+			// Only reset the chosen organization when the fetched list actually excludes it, not when the list couldn't be fetched
 			chosenOrganizationId = undefined;
 			void updateActiveOrganizationId(undefined);
 		}
-		const subscription = getSubscriptionFromCheckIn(data, organizations, chosenOrganizationId);
+		const subscription = getSubscriptionFromCheckIn(data, organizations ?? [], chosenOrganizationId);
 		this._lastValidatedDate = new Date();
 		this.changeSubscription(
 			{
@@ -1642,23 +1602,9 @@ export class SubscriptionService implements Disposable {
 			return;
 		}
 
-		const checkInData = await this._getCheckInData();
-		if (checkInData == null) return;
-
-		const organizationSubscription = getSubscriptionFromCheckIn(checkInData, organizations, pick.org.id);
-
 		if (getConfiguredActiveOrganizationId() !== pick.org.id) {
 			await updateActiveOrganizationId(pick.org.id);
 		}
-
-		this.changeSubscription(
-			{
-				...this._subscription,
-				...organizationSubscription,
-			},
-			source,
-			{ store: true },
-		);
 	}
 
 	@info()


### PR DESCRIPTION
# Description

Client-side adaptation for the org-scoped `gitlens/checkin` API — refs #3546 (internal: gitkraken/vscode-gitlens-private#92).

Users with two orgs holding the same license type see one of them as Community, because the current checkin response keys `paidLicenses` by license *type* and silently drops the colliding org. The server fix scopes the response by the `gk-org-id` header (live on dev, not yet published). This PR makes GitLens correct with **both** response shapes; the user-visible issue is resolved only once the scoped API is published.

**Root cause of the flicker (scoped API):** `switchOrganization` passed the target org to the checkin HTTP request, but `validateAndUpdateSubscriptions` re-read the *configured* (still old) org id and emitted an intermediate subscription computed for it. With a scoped payload the old org has no license in the response, so every switch briefly showed `community-with-account` (~90 ms observed on dev) before a second, corrective emission re-read from the check-in cache. With the current global payload the intermediate emission happens to be correct, which is what masks the bug today.

**Changes:**

- Forwards the target organization id into `validateAndUpdateSubscriptions`, so a switch emits a single, correct subscription change; removes the now-redundant second emission from `switchOrganization`
- Removes the check-in response cache (the in-memory getter, the stored `gk:{userId}:checkin` blob, and its `StoredGK*` types) — the second emission was its only reader, and under the scoped API the stored blob would no longer be a global snapshot of the account
- Keeps the chosen organization when the organization list fails to load during validation — a transient failure no longer erases the configured org (which silently moved the plan to a different org)
- Keeps the already-known organization list on transient fetch failures, and hydrates it from the stored (24h) cache on forced refreshes — so a failed fetch in a fresh window doesn't clear `activeOrganization`, which would drop the `gk-org-id` header from subsequent requests and, under the scoped API, show a paid account as Community until a later validation

**Verification:** live against dev (scoped API): switching test ⇄ test2 (two orgs with same-type Pro licenses) emits exactly one subscription change carrying the correct target plan — previously two, with a wrong intermediate one. Trial states verified unchanged (in-trial license without a payment source, trial reactivation via `nextOptInDate`, headerless login with no organizations). Against the current global API the behavior is indistinguishable aside from the removed redundant emission. `pnpm run check` clean, unit tests (2356) pass.

CHANGELOG entry is deliberately deferred until the server API is published.

# Checklist

- [x] I have followed the guidelines in the Contributing document
- [x] My changes follow the coding style of this project
- [x] My changes build without any errors or warnings
- [x] My changes have been formatted and linted
- [x] My changes include any required corresponding changes to the documentation (including CHANGELOG.md and README.md)
- [x] My changes have been rebased and squashed to the minimal number (typically 1) of relevant commits
- [x] My changes have a descriptive commit message with a short title

🤖 Generated with [Claude Code](https://claude.com/claude-code)
