### PR TITLE
Adds a debug command to simulate the Commit Graph sign-in gate variant

### DIFF
--- a/.claude/skills/live-inspect/SKILL.md
+++ b/.claude/skills/live-inspect/SKILL.md
@@ -492,9 +492,20 @@ execute_command { command: "gitlens.plus.simulate.ai", args: [{ "op": "disable" 
 
 `{op: "enable"}` always clears the stash first, so re-enabling between tests is also safe.
 
-### Build requirement (both simulators)
+## Exercising the Commit Graph sign-in gate A/B
 
-Both simulators are DEBUG-only (`gitlens:debugging` context). Standard dev launch via `launch {}` and `pnpm run build:extension` includes them. Production bundles strip them.
+The **gate simulator** (`gitlens.graph.simulate.signInGateVariant`) forces the sign-in gate's A/B arm, which is otherwise cohort-assigned. The gate renders only while signed out:
+
+```
+set_account { plan: "community" }
+execute_command { command: "gitlens.graph.simulate.signInGateVariant", args: [{ "variant": "intro-video" }] }
+```
+
+`variant` is `"default"` or `"intro-video"`; `{}` ends the simulation; no args opens a QuickPick. The command resolves before the reloaded gate renders — wait on the DOM before screenshotting.
+
+### Build requirement (all simulators)
+
+All simulators above are DEBUG-only (`gitlens:debugging` context). Standard dev launch via `launch {}` and `pnpm run build:extension` includes them. Production bundles strip them. Their debug modules load asynchronously after extension activation — retry the command until it exists.
 
 ## Related skills
 

--- a/contributions.json
+++ b/contributions.json
@@ -4930,6 +4930,10 @@
 				]
 			}
 		},
+		"gitlens.graph.simulate.signInGateVariant": {
+			"label": "Simulate Commit Graph Sign-in Gate (Debugging)",
+			"commandPalette": "gitlens:enabled && gitlens:debugging"
+		},
 		"gitlens.graph.soloBranch": {
 			"label": "Solo Branch",
 			"commandPalette": "gitlens:enabled",

--- a/package.json
+++ b/package.json
@@ -8662,6 +8662,11 @@
 				"icon": "$(gitlens-graph)"
 			},
 			{
+				"command": "gitlens.graph.simulate.signInGateVariant",
+				"title": "Simulate Commit Graph Sign-in Gate (Debugging)",
+				"category": "GitLens"
+			},
+			{
 				"command": "gitlens.graph.soloBranch",
 				"title": "Solo Branch",
 				"category": "GitLens"
@@ -14667,6 +14672,10 @@
 				{
 					"command": "gitlens.graph.showTerminalWorktree",
 					"when": "false"
+				},
+				{
+					"command": "gitlens.graph.simulate.signInGateVariant",
+					"when": "gitlens:enabled && gitlens:debugging"
 				},
 				{
 					"command": "gitlens.graph.soloBranch",

--- a/src/constants.commands.generated.ts
+++ b/src/constants.commands.generated.ts
@@ -1075,6 +1075,7 @@ export type ContributedPaletteCommands =
 	| 'gitlens.gk.switchOrganization'
 	| 'gitlens.graph.followTerminalOff'
 	| 'gitlens.graph.followTerminalOn'
+	| 'gitlens.graph.simulate.signInGateVariant'
 	| 'gitlens.graph.soloBranch'
 	| 'gitlens.graph.soloBranch:views'
 	| 'gitlens.graph.soloTag'

--- a/src/webviews/plus/graph/__debug__signInGateDebug.ts
+++ b/src/webviews/plus/graph/__debug__signInGateDebug.ts
@@ -1,0 +1,103 @@
+import type { QuickPickItem } from 'vscode';
+import { window } from 'vscode';
+import { wait } from '@gitlens/utils/promise.js';
+import type { Container } from '../../../container.js';
+import { registerCommand } from '../../../system/-webview/command.js';
+import { loadChunk } from '../../../system/-webview/loadChunk.js';
+import type { WebviewPanelsProxy } from '../../webviewsController.js';
+import type { GraphWebviewShowingArgs } from './registration.js';
+
+type Variant = 'default' | 'intro-video';
+type VariantPickItem = QuickPickItem & { variant: Variant | undefined };
+
+/** Stamped after each awaited rebuild, so a back-to-back dispatch can wait out the controller's
+ *  refresh coalesce window instead of being silently dropped */
+let lastRefreshCompletedAt = 0;
+
+/** Registers the debug-only sign-in gate simulator command. Unlike the real flag — whose value is
+ *  latched on the first gated render and applies only after a window reload — picking a variant
+ *  here refreshes every graph surface immediately while signed out, the only state the gate
+ *  renders in. */
+export function registerSignInGateDebug<T>(
+	container: Container,
+	panels: WebviewPanelsProxy<'gitlens.graph', GraphWebviewShowingArgs, T>,
+): void {
+	container.context.subscriptions.push(
+		// The optional payload drives the simulation programmatically (e.g. automated live
+		// exercises), mirroring `gitlens.plus.simulate.subscription`; a payload without `variant`
+		// ends the simulation, no payload shows the picker
+		registerCommand(
+			'gitlens.graph.simulate.signInGateVariant',
+			async (args?: { variant?: string }) => {
+				let variant: Variant | undefined;
+				if (args != null) {
+					// Validate the wire payload — a near-miss literal (e.g. 'introVideo') or a positional
+					// string (instead of `{ variant }`) would otherwise silently render the wrong arm, or
+					// end the simulation, while the command reports success
+					const value = typeof args === 'object' ? args.variant : String(args);
+					if (value === 'default' || value === 'intro-video') {
+						variant = value;
+					} else if (value != null) {
+						void window.showErrorMessage(`Unknown sign-in gate variant "${value}"`);
+						return false;
+					}
+				} else {
+					const pick = await window.showQuickPick<VariantPickItem>(
+						[
+							{ label: 'Default Gate', description: 'Pro strip + Learn More', variant: 'default' },
+							{ label: 'Intro Video Gate', description: 'Video thumbnail', variant: 'intro-video' },
+							{
+								label: 'End Simulation',
+								description: 'Re-resolves the real flag on the next gate render',
+								variant: undefined,
+							},
+						],
+						{ title: 'Simulate Sign-in Gate Variant', placeHolder: 'Choose the gate variant to render' },
+					);
+					if (pick == null) return;
+
+					variant = pick.variant;
+				}
+
+				const { setSignInGateVariantOverride } = await loadChunk(
+					() => import(/* webpackChunkName: "webview-graph" */ './graphWebview.js'),
+				);
+				setSignInGateVariantOverride(variant);
+
+				// The gate renders only while signed out — skip tearing down (and rebuilding) every open
+				// graph when it can't be observed; the latch still applies to the next gated render
+				const subscription = await container.subscription.getSubscription();
+				if (subscription.account == null) {
+					// Wait out the controller's refresh coalesce window (`refreshCoalesceMs`, ~1s after the
+					// previous rebuild) — a back-to-back dispatch would otherwise be dropped silently while
+					// the command still reports success
+					const sinceLast = Date.now() - lastRefreshCompletedAt;
+					if (sinceLast < 1100) {
+						await wait(1100 - sinceLast);
+					}
+
+					const refreshes = [container.views.graph.refresh(true)];
+					for (const instance of panels.instances) {
+						refreshes.push(instance.refresh(true));
+					}
+
+					// Awaited so the html swap has landed on every gated surface before reporting success —
+					// the reloaded page still boots after this, so a caller must await the DOM (not this
+					// command) to observe the new arm rendered
+					await Promise.all(refreshes);
+					lastRefreshCompletedAt = Date.now();
+				}
+
+				void window.showInformationMessage(
+					variant == null
+						? 'Sign-in gate simulation ended — the next gate render resolves the real flag'
+						: `Sign-in gate simulating "${variant}" — the gate renders only while signed out`,
+				);
+
+				return true;
+			},
+			undefined,
+			{ returnResult: true },
+		),
+	);
+}

--- a/src/webviews/plus/graph/graphWebview.ts
+++ b/src/webviews/plus/graph/graphWebview.ts
@@ -338,6 +338,13 @@ type CancellableOperations =
  *  `unassigned` = no cohort: rendered as the default gate but kept out of both funnel arms. */
 let signInGateVariant: 'default' | 'intro-video' | 'unassigned' | undefined;
 
+/** Debug-only (see `__debug__signInGateDebug.ts`): forces the latch so the gate renders the given
+ *  variant on the next (re)load; `undefined` re-resolves the real flag on the next bootstrap.
+ *  Never persists or re-stamps telemetry — that happens only when the real flag resolves. */
+export function setSignInGateVariantOverride(variant: 'default' | 'intro-video' | undefined): void {
+	signInGateVariant = variant;
+}
+
 export class GraphWebviewProvider implements WebviewProvider<State, State, GraphWebviewShowingArgs> {
 	private _repository?: GlRepository;
 	private get repository(): GlRepository | undefined {

--- a/src/webviews/plus/graph/registration.ts
+++ b/src/webviews/plus/graph/registration.ts
@@ -142,6 +142,12 @@ export function registerGraphWebviewCommands<T>(
 	container: Container,
 	panels: WebviewPanelsProxy<'gitlens.graph', GraphWebviewShowingArgs, T>,
 ): Disposable {
+	if (DEBUG) {
+		void import(/* webpackChunkName: "__debug__" */ './__debug__signInGateDebug.js').then(m => {
+			m.registerSignInGateDebug(container, panels);
+		});
+	}
+
 	/** Routes to the best graph surface: an existing/visible instance wins over the configured
 	 *  layout, so the request lands on the graph the user is looking at instead of opening a
 	 *  second one in the other surface. */


### PR DESCRIPTION
# Description

Dev tooling for gitkraken/vscode-gitlens-private#98 (companion to #5772): a debug-only **Simulate Commit Graph Sign-in Gate (Debugging)** command that renders either arm of the sign-in gate A/B on demand, instead of having to land in the right ConfigCat cohort or flip the `getFlag` default locally.

- A quick pick — _Default Gate_ (Pro strip + Learn More), _Intro Video Gate_ (video thumbnail), _End Simulation_ — writes the chosen variant straight into the module-scope latch and force-refreshes every Graph surface (editor panels and the sidebar view), so the gate re-renders immediately. The real flag intentionally keeps its latched semantics: a fetch landing mid-session never re-renders the gate — only the window session's first gated render resolves it.
- The simulation never persists `graph:signInGate:introVideoShown` and never re-stamps the `featureFlags` telemetry attribute — both happen only when the real flag resolves. _End Simulation_ clears the latch so the next gate render resolves the real flag again (synchronously, from the cached cohort).
- The command lives in the `__debug__` chunk (DEBUG builds only) and appears in the palette only under `gitlens:debugging`, matching the existing subscription simulator.

No CHANGELOG entry — a debugging-only command, matching the existing `(Debugging)` commands which have never been announced.

Exists in a debug window:

https://github.com/user-attachments/assets/99274d86-7f3f-46a6-97db-e9c1e7e46a41

Does not exist in the normal window:

<img width="500" alt="image" src="https://github.com/user-attachments/assets/8366f420-1312-41c2-90af-5434df912133" />



# Checklist

- [x] I have followed the guidelines in the Contributing document
- [x] My changes follow the coding style of this project
- [x] My changes build without any errors or warnings
- [x] My changes have been formatted and linted
- [x] My changes include any required corresponding changes to the documentation (including CHANGELOG.md and README.md)
- [x] My changes have been rebased and squashed to the minimal number (typically 1) of relevant commits
- [x] My changes have a descriptive commit message with a short title

