### PR TITLE
Fixes flaky createOrderedDispatcher tests with condition-based drain

### DIFF
--- a/src/webviews/apps/shared/__tests__/webviewEndpoint.test.ts
+++ b/src/webviews/apps/shared/__tests__/webviewEndpoint.test.ts
@@ -18,15 +18,7 @@ function wrapCompressed(message: unknown): RpcMessageWrapper {
 	return { [RPC_NAMESPACE]: true, payload: deflated, compressed: 'deflate-raw' };
 }
 
-/**
- * Yields to the macrotask queue so the dispatcher's chain can drain.
- *
- * With a predicate, keeps yielding until it holds or ~1s elapses — a corrupt payload's error
- * propagates through the webstreams/zlib adapters over a variable number of macrotask hops, so a
- * fixed tick count is flaky under scheduler load.
- * Without a predicate, yields a fixed few ticks — for tests asserting nothing gets delivered,
- * where the bounded wait is the point.
- */
+/** Yields to the microtask/macrotask queue a few times so the dispatcher's chain can drain. */
 async function drain(until?: () => boolean): Promise<void> {
 	if (until == null) {
 		for (let i = 0; i < 5; i++) {

--- a/src/webviews/apps/shared/__tests__/webviewEndpoint.test.ts
+++ b/src/webviews/apps/shared/__tests__/webviewEndpoint.test.ts
@@ -18,9 +18,26 @@ function wrapCompressed(message: unknown): RpcMessageWrapper {
 	return { [RPC_NAMESPACE]: true, payload: deflated, compressed: 'deflate-raw' };
 }
 
-/** Yields to the microtask/macrotask queue a few times so the dispatcher's chain can drain. */
-async function drain(): Promise<void> {
-	for (let i = 0; i < 5; i++) {
+/**
+ * Yields to the macrotask queue so the dispatcher's chain can drain.
+ *
+ * With a predicate, keeps yielding until it holds or ~1s elapses — a corrupt payload's error
+ * propagates through the webstreams/zlib adapters over a variable number of macrotask hops, so a
+ * fixed tick count is flaky under scheduler load.
+ * Without a predicate, yields a fixed few ticks — for tests asserting nothing gets delivered,
+ * where the bounded wait is the point.
+ */
+async function drain(until?: () => boolean): Promise<void> {
+	if (until == null) {
+		for (let i = 0; i < 5; i++) {
+			await new Promise<void>(resolve => setImmediate(resolve));
+		}
+
+		return;
+	}
+
+	const deadline = Date.now() + 1000;
+	while (!until() && Date.now() < deadline) {
 		await new Promise<void>(resolve => setImmediate(resolve));
 	}
 }
@@ -49,7 +66,7 @@ suite('createOrderedDispatcher Test Suite', () => {
 		dispatcher.dispatch(wrapCompressed({ id: 1 }), fakeEvent);
 		dispatcher.dispatch(wrapUncompressed({ id: 2 }), fakeEvent);
 
-		await drain();
+		await drain(() => deliveries.length >= 2);
 
 		assert.deepStrictEqual(deliveries, [{ id: 1 }, { id: 2 }]);
 
@@ -94,7 +111,7 @@ suite('createOrderedDispatcher Test Suite', () => {
 		dispatcher.dispatch(corrupt, fakeEvent);
 		dispatcher.dispatch(wrapUncompressed({ id: 'still delivered' }), fakeEvent);
 
-		await drain();
+		await drain(() => deliveries.length >= 1);
 
 		assert.deepStrictEqual(deliveries, [{ id: 'still delivered' }]);
 


### PR DESCRIPTION
# Description

Fixes the flaky `createOrderedDispatcher` tests in `src/webviews/apps/shared/__tests__/webviewEndpoint.test.ts` (reproduced at ~11–12 failures per 40 standalone runs on Node 22; also seen on CI in the Unit Tests job — "drops a corrupt compressed message without stalling later messages" got `[]` instead of `[{id: 'still delivered'}]`).

**Root cause:** the test-local `drain()` helper yielded a fixed 5 `setImmediate` ticks, but a corrupt compressed payload's error propagates through Node's webstreams/zlib adapters (`DecompressionStream` → `InflateRaw` error → stream destroy → end-of-stream callbacks) over a *variable* number of macrotask hops. Under scheduler load 5 ticks are not always enough, so the assertion ran before the dispatcher's chain reached the follow-up message.

**Fix (test file only):** `drain()` now accepts an optional predicate and keeps yielding via `setImmediate` until it holds or ~1s elapses. The two compressed-path delivery tests wait on their expected delivery counts; the two `dispose()` tests that assert nothing gets delivered keep the original bounded fixed-tick form, where the fixed wait is the point.

No production changes — `webviewEndpoint.ts`'s drop path correctly releases the chain (`queued--` in `finally`); this was purely test timing.

**Verification** (test file bundled standalone with the repo's unit-test esbuild settings, run under a minimal TDD harness on Node 22):

- Old `drain()`: 12/40 runs failed, all on the reported test — reproduces the flake
- New `drain()`: 45/45 green plain + 40/40 green under 3 concurrent CPU busy-loops (85 consecutive green runs)

# Checklist

- [x] I have followed the guidelines in the Contributing document
- [x] My changes follow the coding style of this project
- [x] My changes build without any errors or warnings
- [x] My changes have been formatted and linted
- [ ] My changes include any required corresponding changes to the documentation (including CHANGELOG.md and README.md) — n/a, test-only change
- [x] My changes have been rebased and squashed to the minimal number (typically 1) of relevant commits
- [x] My changes have a descriptive commit message with a short title

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_015m8BkNtdfBRdMkMCGdc8eW

---
_Generated by [Claude Code](https://claude.ai/code/session_015m8BkNtdfBRdMkMCGdc8eW)_