### PR TITLE
Fixes Auto-Rebase failure messages ending with a doubled period

### DIFF
--- a/src/plus/coretools/conflict/autoRebaseProgress.ts
+++ b/src/plus/coretools/conflict/autoRebaseProgress.ts
@@ -96,9 +96,13 @@ async function runAndRoute(
 				`Auto-Rebase cancelled — ${session.preRun.branch ?? 'the branch'} is unchanged.`,
 			);
 			break;
-		case 'failed':
-			void window.showErrorMessage(`Auto-Rebase failed${session.failure ? `: ${session.failure}` : ''}.`);
+		case 'failed': {
+			const reason = session.failure;
+			void window.showErrorMessage(
+				reason ? `Auto-Rebase failed: ${reason.endsWith('.') ? reason : `${reason}.`}` : 'Auto-Rebase failed.',
+			);
 			break;
+		}
 		default:
 			break;
 	}


### PR DESCRIPTION
Fixes #5788

**Problem:** The Auto-Rebase failure toast always appended a trailing period to the failure reason (`` `Auto-Rebase failed${session.failure ? `: ${session.failure}` : ''}.` ``), even when the reason already ended in one (e.g. `The rebase never started — its git process may have been interrupted.`). Every failure reason in `autoRebaseService.ts` already carries its own terminal punctuation, so the message always doubled up: `Auto-Rebase failed: ...interrupted..`

**Approach:** Settled on the convention the codebase already uses elsewhere for the same problem (`src/messages.ts`'s `showGitErrorMessage`): only append a period when the reason doesn't already end with one. No period is added twice, and a reason without one still gets terminal punctuation.

**Invariants touched:** none — this is a single-file string-formatting fix in `src/plus/coretools/conflict/autoRebaseProgress.ts`, no change to `AutoRebaseSession` shape or the failure-routing logic.

**Verification:**
- Gates green: `pnpm run check`, `pnpm run fmt:check`, `pnpm run test` (2578 passing).
- `/code-review medium` raised one finding (trailing whitespace/newline in a reason could still produce an oddly placed period) — investigated and rejected: every message that reaches `session.failure` in this codebase is a curated, hand-written string (either a literal in `autoRebaseService.ts` or a `GitCommandError` subclass's `buildErrorMessage`), none of which contain trailing whitespace; matches the same (untrimmed) convention already used in `messages.ts`.
- Verified the formatting logic directly against all three input shapes (reason with a period, reason without one, no reason) — each produces a single, correctly punctuated message.
- Human live run skipped: this is a pure string-formatting change with no logic branching beyond what's exhaustively verified above, and reproducing a genuine Auto-Rebase failure requires a full AI-enabled repro disproportionate to a punctuation fix.