### PR TITLE
Adds an "Add to .gitignore" action to untracked working-changes files

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -8,6 +8,7 @@
 .claude/*.lock
 .codex
 .DS_Store
+.gitlens/workflow.state.json
 .work/
 .stylelintcache
 .superpowers

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/) and this p
 ### Added
 
 - Adds _Copy Worktree Path_ to worktree branch pills and _Copy Branch Name_ to working-changes (WIP) rows in the _Commit Graph_
+- Adds an _Add to .gitignore_ action to untracked files in the _Commit Graph_ details and _Inspect_ views ([#5780](https://github.com/gitkraken/vscode-gitlens/issues/5780)) &mdash; appends the repo-relative path of the selected file (or files) to the repository's `.gitignore`, creating it when missing, so a file can be ignored without leaving the view
 - Adds a _Show Resource Usage_ command to the Command Palette &mdash; shows resource counts for long-lived GitLens caches and trackers plus memory usage for the entire VS Code extension host, where available, in a dedicated output channel; extension-host memory cannot be attributed to GitLens alone; an aggregate of the same data is also sampled as telemetry once an hour while the window is focused ([#5504](https://github.com/gitkraken/vscode-gitlens/issues/5504))
 
 - Adds a `gitlens.openInTerminalLocation` setting &mdash; controls where GitLens opens the terminals it creates (the _Open in Integrated Terminal_ actions in the views and _Commit Graph_, plus agent session start/resume terminals), either in the terminal panel (default) or as an editor tab; a one-time notification offers to switch to editor tabs

--- a/contributions.json
+++ b/contributions.json
@@ -23,6 +23,54 @@
 				]
 			}
 		},
+		"gitlens.addToGitignore:commitDetails": {
+			"label": "Add to .gitignore",
+			"menus": {
+				"webview/context": [
+					{
+						"when": "webviewItem =~ /gitlens:file\\b(?=.*?\\b\\+untracked\\b)/ && !gitlens:readonly && !gitlens:untrusted && !gitlens:hasVirtualFolders && webview == gitlens.views.commitDetails",
+						"group": "1_gitlens_actions",
+						"order": 5
+					}
+				]
+			}
+		},
+		"gitlens.addToGitignore:graphDetails": {
+			"label": "Add to .gitignore",
+			"menus": {
+				"webview/context": [
+					{
+						"when": "webviewItem =~ /gitlens:file\\b(?=.*?\\b\\+untracked\\b)/ && !gitlens:readonly && !gitlens:untrusted && !gitlens:hasVirtualFolders && (webview == gitlens.graph || webview == gitlens.views.graph)",
+						"group": "1_gitlens_actions",
+						"order": 5
+					}
+				]
+			}
+		},
+		"gitlens.addToGitignore.multi:commitDetails": {
+			"label": "Add to .gitignore",
+			"menus": {
+				"webview/context": [
+					{
+						"when": "listMultiSelection && !gitlens:readonly && !gitlens:untrusted && !gitlens:hasVirtualFolders && webview == gitlens.views.commitDetails && webviewItemsUnion =~ /gitlens:file\\b(?=.*?\\b\\+untracked\\b)(?!.*?\\b\\+(committed|stashed)\\b)/",
+						"group": "1_gitlens_actions",
+						"order": 5
+					}
+				]
+			}
+		},
+		"gitlens.addToGitignore.multi:graphDetails": {
+			"label": "Add to .gitignore",
+			"menus": {
+				"webview/context": [
+					{
+						"when": "webviewItemsUnion =~ /gitlens:file\\b(?=.*?\\b\\+untracked\\b)(?!.*?\\b\\+(committed|stashed)\\b)/ && listMultiSelection && !gitlens:readonly && !gitlens:untrusted && !gitlens:hasVirtualFolders && (webview == gitlens.graph || webview == gitlens.views.graph)",
+						"group": "1_gitlens_actions",
+						"order": 5
+					}
+				]
+			}
+		},
 		"gitlens.agents.allowPermission": {
 			"label": "Allow",
 			"icon": "$(check)",

--- a/package.json
+++ b/package.json
@@ -6867,6 +6867,22 @@
 				"icon": "$(person-add)"
 			},
 			{
+				"command": "gitlens.addToGitignore:commitDetails",
+				"title": "Add to .gitignore"
+			},
+			{
+				"command": "gitlens.addToGitignore:graphDetails",
+				"title": "Add to .gitignore"
+			},
+			{
+				"command": "gitlens.addToGitignore.multi:commitDetails",
+				"title": "Add to .gitignore"
+			},
+			{
+				"command": "gitlens.addToGitignore.multi:graphDetails",
+				"title": "Add to .gitignore"
+			},
+			{
 				"command": "gitlens.agents.allowPermission",
 				"title": "Allow",
 				"icon": "$(check)"
@@ -13249,6 +13265,22 @@
 				{
 					"command": "gitlens.addAuthors",
 					"when": "gitlens:enabled && !gitlens:readonly && !gitlens:untrusted && !gitlens:hasVirtualFolders"
+				},
+				{
+					"command": "gitlens.addToGitignore:commitDetails",
+					"when": "false"
+				},
+				{
+					"command": "gitlens.addToGitignore:graphDetails",
+					"when": "false"
+				},
+				{
+					"command": "gitlens.addToGitignore.multi:commitDetails",
+					"when": "false"
+				},
+				{
+					"command": "gitlens.addToGitignore.multi:graphDetails",
+					"when": "false"
 				},
 				{
 					"command": "gitlens.agents.allowPermission",
@@ -27836,28 +27868,8 @@
 					"group": "4_worktree@1"
 				},
 				{
-					"command": "gitlens.openWorktree:graph",
-					"when": "webviewItem =~ /gitlens:branch\\b(?=.*?\\b\\+worktree\\b)/ && !gitlens:hasVirtualFolders",
-					"group": "1_gitlens_action@1"
-				},
-				{
-					"command": "gitlens.switchToBranch:graph",
-					"when": "webviewItem =~ /gitlens:branch\\b(?!.*?\\b\\+(current|checkedout|worktree)\\b)/ && !gitlens:readonly && !gitlens:untrusted && !gitlens:hasVirtualFolders",
-					"group": "1_gitlens_action@1"
-				},
-				{
-					"command": "gitlens.openWorktreeInNewWindow:graph",
-					"when": "webviewItem =~ /gitlens:branch\\b(?=.*?\\b\\+worktree\\b)/ && !gitlens:hasVirtualFolders",
-					"group": "1_gitlens_action@2"
-				},
-				{
 					"command": "gitlens.graph.openInWorktree",
 					"when": "webviewItem =~ /gitlens:branch\\b(?!.*?\\b\\+(current|checkedout|worktree)\\b)/ && !gitlens:hasVirtualFolders",
-					"group": "1_gitlens_action@3"
-				},
-				{
-					"command": "gitlens.switchToAnotherBranch:graph",
-					"when": "webviewItem =~ /gitlens:branch\\b(?=.*?\\b\\+(current|checkedout)\\b)/ && !gitlens:readonly && !gitlens:untrusted && !gitlens:hasVirtualFolders",
 					"group": "1_gitlens_action@3"
 				},
 				{
@@ -27871,291 +27883,6 @@
 					"group": "1_gitlens_actions@2"
 				},
 				{
-					"command": "gitlens.publishBranch:graph",
-					"when": "webviewItem =~ /gitlens:branch\\b(?!.*?\\b\\+remote\\b)(?!.*?\\b\\+tracking\\b)(?!.*?\\b\\+closed\\b)/ && !gitlens:readonly && !gitlens:untrusted && !gitlens:hasVirtualFolders && gitlens:repos:withRemotes",
-					"group": "1_gitlens_actions@2"
-				},
-				{
-					"command": "gitlens.setUpstream:graph",
-					"when": "webviewItem =~ /gitlens:branch\\b(?!.*?\\b\\+remote\\b)(?!.*?\\b\\+closed\\b)(?!.*?\\b\\+tracking\\b)/ && !listMultiSelection && !gitlens:readonly && !gitlens:untrusted && !gitlens:hasVirtualFolders",
-					"group": "1_gitlens_actions@10"
-				},
-				{
-					"command": "gitlens.graph.resetToTip",
-					"when": "webviewItem =~ /gitlens:branch\\b/ && !gitlens:readonly && !gitlens:untrusted && !gitlens:hasVirtualFolders",
-					"group": "1_gitlens_actions_1@4"
-				},
-				{
-					"command": "gitlens.graph.squashFixups",
-					"when": "webviewItem =~ /gitlens:branch\\b(?=.*?\\b\\+current\\b)/ && !gitlens:readonly && !gitlens:untrusted && !gitlens:hasVirtualFolders",
-					"group": "1_gitlens_actions_1@5"
-				},
-				{
-					"command": "gitlens.graph.renameBranch",
-					"when": "webviewItem =~ /gitlens:branch\\b/ && !gitlens:readonly && !gitlens:untrusted && !gitlens:hasVirtualFolders",
-					"group": "1_gitlens_actions_2@2"
-				},
-				{
-					"command": "gitlens.views.compareWithSelected:graph",
-					"when": "webviewItem =~ /gitlens:(branch|commit|stash|tag)\\b/ && !listMultiSelection && gitlens:views:canCompare",
-					"group": "4_gitlens_compare@98"
-				},
-				{
-					"command": "gitlens.views.selectForCompare:graph",
-					"when": "webviewItem =~ /gitlens:(branch|commit|stash|tag)\\b/ && !listMultiSelection",
-					"group": "4_gitlens_compare@99"
-				},
-				{
-					"submenu": "gitlens/share",
-					"when": "webviewItem =~ /gitlens:(branch|commit|stash|tag|file\\b(?=.*?\\b\\+(committed|staged|unstaged)\\b))\\b/",
-					"group": "7_gitlens_a_share@1"
-				},
-				{
-					"command": "gitlens.star.branch:graph",
-					"when": "webviewItem =~ /gitlens:branch\\b(?!.*?\\b\\+starred\\b)/ && !listMultiSelection",
-					"group": "8_gitlens_actions@1"
-				},
-				{
-					"command": "gitlens.unstar.branch:graph",
-					"when": "webviewItem =~ /gitlens:branch\\b(?=.*?\\b\\+starred\\b)/ && !listMultiSelection",
-					"group": "8_gitlens_actions@1"
-				},
-				{
-					"command": "gitlens.graph.unpinBranchFromEdge",
-					"when": "webviewItem =~ /gitlens:branch\\b(?=.*?\\b\\+pinned\\b)/",
-					"group": "8_gitlens_actions@8"
-				},
-				{
-					"command": "gitlens.graph.soloBranch",
-					"when": "webviewItem =~ /gitlens:branch\\b/",
-					"group": "8_gitlens_actions@9"
-				},
-				{
-					"command": "gitlens.graph.showRemote",
-					"when": "webviewItem =~ /gitlens:branch\\b(?=.*?\\b\\+remote\\b)(?=.*?\\b\\+hiddenbyremote\\b)/",
-					"group": "8_gitlens_actions@10"
-				},
-				{
-					"command": "gitlens.graph.showLocalBranch",
-					"when": "webviewItem =~ /gitlens:branch\\b(?!.*?\\b\\+(current|remote)\\b)(?=.*?\\b\\+hidden\\b)/",
-					"group": "8_gitlens_actions@11"
-				},
-				{
-					"command": "gitlens.graph.showRemoteBranch",
-					"when": "webviewItem =~ /gitlens:branch\\b(?=.*?\\b\\+remote\\b)(?!.*?\\b\\+current\\b)(?=.*?\\b\\+hidden(byremote)?\\b)/",
-					"group": "8_gitlens_actions@11"
-				},
-				{
-					"command": "gitlens.graph.undoCommit",
-					"when": "webviewItem =~ /gitlens:commit\\b(?=.*?\\b\\+HEAD\\b)/ && !listMultiSelection && !gitlens:readonly && !gitlens:untrusted && !gitlens:hasVirtualFolders",
-					"group": "1_gitlens_actions@1"
-				},
-				{
-					"command": "gitlens.graph.undoCommitOnWorktree",
-					"when": "webviewItem =~ /gitlens:commit\\b(?=.*?\\b\\+worktreeHEAD\\b)/ && !listMultiSelection && !gitlens:readonly && !gitlens:untrusted && !gitlens:hasVirtualFolders",
-					"group": "1_gitlens_actions@2"
-				},
-				{
-					"command": "gitlens.views.openChanges:commitDetails",
-					"when": "webviewItem =~ /gitlens:file\\b(?=.*?\\b\\+(committed|stashed)\\b)/ && webview == gitlens.views.commitDetails",
-					"group": "0_gitlens_open@1"
-				},
-				{
-					"command": "gitlens.views.openChanges:graphDetails",
-					"when": "webviewItem =~ /gitlens:file\\b(?!.*?\\b\\+mixed\\b)/ && (webview == gitlens.graph || webview == gitlens.views.graph)",
-					"group": "0_gitlens_open@1"
-				},
-				{
-					"submenu": "gitlens/commit/file/changes",
-					"when": "webviewItem =~ /gitlens:file\\b/",
-					"group": "0_gitlens_open@4"
-				},
-				{
-					"command": "gitlens.views.applyChanges:commitDetails",
-					"when": "webviewItem =~ /gitlens:file\\b(?=.*?\\b\\+stashed\\b)(?!.*?\\+submodule)/ && !gitlens:readonly && !gitlens:untrusted && !gitlens:hasVirtualFolders && webview == gitlens.views.commitDetails",
-					"group": "1_gitlens_actions@1"
-				},
-				{
-					"command": "gitlens.views.applyChanges:graphDetails",
-					"when": "webviewItem =~ /gitlens:file\\b(?=.*?\\b\\+stashed\\b)(?!.*?\\+submodule)/ && !gitlens:readonly && !gitlens:untrusted && !gitlens:hasVirtualFolders && (webview == gitlens.graph || webview == gitlens.views.graph)",
-					"group": "1_gitlens_actions@1"
-				},
-				{
-					"command": "gitlens.views.stageFile:graphDetails",
-					"when": "webviewItem =~ /gitlens:file\\b(?=.*?\\b\\+unstaged\\b)/ && (webview == gitlens.graph || webview == gitlens.views.graph)",
-					"group": "1_gitlens_actions@1"
-				},
-				{
-					"command": "gitlens.views.stageFile.multi:graphDetails",
-					"when": "webviewItemsUnion =~ /gitlens:file\\b(?=.*?\\b\\+unstaged\\b)(?!.*?\\b\\+(committed|stashed)\\b)/ && listMultiSelection && (webview == gitlens.graph || webview == gitlens.views.graph)",
-					"group": "1_gitlens_actions@1"
-				},
-				{
-					"command": "gitlens.views.mergeChangesWithWorking:commitDetails",
-					"when": "webviewItem =~ /gitlens:file\\b(?=.*?\\b\\+stashed\\b)(?!.*?\\+submodule)/ && webview == gitlens.views.commitDetails",
-					"group": "1_gitlens_actions@2"
-				},
-				{
-					"command": "gitlens.views.mergeChangesWithWorking:graphDetails",
-					"when": "webviewItem =~ /gitlens:file\\b(?=.*?\\b\\+stashed\\b)(?!.*?\\+submodule)/ && (webview == gitlens.graph || webview == gitlens.views.graph)",
-					"group": "1_gitlens_actions@2"
-				},
-				{
-					"command": "gitlens.views.unstageFile:graphDetails",
-					"when": "webviewItem =~ /gitlens:file\\b(?=.*?\\b\\+(staged|mixed)\\b)/ && (webview == gitlens.graph || webview == gitlens.views.graph)",
-					"group": "1_gitlens_actions@2"
-				},
-				{
-					"command": "gitlens.restore.file:commitDetails",
-					"when": "webviewItem =~ /gitlens:file\\b(?=.*?\\b\\+stashed\\b)(?!.*?\\+submodule)/ && !gitlens:readonly && !gitlens:untrusted && !gitlens:hasVirtualFolders && webview == gitlens.views.commitDetails",
-					"group": "1_gitlens_actions@3"
-				},
-				{
-					"command": "gitlens.restore.file:graphDetails",
-					"when": "webviewItem =~ /gitlens:file\\b(?=.*?\\b\\+stashed\\b)(?!.*?\\+submodule)/ && !gitlens:readonly && !gitlens:untrusted && !gitlens:hasVirtualFolders && (webview == gitlens.graph || webview == gitlens.views.graph)",
-					"group": "1_gitlens_actions@3"
-				},
-				{
-					"command": "gitlens.stashChanges:commitDetails",
-					"when": "webviewItem =~ /gitlens:file\\b(?=.*?\\b\\+(staged|unstaged)\\b)/ && !gitlens:readonly && !gitlens:untrusted && !gitlens:hasVirtualFolders && webview == gitlens.views.commitDetails",
-					"group": "1_gitlens_actions@4"
-				},
-				{
-					"command": "gitlens.stashChanges:graphDetails",
-					"when": "webviewItem =~ /gitlens:file\\b(?=.*?\\b\\+(staged|unstaged)\\b)/ && !gitlens:readonly && !gitlens:untrusted && !gitlens:hasVirtualFolders && (webview == gitlens.graph || webview == gitlens.views.graph)",
-					"group": "1_gitlens_actions@4"
-				},
-				{
-					"command": "gitlens.revealFileInExplorer:commitDetails",
-					"when": "webviewItem =~ /gitlens:file\\b(?=.*?\\b\\+(staged|unstaged|conflict)\\b)/ && webview == gitlens.views.commitDetails",
-					"group": "2_gitlens_quickopen_file@5"
-				},
-				{
-					"command": "gitlens.revealFileInExplorer:graphDetails",
-					"when": "webviewItem =~ /gitlens:file\\b(?=.*?\\b\\+(staged|unstaged|conflict)\\b)/ && (webview == gitlens.graph || webview == gitlens.views.graph)",
-					"group": "2_gitlens_quickopen_file@5"
-				},
-				{
-					"command": "gitlens.restore.file:commitDetails",
-					"when": "webviewItem =~ /gitlens:file\\b(?=.*?\\b\\+committed\\b)(?!.*?\\+submodule)/ && !gitlens:readonly && !gitlens:untrusted && !gitlens:hasVirtualFolders && webview == gitlens.views.commitDetails",
-					"group": "8_gitlens_actions@3"
-				},
-				{
-					"command": "gitlens.restore.file:graphDetails",
-					"when": "webviewItem =~ /gitlens:file\\b((?=.*?\\b\\+committed\\b)|:comparison)(?!.*?\\+submodule)/ && !gitlens:readonly && !gitlens:untrusted && !gitlens:hasVirtualFolders && (webview == gitlens.graph || webview == gitlens.views.graph)",
-					"group": "8_gitlens_actions@3"
-				},
-				{
-					"command": "gitlens.restorePrevious.file:commitDetails",
-					"when": "webviewItem =~ /gitlens:file\\b(?=.*?\\b\\+committed\\b)(?!.*?\\+submodule)/ && webview == gitlens.views.commitDetails",
-					"group": "8_gitlens_actions@4"
-				},
-				{
-					"command": "gitlens.restorePrevious.file:graphDetails",
-					"when": "webviewItem =~ /gitlens:file\\b((?=.*?\\b\\+committed\\b)|:comparison)(?!.*?\\+submodule)/ && (webview == gitlens.graph || webview == gitlens.views.graph)",
-					"group": "8_gitlens_actions@4"
-				},
-				{
-					"command": "gitlens.switchToPullRequest:graph",
-					"when": "webviewItem =~ /gitlens:pullrequest\\b(?=.*?\\b\\+head\\b)(?!.*?\\b\\+closed\\b)(?!.*?\\b\\+current\\b)/ && !gitlens:readonly && !gitlens:untrusted && !gitlens:hasVirtualFolders",
-					"group": "1_gitlens_action@1"
-				},
-				{
-					"command": "gitlens.rebase.stageCurrentChanges:rebase",
-					"when": "webviewItem =~ /gitlens:rebase:conflict\\+file\\b(?=.*?\\+canStageCurrent\\b)/ && webview == gitlens.rebase",
-					"group": "1_conflict@1"
-				},
-				{
-					"command": "gitlens.rebase.stageIncomingChanges:rebase",
-					"when": "webviewItem =~ /gitlens:rebase:conflict\\+file\\b(?=.*?\\+canStageIncoming\\b)/ && webview == gitlens.rebase",
-					"group": "1_conflict@2"
-				},
-				{
-					"command": "gitlens.pruneRemote:graph",
-					"when": "webviewItem =~ /gitlens:remote\\b/ && !gitlens:readonly && !gitlens:untrusted",
-					"group": "1_gitlens_actions@2"
-				},
-				{
-					"command": "gitlens.removeRemote:graph",
-					"when": "webviewItem =~ /gitlens:remote\\b/ && !gitlens:readonly && !gitlens:untrusted",
-					"group": "7_gitlens_destructive@1"
-				},
-				{
-					"command": "gitlens.setRemoteAsDefault:graph",
-					"when": "webviewItem =~ /gitlens:remote\\b(?!.*?\\b\\+default\\b)/",
-					"group": "8_gitlens_actions@1"
-				},
-				{
-					"command": "gitlens.unsetRemoteAsDefault:graph",
-					"when": "webviewItem =~ /gitlens:remote\\b(?=.*?\\b\\+default\\b)/",
-					"group": "8_gitlens_actions@1"
-				},
-				{
-					"command": "gitlens.stashApply:graph",
-					"when": "webviewItem == gitlens:stash && !listMultiSelection && !gitlens:readonly && !gitlens:untrusted && !gitlens:hasVirtualFolders",
-					"group": "1_gitlens_actions@1"
-				},
-				{
-					"command": "gitlens.stashRename:graph",
-					"when": "webviewItem == gitlens:stash && !listMultiSelection && !gitlens:readonly && !gitlens:untrusted && !gitlens:hasVirtualFolders",
-					"group": "1_gitlens_actions@2"
-				},
-				{
-					"command": "gitlens.stashDelete:graph",
-					"when": "webviewItem == gitlens:stash && !listMultiSelection && !gitlens:readonly && !gitlens:untrusted && !gitlens:hasVirtualFolders",
-					"group": "1_gitlens_actions@3"
-				},
-				{
-					"command": "gitlens.openWorktreeInNewWindow:graph",
-					"when": "webviewItem =~ /^gitlens:wip\\b(?=.*?\\b\\+worktree\\b)/ && !gitlens:hasVirtualFolders",
-					"group": "0_gitlens_worktree@2"
-				},
-				{
-					"command": "gitlens.runTaskOnWorktree:graph",
-					"when": "webviewItem =~ /^gitlens:wip\\b(?=.*?\\b\\+worktree\\b)/ && !listMultiSelection && !gitlens:untrusted && !gitlens:hasVirtualFolders",
-					"group": "0_gitlens_worktree_1@2"
-				},
-				{
-					"command": "gitlens.reviewChanges:graph",
-					"when": "webviewItem =~ /^gitlens:wip\\b/ && !listMultiSelection && !gitlens:untrusted",
-					"group": "1_gitlens@2"
-				},
-				{
-					"command": "gitlens.stashSave:graph",
-					"when": "webviewItem =~ /^gitlens:wip\\b/ && !listMultiSelection && !gitlens:readonly && !gitlens:untrusted && !gitlens:hasVirtualFolders",
-					"group": "1_gitlens_actions@3"
-				},
-				{
-					"command": "gitlens.stashChanges.multi:graphDetails",
-					"when": "webviewItemsUnion =~ /gitlens:file\\b(?=.*?\\b\\+(staged|unstaged)\\b)(?!.*?\\b\\+(committed|stashed)\\b)/ && listMultiSelection && !gitlens:readonly && !gitlens:untrusted && !gitlens:hasVirtualFolders && (webview == gitlens.graph || webview == gitlens.views.graph)",
-					"group": "1_gitlens_actions@4"
-				},
-				{
-					"command": "gitlens.stashApply:graph",
-					"when": "webviewItem =~ /^gitlens:wip\\b/ && !listMultiSelection && !gitlens:readonly && !gitlens:untrusted && !gitlens:hasVirtualFolders",
-					"group": "1_gitlens_actions_1@1"
-				},
-				{
-					"command": "gitlens.openWorktreeInNewWindow:graph",
-					"when": "webviewItem =~ /gitlens:worktree\\b(?!.*?\\b\\+active\\b)/ && !gitlens:hasVirtualFolders",
-					"group": "0_gitlens_worktree@2"
-				},
-				{
-					"command": "gitlens.openWorktreeInNewWindow:graph",
-					"when": "webviewItem =~ /gitlens:worktree\\b(?=.*?\\b\\+active\\b)/ && !gitlens:hasVirtualFolders && workspaceFolderCount != 1",
-					"group": "0_gitlens_worktree@2"
-				},
-				{
-					"command": "gitlens.publishBranch:graph",
-					"when": "webviewItem =~ /gitlens:worktree\\b(?=.*?\\b\\+branch\\b)(?!.*?\\b\\+tracking\\b)/ && !gitlens:readonly && !gitlens:untrusted && !gitlens:hasVirtualFolders && gitlens:repos:withRemotes",
-					"group": "1_gitlens_actions@2"
-				},
-				{
-					"command": "gitlens.views.unstageFile.multi:graphDetails",
-					"when": "webviewItemsUnion =~ /gitlens:file\\b(?=.*?\\b\\+(staged|mixed)\\b)(?!.*?\\b\\+(committed|stashed)\\b)/ && listMultiSelection && (webview == gitlens.graph || webview == gitlens.views.graph)",
-					"group": "1_gitlens_actions@2"
-				},
-				{
 					"command": "gitlens.discardChanges.multi:commitDetails",
 					"when": "listMultiSelection && !gitlens:readonly && !gitlens:untrusted && !gitlens:hasVirtualFolders && webview == gitlens.views.commitDetails && webviewItemsUnion =~ /gitlens:file\\b(?=.*?\\b\\+(staged|unstaged|conflict)\\b)(?!.*?\\b\\+(committed|stashed)\\b)/",
 					"group": "1_gitlens_actions@3"
@@ -28164,16 +27891,6 @@
 					"command": "gitlens.graph.mergeBranchInto",
 					"when": "webviewItem =~ /gitlens:branch\\b(?!.*?\\b\\+current\\b)/ && !gitlens:readonly && !gitlens:untrusted && !gitlens:hasVirtualFolders",
 					"group": "1_gitlens_actions_1@1"
-				},
-				{
-					"command": "gitlens.graph.rebaseOntoBranch",
-					"when": "webviewItem =~ /gitlens:branch\\b(?!.*?\\b\\+current\\b)/ && !gitlens:readonly && !gitlens:untrusted && !gitlens:hasVirtualFolders",
-					"group": "1_gitlens_actions_1@3"
-				},
-				{
-					"command": "gitlens.graph.rebaseOntoUpstream",
-					"when": "webviewItem =~ /gitlens:branch\\b(?=.*?\\b\\+current\\b)(?=.*?\\b\\+tracking\\b)/ && !gitlens:readonly && !gitlens:untrusted && !gitlens:hasVirtualFolders",
-					"group": "1_gitlens_actions_1@3"
 				},
 				{
 					"command": "gitlens.graph.deleteBranch",
@@ -28276,6 +27993,11 @@
 					"group": "8_gitlens_actions@11"
 				},
 				{
+					"command": "gitlens.graph.cherryPick",
+					"when": "webviewItem =~ /gitlens:commit\\b(?!.*?\\b\\+(current|rebase)\\b)/ && !listMultiSelection && !gitlens:readonly && !gitlens:untrusted && !gitlens:hasVirtualFolders",
+					"group": "1_gitlens_actions@3"
+				},
+				{
 					"command": "gitlens.graph.pushToCommit",
 					"when": "webviewItem =~ /gitlens:commit\\b(?=.*?\\b\\+unpublished\\b)/ && !listMultiSelection && !gitlens:readonly && !gitlens:untrusted && !gitlens:hasVirtualFolders && gitlens:repos:withRemotes",
 					"group": "1_gitlens_actions@6"
@@ -28289,11 +28011,6 @@
 					"command": "gitlens.graph.modifyCommits",
 					"when": "webviewItem =~ /gitlens:commit\\b(?=.*?\\b\\+rewriteable\\b)(?!.*?\\b\\+rebase\\b)/ && !listMultiSelection && !gitlens:readonly && !gitlens:untrusted && !gitlens:hasVirtualFolders",
 					"group": "1_gitlens_actions@11"
-				},
-				{
-					"command": "gitlens.graph.rebaseOntoCommit",
-					"when": "webviewItem =~ /gitlens:commit\\b(?!.*?\\b\\+rewriteable\\b)/ && !listMultiSelection && !gitlens:readonly && !gitlens:untrusted && !gitlens:hasVirtualFolders",
-					"group": "1_gitlens_actions@16"
 				},
 				{
 					"command": "gitlens.createBranch:graph",
@@ -28331,6 +28048,16 @@
 					"group": "4_gitlens_compare@2"
 				},
 				{
+					"command": "gitlens.copyPatchToClipboard:graph",
+					"when": "webviewItem =~ /gitlens:(commit|stash)\\b/ && !listMultiSelection && !gitlens:untrusted && !gitlens:hasVirtualFolders",
+					"group": "7_gitlens_cutcopypaste@97"
+				},
+				{
+					"command": "gitlens.graph.addAuthor",
+					"when": "webviewItem =~ /gitlens:contributor\\b(?!.*?\\b\\+current\\b)/ && !gitlens:readonly && !gitlens:untrusted && !gitlens:hasVirtualFolders",
+					"group": "1_gitlens_actions@2"
+				},
+				{
 					"command": "gitlens.discardChanges:commitDetails",
 					"when": "webviewItem =~ /gitlens:file\\b(?=.*?\\b\\+(staged|unstaged|conflict)\\b)/ && !gitlens:readonly && !gitlens:untrusted && !gitlens:hasVirtualFolders && webview == gitlens.views.commitDetails",
 					"group": "1_gitlens_actions@3"
@@ -28339,6 +28066,11 @@
 					"command": "gitlens.discardChanges:graphDetails",
 					"when": "webviewItem =~ /gitlens:file\\b(?=.*?\\b\\+(staged|unstaged|conflict)\\b)/ && !gitlens:readonly && !gitlens:untrusted && !gitlens:hasVirtualFolders && (webview == gitlens.graph || webview == gitlens.views.graph)",
 					"group": "1_gitlens_actions@3"
+				},
+				{
+					"command": "gitlens.graph.columnAuthorOff",
+					"when": "webviewItem =~ /gitlens:graph:(columns|settings)\\b/ && webviewItemValue =~ /\\bcolumn:author:visible\\b/",
+					"group": "2_columns@1"
 				},
 				{
 					"command": "gitlens.graph.columnAuthorOn",
@@ -28451,6 +28183,26 @@
 					"group": "1_gitlens_actions@3"
 				},
 				{
+					"command": "gitlens.addToGitignore:commitDetails",
+					"when": "webviewItem =~ /gitlens:file\\b(?=.*?\\b\\+untracked\\b)/ && !gitlens:readonly && !gitlens:untrusted && !gitlens:hasVirtualFolders && webview == gitlens.views.commitDetails",
+					"group": "1_gitlens_actions@5"
+				},
+				{
+					"command": "gitlens.addToGitignore:graphDetails",
+					"when": "webviewItem =~ /gitlens:file\\b(?=.*?\\b\\+untracked\\b)/ && !gitlens:readonly && !gitlens:untrusted && !gitlens:hasVirtualFolders && (webview == gitlens.graph || webview == gitlens.views.graph)",
+					"group": "1_gitlens_actions@5"
+				},
+				{
+					"command": "gitlens.addToGitignore.multi:commitDetails",
+					"when": "listMultiSelection && !gitlens:readonly && !gitlens:untrusted && !gitlens:hasVirtualFolders && webview == gitlens.views.commitDetails && webviewItemsUnion =~ /gitlens:file\\b(?=.*?\\b\\+untracked\\b)(?!.*?\\b\\+(committed|stashed)\\b)/",
+					"group": "1_gitlens_actions@5"
+				},
+				{
+					"command": "gitlens.addToGitignore.multi:graphDetails",
+					"when": "webviewItemsUnion =~ /gitlens:file\\b(?=.*?\\b\\+untracked\\b)(?!.*?\\b\\+(committed|stashed)\\b)/ && listMultiSelection && !gitlens:readonly && !gitlens:untrusted && !gitlens:hasVirtualFolders && (webview == gitlens.graph || webview == gitlens.views.graph)",
+					"group": "1_gitlens_actions@5"
+				},
+				{
 					"command": "gitlens.agents.allowPermission",
 					"when": "webviewItem =~ /gitlens:agent-session\\b(?=.*?\\b\\+resolvable\\b)(?!.*?\\b\\+peer\\b)(?!.*?\\b\\+plan\\b)/ && !listMultiSelection && gitlens:agents:enabled && (webview == gitlens.graph || webview == gitlens.views.graph)",
 					"group": "1_resolve@1"
@@ -28516,6 +28268,31 @@
 					"group": "9_manage@1"
 				},
 				{
+					"command": "gitlens.openWorktree:graph",
+					"when": "webviewItem =~ /gitlens:branch\\b(?=.*?\\b\\+worktree\\b)/ && !gitlens:hasVirtualFolders",
+					"group": "1_gitlens_action@1"
+				},
+				{
+					"command": "gitlens.switchToBranch:graph",
+					"when": "webviewItem =~ /gitlens:branch\\b(?!.*?\\b\\+(current|checkedout|worktree)\\b)/ && !gitlens:readonly && !gitlens:untrusted && !gitlens:hasVirtualFolders",
+					"group": "1_gitlens_action@1"
+				},
+				{
+					"command": "gitlens.openWorktreeInNewWindow:graph",
+					"when": "webviewItem =~ /gitlens:branch\\b(?=.*?\\b\\+worktree\\b)/ && !gitlens:hasVirtualFolders",
+					"group": "1_gitlens_action@2"
+				},
+				{
+					"command": "gitlens.switchToAnotherBranch:graph",
+					"when": "webviewItem =~ /gitlens:branch\\b(?=.*?\\b\\+(current|checkedout)\\b)/ && !gitlens:readonly && !gitlens:untrusted && !gitlens:hasVirtualFolders",
+					"group": "1_gitlens_action@3"
+				},
+				{
+					"command": "gitlens.publishBranch:graph",
+					"when": "webviewItem =~ /gitlens:branch\\b(?!.*?\\b\\+remote\\b)(?!.*?\\b\\+tracking\\b)(?!.*?\\b\\+closed\\b)/ && !gitlens:readonly && !gitlens:untrusted && !gitlens:hasVirtualFolders && gitlens:repos:withRemotes",
+					"group": "1_gitlens_actions@2"
+				},
+				{
 					"command": "gitlens.fetch:graph",
 					"when": "webviewItem =~ /gitlens:branch\\b(?=.*?\\b\\+(remote|tracking)\\b)(?!.*?\\b\\+closed\\b)/ && !gitlens:readonly && !gitlens:untrusted && !gitlens:hasVirtualFolders && gitlens:repos:withRemotes",
 					"group": "1_gitlens_actions@3"
@@ -28526,14 +28303,44 @@
 					"group": "1_gitlens_actions@10"
 				},
 				{
+					"command": "gitlens.setUpstream:graph",
+					"when": "webviewItem =~ /gitlens:branch\\b(?!.*?\\b\\+remote\\b)(?!.*?\\b\\+closed\\b)(?!.*?\\b\\+tracking\\b)/ && !listMultiSelection && !gitlens:readonly && !gitlens:untrusted && !gitlens:hasVirtualFolders",
+					"group": "1_gitlens_actions@10"
+				},
+				{
 					"command": "gitlens.ai.recomposeBranch:graph",
 					"when": "webviewItem =~ /gitlens:branch\\b(?!.*?\\b\\+remote\\b)/ && !listMultiSelection && !gitlens:readonly && !gitlens:untrusted && gitlens:ai:allowed",
 					"group": "1_gitlens_actions_1@2"
 				},
 				{
+					"command": "gitlens.graph.rebaseOntoBranch",
+					"when": "webviewItem =~ /gitlens:branch\\b(?!.*?\\b\\+current\\b)/ && !gitlens:readonly && !gitlens:untrusted && !gitlens:hasVirtualFolders",
+					"group": "1_gitlens_actions_1@3"
+				},
+				{
+					"command": "gitlens.graph.rebaseOntoUpstream",
+					"when": "webviewItem =~ /gitlens:branch\\b(?=.*?\\b\\+current\\b)(?=.*?\\b\\+tracking\\b)/ && !gitlens:readonly && !gitlens:untrusted && !gitlens:hasVirtualFolders",
+					"group": "1_gitlens_actions_1@3"
+				},
+				{
+					"command": "gitlens.graph.resetToTip",
+					"when": "webviewItem =~ /gitlens:branch\\b/ && !gitlens:readonly && !gitlens:untrusted && !gitlens:hasVirtualFolders",
+					"group": "1_gitlens_actions_1@4"
+				},
+				{
+					"command": "gitlens.graph.squashFixups",
+					"when": "webviewItem =~ /gitlens:branch\\b(?=.*?\\b\\+current\\b)/ && !gitlens:readonly && !gitlens:untrusted && !gitlens:hasVirtualFolders",
+					"group": "1_gitlens_actions_1@5"
+				},
+				{
 					"command": "gitlens.associateIssueWithBranch:graph",
 					"when": "webviewItem =~ /gitlens:branch\\b(?!.*?\\b\\+remote\\b)/ && !gitlens:readonly && !gitlens:untrusted && !gitlens:hasVirtualFolders",
 					"group": "1_gitlens_actions_2@1"
+				},
+				{
+					"command": "gitlens.graph.renameBranch",
+					"when": "webviewItem =~ /gitlens:branch\\b/ && !gitlens:readonly && !gitlens:untrusted && !gitlens:hasVirtualFolders",
+					"group": "1_gitlens_actions_2@2"
 				},
 				{
 					"command": "gitlens.ai.generateChangelogFrom:graph",
@@ -28551,19 +28358,69 @@
 					"group": "1_gitlens_ai@20"
 				},
 				{
+					"command": "gitlens.views.compareWithSelected:graph",
+					"when": "webviewItem =~ /gitlens:(branch|commit|stash|tag)\\b/ && !listMultiSelection && gitlens:views:canCompare",
+					"group": "4_gitlens_compare@98"
+				},
+				{
+					"command": "gitlens.views.selectForCompare:graph",
+					"when": "webviewItem =~ /gitlens:(branch|commit|stash|tag)\\b/ && !listMultiSelection",
+					"group": "4_gitlens_compare@99"
+				},
+				{
+					"submenu": "gitlens/share",
+					"when": "webviewItem =~ /gitlens:(branch|commit|stash|tag|file\\b(?=.*?\\b\\+(committed|staged|unstaged)\\b))\\b/",
+					"group": "7_gitlens_a_share@1"
+				},
+				{
+					"command": "gitlens.star.branch:graph",
+					"when": "webviewItem =~ /gitlens:branch\\b(?!.*?\\b\\+starred\\b)/ && !listMultiSelection",
+					"group": "8_gitlens_actions@1"
+				},
+				{
+					"command": "gitlens.unstar.branch:graph",
+					"when": "webviewItem =~ /gitlens:branch\\b(?=.*?\\b\\+starred\\b)/ && !listMultiSelection",
+					"group": "8_gitlens_actions@1"
+				},
+				{
 					"command": "gitlens.focusBranch:graph",
 					"when": "webviewItem =~ /gitlens:branch\\b/",
 					"group": "8_gitlens_actions@7"
 				},
 				{
-					"command": "gitlens.graph.cherryPick",
-					"when": "webviewItem =~ /gitlens:commit\\b(?!.*?\\b\\+(current|rebase)\\b)/ && !listMultiSelection && !gitlens:readonly && !gitlens:untrusted && !gitlens:hasVirtualFolders",
-					"group": "1_gitlens_actions@3"
+					"command": "gitlens.graph.unpinBranchFromEdge",
+					"when": "webviewItem =~ /gitlens:branch\\b(?=.*?\\b\\+pinned\\b)/",
+					"group": "8_gitlens_actions@8"
 				},
 				{
-					"command": "gitlens.stashChanges.multi:commitDetails",
-					"when": "listMultiSelection && !gitlens:readonly && !gitlens:untrusted && !gitlens:hasVirtualFolders && webview == gitlens.views.commitDetails && webviewItemsUnion =~ /gitlens:file\\b(?=.*?\\b\\+(staged|unstaged)\\b)(?!.*?\\b\\+(committed|stashed)\\b)/",
-					"group": "1_gitlens_actions@4"
+					"command": "gitlens.graph.soloBranch",
+					"when": "webviewItem =~ /gitlens:branch\\b/",
+					"group": "8_gitlens_actions@9"
+				},
+				{
+					"command": "gitlens.graph.showRemote",
+					"when": "webviewItem =~ /gitlens:branch\\b(?=.*?\\b\\+remote\\b)(?=.*?\\b\\+hiddenbyremote\\b)/",
+					"group": "8_gitlens_actions@10"
+				},
+				{
+					"command": "gitlens.graph.showLocalBranch",
+					"when": "webviewItem =~ /gitlens:branch\\b(?!.*?\\b\\+(current|remote)\\b)(?=.*?\\b\\+hidden\\b)/",
+					"group": "8_gitlens_actions@11"
+				},
+				{
+					"command": "gitlens.graph.showRemoteBranch",
+					"when": "webviewItem =~ /gitlens:branch\\b(?=.*?\\b\\+remote\\b)(?!.*?\\b\\+current\\b)(?=.*?\\b\\+hidden(byremote)?\\b)/",
+					"group": "8_gitlens_actions@11"
+				},
+				{
+					"command": "gitlens.graph.undoCommit",
+					"when": "webviewItem =~ /gitlens:commit\\b(?=.*?\\b\\+HEAD\\b)/ && !listMultiSelection && !gitlens:readonly && !gitlens:untrusted && !gitlens:hasVirtualFolders",
+					"group": "1_gitlens_actions@1"
+				},
+				{
+					"command": "gitlens.graph.undoCommitOnWorktree",
+					"when": "webviewItem =~ /gitlens:commit\\b(?=.*?\\b\\+worktreeHEAD\\b)/ && !listMultiSelection && !gitlens:readonly && !gitlens:untrusted && !gitlens:hasVirtualFolders",
+					"group": "1_gitlens_actions@2"
 				},
 				{
 					"command": "gitlens.graph.revert",
@@ -28591,6 +28448,11 @@
 					"group": "1_gitlens_actions@15"
 				},
 				{
+					"command": "gitlens.graph.rebaseOntoCommit",
+					"when": "webviewItem =~ /gitlens:commit\\b(?!.*?\\b\\+rewriteable\\b)/ && !listMultiSelection && !gitlens:readonly && !gitlens:untrusted && !gitlens:hasVirtualFolders",
+					"group": "1_gitlens_actions@16"
+				},
+				{
 					"command": "gitlens.graph.switchToCommit",
 					"when": "webviewItem =~ /gitlens:commit\\b/ && !listMultiSelection && !gitlens:readonly && !gitlens:untrusted && !gitlens:hasVirtualFolders",
 					"group": "1_gitlens_actions@17"
@@ -28606,16 +28468,6 @@
 					"group": "2_gitlens_quickopen@1"
 				},
 				{
-					"command": "gitlens.copyPatchToClipboard:graph",
-					"when": "webviewItem =~ /gitlens:(commit|stash)\\b/ && !listMultiSelection && !gitlens:untrusted && !gitlens:hasVirtualFolders",
-					"group": "7_gitlens_cutcopypaste@97"
-				},
-				{
-					"command": "gitlens.graph.addAuthor",
-					"when": "webviewItem =~ /gitlens:contributor\\b(?!.*?\\b\\+current\\b)/ && !gitlens:readonly && !gitlens:untrusted && !gitlens:hasVirtualFolders",
-					"group": "1_gitlens_actions@2"
-				},
-				{
 					"command": "gitlens.openBothChanges:commitDetails",
 					"when": "webviewItem =~ /gitlens:file\\b(?=.*?\\b\\+(staged|unstaged|mixed)\\b)/ && webview == gitlens.views.commitDetails",
 					"group": "0_gitlens_open@1"
@@ -28628,6 +28480,16 @@
 				{
 					"command": "gitlens.openUnstagedChanges:graphDetails",
 					"when": "webviewItem =~ /gitlens:file\\b(?=.*?\\b\\+mixed\\b)/ && (webview == gitlens.graph || webview == gitlens.views.graph)",
+					"group": "0_gitlens_open@1"
+				},
+				{
+					"command": "gitlens.views.openChanges:commitDetails",
+					"when": "webviewItem =~ /gitlens:file\\b(?=.*?\\b\\+(committed|stashed)\\b)/ && webview == gitlens.views.commitDetails",
+					"group": "0_gitlens_open@1"
+				},
+				{
+					"command": "gitlens.views.openChanges:graphDetails",
+					"when": "webviewItem =~ /gitlens:file\\b(?!.*?\\b\\+mixed\\b)/ && (webview == gitlens.graph || webview == gitlens.views.graph)",
 					"group": "0_gitlens_open@1"
 				},
 				{
@@ -28646,6 +28508,11 @@
 					"group": "0_gitlens_open@3"
 				},
 				{
+					"submenu": "gitlens/commit/file/changes",
+					"when": "webviewItem =~ /gitlens:file\\b/",
+					"group": "0_gitlens_open@4"
+				},
+				{
 					"command": "gitlens.ai.resolveConflicts:graph",
 					"when": "webviewItem =~ /gitlens:file\\b(?=.*?\\+conflict\\b)/ && !listMultiSelection && !gitlens:readonly && !gitlens:untrusted && gitlens:ai:allowed && (webview == gitlens.graph || webview == gitlens.views.graph)",
 					"group": "1_conflict@0"
@@ -28659,6 +28526,66 @@
 					"command": "gitlens.graph.stageConflictIncomingChanges:graph",
 					"when": "webviewItem =~ /gitlens:file\\b(?=.*?\\+conflict\\b)(?=.*?\\+canStageIncoming\\b)/ && (webview == gitlens.graph || webview == gitlens.views.graph)",
 					"group": "1_conflict@2"
+				},
+				{
+					"command": "gitlens.views.applyChanges:commitDetails",
+					"when": "webviewItem =~ /gitlens:file\\b(?=.*?\\b\\+stashed\\b)(?!.*?\\+submodule)/ && !gitlens:readonly && !gitlens:untrusted && !gitlens:hasVirtualFolders && webview == gitlens.views.commitDetails",
+					"group": "1_gitlens_actions@1"
+				},
+				{
+					"command": "gitlens.views.applyChanges:graphDetails",
+					"when": "webviewItem =~ /gitlens:file\\b(?=.*?\\b\\+stashed\\b)(?!.*?\\+submodule)/ && !gitlens:readonly && !gitlens:untrusted && !gitlens:hasVirtualFolders && (webview == gitlens.graph || webview == gitlens.views.graph)",
+					"group": "1_gitlens_actions@1"
+				},
+				{
+					"command": "gitlens.views.stageFile:graphDetails",
+					"when": "webviewItem =~ /gitlens:file\\b(?=.*?\\b\\+unstaged\\b)/ && (webview == gitlens.graph || webview == gitlens.views.graph)",
+					"group": "1_gitlens_actions@1"
+				},
+				{
+					"command": "gitlens.views.stageFile.multi:graphDetails",
+					"when": "webviewItemsUnion =~ /gitlens:file\\b(?=.*?\\b\\+unstaged\\b)(?!.*?\\b\\+(committed|stashed)\\b)/ && listMultiSelection && (webview == gitlens.graph || webview == gitlens.views.graph)",
+					"group": "1_gitlens_actions@1"
+				},
+				{
+					"command": "gitlens.views.mergeChangesWithWorking:commitDetails",
+					"when": "webviewItem =~ /gitlens:file\\b(?=.*?\\b\\+stashed\\b)(?!.*?\\+submodule)/ && webview == gitlens.views.commitDetails",
+					"group": "1_gitlens_actions@2"
+				},
+				{
+					"command": "gitlens.views.mergeChangesWithWorking:graphDetails",
+					"when": "webviewItem =~ /gitlens:file\\b(?=.*?\\b\\+stashed\\b)(?!.*?\\+submodule)/ && (webview == gitlens.graph || webview == gitlens.views.graph)",
+					"group": "1_gitlens_actions@2"
+				},
+				{
+					"command": "gitlens.views.unstageFile:graphDetails",
+					"when": "webviewItem =~ /gitlens:file\\b(?=.*?\\b\\+(staged|mixed)\\b)/ && (webview == gitlens.graph || webview == gitlens.views.graph)",
+					"group": "1_gitlens_actions@2"
+				},
+				{
+					"command": "gitlens.views.unstageFile.multi:graphDetails",
+					"when": "webviewItemsUnion =~ /gitlens:file\\b(?=.*?\\b\\+(staged|mixed)\\b)(?!.*?\\b\\+(committed|stashed)\\b)/ && listMultiSelection && (webview == gitlens.graph || webview == gitlens.views.graph)",
+					"group": "1_gitlens_actions@2"
+				},
+				{
+					"command": "gitlens.restore.file:commitDetails",
+					"when": "webviewItem =~ /gitlens:file\\b(?=.*?\\b\\+stashed\\b)(?!.*?\\+submodule)/ && !gitlens:readonly && !gitlens:untrusted && !gitlens:hasVirtualFolders && webview == gitlens.views.commitDetails",
+					"group": "1_gitlens_actions@3"
+				},
+				{
+					"command": "gitlens.restore.file:graphDetails",
+					"when": "webviewItem =~ /gitlens:file\\b(?=.*?\\b\\+stashed\\b)(?!.*?\\+submodule)/ && !gitlens:readonly && !gitlens:untrusted && !gitlens:hasVirtualFolders && (webview == gitlens.graph || webview == gitlens.views.graph)",
+					"group": "1_gitlens_actions@3"
+				},
+				{
+					"command": "gitlens.stashChanges:commitDetails",
+					"when": "webviewItem =~ /gitlens:file\\b(?=.*?\\b\\+(staged|unstaged)\\b)/ && !gitlens:readonly && !gitlens:untrusted && !gitlens:hasVirtualFolders && webview == gitlens.views.commitDetails",
+					"group": "1_gitlens_actions@4"
+				},
+				{
+					"command": "gitlens.stashChanges:graphDetails",
+					"when": "webviewItem =~ /gitlens:file\\b(?=.*?\\b\\+(staged|unstaged)\\b)/ && !gitlens:readonly && !gitlens:untrusted && !gitlens:hasVirtualFolders && (webview == gitlens.graph || webview == gitlens.views.graph)",
+					"group": "1_gitlens_actions@4"
 				},
 				{
 					"command": "gitlens.views.openFile:commitDetails",
@@ -28679,6 +28606,16 @@
 					"command": "gitlens.openWorktreeFile:graphDetails",
 					"when": "webviewItem =~ /gitlens:file\\b(?=.*?\\b\\+committed\\b)(?=.*?\\b\\+worktree\\b)/ && (webview == gitlens.graph || webview == gitlens.views.graph)",
 					"group": "2_gitlens_quickopen_file@4"
+				},
+				{
+					"command": "gitlens.revealFileInExplorer:commitDetails",
+					"when": "webviewItem =~ /gitlens:file\\b(?=.*?\\b\\+(staged|unstaged|conflict)\\b)/ && webview == gitlens.views.commitDetails",
+					"group": "2_gitlens_quickopen_file@5"
+				},
+				{
+					"command": "gitlens.revealFileInExplorer:graphDetails",
+					"when": "webviewItem =~ /gitlens:file\\b(?=.*?\\b\\+(staged|unstaged|conflict)\\b)/ && (webview == gitlens.graph || webview == gitlens.views.graph)",
+					"group": "2_gitlens_quickopen_file@5"
 				},
 				{
 					"command": "gitlens.views.openFileRevision:commitDetails",
@@ -28781,6 +28718,26 @@
 					"group": "8_gitlens_actions@2"
 				},
 				{
+					"command": "gitlens.restore.file:commitDetails",
+					"when": "webviewItem =~ /gitlens:file\\b(?=.*?\\b\\+committed\\b)(?!.*?\\+submodule)/ && !gitlens:readonly && !gitlens:untrusted && !gitlens:hasVirtualFolders && webview == gitlens.views.commitDetails",
+					"group": "8_gitlens_actions@3"
+				},
+				{
+					"command": "gitlens.restore.file:graphDetails",
+					"when": "webviewItem =~ /gitlens:file\\b((?=.*?\\b\\+committed\\b)|:comparison)(?!.*?\\+submodule)/ && !gitlens:readonly && !gitlens:untrusted && !gitlens:hasVirtualFolders && (webview == gitlens.graph || webview == gitlens.views.graph)",
+					"group": "8_gitlens_actions@3"
+				},
+				{
+					"command": "gitlens.restorePrevious.file:commitDetails",
+					"when": "webviewItem =~ /gitlens:file\\b(?=.*?\\b\\+committed\\b)(?!.*?\\+submodule)/ && webview == gitlens.views.commitDetails",
+					"group": "8_gitlens_actions@4"
+				},
+				{
+					"command": "gitlens.restorePrevious.file:graphDetails",
+					"when": "webviewItem =~ /gitlens:file\\b((?=.*?\\b\\+committed\\b)|:comparison)(?!.*?\\+submodule)/ && (webview == gitlens.graph || webview == gitlens.views.graph)",
+					"group": "8_gitlens_actions@4"
+				},
+				{
 					"submenu": "gitlens/webview/folder/history",
 					"when": "webviewItem =~ /gitlens:folder\\b/ && (webview == gitlens.views.commitDetails || webview == gitlens.graph || webview == gitlens.views.graph)",
 					"group": "4_timeline@1"
@@ -28799,11 +28756,6 @@
 					"command": "gitlens.graph.setStyleTable",
 					"when": "webviewItem =~ /gitlens:graph:(columns|settings)\\b/",
 					"group": "1_view@3"
-				},
-				{
-					"command": "gitlens.graph.columnAuthorOff",
-					"when": "webviewItem =~ /gitlens:graph:(columns|settings)\\b/ && webviewItemValue =~ /\\bcolumn:author:visible\\b/",
-					"group": "2_columns@1"
 				},
 				{
 					"command": "gitlens.graph.setLaneDensityToCompact",
@@ -28891,6 +28843,11 @@
 					"group": "1_markers@6"
 				},
 				{
+					"command": "gitlens.switchToPullRequest:graph",
+					"when": "webviewItem =~ /gitlens:pullrequest\\b(?=.*?\\b\\+head\\b)(?!.*?\\b\\+closed\\b)(?!.*?\\b\\+current\\b)/ && !gitlens:readonly && !gitlens:untrusted && !gitlens:hasVirtualFolders",
+					"group": "1_gitlens_action@1"
+				},
+				{
 					"command": "gitlens.openPullRequestChanges:graph",
 					"when": "webviewItem =~ /gitlens:pullrequest\\b(?=.*?\\b\\+shas\\b)/",
 					"group": "1_gitlens_actions@1"
@@ -28921,6 +28878,21 @@
 					"group": "8_gitlens_actions@7"
 				},
 				{
+					"command": "gitlens.rebase.stageCurrentChanges:rebase",
+					"when": "webviewItem =~ /gitlens:rebase:conflict\\+file\\b(?=.*?\\+canStageCurrent\\b)/ && webview == gitlens.rebase",
+					"group": "1_conflict@1"
+				},
+				{
+					"command": "gitlens.rebase.stageIncomingChanges:rebase",
+					"when": "webviewItem =~ /gitlens:rebase:conflict\\+file\\b(?=.*?\\+canStageIncoming\\b)/ && webview == gitlens.rebase",
+					"group": "1_conflict@2"
+				},
+				{
+					"command": "gitlens.pruneRemote:graph",
+					"when": "webviewItem =~ /gitlens:remote\\b/ && !gitlens:readonly && !gitlens:untrusted",
+					"group": "1_gitlens_actions@2"
+				},
+				{
 					"command": "gitlens.openRepoOnRemote:graph",
 					"when": "webviewItem =~ /gitlens:remote\\b/",
 					"group": "5_gitlens_open@1",
@@ -28943,6 +28915,31 @@
 					"group": "6_gitlens_copy@2"
 				},
 				{
+					"command": "gitlens.copyPath.multi:graphDetails",
+					"when": "webviewItems =~ /gitlens:(file|folder)\\b/ && listMultiSelection && (webview == gitlens.graph || webview == gitlens.views.graph)",
+					"group": "7_gitlens_cutcopypaste@1"
+				},
+				{
+					"command": "gitlens.copyPatchToClipboard.multi:graphDetails",
+					"when": "webviewItemsUnion =~ /gitlens:file\\b(?=.*?\\b\\+(staged|unstaged)\\b)(?!.*?\\b\\+(committed|stashed)\\b)/ && listMultiSelection && !gitlens:untrusted && !gitlens:hasVirtualFolders && (webview == gitlens.graph || webview == gitlens.views.graph)",
+					"group": "7_gitlens_cutcopypaste@3"
+				},
+				{
+					"command": "gitlens.removeRemote:graph",
+					"when": "webviewItem =~ /gitlens:remote\\b/ && !gitlens:readonly && !gitlens:untrusted",
+					"group": "7_gitlens_destructive@1"
+				},
+				{
+					"command": "gitlens.setRemoteAsDefault:graph",
+					"when": "webviewItem =~ /gitlens:remote\\b(?!.*?\\b\\+default\\b)/",
+					"group": "8_gitlens_actions@1"
+				},
+				{
+					"command": "gitlens.unsetRemoteAsDefault:graph",
+					"when": "webviewItem =~ /gitlens:remote\\b(?=.*?\\b\\+default\\b)/",
+					"group": "8_gitlens_actions@1"
+				},
+				{
 					"command": "gitlens.graph.hideRemote",
 					"when": "webviewItem =~ /gitlens:remote\\b(?!.*?\\b\\+hidden\\b)/",
 					"group": "8_gitlens_actions@2"
@@ -28961,6 +28958,21 @@
 					"command": "gitlens.disconnectRemoteProvider:graph",
 					"when": "webviewItem =~ /gitlens:remote\\b(?=.*?\\b\\+connected\\b)/ && config.gitlens.integrations.enabled",
 					"group": "9_gitlens_integrations@2"
+				},
+				{
+					"command": "gitlens.stashApply:graph",
+					"when": "webviewItem == gitlens:stash && !listMultiSelection && !gitlens:readonly && !gitlens:untrusted && !gitlens:hasVirtualFolders",
+					"group": "1_gitlens_actions@1"
+				},
+				{
+					"command": "gitlens.stashRename:graph",
+					"when": "webviewItem == gitlens:stash && !listMultiSelection && !gitlens:readonly && !gitlens:untrusted && !gitlens:hasVirtualFolders",
+					"group": "1_gitlens_actions@2"
+				},
+				{
+					"command": "gitlens.stashDelete:graph",
+					"when": "webviewItem == gitlens:stash && !listMultiSelection && !gitlens:readonly && !gitlens:untrusted && !gitlens:hasVirtualFolders",
+					"group": "1_gitlens_actions@3"
 				},
 				{
 					"command": "gitlens.ai.explainStash:graph",
@@ -29028,9 +29040,19 @@
 					"group": "0_gitlens_worktree@1"
 				},
 				{
+					"command": "gitlens.openWorktreeInNewWindow:graph",
+					"when": "webviewItem =~ /^gitlens:wip\\b(?=.*?\\b\\+worktree\\b)/ && !gitlens:hasVirtualFolders",
+					"group": "0_gitlens_worktree@2"
+				},
+				{
 					"command": "gitlens.openInIntegratedTerminal:graph",
 					"when": "webviewItem =~ /^gitlens:wip\\b/ && !listMultiSelection && !gitlens:hasVirtualFolders",
 					"group": "0_gitlens_worktree_1@1"
+				},
+				{
+					"command": "gitlens.runTaskOnWorktree:graph",
+					"when": "webviewItem =~ /^gitlens:wip\\b(?=.*?\\b\\+worktree\\b)/ && !listMultiSelection && !gitlens:untrusted && !gitlens:hasVirtualFolders",
+					"group": "0_gitlens_worktree_1@2"
 				},
 				{
 					"command": "gitlens.graph.startAgentSession",
@@ -29058,9 +29080,29 @@
 					"group": "1_gitlens@1"
 				},
 				{
+					"command": "gitlens.reviewChanges:graph",
+					"when": "webviewItem =~ /^gitlens:wip\\b/ && !listMultiSelection && !gitlens:untrusted",
+					"group": "1_gitlens@2"
+				},
+				{
+					"command": "gitlens.stashSave:graph",
+					"when": "webviewItem =~ /^gitlens:wip\\b/ && !listMultiSelection && !gitlens:readonly && !gitlens:untrusted && !gitlens:hasVirtualFolders",
+					"group": "1_gitlens_actions@3"
+				},
+				{
 					"command": "gitlens.copyWorkingChangesToWorktree:graph",
 					"when": "webviewItem =~ /^gitlens:wip\\b/ && !listMultiSelection && !gitlens:readonly && !gitlens:untrusted && !gitlens:hasVirtualFolders",
 					"group": "1_gitlens_actions@4"
+				},
+				{
+					"command": "gitlens.stashChanges.multi:graphDetails",
+					"when": "webviewItemsUnion =~ /gitlens:file\\b(?=.*?\\b\\+(staged|unstaged)\\b)(?!.*?\\b\\+(committed|stashed)\\b)/ && listMultiSelection && !gitlens:readonly && !gitlens:untrusted && !gitlens:hasVirtualFolders && (webview == gitlens.graph || webview == gitlens.views.graph)",
+					"group": "1_gitlens_actions@4"
+				},
+				{
+					"command": "gitlens.stashApply:graph",
+					"when": "webviewItem =~ /^gitlens:wip\\b/ && !listMultiSelection && !gitlens:readonly && !gitlens:untrusted && !gitlens:hasVirtualFolders",
+					"group": "1_gitlens_actions_1@1"
 				},
 				{
 					"command": "gitlens.applyPatchFromClipboard:graph",
@@ -29113,6 +29155,16 @@
 					"group": "0_gitlens_worktree@1"
 				},
 				{
+					"command": "gitlens.openWorktreeInNewWindow:graph",
+					"when": "webviewItem =~ /gitlens:worktree\\b(?!.*?\\b\\+active\\b)/ && !gitlens:hasVirtualFolders",
+					"group": "0_gitlens_worktree@2"
+				},
+				{
+					"command": "gitlens.openWorktreeInNewWindow:graph",
+					"when": "webviewItem =~ /gitlens:worktree\\b(?=.*?\\b\\+active\\b)/ && !gitlens:hasVirtualFolders && workspaceFolderCount != 1",
+					"group": "0_gitlens_worktree@2"
+				},
+				{
 					"command": "gitlens.graph.revealWorktreeInExplorer",
 					"when": "webviewItem =~ /gitlens:worktree\\b/ && !listMultiSelection",
 					"group": "0_gitlens_worktree_2@1"
@@ -29138,9 +29190,19 @@
 					"group": "1_gitlens_actions@2"
 				},
 				{
+					"command": "gitlens.publishBranch:graph",
+					"when": "webviewItem =~ /gitlens:worktree\\b(?=.*?\\b\\+branch\\b)(?!.*?\\b\\+tracking\\b)/ && !gitlens:readonly && !gitlens:untrusted && !gitlens:hasVirtualFolders && gitlens:repos:withRemotes",
+					"group": "1_gitlens_actions@2"
+				},
+				{
 					"command": "gitlens.fetch:graph",
 					"when": "webviewItem =~ /gitlens:worktree\\b(?=.*?\\b\\+tracking\\b)/ && !gitlens:readonly && !gitlens:untrusted && !gitlens:hasVirtualFolders && gitlens:repos:withRemotes",
 					"group": "1_gitlens_actions@3"
+				},
+				{
+					"command": "gitlens.stashChanges.multi:commitDetails",
+					"when": "listMultiSelection && !gitlens:readonly && !gitlens:untrusted && !gitlens:hasVirtualFolders && webview == gitlens.views.commitDetails && webviewItemsUnion =~ /gitlens:file\\b(?=.*?\\b\\+(staged|unstaged)\\b)(?!.*?\\b\\+(committed|stashed)\\b)/",
+					"group": "1_gitlens_actions@4"
 				},
 				{
 					"command": "gitlens.changeUpstream:graph",
@@ -29373,11 +29435,6 @@
 					"group": "7_gitlens_cutcopypaste@1"
 				},
 				{
-					"command": "gitlens.copyPath.multi:graphDetails",
-					"when": "webviewItems =~ /gitlens:(file|folder)\\b/ && listMultiSelection && (webview == gitlens.graph || webview == gitlens.views.graph)",
-					"group": "7_gitlens_cutcopypaste@1"
-				},
-				{
 					"command": "gitlens.copyRelativePathToClipboard.multi:commitDetails",
 					"when": "webviewItems =~ /gitlens:(file|folder)\\b/ && listMultiSelection && webview == gitlens.views.commitDetails",
 					"group": "7_gitlens_cutcopypaste@2"
@@ -29390,11 +29447,6 @@
 				{
 					"command": "gitlens.copyPatchToClipboard.multi:commitDetails",
 					"when": "listMultiSelection && !gitlens:untrusted && !gitlens:hasVirtualFolders && webview == gitlens.views.commitDetails && webviewItemsUnion =~ /gitlens:file\\b(?=.*?\\b\\+(staged|unstaged)\\b)(?!.*?\\b\\+(committed|stashed)\\b)/",
-					"group": "7_gitlens_cutcopypaste@3"
-				},
-				{
-					"command": "gitlens.copyPatchToClipboard.multi:graphDetails",
-					"when": "webviewItemsUnion =~ /gitlens:file\\b(?=.*?\\b\\+(staged|unstaged)\\b)(?!.*?\\b\\+(committed|stashed)\\b)/ && listMultiSelection && !gitlens:untrusted && !gitlens:hasVirtualFolders && (webview == gitlens.graph || webview == gitlens.views.graph)",
 					"group": "7_gitlens_cutcopypaste@3"
 				}
 			]

--- a/src/constants.commands.generated.ts
+++ b/src/constants.commands.generated.ts
@@ -6,6 +6,10 @@ export type ContributedCommands =
 	| ContributedPaletteCommands
 	| ContributedOrphansOrInternalCommands
 	| 'gitlens.addAuthors'
+	| 'gitlens.addToGitignore.multi:commitDetails'
+	| 'gitlens.addToGitignore.multi:graphDetails'
+	| 'gitlens.addToGitignore:commitDetails'
+	| 'gitlens.addToGitignore:graphDetails'
 	| 'gitlens.agents.allowPermission'
 	| 'gitlens.agents.alwaysAllowPermission'
 	| 'gitlens.agents.approvePlan'

--- a/src/system/__tests__/webview.test.ts
+++ b/src/system/__tests__/webview.test.ts
@@ -1,5 +1,5 @@
 import * as assert from 'assert';
-import { mergeWebviewItems, mergeWebviewItemsUnion } from '../webview.js';
+import { getWipFileWebviewItem, mergeWebviewItems, mergeWebviewItemsUnion } from '../webview.js';
 
 suite('mergeWebviewItems', () => {
 	test('returns undefined for an empty list', () => {
@@ -76,5 +76,25 @@ suite('mergeWebviewItemsUnion', () => {
 
 	test('differing base types → undefined', () => {
 		assert.strictEqual(mergeWebviewItemsUnion(['gitlens:file+staged', 'gitlens:commit']), undefined);
+	});
+});
+
+suite('getWipFileWebviewItem', () => {
+	// The `+untracked` flag is the only thing the Add to .gitignore menus gate on, so these pin the
+	// exact strings every WIP file row (graph details + Inspect) is expected to produce.
+	test('flags an untracked file', () => {
+		assert.strictEqual(getWipFileWebviewItem({ staged: false, status: '?' }), 'gitlens:file+unstaged+untracked');
+	});
+
+	test('leaves a tracked working-tree change unflagged', () => {
+		assert.strictEqual(getWipFileWebviewItem({ staged: false, status: 'M' }), 'gitlens:file+unstaged');
+	});
+
+	test('uses the staged base for a staged file', () => {
+		assert.strictEqual(getWipFileWebviewItem({ staged: true, status: 'A' }), 'gitlens:file+staged');
+	});
+
+	test('omits the flag when the status is unknown', () => {
+		assert.strictEqual(getWipFileWebviewItem({}), 'gitlens:file+unstaged');
 	});
 });

--- a/src/system/webview.ts
+++ b/src/system/webview.ts
@@ -1,3 +1,4 @@
+import type { GitFileStatus } from '@gitlens/git/models/fileStatus.js';
 import type { GlPlusCommands, GlWebviewCommands } from '../constants.commands.js';
 import type { WebviewIds } from '../constants.views.js';
 
@@ -75,6 +76,12 @@ export function withWebviewItemFlag<T extends WebviewItemContext>(context: T, fl
 	const re = new RegExp(`\\+${flag}\\b`);
 	if (re.test(context.webviewItem)) return context;
 	return { ...context, webviewItem: `${context.webviewItem}+${flag}` };
+}
+
+/** The `webviewItem` context for a working-changes (WIP) file row. */
+export function getWipFileWebviewItem(file: { staged?: boolean; status?: GitFileStatus }): string {
+	const item = file.staged ? 'gitlens:file+staged' : 'gitlens:file+unstaged';
+	return file.status === '?' ? `${item}+untracked` : item;
 }
 
 /**

--- a/src/webviews/apps/commitDetails/components/gl-details-commit-panel.ts
+++ b/src/webviews/apps/commitDetails/components/gl-details-commit-panel.ts
@@ -9,7 +9,7 @@ import { formatIdentityDisplayName } from '@gitlens/git/utils/commit.utils.js';
 import { getPullRequestNumberFromUrl } from '@gitlens/git/utils/pullRequest.utils.js';
 import { createReference } from '@gitlens/git/utils/reference.utils.js';
 import type { Autolink } from '../../../../autolinks/models/autolinks.js';
-import { serializeWebviewItemContext } from '../../../../system/webview.js';
+import { getWipFileWebviewItem, serializeWebviewItemContext } from '../../../../system/webview.js';
 import type { WireSerialized } from '../../../../system/wireSerialize.js';
 import type {
 	State as _State,
@@ -1315,7 +1315,7 @@ export class GlDetailsCommitPanel extends GlDetailsBase {
 		// (open at revision / on remote / restore previous). Mirrors the WIP panel's file context.
 		if (this.isUncommitted) {
 			const context: DetailsItemTypedContext = {
-				webviewItem: `gitlens:file${file.staged ? '+staged' : '+unstaged'}${submodule}`,
+				webviewItem: `${getWipFileWebviewItem(file)}${submodule}`,
 				webviewItemValue: {
 					type: 'file',
 					path: file.path,

--- a/src/webviews/apps/commitDetails/components/gl-details-wip-panel.ts
+++ b/src/webviews/apps/commitDetails/components/gl-details-wip-panel.ts
@@ -10,7 +10,7 @@ import { canStageCurrent, canStageIncoming } from '@gitlens/git/utils/conflictRe
 import { isConflictStatus } from '@gitlens/git/utils/fileStatus.utils.js';
 import { isDescendant, normalizePath, relative } from '@gitlens/utils/path.js';
 import type { AgentSessionState } from '../../../../agents/models/agentSessionState.js';
-import { serializeWebviewItemContext } from '../../../../system/webview.js';
+import { getWipFileWebviewItem, serializeWebviewItemContext } from '../../../../system/webview.js';
 import type { DetailsItemTypedContext, Wip } from '../../../commitDetails/protocol.js';
 import { buildFolderContext } from '../../../commitDetails/protocol.js';
 import type { Change } from '../../../plus/patchDetails/protocol.js';
@@ -866,7 +866,7 @@ export class GlDetailsWipPanel extends GlDetailsBase {
 			}
 			webviewItem = `gitlens:file${modifiers.join('')}`;
 		} else {
-			webviewItem = file.staged ? 'gitlens:file+staged' : 'gitlens:file+unstaged';
+			webviewItem = getWipFileWebviewItem(file);
 			// Checkbox mode dedupes a mixed file (staged + unstaged) to its unstaged row; gl-wip-tree-pane
 			// flags that row via `options.mixed` (same source as the inline Stage/Unstage actions) so the
 			// context menu can offer the staged/combined diffs the single row otherwise can't reach.

--- a/src/webviews/apps/plus/graph/components/gl-details-compare-mode-panel.ts
+++ b/src/webviews/apps/plus/graph/components/gl-details-compare-mode-panel.ts
@@ -7,7 +7,7 @@ import type { IssueOrPullRequest } from '@gitlens/git/models/issueOrPullRequest.
 import { uncommitted } from '@gitlens/git/models/revision.js';
 import { shortenRevision } from '@gitlens/git/utils/revision.utils.js';
 import type { Autolink } from '../../../../../autolinks/models/autolinks.js';
-import { serializeWebviewItemContext } from '../../../../../system/webview.js';
+import { getWipFileWebviewItem, serializeWebviewItemContext } from '../../../../../system/webview.js';
 import type { DetailsItemTypedContext, Preferences, State } from '../../../../plus/graph/detailsProtocol.js';
 import { buildFolderContext } from '../../../../plus/graph/detailsProtocol.js';
 import type {
@@ -785,7 +785,7 @@ export class GlDetailsCompareModePanel extends LitElement {
 		// WIP context (sha: uncommitted → HEAD↔working) would be wrong there.
 		if (this.selectedCommitSha === uncommitted || (this.activeTab === 'ahead' && this.aheadOnlyWip)) {
 			const context: DetailsItemTypedContext = {
-				webviewItem: file.staged ? 'gitlens:file+staged' : 'gitlens:file+unstaged',
+				webviewItem: getWipFileWebviewItem(file),
 				webviewItemValue: {
 					type: 'file',
 					path: file.path,

--- a/src/webviews/apps/plus/graph/components/gl-details-compose-mode-panel.ts
+++ b/src/webviews/apps/plus/graph/components/gl-details-compose-mode-panel.ts
@@ -9,7 +9,7 @@ import { splitCommitMessage } from '@gitlens/git/utils/commit.utils.js';
 import { fromNow } from '@gitlens/utils/date.js';
 import { pluralize } from '@gitlens/utils/string.js';
 import type { ViewFilesLayout } from '../../../../../config.js';
-import { serializeWebviewItemContext } from '../../../../../system/webview.js';
+import { getWipFileWebviewItem, serializeWebviewItemContext } from '../../../../../system/webview.js';
 import type { DetailsItemTypedContext } from '../../../../plus/graph/detailsProtocol.js';
 import { buildFolderContext } from '../../../../plus/graph/detailsProtocol.js';
 import type {
@@ -711,7 +711,7 @@ export class GlDetailsComposeModePanel extends LitElement {
 		}
 
 		const context: DetailsItemTypedContext = {
-			webviewItem: file.staged ? 'gitlens:file+staged' : 'gitlens:file+unstaged',
+			webviewItem: getWipFileWebviewItem(file),
 			webviewItemValue: {
 				type: 'file',
 				path: file.path,
@@ -1192,7 +1192,7 @@ export class GlDetailsComposeModePanel extends LitElement {
 			};
 		} else {
 			context = {
-				webviewItem: file.staged ? 'gitlens:file+staged' : 'gitlens:file+unstaged',
+				webviewItem: getWipFileWebviewItem(file),
 				webviewItemValue: {
 					type: 'file',
 					path: file.path,

--- a/src/webviews/apps/plus/graph/components/gl-details-resolve-mode-panel.ts
+++ b/src/webviews/apps/plus/graph/components/gl-details-resolve-mode-panel.ts
@@ -15,7 +15,7 @@ import type { ConflictKind } from '@gitlens/git/utils/conflictResolution.utils.j
 import { isConflictStatus } from '@gitlens/git/utils/fileStatus.utils.js';
 import { pluralize } from '@gitlens/utils/string.js';
 import type { ViewFilesLayout } from '../../../../../config.js';
-import { serializeWebviewItemContext } from '../../../../../system/webview.js';
+import { getWipFileWebviewItem, serializeWebviewItemContext } from '../../../../../system/webview.js';
 import type { DetailsItemTypedContext } from '../../../../plus/graph/detailsProtocol.js';
 import { buildFolderContext } from '../../../../plus/graph/detailsProtocol.js';
 import type {
@@ -1182,7 +1182,7 @@ export class GlDetailsResolveModePanel extends LitElement {
 			}
 			webviewItem = `gitlens:file${modifiers.join('')}`;
 		} else {
-			webviewItem = file.staged ? 'gitlens:file+staged' : 'gitlens:file+unstaged';
+			webviewItem = getWipFileWebviewItem(file);
 		}
 
 		const context: DetailsItemTypedContext = {

--- a/src/webviews/apps/plus/graph/components/gl-details-review-mode-panel.ts
+++ b/src/webviews/apps/plus/graph/components/gl-details-review-mode-panel.ts
@@ -13,7 +13,7 @@ import type { GitCommitSearchContext } from '@gitlens/git/models/search.js';
 import { shortenRevision } from '@gitlens/git/utils/revision.utils.js';
 import { pluralize } from '@gitlens/utils/string.js';
 import type { ViewFilesLayout } from '../../../../../config.js';
-import { serializeWebviewItemContext } from '../../../../../system/webview.js';
+import { getWipFileWebviewItem, serializeWebviewItemContext } from '../../../../../system/webview.js';
 import type { DetailsItemTypedContext } from '../../../../plus/graph/detailsProtocol.js';
 import { buildFolderContext } from '../../../../plus/graph/detailsProtocol.js';
 import type { ScopeFile, ScopeSelection } from '../../../../plus/graph/graphService.js';
@@ -805,7 +805,7 @@ export class GlDetailsReviewModePanel extends LitElement {
 				}
 
 				context = {
-					webviewItem: file.staged ? 'gitlens:file+staged' : 'gitlens:file+unstaged',
+					webviewItem: getWipFileWebviewItem(file),
 					webviewItemValue: {
 						type: 'file',
 						path: file.path,

--- a/src/webviews/commitDetails/__tests__/detailsFileCommands.test.ts
+++ b/src/webviews/commitDetails/__tests__/detailsFileCommands.test.ts
@@ -1,0 +1,34 @@
+import * as assert from 'assert';
+import { toGitignorePattern } from '../detailsFileCommands.js';
+
+// Each case pins a piece of gitignore syntax that would otherwise make the written line match
+// something other than the file the user picked — verified against real git.
+suite('toGitignorePattern', () => {
+	test('anchors a root file so the name is not ignored elsewhere in the tree', () => {
+		assert.strictEqual(toGitignorePattern('notes.md'), '/notes.md');
+	});
+
+	test('anchors a nested path without touching its separators', () => {
+		assert.strictEqual(toGitignorePattern('src/notes.md'), '/src/notes.md');
+	});
+
+	test('escapes `[` so the name cannot open a character class', () => {
+		assert.strictEqual(toGitignorePattern('weird[1].log'), '/weird\\[1].log');
+	});
+
+	test('escapes `*` and `?` so the pattern cannot match neighbouring files', () => {
+		assert.strictEqual(toGitignorePattern('a*b?.log'), '/a\\*b\\?.log');
+	});
+
+	test('quotes a trailing space, which git would otherwise strip', () => {
+		assert.strictEqual(toGitignorePattern('report '), '/report\\ ');
+	});
+
+	test('a leading `#` is data, not a comment — the anchor keeps it off the line start', () => {
+		assert.strictEqual(toGitignorePattern('#autosave#'), '/#autosave#');
+	});
+
+	test('a leading `!` is data, not a negation', () => {
+		assert.strictEqual(toGitignorePattern('!draft.md'), '/!draft.md');
+	});
+});

--- a/src/webviews/commitDetails/detailsFileCommands.ts
+++ b/src/webviews/commitDetails/detailsFileCommands.ts
@@ -1,5 +1,5 @@
 import type { TextDocumentShowOptions } from 'vscode';
-import { env, window } from 'vscode';
+import { EndOfLine, env, window, workspace, WorkspaceEdit } from 'vscode';
 import { CheckoutError } from '@gitlens/git/errors.js';
 import { GitCommit } from '@gitlens/git/models/commit.js';
 import type { GitFileChange } from '@gitlens/git/models/fileChange.js';
@@ -11,6 +11,7 @@ import { getFileDiffPathspecs } from '@gitlens/git/utils/fileStatus.utils.js';
 import { createReference } from '@gitlens/git/utils/reference.utils.js';
 import { isUncommitted } from '@gitlens/git/utils/revision.utils.js';
 import { debug } from '@gitlens/utils/decorators/log.js';
+import { Logger } from '@gitlens/utils/logger.js';
 import { basename } from '@gitlens/utils/path.js';
 import { getSettledValue } from '@gitlens/utils/promise.js';
 import type { CopyDeepLinkCommandArgs, CopyFileDeepLinkCommandArgs } from '../../commands/copyDeepLink.js';
@@ -48,6 +49,14 @@ import type { ComparisonContext, ResolvedDetailsFile } from './commitDetailsWebv
 const { command, getCommands } = createCommandDecorator<string>();
 const { command: multiCommand, getCommands: getMultiCommands } = createCommandDecorator<string>();
 export { getCommands as getDetailsFileCommands, getMultiCommands as getDetailsFileMultiCommands };
+
+// Anchored with a leading `/` so the pattern ignores the selected file rather than that name
+// anywhere in the repo — which also keeps a name starting with `#` or `!` from being read as a
+// comment or a negation. Glob metacharacters and a trailing space (which git would otherwise
+// strip) are escaped so the pattern matches only the file that was picked.
+export function toGitignorePattern(relativePath: string): string {
+	return `/${relativePath.replace(/[*?[]| $/g, '\\$&')}`;
+}
 
 export class DetailsFileCommands {
 	// Reuse the WIP discard service (its confirm + trash + restore core) so the context-menu Discard
@@ -339,6 +348,68 @@ export class DetailsFileCommands {
 		// `includeUntracked` so an untracked selected file is stashed too; the stash wizard confirms.
 		await StashActions.push(file.repoPath, [file.uri], undefined, true);
 	}
+
+	@command('gitlens.addToGitignore:')
+	@debug()
+	async addToGitignore(_commit: GitCommit, file: GitFileChange): Promise<void> {
+		const relativePath = this.container.git.getRelativePath(file.uri, file.repoPath);
+		await this.appendToGitignore(file.repoPath, [relativePath], `'${relativePath}'`);
+	}
+
+	/** Appends the given repo-relative paths to the repo root's `.gitignore`, creating it when missing. */
+	private async appendToGitignore(repoPath: string, relativePaths: string[], subject: string): Promise<void> {
+		const gitignoreUri = this.container.git.getAbsoluteUri('.gitignore', repoPath);
+		const entries = relativePaths.map(toGitignorePattern);
+
+		try {
+			let exists = true;
+			try {
+				await workspace.fs.stat(gitignoreUri);
+			} catch {
+				exists = false;
+			}
+
+			// A missing .gitignore has no document to open yet, so create it with its entries in place
+			if (!exists) {
+				await workspace.fs.writeFile(gitignoreUri, new TextEncoder().encode(`${entries.join('\n')}\n`));
+			}
+
+			const document = await workspace.openTextDocument(gitignoreUri);
+
+			// Reveal it before editing, as the built-in Git extension's "Add to .gitignore" does: the
+			// only signal the user gets about what was written is the file itself, and the pattern is
+			// anchored and escaped, so it isn't always the bare path that was picked
+			await window.showTextDocument(document, { preview: false });
+
+			if (exists) {
+				// Append through the text document rather than `workspace.fs` so an open — possibly
+				// dirty — editor stays in sync: a write behind its back strands the buffer, and the
+				// user's next save either raises a conflict or silently drops the entries. Saving
+				// commits their unsaved edits along with ours, and the append is undoable.
+				const eol = document.eol === EndOfLine.CRLF ? '\r\n' : '\n';
+				const lastLine = document.lineAt(document.lineCount - 1);
+
+				const edit = new WorkspaceEdit();
+				edit.insert(
+					document.uri,
+					lastLine.range.end,
+					`${lastLine.text.length ? eol : ''}${entries.join(eol)}${eol}`,
+				);
+				if (!(await workspace.applyEdit(edit))) throw new Error('the edit could not be applied');
+
+				// `save()` also answers false for a document that isn't dirty (auto-save can beat us
+				// to it), so only a dirty document that refuses to save is a failure. The document is
+				// already revealed, so a pending edit isn't left dirty out of sight.
+				if (document.isDirty && !(await document.save())) {
+					throw new Error('the edit could not be saved');
+				}
+			}
+		} catch (ex) {
+			Logger.error(ex, `Unable to add ${subject} to .gitignore`);
+			void window.showErrorMessage(`Unable to add ${subject} to .gitignore\n${String(ex)}`);
+		}
+	}
+
 	@command('gitlens.views.applyChanges:')
 	@debug()
 	applyChanges(
@@ -807,6 +878,18 @@ export class DetailsFileCommands {
 			undefined,
 			true,
 		);
+	}
+
+	@multiCommand('gitlens.addToGitignore.multi:')
+	@debug()
+	async addToGitignoreMulti(items: ResolvedDetailsFile[]): Promise<void> {
+		// Union-gated - the menu shows if ANY selected file is untracked
+		const files = items.filter(i => i.webviewItem?.includes('+untracked'));
+		if (!files.length) return;
+
+		const repoPath = files[0].file.repoPath;
+		const relativePaths = files.map(i => this.container.git.getRelativePath(i.file.uri, repoPath));
+		await this.appendToGitignore(repoPath, relativePaths, 'the selected files');
 	}
 
 	@multiCommand('gitlens.copyPatchToClipboard.multi:')


### PR DESCRIPTION
# Description

Adds an _Add to .gitignore_ context-menu item to untracked file rows in the _Commit Graph_
details and _Inspect_ views, so a file can be ignored without leaving the view. A bulk variant
handles a multi-selection in one write, matching how every other working-changes file action
pairs a single-select command with a `.multi` one.

Notes for review:

- **Scoped to untracked files.** git exempts already-tracked files from ignore rules, so offering
  this on a modified tracked file would append an entry that does nothing while the file stays in
  `git status`. That needed a new `+untracked` flag on the WIP file context, built by a shared
  `getWipFileWebviewItem()` for all seven WIP context producers — including the one in
  `gl-details-commit-panel`, which is what _Inspect_ renders. The built-in Git extension
  contributes its own action for both groups and has that dead case; GitLens has the file status
  to hand, so it doesn't need to.
- **The written pattern is anchored** with a leading `/`, so it ignores the selected file rather
  than every file with that name in the tree, and a name starting with `#` or `!` can't land as a
  comment or a negation. Glob metacharacters and a trailing space are quoted so the pattern can't
  match a file the user didn't pick. Backslash is deliberately left alone — `getRelativePath`
  normalizes separators through `normalizePath`.
- **Writes through `openTextDocument` + `WorkspaceEdit` + `save()`** rather than `workspace.fs`,
  so an open (possibly dirty) `.gitignore` stays in sync: a write behind its back strands the
  buffer, and the user's next save then either raises a conflict or drops the entries. The append
  is also undoable and picks up the document's own EOL.
- Unit tests pin both helpers — `+untracked` is the only thing the four menu entries gate on, so
  a silent change to it would drop the feature with no error anywhere.

Verified on a running instance against real git: the item appears only on untracked rows (hidden
for staged, modified-tracked and committed rows) in the Graph details, Inspect, and the graph's
compare/compose/review modes; a mixed bulk selection adds only its untracked files; and
`git check-ignore` confirms each written line matches exactly the file that was picked, including
names containing `[`, `*`, `?`, a leading `#` or `!`, and a trailing space.

Closes #5780

# Checklist

- [x] I have followed the guidelines in the Contributing document
- [x] My changes follow the coding style of this project
- [x] My changes build without any errors or warnings
- [x] My changes have been formatted and linted
- [x] My changes include any required corresponding changes to the documentation (including CHANGELOG.md and README.md)
- [x] My changes have been rebased and squashed to the minimal number (typically 1) of relevant commits
- [x] My changes have a descriptive commit message with a short title, including a `Fixes $XXX -` or `Closes #XXX -` prefix to auto-close the issue that your PR addresses
