### PR TITLE
Fixes Auto-Rebase reporting a successful no-op run as cancelled

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -78,6 +78,7 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/) and this p
 
 ### Fixed
 
+- Fixes Auto-Rebase reporting a successful run that left the branch unchanged as cancelled &mdash; a rebase with nothing to rewrite (including one handed off from the _Interactive Rebase Editor_ that finishes without ever pausing) is now reported as completed with nothing to rewrite; "cancelled" is reserved for a rebase that was actually aborted and rolled back ([#5787](https://github.com/gitkraken/vscode-gitlens/issues/5787))
 - Fixes _Copy_ on a worktree branch's ref pill in the _Commit Graph_ copying the worktree's folder path instead of the branch name
 - Fixes deleting an unmerged branch from the _Commit Graph_ or views showing a generic error instead of offering the force-delete confirmation &mdash; delete failures were left unclassified, so the "delete anyway?" prompt could never trigger; a failed remote-ref delete where the ref no longer exists is also reported as such now instead of a generic rejection
 - Fixes quick picks opened from the _Commit Graph_ (repository switcher, search filter pickers, compare-ref choosers, _Add Co-authors_) sometimes closing immediately &mdash; the webview could win back focus from the picker while the click's focus was still settling; the webview now releases focus before opening the picker, and pickers no longer hang when dismissed while their items are still loading

--- a/src/plus/coretools/conflict/__tests__/autoRebaseService.test.ts
+++ b/src/plus/coretools/conflict/__tests__/autoRebaseService.test.ts
@@ -247,7 +247,7 @@ function makePausedRebaseStatus(): GitPausedOperationStatus {
  * cancel that races the run finishing), and `abortPausedOperation` then reports `nothingToAbort` —
  * the rebase already ended. Whether that resolves to `completed` or `aborted` turns on HEAD.
  */
-function makeTakeoverFakes(headSha: string) {
+function makeTakeoverFakes(headSha: string, reflogSubject?: string) {
 	const state = { headSha: headSha, resets: [] as string[], statusReads: 0 };
 	const storage = new Map<string, unknown>();
 
@@ -280,7 +280,8 @@ function makeTakeoverFakes(headSha: string) {
 			},
 		},
 		staging: { stageFiles: () => Promise.resolve() },
-		createUnsafeGit: () => undefined,
+		createUnsafeGit:
+			reflogSubject != null ? () => ({ run: () => Promise.resolve({ stdout: reflogSubject }) }) : () => undefined,
 	};
 
 	const container = {
@@ -437,6 +438,16 @@ suite('coretools/conflict/AutoRebaseService late cancel', () => {
 		assert.strictEqual(session.phase, 'aborted');
 		assert.strictEqual(storage.has('autoRebase:undo:/repo'), false);
 	});
+
+	test('a cancel that lands on a genuine no-op completes rather than misreporting an abort', async () => {
+		const { service, storage, svc } = makeTakeoverFakes('orig', 'rebase (finish): returning to refs/heads/feature');
+
+		const session = await service.takeover(svc, { source: 'commandPalette' });
+
+		assert.strictEqual(session.phase, 'completed');
+		// Nothing was rewritten, so there's still nothing to undo
+		assert.strictEqual(storage.has('autoRebase:undo:/repo'), false);
+	});
 });
 
 /**
@@ -573,7 +584,7 @@ interface HandoffTick {
  */
 function makeHandoffFakes(
 	ticks: HandoffTick[],
-	options?: { headSha?: string; gitDirPath?: string; releaseError?: Error },
+	options?: { headSha?: string; gitDirPath?: string; releaseError?: Error; reflogSubject?: string },
 ) {
 	const state = { reads: 0, aborts: 0, continues: 0, calls: [] as string[] };
 	const storage = new Map<string, unknown>();
@@ -613,7 +624,10 @@ function makeHandoffFakes(
 		},
 		ops: { reset: () => Promise.resolve() },
 		staging: { stageFiles: () => Promise.resolve() },
-		createUnsafeGit: () => undefined,
+		createUnsafeGit:
+			options?.reflogSubject != null
+				? () => ({ run: () => Promise.resolve({ stdout: options.reflogSubject }) })
+				: () => undefined,
 	} as unknown as Record<string, unknown>;
 	svc.revision = {
 		resolveRevision: () =>
@@ -748,6 +762,20 @@ suite('coretools/conflict/AutoRebaseService handoff', () => {
 		const session = await service.handoffPending(svc, { source: 'rebaseEditor' }, release);
 
 		assert.strictEqual(session.phase, 'aborted');
+		assert.strictEqual(storage.has('autoRebase:undo:/repo'), false);
+	});
+
+	test('a rebase that replays with nothing to rewrite completes rather than reporting an abort', async () => {
+		const { service, storage, release, svc } = makeHandoffFakes(
+			[{ status: pendingRebaseStatus() }, { status: undefined }],
+			// HEAD never had to move, but git's reflog confirms the rebase actually finished
+			{ headSha: 'orig', reflogSubject: 'rebase (finish): returning to refs/heads/feature' },
+		);
+
+		const session = await service.handoffPending(svc, { source: 'rebaseEditor' }, release);
+
+		assert.strictEqual(session.phase, 'completed');
+		// Nothing was rewritten, so there's still nothing to undo
 		assert.strictEqual(storage.has('autoRebase:undo:/repo'), false);
 	});
 

--- a/src/plus/coretools/conflict/autoRebase.types.ts
+++ b/src/plus/coretools/conflict/autoRebase.types.ts
@@ -212,3 +212,10 @@ export interface AutoRebaseChangeEvent {
 	/** `undefined` when the session was dismissed */
 	session: AutoRebaseSession | undefined;
 }
+
+/** Whether a terminal run left the branch tip exactly where it started — distinguishes a `completed`
+ *  run that had nothing to rewrite from one that cleanly rewrote every commit. `false` before the run
+ *  reaches a terminal phase (`postRun` unset). */
+export function isAutoRebaseUnchanged(session: AutoRebaseSession): boolean {
+	return session.postRun?.headSha === session.preRun.headSha;
+}

--- a/src/plus/coretools/conflict/autoRebaseProgress.ts
+++ b/src/plus/coretools/conflict/autoRebaseProgress.ts
@@ -5,6 +5,7 @@ import type { Container } from '../../../container.js';
 import type { GitRepositoryService } from '../../../git/gitRepositoryService.js';
 import { executeCommand } from '../../../system/-webview/command.js';
 import type { AutoRebaseEscalationReason, AutoRebaseSession } from './autoRebase.types.js';
+import { isAutoRebaseUnchanged } from './autoRebase.types.js';
 import type { AutoRebaseStartOptions } from './autoRebaseService.js';
 
 // Escalation reasons that leave unmerged files for the user to resolve — these auto-open Resolve
@@ -119,7 +120,9 @@ function onCompleted(container: Container, session: AutoRebaseSession): void {
 	}
 
 	// No conflicts, so there's no meaningful summary to open — a brief toast is enough.
-	let message = 'Auto-Rebase completed — no conflicts.';
+	let message = isAutoRebaseUnchanged(session)
+		? `Auto-Rebase completed — ${session.preRun.branch ?? 'the branch'} had nothing to rewrite.`
+		: 'Auto-Rebase completed — no conflicts.';
 	if (session.postRun?.autostash === 'left-in-stash') {
 		message += ' Your uncommitted changes conflicted when re-applied — they are safe in the stash.';
 	}

--- a/src/plus/coretools/conflict/autoRebaseService.ts
+++ b/src/plus/coretools/conflict/autoRebaseService.ts
@@ -880,12 +880,14 @@ export class AutoRebaseService implements Disposable {
 		const { session } = active;
 		const headSha = (await svc.revision.resolveRevision('HEAD')).sha;
 
-		// The loop reported completion but the tip is back at the start: the rebase was aborted
-		// externally (`git rebase --abort`) while we were driving it — there is nothing to undo (or
-		// summarize as applied). Gate on `fromLoop` rather than `steps.length` so an abort *before* the
-		// first step is recorded is still caught, without misclassifying `start()`'s "already up to
-		// date" no-op (which reaches finalize directly, never from the loop, also with 0 steps).
-		if (options?.fromLoop && headSha === session.preRun.headSha) {
+		// The loop reported completion but the tip is back at the start — that's ambiguous on its own:
+		// it's just as true of a genuine no-op completion (nothing to rewrite) as it is of an external
+		// `git rebase --abort` that raced us while driving it. Git's own reflog tells the two apart
+		// (`rebase (finish): …` vs `rebase (abort): …`) regardless of whether the SHA moved. Gate on
+		// `fromLoop` rather than `steps.length` so an abort *before* the first step is recorded is still
+		// caught, without misclassifying `start()`'s "already up to date" no-op (which reaches finalize
+		// directly, never from the loop, also with 0 steps).
+		if (options?.fromLoop && headSha === session.preRun.headSha && !(await this.rebaseReflogFinished(svc))) {
 			session.phase = 'aborted';
 			clearTransientProgress(session);
 			this.fireChange(session);
@@ -969,12 +971,13 @@ export class AutoRebaseService implements Disposable {
 				return;
 			}
 
-			// Nothing to abort — the rebase already ended. If HEAD moved past the pre-rebase tip the
-			// run actually finished (a cancel that raced the final successful continue), so finalize
-			// it (summary + undo record) instead of misreporting an unchanged branch. Only when HEAD
-			// is still at the pre-rebase tip is "aborted — branch unchanged" literally true.
+			// Nothing to abort — the rebase already ended, racing our cancel. If HEAD moved, the run
+			// actually finished (a cancel that raced the final successful continue). If HEAD didn't
+			// move, that alone doesn't mean it was aborted — a no-op completion (nothing to rewrite)
+			// looks identical by SHA — so check the reflog too. Either signal routes through finalize
+			// for the summary + undo record instead of misreporting a completed run as cancelled.
 			const headSha = (await svc.revision.resolveRevision('HEAD')).sha;
-			if (headSha !== session.preRun.headSha) {
+			if (headSha !== session.preRun.headSha || (await this.rebaseReflogFinished(svc))) {
 				await this.finalize(svc, active, { fromLoop: true });
 				return;
 			}
@@ -1168,6 +1171,22 @@ export class AutoRebaseService implements Disposable {
 		}
 
 		return { ok: true };
+	}
+
+	/** Whether git's own record says the rebase actually finished, for the moments HEAD staying at the
+	 *  pre-rebase tip can't tell a genuine no-op completion apart from an external abort — both leave
+	 *  HEAD unmoved, but git tags the reflog entry `rebase (finish): …` or `rebase (abort): …`
+	 *  accordingly regardless. `false` (the conservative default) when reflog is unreadable. */
+	private async rebaseReflogFinished(svc: GitRepositoryService): Promise<boolean> {
+		const git = svc.createUnsafeGit();
+		if (git == null) return false;
+
+		try {
+			const result = await git.run(['reflog', '-1', '--format=%gs', 'HEAD']);
+			return result.stdout.trim().startsWith('rebase (finish)');
+		} catch {
+			return false;
+		}
 	}
 
 	private async listStashMessages(svc: GitRepositoryService): Promise<string[]> {

--- a/src/webviews/apps/plus/graph/components/gl-details-resolve-mode-panel.ts
+++ b/src/webviews/apps/plus/graph/components/gl-details-resolve-mode-panel.ts
@@ -915,6 +915,11 @@ export class GlDetailsResolveModePanel extends LitElement {
 		// Git drops a step whose resolution left nothing to commit — a completed run has to say so here,
 		// where the eye lands, not only on the step row further down.
 		const emptied = describeEmptySkipped(run.steps);
+		// Like the cancelled message below, only reachable for a render or two before the mode exit
+		// lands (see `auto-rebase-exit`).
+		const noStepsMessage = run.unchanged
+			? `Rebase completed — ${run.branch ?? 'the branch'} had nothing to rewrite.`
+			: 'Rebase completed — no conflicts.';
 		const outcome =
 			run.phase === 'completed'
 				? [
@@ -922,9 +927,7 @@ export class GlDetailsResolveModePanel extends LitElement {
 							? `Rebase completed — ${pluralize('conflicted file', resolvedByAi)} resolved with AI.`
 							: run.steps.length > 0
 								? 'Rebase completed — you resolved every conflict.'
-								: // Like the cancelled message below, only reachable for a render or two before the
-									// mode exit lands (see `auto-rebase-exit`).
-									'Rebase completed — no conflicts.',
+								: noStepsMessage,
 						emptied,
 					]
 						.filter(Boolean)

--- a/src/webviews/plus/graph/graphInspectServices.ts
+++ b/src/webviews/plus/graph/graphInspectServices.ts
@@ -38,6 +38,7 @@ import {
 	gatherContextForChanges,
 } from '../../../plus/ai/utils/-webview/changesContext.js';
 import type { AutoRebaseSession } from '../../../plus/coretools/conflict/autoRebase.types.js';
+import { isAutoRebaseUnchanged } from '../../../plus/coretools/conflict/autoRebase.types.js';
 import type { ConsultedTool } from '../../../plus/coretools/conflict/consultation.js';
 import { getConsultations, recordConsultation } from '../../../plus/coretools/conflict/consultation.js';
 import type { ConflictToolsIntegration } from '../../../plus/coretools/conflict/integration.js';
@@ -163,6 +164,7 @@ function toAutoRebaseRunUpdate(
 			session.escalation != null
 				? { reason: session.escalation.reason, message: session.escalation.message }
 				: undefined,
+		unchanged: isAutoRebaseUnchanged(session),
 		steps: session.steps.map(step => ({
 			step: step.stepNumber,
 			totalSteps: step.totalSteps,

--- a/src/webviews/plus/graph/graphService.ts
+++ b/src/webviews/plus/graph/graphService.ts
@@ -232,6 +232,10 @@ export type AutoRebaseRunUpdate = {
 	/** Why automation stopped, when it escalated — lets the panel distinguish a user-requested stop
 	 *  (`stopped`) from a genuine escalation. */
 	escalation?: { reason: string; message: string };
+	/** Whether the branch tip is exactly where it started — only meaningful once `phase` is terminal.
+	 *  Distinguishes a `completed` run that had nothing to rewrite from one that cleanly rewrote
+	 *  every commit. */
+	unchanged: boolean;
 	/** Steps recorded so far — only paused (conflicted/skipped) steps surface; clean picks never do.
 	 *  Files carry no `virtualRef` while running: before/after diffs stay a summary-sheet affordance so
 	 *  no virtual sessions are registered per progress tick. */


### PR DESCRIPTION
## Problem

Fixes #5787. When an Auto-Rebase run completes but had nothing to rewrite (the branch already sits on its upstream's tip), GitLens reported it as "Auto-Rebase cancelled — `<branch>` is unchanged." — as if it had been called off, when git itself reported success and nothing was cancelled.

## Root cause

`AutoRebaseService.finalize()` and `handleCancelled()` used "did HEAD move from its pre-run SHA?" as their only signal for whether a rebase was externally aborted. A genuinely successful no-op rebase leaves HEAD unmoved too, so the two outcomes were indistinguishable by SHA alone — most visibly via `handoffPending()` → `waitForFirstPause()` returning `completed` before the rebase ever paused (a no-op replays start-to-finish without pausing).

## Approach

Git tags every rebase's terminal reflog entry differently regardless of whether the SHA moved — `rebase (finish): ...` on completion (including a no-op) vs. `rebase (abort): ...` on abort. I verified this empirically against real git before relying on it. Both ambiguous branches now consult the reflog subject instead of the SHA delta alone, falling back to the existing conservative "aborted" behavior when reflog is unreadable.

The completion messaging (toast + Commit Graph Resolve panel) now also distinguishes "nothing to rewrite" from "no conflicts" (a clean rewrite with no conflicts), per the issue's expected behavior.

## Invariants touched

- `AutoRebasePhase` classification (no new phase — same enum, corrected classification logic)
- Undo-record gating is unaffected — a true no-op still correctly stores no undo record

## Verification

- `pnpm run check` clean; full unit suite green (2580+ tests), including 2 new regression cases for the fixed classification
- `/code-review medium` converged with no findings; `/simplify` pass applied (deduped a repeated computation into a shared `isAutoRebaseUnchanged` helper)
- **Live-verified end-to-end** against a real running Extension Development Host with genuine `git rebase -i` subprocesses (not just mocks):
  - The exact reported scenario (branch already on its upstream's tip) now shows "Auto-Rebase completed — `<branch>` had nothing to rewrite." with no Undo offered, confirmed via the real Notifications Center
  - A real conflict-resolving run is unaffected: still shows "Rebase completed — N conflicted file(s) resolved with AI."
  - The genuine-abort path wasn't re-reproduced live (the AI conflict resolution completed too fast to catch a cancel window), but is unchanged by construction — the new check only ever adds cases that resolve to `completed`; a real `git rebase --abort`'s reflog subject never matches, so its classification is identical to before. This is also covered by the existing (unmodified) unit tests for that path.

## Out of scope

Per the issue's own "Risk" note: a separate, unrelated shape ("a run that finished faster than the progress display engaged was reported as never having started") is explicitly not part of this fix.