### PR TITLE
Fixes the Graph pin E2E probes and a dropped teardown - closes #5627

### DIFF
--- a/tests/e2e/pageObjects/gitLensPage.ts
+++ b/tests/e2e/pageObjects/gitLensPage.ts
@@ -23,7 +23,7 @@ export class GitLensPage extends VSCodePage {
 	 */
 	async startSubscriptionSimulation(
 		state: SimulationState = { state: 6 /*SubscriptionState.Paid*/, planId: 'pro' },
-	): Promise<{ success: boolean } & Disposable> {
+	): Promise<{ success: boolean } & Disposable & AsyncDisposable> {
 		if (!(await this.waitForCommand('gitlens.plus.simulate.subscription'))) {
 			throw new Error('gitlens.plus.simulate.subscription command not found');
 		}
@@ -33,9 +33,18 @@ export class GitLensPage extends VSCodePage {
 		await this.page.waitForTimeout(ShortTimeout);
 		return {
 			success: success,
-			[Symbol.dispose]: async () => {
-				await this.stopSubscriptionSimulation();
+			// `using` calls the SYNC disposer and drops whatever it returns, so teardown can't be awaited
+			// through it — `asyncDispose` below is the awaited path. What the sync one has to guarantee is
+			// that its floating promise never surfaces as an UNHANDLED rejection: the worker fixture
+			// force-kills the editor before closing it, so a late `evaluate()` lands on a dead HTTP server
+			// and rejects with `SocketError: other side closed`. Unhandled, that takes the whole worker
+			// down — Playwright reports it as "errors were not a part of any test", turning a run whose
+			// every test passed into a red one. Swallowing is right here precisely because this path can't
+			// report anyway; callers that need to know use the async disposer.
+			[Symbol.dispose]: () => {
+				void this.stopSubscriptionSimulation().catch(() => {});
 			},
+			[Symbol.asyncDispose]: () => this.stopSubscriptionSimulation(),
 		};
 	}
 

--- a/tests/e2e/specs/graphDetails.test.ts
+++ b/tests/e2e/specs/graphDetails.test.ts
@@ -79,9 +79,10 @@ async function openGraphWithPro(vscode: VSCodeInstance): Promise<{
 
 	return {
 		graphWebview: graphWebview!,
-		dispose: () => {
-			sim[Symbol.dispose]();
-			return Promise.resolve();
+		// Awaits the real teardown: the sync disposer drops its promise, which let the next test start
+		// while the simulated subscription was still being torn down.
+		dispose: async () => {
+			await sim[Symbol.asyncDispose]();
 		},
 	};
 }

--- a/tests/e2e/specs/graphPin.test.ts
+++ b/tests/e2e/specs/graphPin.test.ts
@@ -18,6 +18,23 @@ interface GraphStateInfo {
 	pinnedRef?: { id: string; name: string; type: string } | undefined;
 }
 
+/**
+ * The pinned ref, wherever it currently lives.
+ *
+ * NOT in the serialized `_state` snapshot: `pinnedRef` was dropped from the Graph webview protocol's
+ * `State` when the write planes moved onto RPC services, and the state provider's own accessor is what
+ * carries it now. `_state` still exists and still carries `webviewId`/`selectedRepository`, so a probe
+ * that prefers `_state` keeps working — and keeps reporting the pin as absent, indistinguishable from
+ * "not pinned". Both places are read so this survives the field moving again in either direction.
+ *
+ * Callers fold the result with ?? undefined where an unpinned graph should omit the key entirely.
+ */
+const pinnedRefExpr = `(() => {
+	const app = document.querySelector('gl-graph-app');
+	const p = app?.graphState?.pinnedRef ?? app?.graphState?._state?.pinnedRef;
+	return p ? { id: p.id, name: p.name, type: p.type } : null;
+})()`;
+
 const getGraphStateScript = `(() => {
 	const app = document.querySelector('gl-graph-app');
 	if (!app) return JSON.stringify(null);
@@ -26,16 +43,11 @@ const getGraphStateScript = `(() => {
 		webviewId: s?.webviewId,
 		webviewInstanceId: s?.webviewInstanceId,
 		repoPath: s?.selectedRepository,
-		pinnedRef: s?.pinnedRef ? { id: s.pinnedRef.id, name: s.pinnedRef.name, type: s.pinnedRef.type } : undefined,
+		pinnedRef: ${pinnedRefExpr} ?? undefined,
 	});
 })()`;
 
-const getPinnedRefScript = `(() => {
-	const app = document.querySelector('gl-graph-app');
-	const s = app?.graphState?._state || app?.graphState;
-	const p = s?.pinnedRef;
-	return JSON.stringify(p ? { id: p.id, name: p.name, type: p.type } : null);
-})()`;
+const getPinnedRefScript = `(() => JSON.stringify(${pinnedRefExpr}))()`;
 
 const hasPinnedContextScript = `(() => {
 	var el = document.querySelector('[data-vscode-context*="+pinned"]');

--- a/tests/e2e/specs/graphReview.test.ts
+++ b/tests/e2e/specs/graphReview.test.ts
@@ -103,9 +103,9 @@ test.describe('Review & Compose Sub-Panels', () => {
 			state: 6 /* SubscriptionState.Paid */,
 			planId: 'pro',
 		});
-		dispose = () => {
-			sim[Symbol.dispose]();
-			return Promise.resolve();
+		// Awaits the real teardown — see the note in the other graph specs' helpers.
+		dispose = async () => {
+			await sim[Symbol.asyncDispose]();
 		};
 
 		await vscode.gitlens.showCommitGraphView();

--- a/tests/e2e/specs/treeView.test.ts
+++ b/tests/e2e/specs/treeView.test.ts
@@ -77,9 +77,10 @@ async function openGraphWithPro(vscode: VSCodeInstance): Promise<{
 
 	return {
 		graphWebview: graphWebview!,
-		dispose: () => {
-			sim[Symbol.dispose]();
-			return Promise.resolve();
+		// Awaits the real teardown: the sync disposer drops its promise, which let the next test start
+		// while the simulated subscription was still being torn down.
+		dispose: async () => {
+			await sim[Symbol.asyncDispose]();
 		},
 	};
 }


### PR DESCRIPTION
# Description

Two E2E fixes. Together they take the CI dispatch on `main` from red back to green — the required jobs (VS Code and Windsurf) were both failing, and neither failure was a product defect.

Closes #5627.

## 1. The pin probes were reading a field that had moved

`pinnedRef` was dropped from the Graph webview protocol's `State` when the write planes moved onto RPC services (`9aced7e58`), leaving the state provider's own accessor as the only thing carrying it. The specs' probes read `app.graphState?._state || app.graphState` and then `.pinnedRef` — and `_state` still exists, still carrying `webviewId` and `selectedRepository`, so the `||` fallback never fires. The probe kept working and kept reporting the pin as absent, indistinguishable from "not pinned".

`pinBranch` polled that for 15s and failed; `mode: 'serial'` cascaded it into the rest of the file, on every editor and through every retry — 5 failed on VS Code, the same set on Windsurf and Positron.

Two consequences beyond the assertion that was failing, both fixed by the same change:

- `getGraphState`'s `pinnedRef` was always `undefined`, so the pre-condition asserting the graph opens unpinned passed **vacuously**. It means something again.
- `clearEdgePin` bailed early on that same `undefined` and so never unpinned, leaking the pin (persisted per-repo in workspace storage) into the next serial test.

The pin is now read from both places, so neither this move nor a future one blinds the probe.

## 2. A dropped teardown was killing E2E workers

A worker that passed every one of its tests could still take the run red: Playwright reported `TypeError: fetch failed` / `SocketError: other side closed` as "N errors were not a part of any test", and the job exited 1 with **zero failed tests**. It hit the workers running `graphDetails` and `treeView`.

`startSubscriptionSimulation` exposed its teardown as `Symbol.dispose` — the *synchronous* protocol — with an `async` body, so `using` called it and dropped the returned promise. That promise runs `stopSubscriptionSimulation()`, which reaches the extension host over HTTP. The worker fixture force-kills the editor before closing it, so a late call lands on a dead server and rejects; unhandled, that rejection takes the worker process down.

Three specs made it worse still, calling the async disposer synchronously and then returning an already-resolved promise — so their callers awaited nothing while the real teardown was in flight, which also let a test start while the previous one's simulated subscription was being torn back to Community.

Adds `Symbol.asyncDispose` as the awaited path, switches those three helpers to it, and makes the sync disposer swallow its own rejection: it cannot report anyway, and what matters is that it can never surface as an unhandled one.

This also cleared the `treeView.test.ts:226` flake on Windsurf, whose symptom was the graph's webview iframe vanishing mid-test — consistent with the previous test's un-awaited teardown flipping the account back underneath it.

# Verification

CI dispatch on this branch (33384833661): **success**. VS Code 224 passed, Windsurf 223 passed, unit tests and build green.

Locally on VS Code: `graphPin` 9/9; `graphDetails` 57 passed with `--repeat-each=3`; `treeView` and `graphReview` green.

For contrast, the dispatch on this branch with only the first fix (33379931861) still failed: VS Code was red at 224 passed / 0 failed purely from the worker crashes, and Windsurf from the `treeView` flake.

# Left as follow-up

- 33 `using` call sites could become `await using` to get the ordering guarantee everywhere, not just in the three helpers.
- `VSCodeEvaluator.close()` is still a no-op. Making it mark the evaluator closed would stop late calls at the source instead of catching their fallout.
- `graphConflictResolution.test.ts:290` fails on **Positron** and is untouched by this PR — pre-existing, and non-blocking (`continue-on-error` for experimental editors). What is established: it passes on VS Code and Windsurf in the same runs, passed on Positron in the last green dispatch (19 Aug), fails on CI Positron across three job runs and all their retries, and does **not** reproduce locally — 7/7 single-worker and 14/14 with two workers and repeats on a local Positron install. Root cause not identified; the run's own artifacts also show a retry on the neighbouring `:278`, which points at the file's shared precondition rather than the `+conflict` assertion.

# Checklist

- [x] I have followed the guidelines in the Contributing document
- [x] My changes follow the coding style of this project
- [x] My changes build without any errors or warnings
- [x] My changes have been formatted and linted (`oxfmt`)
- [x] My changes include any required corresponding changes to the documentation — none apply: this is test-only, matching #5738

🤖 Generated with [Claude Code](https://claude.com/claude-code)
