### PR TITLE
Fixes two Graph details E2E specs that assert the wrong panel state

### DIFF
--- a/tests/e2e/specs/graphReview.test.ts
+++ b/tests/e2e/specs/graphReview.test.ts
@@ -173,8 +173,14 @@ test.describe('Review & Compose Sub-Panels', () => {
 			graphWebview.locator('gl-details-wip-header gl-details-header gl-action-chip[icon="checklist"]'),
 		).not.toBeVisible();
 
-		// WIP details and commit bottom should be hidden
-		await expect(graphDetailsRegion(graphWebview, 'wip')).not.toBeVisible();
+		// WIP details and commit bottom should be hidden. Asserted on the WIP panel element rather than
+		// on the details REGION: entering a mode locks the panel to the context it was entered from
+		// (`resolveContent` returns `resolveByContext(activeModeContext)`), so a mode entered from the
+		// WIP header keeps the region's `Working changes details` name and the region stays visible by
+		// design — it is the container the mode's own panel renders into. What has to be gone is the WIP
+		// BODY, and `renderWip` renders `gl-details-wip-panel` only while no mode is active, so counting
+		// it is both exact and free of the layout-box caveat on `graphDetailsRegion`.
+		await expect(graphWebview.locator('gl-details-wip-panel')).toHaveCount(0);
 		const commitBottom = graphWebview.locator('.commit-panel__bottom');
 		await expect(commitBottom).not.toBeVisible();
 	});

--- a/tests/e2e/specs/treeView.test.ts
+++ b/tests/e2e/specs/treeView.test.ts
@@ -11,6 +11,7 @@ import type { FrameLocator } from '@playwright/test';
 import type { VSCodeInstance } from '../baseTest.js';
 import { test as base, createTmpDir, DefaultTimeout, expect, GitFixture, MaxTimeout } from '../baseTest.js';
 import {
+	ensureGraphDetailsPanelOpen,
 	graphDetailsRegion,
 	scrollDetailsToFileTree,
 	waitForGraphRowsRendered,
@@ -126,7 +127,12 @@ async function selectCommitByMessage(graphWebview: FrameLocator, messageText: st
 }
 
 async function waitForDetailsLoaded(graphWebview: FrameLocator): Promise<void> {
-	await expect(graphDetailsRegion(graphWebview)).toBeVisible({ timeout: 30000 });
+	// The panel starts CLOSED — `graph-app` reads `graphState.details?.visible ?? false`, and the graph
+	// header labels its toggle `Show Details Panel` on a fresh profile — so the details region is mounted
+	// with content but has no visible box, and waiting for it to appear on its own can only time out.
+	// Expand it first (the shared helper retries the toggle, which the header can replace mid-reconcile),
+	// which then gates on the same region this function used to wait for.
+	await ensureGraphDetailsPanelOpen(graphWebview, 30000);
 }
 
 async function waitForTreeItems(graphWebview: FrameLocator): Promise<void> {


### PR DESCRIPTION
Two Graph details E2E specs asserted state the panel does not actually hold, and failed on **every** editor in the last dispatch run. The locators were rewritten when the renderer was extracted; the flows around them were not, so the specs moved on without their premises.

- `graphReview:159` asserted the details REGION goes hidden once a mode is active. Entering a mode locks the panel to the context it was entered from (`resolveContent` returns `resolveByContext(activeModeContext)`), so the region stays visible by design. The assertion now targets the WIP panel element instead.
- `treeView:175` waited for a details region to appear on graph open, but the panel starts CLOSED (`graphState.details?.visible ?? false`) and the region mounts without becoming visible. It now opens the panel through the shared `ensureGraphDetailsPanelOpen` helper.

**Validation.** Proven on CI, not locally — these failures do not reproduce on a local stand. Dispatch run 34116940980: both specs green on all three editors (VS Code green as a whole job; Windsurf and Positron confirmed by name). Clean A/B on the failure lists: Windsurf went 8 → 7 with exactly `graphReview:159` gone and the other seven unchanged; Positron went 2 failed + 2 flaky → 1 failed.

**Scope.** Tests only — no product code is touched. The other failures in that run are tracked separately: `graphScoping*`, `graphHeader`/`graphDetails` and `rebase:179` on Windsurf, `graphConflictResolution:295` on Positron, and the `Unit Tests` job (#5823, unrelated to this branch).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
