### PR TITLE
Fixes the worktree-scoping E2E specs gating on a label the graph degrades

### DIFF
--- a/tests/e2e/graphScopeHelpers.ts
+++ b/tests/e2e/graphScopeHelpers.ts
@@ -285,14 +285,22 @@ export async function openGraphSidebarPanel(vscode: VSCodeInstance, panel: 'work
 /**
  * Double-click a worktree's WIP row — the gesture `graph.doubleClickWorktreeAction` governs.
  *
- * Targets the row's "Working Changes" text rather than the row box: the row also carries an inline
- * branch pill, and a double-click resolved to a ref routes to the ref action (checkout) instead of the
- * row gesture (`surface.ts`'s `onDblClick`).
+ * Targets the row's message ELEMENT rather than the row box: the row also carries an inline branch
+ * pill, and a double-click resolved to a ref routes to the ref action (checkout) instead of the row
+ * gesture (`surface.ts`'s `onDblClick`). The pill renders OUTSIDE `.gl-graph__message`, so the message
+ * span cannot resolve to a ref.
+ *
+ * Deliberately NOT the text "Working Changes": that is the row's visible label, and under width
+ * pressure the renderer swaps it for the short `WIP` form (`wipDisplayLabel`, the first rung of
+ * `computeWipRowFit`'s ladder in the commit-graph package). The swap is visual only — `commit.message`
+ * and the row's aria-label keep the long form — so a text gate holds on a wide host and silently stops
+ * matching on a narrower one, which is how the four scoping specs failed on Windsurf while passing on
+ * VS Code with the identical bundle.
  */
 export async function doubleClickWipRow(webview: FrameLocator, worktreePath: string): Promise<void> {
 	const row = graphWipRow(webview, worktreePath);
 	await expect(row).toBeVisible({ timeout: 30000 });
-	await row.getByText('Working Changes').first().dblclick();
+	await row.locator('.gl-graph__message-subject').first().dblclick();
 }
 
 /** The inline "Undo Commit" action on a commit row (hover-revealed, like every gated row action). */


### PR DESCRIPTION
The four worktree-scoping E2E specs failed on Windsurf while passing on VS Code **with the identical bundle**. One shared helper was the cause.

`doubleClickWipRow` double-clicked the WIP row's "Working Changes" TEXT. Under width pressure the renderer swaps that visible label for the short `WIP` form (`wipDisplayLabel`, the first rung of `computeWipRowFit`'s ladder), so the gate held on a wide host and silently stopped matching on a narrower one. The swap is visual only — `commit.message` and the row's aria-label keep the long form. The helper now targets the message element instead of its text.

Measured on one instance with only the host width differing: at a 299px side bar the span reads `WIP`, at a 1092px editor host it reads `Working Changes`, and the element itself is present either way. The inline branch pill renders outside `.gl-graph__message`, so the original reason for not double-clicking the row box — a dblclick resolved to a ref routes to checkout instead of the row gesture — still holds.

**Validation.** Proven on CI; this family cannot run on a local stand at all (it fails earlier, at the worktree WIP row never appearing). Dispatch run 34120889492 on Windsurf: `graphScoping:115`, `graphScopingReload:95`, `graphScopingWorktreeDeleted:83` and `graphScopingWorktreeHome:71` all green. The fix also unblocked three specs that previously never ran — the serial suite aborted at `:115` and marked them "did not run" — and `graphScoping:157`, `:188` and `graphScopingReload:116` are green as well. No regression: the whole family is green on VS Code, and on Positron it was already green and stayed so.

**Known, out of scope.** `graphScoping:254` becomes reachable for the first time thanks to this fix and fails on Windsurf (it passes on VS Code and Positron). It is test-side, not a product defect: the row-action strip paints above the ref pills (it is last in DOM order, both positioned at `z-index: auto`), but it is deliberately `visibility: hidden; pointer-events: none` unless the row is hovered/focused/selected — and the spec relies on a `hover()` established several awaits before the click. The remedy is to reveal the strip through sticky state rather than hover; that belongs in its own change.

**Scope.** Tests only — no product code is touched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
