### PR TITLE
Fixes two Graph E2E specs gating the WIP row on its degradable label

### DIFF
--- a/tests/e2e/specs/graphDetails.test.ts
+++ b/tests/e2e/specs/graphDetails.test.ts
@@ -167,14 +167,24 @@ async function selectWip(graphWebview: FrameLocator): Promise<void> {
 		return;
 	}
 
-	// Match the visible WIP row label, not the hidden tooltip-content span that also carries the
-	// "Working Changes" text (a plain .first() picks the hidden tooltip span).
+	// Identify the row by its ROLE, not by its visible text. The row reads "Working Changes" only while
+	// that fits: under width pressure the renderer swaps in the short `WIP` form (`wipDisplayLabel`, the
+	// first rung of `computeWipRowFit`'s ladder in the commit-graph package), and a text gate then matches
+	// nothing — which is how this spec timed out on Windsurf while passing on VS Code with the identical
+	// bundle. The swap is visual only: the row's aria-label is built from `commit.message`, so the
+	// accessible name keeps the long form at any width. It also sidesteps the hidden tooltip-content span
+	// carrying the same text, which is why the old gate needed the visibility filter.
 	const wipRow = graphWebview
-		.getByText(/Working (Changes|Tree)/)
+		.getByRole('treeitem', { name: /Working (Changes|Tree)/ })
 		.filter({ visible: true })
 		.first();
 	await expect(wipRow).toBeVisible({ timeout: MaxTimeout });
-	await wipRow.click();
+	// Click the message ELEMENT, not the row box. `getByText` used to resolve to this very span, so this
+	// keeps the gesture the row-selection behaviour was proven with while dropping the text dependency.
+	// The row box is the wrong target: it also carries the inline branch pill, and a click resolved to a
+	// ref routes to the ref action instead of selecting the row. The pill renders OUTSIDE
+	// `.gl-graph__message`, so the message span cannot resolve to a ref.
+	await wipRow.locator('.gl-graph__message-subject').first().click();
 	await ensureDetailsPanelOpen(graphWebview);
 }
 

--- a/tests/e2e/specs/graphHeader.test.ts
+++ b/tests/e2e/specs/graphHeader.test.ts
@@ -67,12 +67,24 @@ async function openHeaderMenu(webview: FrameLocator, label: string, commandInsid
 /** Select the WIP row and wait for its details (which host the commit box + signing indicator). */
 async function selectWipDetails(webview: FrameLocator): Promise<void> {
 	await ensureGraphDetailsPanelOpen(webview, MaxTimeout);
+	// Identify the row by its ROLE, not by its visible text — the text gate failed here two ways. The
+	// details panel this helper just opened renders its own WIP title (`.graph-details-header__wip-title-text`)
+	// carrying the same string, so `.first()` could resolve to the PANEL instead of the row; a click there
+	// is intercepted by the pane overlays and burns the full timeout. And under width pressure the row's
+	// visible label degrades to the short `WIP` form (`wipDisplayLabel`, the first rung of
+	// `computeWipRowFit`'s ladder), matching nothing at all. The row's aria-label is built from
+	// `commit.message` and never sees that swap, so the accessible name identifies the row at any width.
 	const wipRow = webview
-		.getByText(/Working (Changes|Tree)/)
+		.getByRole('treeitem', { name: /Working (Changes|Tree)/ })
 		.filter({ visible: true })
 		.first();
 	await expect(wipRow).toBeVisible({ timeout: MaxTimeout });
-	await wipRow.click();
+	// Click the message ELEMENT, not the row box. `getByText` used to resolve to this very span, so this
+	// keeps the gesture the row-selection behaviour was proven with while dropping the text dependency.
+	// The row box is the wrong target: it also carries the inline branch pill, and a click resolved to a
+	// ref routes to the ref action instead of selecting the row. The pill renders OUTSIDE
+	// `.gl-graph__message`, so the message span cannot resolve to a ref.
+	await wipRow.locator('.gl-graph__message-subject').first().click();
 	await ensureGraphDetailsPanelOpen(webview, MaxTimeout);
 	await expect(graphDetailsRegion(webview, 'wip')).toBeVisible({
 		timeout: 30000,


### PR DESCRIPTION
Two Graph WIP specs failed only on Windsurf while passing on VS Code **with the identical bundle**. One pattern in two helpers — `graphDetails.selectWip` and `graphHeader.selectWipDetails` both reached the WIP row through `getByText(/Working (Changes|Tree)/)` — carried two independent defects.

- **Label degradation.** Under width pressure the renderer swaps the row's visible label for the short `WIP` form (`wipDisplayLabel`, the first rung of `computeWipRowFit`'s ladder), so a text gate matches nothing at all. That is the `graphDetails` failure — "element(s) not found".
- **Ambiguity.** The details panel these helpers open renders the same string in its own title (`.graph-details-header__wip-title-text`), so `.first()` could resolve to the PANEL instead of the row. A click there is intercepted by the pane overlays and burns the full timeout. That is the `graphHeader` failure — the call log shows the locator resolving to that span, not to a row.

Both now identify the row by its **role**. The row's aria-label is built from `commit.message` and never sees the label swap: the type's own docstring says so, `buildAriaLabel` pushes `firstLine(commit.message)` for workdir rows, and `a11y.test.ts` already asserts it. `graphReview` and `graphConflictResolution` have always used the role locator and do find the row on Windsurf, which is the empirical control.

The click still lands on `.gl-graph__message-subject` — the span `getByText` used to resolve to, and the workdir row's whole message shape per `renderWipMessageContent`. The row box is deliberately not the target: it also carries the inline branch pill, and a click resolved to a ref routes to the ref action instead of selecting the row.

**Validation.** Proven on CI; these failures do not reproduce on a local stand. Dispatch run 34125286513: every test in both files is green on Windsurf on the first attempt, including the two that were failing, and `graphDetails` is green on VS Code on the first attempt. `graphHeader`'s signing spec flaked once on VS Code and passed on retry — that failure comes from the shared `ensureGraphDetailsPanelOpen` helper (`graphHelpers.ts:135`, a 10s `toPass` budget for opening the panel), which this change does not touch and which runs before its code. Consolidating the three panel-open mechanisms is a separate follow-up.

**Scope.** Tests only — no product code is touched. Sibling fixes for the other families in the same dispatch runs are #5824 and #5825; `rebase:179` (Windsurf) and `graphConflictResolution:295` (Positron) remain untracked here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
