### PR TITLE
Fixes the two Windsurf-only E2E failures left on main

### DIFF
--- a/tests/e2e/graphScopeHelpers.ts
+++ b/tests/e2e/graphScopeHelpers.ts
@@ -253,6 +253,38 @@ export async function clickSidebarRowAction(row: Locator, label: string): Promis
 	await action.click();
 }
 
+/**
+ * Click a gated action on a GRAPH row, revealing the action strip through SELECTION.
+ *
+ * The strip is `visibility: hidden; pointer-events: none` until its row is hovered, focused or
+ * selected (`graph.scss`), so while inert it is transparent to hit-testing and a click aimed at it
+ * falls through to whatever is beneath. On a narrow host that is real: measured live on Windsurf at a
+ * 299px side bar, rows render in the two-line LIST layout and `.gl-graph__list-line2` (x 81..282)
+ * underlies the strip (x 225..285) for 57px — which is why Playwright names line2, or the merge-target
+ * ref pill inside it, as the interceptor.
+ *
+ * Hover is the wrong key for it, even applied immediately before the click: the graph re-renders rows
+ * on its own (WIP state, avatars), and Chromium does not re-evaluate `:hover` for a freshly inserted
+ * element under a STATIONARY cursor — so the strip can go inert between Playwright's actionability
+ * check and its hit test. That is exactly the shape of the CI failure: attempts reporting "element is
+ * not visible" interleaved with attempts where the element was "visible, enabled and stable" and the
+ * pill intercepted anyway.
+ *
+ * Selection is pointer-independent and sticky, so it holds across a re-render. Verified live on
+ * Windsurf at that same 299px width: with the row selected the strip reports `pointer-events: auto`
+ * and `document.elementFromPoint` at the button's centre returns the button itself; clicking Undo
+ * Commit moved the branch back one commit and left the undone commit's file staged.
+ *
+ * The row's message span is the click target for selecting, never the row box — the box also carries
+ * the inline ref pills, and a click resolved to a ref routes to the ref action instead.
+ */
+export async function clickGraphRowAction(row: Locator, action: Locator): Promise<void> {
+	await row.locator('.gl-graph__message-subject').first().click();
+	await expect(row).toHaveAttribute('aria-selected', 'true', { timeout: MaxTimeout });
+	await expect(action).toBeVisible({ timeout: MaxTimeout });
+	await action.click();
+}
+
 /** The `gl-scope` decoration marking the side bar row the graph is currently scoped to. */
 export function sidebarRowScopedBadge(row: Locator): Locator {
 	return row.locator('code-icon[aria-label="Scoped"]');

--- a/tests/e2e/specs/graphScoping.test.ts
+++ b/tests/e2e/specs/graphScoping.test.ts
@@ -22,6 +22,7 @@ import * as process from 'node:process';
 import { test as base, createTmpDir, expect, GitFixture, MaxTimeout } from '../baseTest.js';
 import {
 	branchPill,
+	clickGraphRowAction,
 	clickSidebarRowAction,
 	doubleClickWipRow,
 	expectScopeTint,
@@ -283,7 +284,10 @@ test.describe('Graph — worktree scope and branch focus', () => {
 		const worktreeShaBefore = await worktree.getSha();
 		const worktreeParent = await worktree.getSha('HEAD~1');
 
-		await undo.click();
+		// Through the helper, not `undo.click()`: the row-action strip is inert unless its row is hovered,
+		// focused or selected, and the helper reveals it by SELECTING the row — sticky state that survives
+		// the graph's own re-renders, which a hover under a stationary cursor does not.
+		await clickGraphRowAction(scopedTip, undo);
 
 		// The proof is on disk, not in the UI: the worktree's branch moved back and its index now holds
 		// the undone commit's file, while the home checkout is untouched in both respects.

--- a/tests/e2e/specs/rebase.test.ts
+++ b/tests/e2e/specs/rebase.test.ts
@@ -170,7 +170,12 @@ async function standardTeardown({ vscode }: { vscode: VSCodeInstance }) {
 
 test.describe('Editor — Core', () => {
 	test.describe.configure({ mode: 'serial' });
-	test.setTimeout(30000);
+	// Above the config's `actionTimeout` (30s), deliberately. When the two are equal a stuck action can
+	// never report its own timeout: the test's budget expires at the same moment, so the failure arrives
+	// as a bare "Test timeout" naming nothing and the page is torn down before `error-context.md` can
+	// capture a snapshot — which is exactly how the abort spec failed on Windsurf, undiagnosably. With
+	// room to spare the action's own timeout fires first and names the locator. Matches `Execute rebase`.
+	test.setTimeout(60000);
 
 	test.describe('Start & Abort', () => {
 		test.beforeEach(standardSetup);
@@ -210,6 +215,12 @@ test.describe('Editor — Core', () => {
 			// Click the Abort button first - this clears the todo file and saves it
 			// Use appearance="secondary" to target the main abort button, not the "Abort > Recompose" button
 			const abortButton = webviewFrame.locator('gl-button[appearance="secondary"]').filter({ hasText: 'Abort' });
+			// Clear notifications first: a toast parked bottom-right covers this button and swallows the click.
+			// On Windsurf that is deterministic — an announcement toast with actions (`.announcement-actions`
+			// inside `.notifications-toasts`) sits over the Abort button and Playwright reported it intercepting
+			// pointer events for the full action budget. `notifications.clearAll` dismisses them outright, which
+			// beats the sleep-then-Escape dance the later specs in this file use.
+			await vscode.gitlens.executeCommand('notifications.clearAll');
 			await abortButton.click();
 
 			// Signal the wait editor to exit after the abort button has cleared the todo file

--- a/tests/e2e/specs/rebase.test.ts
+++ b/tests/e2e/specs/rebase.test.ts
@@ -219,8 +219,11 @@ test.describe('Editor — Core', () => {
 			// On Windsurf that is deterministic — an announcement toast with actions (`.announcement-actions`
 			// inside `.notifications-toasts`) sits over the Abort button and Playwright reported it intercepting
 			// pointer events for the full action budget. `notifications.clearAll` dismisses them outright, which
-			// beats the sleep-then-Escape dance the later specs in this file use.
-			await vscode.gitlens.executeCommand('notifications.clearAll');
+			// beats the sleep-then-Escape dance the later specs in this file use. Guarded with the
+			// `IfAvailable` variant, as `secondarySidebar` does for its workbench commands: `notifications.clearAll`
+			// is built in rather than ours, so a fork that renames or omits it would otherwise hard-fail here on a
+			// missing command. Skipping the clear just leaves the original interception, which is a legible failure.
+			await vscode.gitlens.executeCommandIfAvailable('notifications.clearAll');
 			await abortButton.click();
 
 			// Signal the wait editor to exit after the abort button has cleared the todo file

--- a/tests/e2e/specs/rebase.test.ts
+++ b/tests/e2e/specs/rebase.test.ts
@@ -219,11 +219,13 @@ test.describe('Editor — Core', () => {
 			// On Windsurf that is deterministic — an announcement toast with actions (`.announcement-actions`
 			// inside `.notifications-toasts`) sits over the Abort button and Playwright reported it intercepting
 			// pointer events for the full action budget. `notifications.clearAll` dismisses them outright, which
-			// beats the sleep-then-Escape dance the later specs in this file use. Guarded with the
-			// `IfAvailable` variant, as `secondarySidebar` does for its workbench commands: `notifications.clearAll`
-			// is built in rather than ours, so a fork that renames or omits it would otherwise hard-fail here on a
-			// missing command. Skipping the clear just leaves the original interception, which is a legible failure.
-			await vscode.gitlens.executeCommandIfAvailable('notifications.clearAll');
+			// beats the sleep-then-Escape dance the later specs in this file use. Best-effort on purpose:
+			// `notifications.clearAll` is built in rather than ours, so the `IfAvailable` variant covers a fork
+			// that renames or omits it (as `secondarySidebar` does for its workbench commands) and the swallowed
+			// rejection covers one where it exists but throws. Either way the clear is skipped rather than
+			// failing the test here, and what remains is the original interception at the click — a legible
+			// failure that names the toast, instead of one that names a command this spec isn't about.
+			await vscode.gitlens.executeCommandIfAvailable('notifications.clearAll').catch(() => undefined);
 			await abortButton.click();
 
 			// Signal the wait editor to exit after the abort button has cleared the todo file


### PR DESCRIPTION
The last two Windsurf-only E2E failures on `main`. Both passed on VS Code and Positron with the identical bundle, and neither cause is what its CI log first suggested — the diagnosis came from driving a live Windsurf instance at the width CI runs.

### `graphScoping` — the row-action strip was revealed by hover

The strip is `visibility: hidden; pointer-events: none` until its row is hovered, focused or selected, so while inert it is transparent to hit-testing and a click aimed at it falls through to whatever is beneath. Playwright reported the merge-target ref pill intercepting the Undo Commit click for the full budget, and that reads like a layering bug — it isn't.

Measured live at a 299px side bar, where rows render in the two-line **list** layout: `.gl-graph__list-line2` spans x 81..282 and the strip x 225..285, so line2 and the pill inside it do underlie the strip for 57px. But the strip is last among the row's children and positioned, so it paints above them. With the row **selected**, `document.elementFromPoint` at the button's centre returns that button, the strip reports `pointer-events: auto`, and clicking Undo Commit moved the branch back one commit and left the undone commit's file staged. The pill only ever answers the hit test while the strip is inert.

Hover cannot hold that state open: the graph re-renders rows on its own, and Chromium does not re-evaluate `:hover` for a freshly inserted element under a stationary cursor. That is exactly the interleaving the CI log shows — attempts reporting "element is not visible" mixed with attempts where the element was "visible, enabled and stable" and the pill intercepted anyway. `clickGraphRowAction` now reveals the strip by selecting the row and asserting `aria-selected`, which is pointer-independent and survives a re-render. It clicks the row's message span, never the row box, so the click cannot resolve to a ref pill and route elsewhere.

### `rebase` — a notification toast over the Abort button

The abort spec failed with a bare "Test timeout" that named nothing, because the describe's 30s budget equalled the config's `actionTimeout`: a stuck action could never report its own timeout, and the page was torn down before `error-context.md` could capture a snapshot (it came back 398 bytes). Raising the budget to 60s, matching the `Execute rebase` sibling, made the failure name its locator — an announcement toast (`.announcement-actions` inside `.notifications-toasts bottom-right`) parked over the Abort button, shown on Windsurf and not on VS Code. It is cleared with `notifications.clearAll` before the click, which beats the sleep-then-Escape dance the later specs in this file use.

### Validation

Proven on CI, not locally — these failures do not reproduce on a local stand. Dispatch run 34227047697: the **Windsurf job is green as a whole** (231 passed, 0 failed), with `graphScoping:255` and `rebase:184` passing on the first attempt and the scoping family at 9 green / 0 red. No regression: VS Code is 232 passed with no failures and no flakes, and all 13 `rebase.test.ts` specs pass on both editors, so `notifications.clearAll` disturbed none of them. `Unit Tests` green.

### Scope

Tests only — no product code is touched. Left untracked here: `treeView:235` still flakes on Windsurf (it failed and passed on retry), but its cause is the shared `ensureGraphDetailsPanelOpen` helper rather than the spec, and consolidating the three panel-open mechanisms is its own change; `graphConflictResolution:295` still fails on Positron with a cause that is not established.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
